### PR TITLE
Remove outdated license in `copybara.py` file

### DIFF
--- a/dev/copybara.py
+++ b/dev/copybara.py
@@ -1,22 +1,3 @@
-#
-# DATABRICKS CONFIDENTIAL & PROPRIETARY
-# __________________
-#
-# Copyright 2019 Databricks, Inc.
-# All Rights Reserved.
-#
-# NOTICE:  All information contained herein is, and remains the property of Databricks, Inc.
-# and its suppliers, if any.  The intellectual and technical concepts contained herein are
-# proprietary to Databricks, Inc. and its suppliers and may be covered by U.S. and foreign Patents,
-# patents in process, and are protected by trade secret and/or copyright law. Dissemination, use,
-# or reproduction of this information is strictly forbidden unless prior written permission is
-# obtained from Databricks, Inc.
-#
-# If you view or obtain a copy of this information and believe Databricks, Inc. may not have
-# intended it to be made available, please promptly report it to Databricks Legal Department
-# @ legal@databricks.com.
-#
-
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Since the repository now falls under the Apache 2.0 license, this can probably be removed.