### PR TITLE
Add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore all build artifacts
+**/target
+
+# Ignore generated sbt launch jar
+build/sbt-launch-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 etc/db/h2db.mv.db
+
+# Ignore all build folders
+**/target
+
+# Ignore generated sbt launch jar
+build/sbt-launch-*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11
+
+COPY . /usr/src/myapp
+WORKDIR /usr/src/myapp
+
+RUN build/sbt clean compile
+
+CMD ["bin/start-uc-server"]
+


### PR DESCRIPTION
1. Updates the `.gitignore` to ignore build artifacts
2. Adds a `.dockerignore` to ignore build artifacts
3. Adds a `Dockerfile` to build a Docker container

One problem which I haven't yet found a workaround is that the test data for UC will reside inside the container instead of on the host filesystem. This does make quickstart for the `unity.default.marksheet` default table a little confusing because the data cannot found found at the storage_location on the host 😬 

I think it could be cool to maybe add an additional Docker stage called `quickstart` which installs DuckDB and we can hook it up to stdin so that users can quickly run both unitycatalog and DuckDB in the same Docker container and get started really quickly with a `bin/quickstart.sh` or something.