### PR TITLE
Fix warnings on log level variables on running sbt test command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ lazy val commonSettings = Seq(
     "-target", "1.8",
     "-g:source,lines,vars"
   ),
-  Compile / logLevel := util.Level.Warn,
   resolvers += Resolver.mavenLocal,
   autoScalaLibrary := false,
   crossPaths := false,  // No scala cross building
@@ -212,7 +211,6 @@ lazy val cli = (project in file("examples") / "cli")
     mainClass := Some(orgName + ".cli.UnityCatalogCli"),
     commonSettings,
     javaCheckstyleSettings(file("dev") / "checkstyle-config.xml"),
-    Compile / logLevel := util.Level.Info,
     libraryDependencies ++= Seq(
       "commons-cli" % "commons-cli" % "1.7.0",
       "org.json" % "json" % "20240303",


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.

**Description of changes**
Resolves #91.

> Whenever build/sbt test command is run, the warnings below are printed to the console:
>    [warn] there are 3 keys that are not used by any other settings/tasks:
>    [warn]  
>    [warn] * cli / Compile / logLevel
>    [warn]   +- /home/runner/work/unitycatalog/unitycatalog/build.sbt:206

This issue comes from the [key linting](https://github.com/sbt/sbt/pull/5153) added in sbt 1.4.0, which warns keys are used by some tasks but not by others. In our case, `Compile / logLevel` is used in `cli`, `client`, `server` but not in `apiDocs`.


<!-- Please state what you've changed and how it might affect the users. -->
