### PR TITLE
implement proper error responses for Iceberg REST endpoints

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -1,0 +1,46 @@
+package io.unitycatalog.server.exception;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import io.unitycatalog.server.utils.RESTObjectMapper;
+import lombok.SneakyThrows;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+
+public class IcebergRestExceptionHandler implements ExceptionHandlerFunction {
+  @Override
+  public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+    try {
+      if (cause instanceof BaseException) {
+        return handleBaseException((BaseException)cause);
+      } else if(cause instanceof NoSuchTableException) {
+        return createErrorResponse(HttpStatus.NOT_FOUND, cause);
+      } else {
+        // FIXME!!
+        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, cause);
+      }
+    } catch (Exception e) {
+      return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private HttpResponse handleBaseException(BaseException exception) {
+    return createErrorResponse(exception.getErrorCode().getHttpStatus(), exception);
+  }
+
+  @SneakyThrows
+  private HttpResponse createErrorResponse(HttpStatus status, Throwable cause) {
+    return HttpResponse.of(status, MediaType.JSON, RESTObjectMapper.mapper().writeValueAsString(
+      ErrorResponse.builder()
+        .responseCode(status.code())
+        .withType(cause.getClass().getSimpleName())
+        .withMessage(cause.getMessage())
+        .build()
+    ));
+  }
+
+}

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -165,7 +165,7 @@ public class IcebergRestCatalogService {
       String metadataLocation =
         tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
       if (metadataLocation == null) {
-        throw new NoSuchTableException("Table not found: %s", namespace + "." + table);
+        throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
       } else {
         return HttpResponse.of(HttpStatus.OK);
       }
@@ -187,7 +187,7 @@ public class IcebergRestCatalogService {
     }
 
     if (metadataLocation == null) {
-      throw new NoSuchTableException("Table not found: %s", namespace + "." + table);
+      throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
     }
 
     String metadataJson = new String(Files.readAllBytes(Paths.get(URI.create(metadataLocation))));
@@ -206,7 +206,7 @@ public class IcebergRestCatalogService {
     // a table with given path name and then tries to load a view with that
     // name if it didn't find a table, so for now, let's just return a 404
     // as that should be expected since it didn't find a table with the name
-    throw new NoSuchViewException("View not found.");
+    throw new NoSuchViewException("View does not exist: %s", namespace + "." + view);
   }
 
   @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -1,5 +1,40 @@
 package io.unitycatalog.server.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Head;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
+import io.unitycatalog.server.model.CatalogInfo;
+import io.unitycatalog.server.model.ListCatalogsResponse;
+import io.unitycatalog.server.model.ListSchemasResponse;
+import io.unitycatalog.server.model.ListTablesResponse;
+import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.persist.HibernateUtil;
+import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.utils.JsonUtils;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -9,31 +44,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.*;
-import io.unitycatalog.server.exception.BaseException;
-import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
-import io.unitycatalog.server.model.*;
-import io.unitycatalog.server.persist.HibernateUtil;
-import io.unitycatalog.server.persist.TableRepository;
-import io.unitycatalog.server.utils.JsonUtils;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
-import org.apache.iceberg.rest.responses.ConfigResponse;
-import org.apache.iceberg.rest.responses.GetNamespaceResponse;
-import org.apache.iceberg.rest.responses.ListNamespacesResponse;
-import org.apache.iceberg.rest.responses.LoadTableResponse;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-
-@ExceptionHandler(GlobalExceptionHandler.class)
+@ExceptionHandler(IcebergRestExceptionHandler.class)
 public class IcebergRestCatalogService {
 
   private final CatalogService catalogService;
@@ -155,7 +166,7 @@ public class IcebergRestCatalogService {
       String metadataLocation =
         tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
       if (metadataLocation == null) {
-        return HttpResponse.of(HttpStatus.NOT_FOUND);
+        throw new NoSuchTableException("Table not found: %s", namespace + "." + table);
       } else {
         return HttpResponse.of(HttpStatus.OK);
       }
@@ -177,7 +188,7 @@ public class IcebergRestCatalogService {
     }
 
     if (metadataLocation == null) {
-      throw new BaseException(ErrorCode.NOT_FOUND, "Table not found: " + namespace + "." + table);
+      throw new NoSuchTableException("Table not found: %s", namespace + "." + table);
     }
 
     String metadataJson = new String(Files.readAllBytes(Paths.get(URI.create(metadataLocation))));
@@ -186,6 +197,17 @@ public class IcebergRestCatalogService {
     return LoadTableResponse.builder()
       .withTableMetadata(tableMetadata)
       .build();
+  }
+
+  @Get("/v1/namespaces/{namespace}/views/{view}")
+  @ProducesJson
+  public LoadViewResponse loadView(@Param("namespace") String namespace,
+                                   @Param("view") String view) {
+    // this is not supported yet, but Iceberg REST client tries to load
+    // a table with given path name and then tries to load a view with that
+    // name if it didn't find a table, so for now, let's just return a 404
+    // as that should be expected since it didn't find a table with the name
+    throw new NoSuchTableException("Table not found.");
   }
 
   @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -10,8 +10,6 @@ import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
-import io.unitycatalog.server.exception.BaseException;
-import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.ListCatalogsResponse;
@@ -26,6 +24,7 @@ import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
@@ -207,7 +206,7 @@ public class IcebergRestCatalogService {
     // a table with given path name and then tries to load a view with that
     // name if it didn't find a table, so for now, let's just return a 404
     // as that should be expected since it didn't find a table with the name
-    throw new NoSuchTableException("Table not found.");
+    throw new NoSuchViewException("View not found.");
   }
 
   @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")
@@ -254,7 +253,7 @@ public class IcebergRestCatalogService {
     List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
     if (namespaceParts.size() != 2) {
       String errMsg = "Invalid two-part namespace " + namespace;
-      throw new BaseException(ErrorCode.INVALID_ARGUMENT, errMsg);
+      throw new IllegalArgumentException(errMsg);
     }
 
     return namespaceParts;

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IcebergRestCatalogTest extends BaseServerTest {

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -1,16 +1,16 @@
 package io.unitycatalog.server.iceberg;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.auth.AuthToken;
 import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.model.*;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.base.BaseServerTest;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
@@ -24,6 +24,9 @@ import io.unitycatalog.server.utils.RESTObjectMapper;
 import io.unitycatalog.server.utils.TestUtils;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -32,6 +35,14 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -197,6 +208,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
           "/v1/namespaces/" + TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "/tables/" +
             TestUtils.TABLE_NAME).aggregate().join();
       assertThat(resp.status().code()).isEqualTo(404);
+      ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
+      assertThat(errorResponse.type()).isEqualTo(NoSuchTableException.class.getSimpleName());
     }
 
     // Add the uniform metadata
@@ -249,12 +262,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   public void testLoadTablesInvalidNamespace() {
     AggregatedHttpResponse resp = client.get("/v1/namespaces/incomplete_namespace/tables/some_table").aggregate().join();
     assertThat(resp.status().code()).isEqualTo(400);
+    ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(errorResponse.type()).isEqualTo(IllegalArgumentException.class.getSimpleName());
   }
 
   @Test
   public void testListTablesInvalidNamespace() {
     AggregatedHttpResponse resp = client.get("/v1/namespaces/incomplete_namespace/tables").aggregate().join();
     assertThat(resp.status().code()).isEqualTo(400);
+    ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(errorResponse.type()).isEqualTo(IllegalArgumentException.class.getSimpleName());
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Added a specific Iceberg REST handler for the Iceberg REST service/endpoints. This produces JSON error responses in line with Iceberg REST spec.

Also stubbed out an endpoint for loadView because the Iceberg REST client tries to load a table with given name and if table is not found, it will try to load a view with given name (so, for now, we're just returning a 404 for that endpoint).

**Related Issue**

Addresses https://github.com/unitycatalog/unitycatalog/issues/46

**Testing**

Added Iceberg REST error parsing to current tests.
