### PR TITLE
Replace assert with assertThat in tests

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/base/function/BaseFunctionCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/function/BaseFunctionCRUDTest.java
@@ -11,6 +11,7 @@ import io.unitycatalog.server.base.schema.SchemaOperations;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static io.unitycatalog.server.utils.TestUtils.*;
 
@@ -108,7 +109,7 @@ public abstract class BaseFunctionCRUDTest extends BaseCRUDTest {
         // List functions
         Iterable<FunctionInfo> functionInfos = functionOperations.listFunctions(CATALOG_NAME, SCHEMA_NAME);
         assertTrue(contains(functionInfos, functionInfo, f -> {
-            assert f.getFunctionId() != null;
+            assertThat(f.getFunctionId()).isNotNull();
             if (!f.getFunctionId().equals(functionInfo.getFunctionId())) return false;
             if (f.getInputParams() != null && f.getInputParams().getParameters() != null) {
                 return f.getInputParams().getParameters().stream().anyMatch(p -> p.getName().equals("param1"));

--- a/server/src/test/java/io/unitycatalog/server/base/volume/BaseVolumeCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/volume/BaseVolumeCRUDTest.java
@@ -16,6 +16,7 @@ import io.unitycatalog.server.base.schema.SchemaOperations;
 import java.util.Date;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static io.unitycatalog.server.utils.TestUtils.*;
 
@@ -108,7 +109,7 @@ public abstract class BaseVolumeCRUDTest extends BaseCRUDTest {
         System.out.println("Testing list volumes..");
         Iterable<VolumeInfo> volumeInfos = volumeOperations.listVolumes(CATALOG_NAME, SCHEMA_NAME);
         assertTrue(contains(volumeInfos, volumeInfo, (volume) -> {
-            assert volume.getName() != null;
+            assertThat(volume.getName()).isNotNull();
             return volume.getName().equals(VOLUME_NAME);
         }));
 
@@ -170,7 +171,7 @@ public abstract class BaseVolumeCRUDTest extends BaseCRUDTest {
         Iterable<VolumeInfo> volumeInfosManaged = volumeOperations.listVolumes(CATALOG_NAME, SCHEMA_NAME);
         assertEquals(1, getSize(volumeInfosManaged));
         assertTrue(contains(volumeInfosManaged, managedVolumeInfo, (volume) -> {
-            assert volume.getName() != null;
+            assertThat(volume.getName()).isNotNull();
             return volume.getName().equals(VOLUME_NAME);
         }));
 

--- a/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/iceberg/IcebergRestCatalogTest.java
@@ -203,7 +203,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     try (Session session = HibernateUtil.getSessionFactory().openSession()) {
       Transaction tx = session.beginTransaction();
       TableInfoDAO tableInfoDAO = TableInfoDAO.builder().build();
-      assert tableInfo.getTableId() != null;
+      assertThat(tableInfo.getTableId()).isNotNull();
       session.load(tableInfoDAO, UUID.fromString(tableInfo.getTableId()));
       String metadataLocation = Objects.requireNonNull(
         this.getClass().getResource("/metadata.json")).toURI().toString();

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -15,8 +15,7 @@ import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.Objects;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SdkTableCRUDTest extends BaseTableCRUDTest {
 
@@ -59,7 +58,11 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
         createCommonResources();
         TableInfo testingTable = createDefaultTestingTable();
         ListTablesResponse resp = localTablesApi.listTables(testingTable.getCatalogName(), testingTable.getSchemaName(), 100, null);
-        assert resp.getNextPageToken() == null;
-        assert Objects.equals(resp.getTables(), List.of(testingTable));
+        assertThat(resp.getNextPageToken()).isNotNull();
+        assertThat(resp.getTables()).hasSize(1)
+                .first()
+                .usingRecursiveComparison()
+                .ignoringFields("columns", "storageLocation")
+                .isEqualTo(testingTable);
     }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/FileUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/FileUtilsTest.java
@@ -5,6 +5,8 @@ import io.unitycatalog.server.persist.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class FileUtilsTest {
 
     @Test
@@ -15,8 +17,8 @@ public class FileUtilsTest {
         String tablePath = FileUtils.createTableDirectory("catalog", "schema", "table");
         String volumePath = FileUtils.createVolumeDirectory("volume");
 
-        assert tablePath.equals("file:///tmp/catalog/schema/tables/table/");
-        assert volumePath.equals("file:///tmp/volume/");
+        assertThat(tablePath).isEqualTo("file:///tmp/catalog/schema/tables/table/");
+        assertThat(volumePath).isEqualTo("file:///tmp/volume/");
 
         FileUtils.deleteDirectory(tablePath);
         FileUtils.deleteDirectory(volumePath);
@@ -26,8 +28,8 @@ public class FileUtilsTest {
         tablePath = FileUtils.createTableDirectory("catalog", "schema", "table");
         volumePath = FileUtils.createVolumeDirectory("volume");
 
-        assert tablePath.equals("file:///tmp/random/catalog/schema/tables/table/");
-        assert volumePath.equals("file:///tmp/random/volume/");
+        assertThat(tablePath).isEqualTo("file:///tmp/random/catalog/schema/tables/table/");
+        assertThat(volumePath).isEqualTo("file:///tmp/random/volume/");
 
         FileUtils.deleteDirectory(tablePath);
         FileUtils.deleteDirectory(volumePath);


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The `assert` keyboard in Java needs to be explicitly enabled (via `-ea`), otherwise it doesn't do anything and gets optimized away. There are also a few `assert` usages in web service code and those should be replaced either with `Preconditions.checkNotNull` or with a Validation API 
