### PR TITLE
added Dockerfile and updated tutorials.md on how to use the Dockerfile

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.20.0
+
+LABEL version="0.0.1"
+LABEL description="First cut of docker image for running UC in a container.\
+                   After building, start by running it as a detach container \
+                   `docker run -d -p 8080:8080 <image_id>`"
+
+ARG jdkHomeDir=/etc/zulu11-jdk11
+
+ENV JAVA_HOME=$jdkHomeDir
+ENV UNITYCATALOG_HOME="/unitycatalog"
+ENV PATH="$PATH:$JAVA_HOME/bin:$UNITYCATALOG_HOME/bin"
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache git curl bash tar && \
+    git clone https://github.com/unitycatalog/unitycatalog.git && \
+    curl -L https://cdn.azul.com/zulu/bin/zulu11.72.19-ca-jdk11.0.23-linux_musl_x64.tar.gz -o zulu11-jdk11.tar.gz && \
+    mkdir $jdkHomeDir && \
+    tar xvfz zulu11-jdk11.tar.gz --strip-components=1 -C $jdkHomeDir  && \
+    rm zulu11-jdk11.tar.gz && \
+    cd /unitycatalog && \
+    ./build/sbt -info clean package
+
+WORKDIR /unitycatalog
+
+EXPOSE 8080
+
+ENTRYPOINT ["start-uc-server"]
+CMD ["8080"]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -229,3 +229,22 @@ SELECT * FROM iceberg."unity.default".marksheet_uniform
 ## APIs and Compatibility
 - Open API specification: The Unity Catalog Rest API is documented [here](../api).
 - Compatibility and stability: The APIs are currently evolving and should not be assumed to be stable.
+
+# Running in a docker container
+The docker folder contains a Dockerfile that help users get up and running with UnityCatalog within a dockerized environment.
+
+You can build it with:
+```docker
+docker build -f Dockerfile -t <tagname>:<version> .
+```
+
+After building, start by running it as a detach container with:
+```docker
+`docker run -d -p 8080:8080 <image_id>`
+```
+By default, it runs on port `8080` but if you are already using that port in your service, you can change it in the `dockerfile`
+
+Finally, you can test it with an example:
+```bash
+curl http://localhost:8080/api/2.1/unity-catalog/catalogs # list catalogs output.
+```


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
Created a Dockerfile to allow users to quickly and easily get up and running with UC. Currently this sets up the default stack and runs on port 8080. `server.properties` file is also currently at the default location, so users can still make amendments within the Dockerfile for their respective environments. 

This Dockerfile also builds the sbt packages within the image so that users don't have to build it each time the container starts. 

- No related issue to be linked to the PR 