### PR TITLE
Remove redundant column properties from entity objects

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/CatalogInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/CatalogInfoDAO.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.time.Instant;
 import java.util.Date;

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ColumnInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ColumnInfoDAO.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 
 import org.hibernate.annotations.UuidGenerator;
 
-import java.io.Serializable;
 import java.util.UUID;
 
 import lombok.Builder;

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ColumnInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ColumnInfoDAO.java
@@ -42,7 +42,7 @@ public class ColumnInfoDAO {
     @Column(name = "ordinal_position", nullable = false)
     private short ordinalPosition;
 
-    @Column(name = "name", nullable = false, length = 255)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @Lob
@@ -62,7 +62,7 @@ public class ColumnInfoDAO {
     @Column(name = "type_scale")
     private Integer typeScale;
 
-    @Column(name = "type_interval_type", length = 255)
+    @Column(name = "type_interval_type")
     private String typeIntervalType;
 
     @Column(name = "nullable", nullable = false)

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
-import java.io.Serializable;
 import java.util.UUID;
 
 //Hibernate annotations

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/SchemaInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/SchemaInfoDAO.java
@@ -6,9 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -1,6 +1,5 @@
 package io.unitycatalog.server.persist.dao;
 
-
 import jakarta.persistence.*;
 
 import lombok.*;

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -55,7 +55,7 @@ public class TableInfoDAO {
     @Column(name = "column_count")
     private Integer columnCount;
 
-    @OneToMany(mappedBy = "tableId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "tableId", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ColumnInfoDAO> columns;
 
     @Column(name = "uniform_iceberg_metadata_location", columnDefinition = "TEXT")

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
@@ -22,18 +22,25 @@ public class VolumeInfoDAO {
     @Id
     @Column(name = "id", columnDefinition = "BINARY(16)")
     private UUID id;
+
     @Column(name = "name")
     private String name;
+
     @Column(name = "schema_id", columnDefinition = "BINARY(16)")
     private UUID schemaId;
+
     @Column(name = "comment")
     private String comment;
+
     @Column(name = "storage_location")
     private String storageLocation;
+
     @Column(name = "created_at")
     private Date createdAt;
+
     @Column(name = "updated_at")
     private Date updatedAt;
+
     @Column(name = "volume_type")
     private String volumeType;
 


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.

**Description of changes**
Resolves #92.

Removes redundant entity model persistence attributes and aligns the formatting across models.
- The default [@Column#length() is 255](https://jakarta.ee/specifications/persistence/2.2/apidocs/javax/persistence/column#length())
- The default [@OneToMany#fetch() strategy is FetchType.LAZY](https://jakarta.ee/specifications/persistence/2.2/apidocs/javax/persistence/onetomany#fetch())
