### PR TITLE
Hide Trino integration from documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,6 @@ nav:
   - Integrations:
       - Daft: integrations/unity-catalog-daft.md
       - DuckDB: integrations/unity-catalog-duckdb.md
-      - Trino: integrations/unity-catalog-trino.md
   - Deployment: deployment.md
 
 plugins:


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Trino Iceberg connector doesn't have any tests for Unity catalog and it doesn't work as far as I confirmed. 
I would recommend hiding the documentation until the connector supports the integration officially. 

Relates to https://github.com/unitycatalog/unitycatalog/issues/162