### PR TITLE
Change the cmd flag from --format to --output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Let's list the tables.
 bin/uc table list --catalog unity --schema default
 ```
 You should see a few tables. Some details are truncated because of the nested nature of the data.
-To see all the content, you can add `--format jsonPretty` to any command.
+To see all the content, you can add `--output jsonPretty` to any command.
 
 Next, let's get the metadata of one those tables. 
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,7 +45,7 @@ Let's list the tables.
 bin/uc table list --catalog unity --schema default
 ```
 You should see a few tables. Some details are truncated because of the nested nature of the data.
-To see all the content, you can add `--format jsonPretty` to any command.
+To see all the content, you can add `--output jsonPretty` to any command.
 
 Next, let's get the metadata of one those tables.
 


### PR DESCRIPTION
Change the cmd flag from --format to --output. Otherwise following error will raise:
```
$ bin/uc table list --catalog unity --schema default --format jsonPretty
Some of the provided parameters are not valid.
Usage: bin/uc table list [options]
Required Params:
  --catalog The name of the catalog.
  --schema The name of the schema.
Optional Params:
  --max_results The maximum number of results to return.
```