### PR TITLE
issue 98 - item 1 - removed doctype to allow checkstyle to run

### DIFF
--- a/dev/checkstyle-config.xml
+++ b/dev/checkstyle-config.xml
@@ -15,10 +15,6 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "https://checkstyle.org/dtds/configuration_1_3.dtd">
-
 <!--
 
     Checkstyle configuration based on the Google coding conventions from:


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

removed docstyle declaration to enable the checkstyle to run - this docstyle element was not present in spark and delta for example

linked issue: https://github.com/unitycatalog/unitycatalog/issues/98

checkstyle now runs and flags 1538 errors