### PR TITLE
Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+**PR Checklist**
+
+- [ ] A description of the changes is added to the description of this PR.
+- [ ] If there is a related issue, make sure it is linked to this PR.
+- [ ] If you've fixed a bug or added code that should be tested, add tests!
+- [ ] If you've added or modified a feature, documentation in `docs` is updated
+
+**Description of changes**
+
+<!-- Please state what you've changed and how it might affect the users. -->


### PR DESCRIPTION
Probably useful to have a PR template, similar to [here](https://github.com/fpgmaas/deptry/blob/main/.github/pull_request_template.md)

<img width="915" alt="image" src="https://github.com/unitycatalog/unitycatalog/assets/12008199/5f3b35c0-6ef1-40be-8015-5a744a27c228">
