### PR TITLE
Set managed table's credential to table scan/write operator's options

### DIFF
--- a/connectors/spark/etc/conf/server.properties
+++ b/connectors/spark/etc/conf/server.properties
@@ -1,0 +1,6 @@
+server.env=dev
+## temp credential config for s3 (Multiple s3 config can be added by incrementing the index)
+s3.bucketPath.0=s3://test-bucket
+s3.accessKey.0=test1
+s3.secretKey.0=test2
+s3.sessionToken.0=test3


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
To support credential, the first step is to get credential of the managed table and put it into table scan/write operator's options, so that it will be part of the Hadoop conf that is used to do the actual file operations.