### PR TITLE
Use platform-specific classpath separator for the generated classpath…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import java.nio.file.Files
+import java.io.File
 import sbt.util
 
 val orgName = "io.unitycatalog"
@@ -245,7 +246,7 @@ def generateClasspathFile(targetDir: File, classpath: Classpath): Unit = {
   // Generate a classpath file with the entire runtime class path.
   // This is used by the launcher scripts for launching CLI directly with JAR instead of SBT.
   val classpathFile = targetDir / "classpath"
-  Files.write(classpathFile.toPath, classpath.files.mkString(":").getBytes)
+  Files.write(classpathFile.toPath, classpath.files.mkString(File.pathSeparator).getBytes)
   println(s"Generated classpath file '$classpathFile'")
 }
 


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.

**Description of changes**
Resolves #120

The generated classpath file uses a colon separator which causes issues on Windows since it uses colons as part of the filesystem paths.

Initially generated classpath file:
```
C:\..\unitycatalog\server\target\classes:C:\..\cache\v1\https\repo1.maven.org\maven2\io\netty\netty-tcnative-boringssl-static\2.0.65.Final\netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar:C:\..
```
The classpath file now uses a platform-specific classpath separator, which is a semicolon for Windows.
```
C:\..\unitycatalog\server\target\classes;C:\..\cache\v1\https\repo1.maven.org\maven2\io\netty\netty-tcnative-boringssl-static\2.0.65.Final\netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar;C:\..
```