### PR TITLE
Iceberg REST Service: Throw 400 if namespace is invalid

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -147,10 +147,7 @@ public class IcebergRestCatalogService {
   @Head("/v1/namespaces/{namespace}/tables/{table}")
   public HttpResponse tableExists(@Param("namespace") String namespace,
                                   @Param("table") String table) {
-    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
-    if (namespaceParts.size() != 2) {
-      throw new IllegalArgumentException("invalid namespace " + namespace);
-    }
+    List<String> namespaceParts = splitTwoPartNamespace(namespace);
     String catalog = namespaceParts.get(0);
     String schema = namespaceParts.get(1);
     try (Session session = sessionFactory.openSession()) {
@@ -169,10 +166,7 @@ public class IcebergRestCatalogService {
   @ProducesJson
   public LoadTableResponse loadTable(@Param("namespace") String namespace,
                                      @Param("table") String table) throws IOException {
-    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
-    if (namespaceParts.size() != 2) {
-      throw new IllegalArgumentException("invalid namespace " + namespace);
-    }
+    List<String> namespaceParts = splitTwoPartNamespace(namespace);
     String catalog = namespaceParts.get(0);
     String schema = namespaceParts.get(1);
     String metadataLocation;
@@ -205,10 +199,7 @@ public class IcebergRestCatalogService {
   public org.apache.iceberg.rest.responses.ListTablesResponse listTables(
     @Param("namespace") String namespace)
     throws JsonProcessingException {
-    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
-    if (namespaceParts.size() != 2) {
-      throw new IllegalArgumentException("invalid namespace " + namespace);
-    }
+    List<String> namespaceParts = splitTwoPartNamespace(namespace);
     String catalog = namespaceParts.get(0);
     String schema = namespaceParts.get(1);
     AggregatedHttpResponse resp =
@@ -237,4 +228,13 @@ public class IcebergRestCatalogService {
       .build();
   }
 
+  private List<String> splitTwoPartNamespace(String namespace) {
+    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
+    if (namespaceParts.size() != 2) {
+      String errMsg = "Invalid two-part namespace " + namespace;
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, errMsg);
+    }
+
+    return namespaceParts;
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -251,4 +251,21 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     }
   }
 
+  @Test
+  public void testLoadTablesInvalidNamespace() {
+    AggregatedHttpResponse resp = client.get("/v1/namespaces/incomplete_namespace/tables/some_table").aggregate().join();
+    Assert.assertEquals(resp.status().code(), 400);
+  }
+
+  @Test
+  public void testListTablesInvalidNamespace() {
+    AggregatedHttpResponse resp = client.get("/v1/namespaces/incomplete_namespace/tables").aggregate().join();
+    Assert.assertEquals(resp.status().code(), 400);
+  }
+
+  @Test
+  public void testTableExistsInvalidNamespace() {
+    AggregatedHttpResponse resp = client.head("/v1/namespaces/incomplete_namespace/tables").aggregate().join();
+    Assert.assertEquals(resp.status().code(), 400);
+  }
 }


### PR DESCRIPTION
Fixes #10 to have the right behavior of a 400 when failing.

Currently, an IllegalArgumentException for invalid namespace will be thrown which will end up surfacing as a 500 response due to https://github.com/unitycatalog/unitycatalog/blob/main/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java#L26 treating this as an arbitrary runtime exception. Instead a Base exception with an invalid argument error code should be thrown (looking at other parts of the code, this seems to be the practice).