### PR TITLE
Set Test Log Level to Info globally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val commonSettings = Seq(
 
   // Test configs
   Test / testOptions  := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"), Tests.Filter(name => !(name startsWith s"$orgName.server.base"))),
+  Test / logLevel := util.Level.Info,
   Test / publishArtifact := false,
   fork := true,
   outputStrategy := Some(StdoutOutput),


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Set Test Log Level to `Info` globally. Previously we were not seeing individual test information for `server`  sbt project. This global setting enables printing of the same while running tests.

**Testing**

The same can be cross-checked from the `Run tests`  steps of the `build` Workflow of this PR. 
