### PR TITLE
implement iceberg rest catalog register table endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/model/DataSourceFormat.java
+++ b/server/src/main/java/io/unitycatalog/server/model/DataSourceFormat.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum DataSourceFormat {
   
   DELTA("DELTA"),
+
+  ICEBERG("ICEBERG"),
   
   CSV("CSV"),
   

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -174,7 +174,7 @@ public class IcebergRestCatalogService {
     try (Session session = sessionFactory.openSession()) {
       TableInfo tableInfo = tableRepository.getTable(namespace + "." + table);
       metadataLocation = tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG ? tableInfo.getStorageLocation() :
-          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
+        tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
     }
 
     if (metadataLocation == null) {
@@ -184,8 +184,8 @@ public class IcebergRestCatalogService {
     TableMetadata tableMetadata = parseTableMetadataFromLocation(metadataLocation);
 
     return LoadTableResponse.builder()
-        .withTableMetadata(tableMetadata)
-        .build();
+      .withTableMetadata(tableMetadata)
+      .build();
   }
 
   @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")
@@ -213,8 +213,8 @@ public class IcebergRestCatalogService {
         .stream()
         .filter(tableInfo -> {
           String metadataLocation =
-                  tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG ? tableInfo.getStorageLocation() :
-                          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, tableInfo.getName());
+            tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG ? tableInfo.getStorageLocation() :
+              tableRepository.getTableUniformMetadataLocation(session, catalog, schema, tableInfo.getName());
           return metadataLocation != null;
         })
         .map(tableInfo -> TableIdentifier.of(tableInfo.getCatalogName(), tableInfo.getSchemaName(),

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -154,7 +154,8 @@ public class IcebergRestCatalogService {
     try (Session session = sessionFactory.openSession()) {
       TableInfo tableInfo = tableRepository.getTable(namespace + "." + table);
 
-      if (tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG || tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table) != null) {
+      if (tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG ||
+          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table) != null) {
         return HttpResponse.of(HttpStatus.OK);
       } else {
         return HttpResponse.of(HttpStatus.NOT_FOUND);
@@ -173,7 +174,7 @@ public class IcebergRestCatalogService {
     try (Session session = sessionFactory.openSession()) {
       TableInfo tableInfo = tableRepository.getTable(namespace + "." + table);
       metadataLocation = tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG ? tableInfo.getStorageLocation() :
-              tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
+          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
     }
 
     if (metadataLocation == null) {
@@ -183,8 +184,8 @@ public class IcebergRestCatalogService {
     TableMetadata tableMetadata = parseTableMetadataFromLocation(metadataLocation);
 
     return LoadTableResponse.builder()
-            .withTableMetadata(tableMetadata)
-            .build();
+        .withTableMetadata(tableMetadata)
+        .build();
   }
 
   @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")
@@ -230,8 +231,8 @@ public class IcebergRestCatalogService {
   @Post("/v1/namespaces/{namespace}/register")
   @ProducesJson
   @ConsumesJson
-  public LoadTableResponse registerTable(@Param("namespace") String namespace, RegisterTableRequest request) throws IOException
-  {
+  public LoadTableResponse registerTable(@Param("namespace") String namespace,
+                                         RegisterTableRequest request) throws IOException {
     List<String> namespaceParts = splitTwoPartNamespace(namespace);
     String catalog = namespaceParts.get(0);
     String schema = namespaceParts.get(1);
@@ -240,15 +241,15 @@ public class IcebergRestCatalogService {
     TableMetadata tableMetadata = parseTableMetadataFromLocation(request.metadataLocation());
 
     CreateTable createTable = new CreateTable()
-            .name(request.name())
-            .catalogName(catalog)
-            .schemaName(schema)
-            .properties(tableMetadata.properties())
-            .tableType(TableType.EXTERNAL)
-            //.columns()
-            //.comment()
-            .dataSourceFormat(DataSourceFormat.ICEBERG)
-            .storageLocation(request.metadataLocation());
+        .name(request.name())
+        .catalogName(catalog)
+        .schemaName(schema)
+        .properties(tableMetadata.properties())
+        .tableType(TableType.EXTERNAL)
+        //.columns()
+        //.comment()
+        .dataSourceFormat(DataSourceFormat.ICEBERG)
+        .storageLocation(request.metadataLocation());
     tableService.createTable(createTable);
 
     // return LoadTableResponse per spec

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -3,9 +3,11 @@ package io.unitycatalog.server.iceberg;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.auth.AuthToken;
@@ -15,6 +17,7 @@ import io.unitycatalog.server.base.BaseServerTest;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.persist.FileUtils;
 import io.unitycatalog.server.persist.HibernateUtil;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
@@ -53,6 +56,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     client = WebClient
       .builder(uri)
       .auth(AuthToken.ofOAuth2(token))
+            .addHeader("Content-Type", "application/json")
       .build();
     cleanUp();
   }
@@ -248,6 +252,49 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         RESTObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
       Assert.assertEquals(List.of(TableIdentifier.of(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME)),
         loadTableResponse.identifiers());
+    }
+  }
+
+  @Test
+  public void testRegisterTable() throws ApiException, IOException, URISyntaxException, JsonProcessingException {
+    catalogOperations.createCatalog(TestUtils.CATALOG_NAME, "testCatalog");
+    schemaOperations.createSchema(
+            new CreateSchema()
+                    .catalogName(TestUtils.CATALOG_NAME)
+                    .name(TestUtils.SCHEMA_NAME)
+    );
+
+    String metadataLocation = FileUtils.convertRelativePathToURI(this.getClass().getResource("/metadata.json").toURI().toString());
+
+    {
+      Map<String, String> payload = Map.of("name", TestUtils.TABLE_NAME, "metadata-location", metadataLocation);
+
+      AggregatedHttpResponse resp =
+              client.post(
+                              "/v1/namespaces/"
+                                      + TestUtils.CATALOG_NAME
+                                      + "."
+                                      + TestUtils.SCHEMA_NAME
+                                      + "/register",
+                              RESTObjectMapper.mapper().writeValueAsString(payload))
+                      .aggregate()
+                      .join();
+      Assert.assertEquals(resp.status().code(), 200);
+      LoadTableResponse loadTableResponse =
+              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      Assert.assertEquals(metadataLocation, loadTableResponse.tableMetadata().metadataFileLocation());
+    }
+
+    // Get newly registered table
+    {
+      AggregatedHttpResponse resp =
+              client.get(
+                      "/v1/namespaces/" + TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "/tables/" +
+                              TestUtils.TABLE_NAME).aggregate().join();
+      Assert.assertEquals(resp.status().code(), 200);
+      LoadTableResponse loadTableResponse =
+              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      Assert.assertEquals(metadataLocation, loadTableResponse.tableMetadata().metadataFileLocation());
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -56,7 +56,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     client = WebClient
       .builder(uri)
       .auth(AuthToken.ofOAuth2(token))
-            .addHeader("Content-Type", "application/json")
+      .addHeader("Content-Type", "application/json")
       .build();
     cleanUp();
   }
@@ -256,12 +256,12 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   }
 
   @Test
-  public void testRegisterTable() throws ApiException, IOException, URISyntaxException, JsonProcessingException {
+  public void testRegisterTable() throws ApiException, IOException, URISyntaxException {
     catalogOperations.createCatalog(TestUtils.CATALOG_NAME, "testCatalog");
     schemaOperations.createSchema(
-            new CreateSchema()
-                    .catalogName(TestUtils.CATALOG_NAME)
-                    .name(TestUtils.SCHEMA_NAME)
+        new CreateSchema()
+            .catalogName(TestUtils.CATALOG_NAME)
+            .name(TestUtils.SCHEMA_NAME)
     );
 
     String metadataLocation = FileUtils.convertRelativePathToURI(this.getClass().getResource("/metadata.json").toURI().toString());
@@ -270,30 +270,30 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       Map<String, String> payload = Map.of("name", TestUtils.TABLE_NAME, "metadata-location", metadataLocation);
 
       AggregatedHttpResponse resp =
-              client.post(
-                              "/v1/namespaces/"
-                                      + TestUtils.CATALOG_NAME
-                                      + "."
-                                      + TestUtils.SCHEMA_NAME
-                                      + "/register",
-                              RESTObjectMapper.mapper().writeValueAsString(payload))
-                      .aggregate()
-                      .join();
+          client.post(
+                  "/v1/namespaces/"
+                      + TestUtils.CATALOG_NAME
+                      + "."
+                      + TestUtils.SCHEMA_NAME
+                      + "/register",
+                  RESTObjectMapper.mapper().writeValueAsString(payload))
+              .aggregate()
+              .join();
       Assert.assertEquals(resp.status().code(), 200);
       LoadTableResponse loadTableResponse =
-              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
       Assert.assertEquals(metadataLocation, loadTableResponse.tableMetadata().metadataFileLocation());
     }
 
     // Get newly registered table
     {
       AggregatedHttpResponse resp =
-              client.get(
-                      "/v1/namespaces/" + TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "/tables/" +
-                              TestUtils.TABLE_NAME).aggregate().join();
+          client.get(
+              "/v1/namespaces/" + TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "/tables/" +
+                  TestUtils.TABLE_NAME).aggregate().join();
       Assert.assertEquals(resp.status().code(), 200);
       LoadTableResponse loadTableResponse =
-              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          RESTObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
       Assert.assertEquals(metadataLocation, loadTableResponse.tableMetadata().metadataFileLocation());
     }
   }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Adds registerTable endpoint to Iceberg REST catalog service
- Adds "ICEBERG" as a data source format

This makes a native iceberg table more "top-level" like a delta table and adds the ability to register/store an existing native iceberg table in UC (instead of UC considering an iceberg table just a delta table with uniform enabled, i.e. having a uniform iceberg metadata location set).

Here's an example of it working locally with OSS Spark using the iceberg-spark 'register_table' procedure (Note: you need to manually create the new schema/namespace using cli first):

```
spark-sql (default)> create table hadoop.uctest.table1 (id int);
Time taken: 0.501 seconds
spark-sql (default)> insert into hadoop.uctest.table1 values (1),(2),(3);
Time taken: 0.919 seconds
spark-sql (default)> select * from hadoop.uctest.table1;
1
2
3
Time taken: 0.065 seconds, Fetched 3 row(s)
spark-sql (default)> select * from iceberg.unity.test.table1;
...
[TABLE_OR_VIEW_NOT_FOUND] The table or view `iceberg`.`unity`.`test`.`table1` cannot be found. Verify the spelling and correctness of the schema and catalog.
...
spark-sql (default)> CALL iceberg.system.register_table (table => 'unity.test.ice1', metadata_file => 'file:///tmp/warehouse/uctest/table1/metadata/v2.metadata.json');
8507157311815341168	3	3
Time taken: 0.034 seconds, Fetched 1 row(s)
spark-sql (default)> select * from iceberg.unity.test.ice1;
1
2
3
Time taken: 0.269 seconds, Fetched 3 row(s)
```

Spark conf for above example:

```
spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.1,org.apache.iceberg:iceberg-aws-bundle:1.5.1

spark.sql.extensions org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions

spark.sql.catalog.iceberg org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.iceberg.catalog-impl org.apache.iceberg.rest.RESTCatalog
spark.sql.catalog.iceberg.uri http://127.0.0.1:8080/api/2.1/unity-catalog/iceberg
spark.sql.catalog.iceberg.token not_used

spark.sql.catalog.hadoop org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.hadoop.type hadoop
spark.sql.catalog.hadoop.warehouse /tmp/warehouse
```

**Related Issue**

Addresses part of adding additional Iceberg REST Endpoints https://github.com/unitycatalog/unitycatalog/issues/3

**Testing**

Test cases for the above mentioned scenarios have been added and are running fine.
