### PR TITLE
Include connectors/spark in aggregate for publishLocal to build it locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,8 +313,9 @@ lazy val spark = (project in file("connectors/spark"))
     name := s"$artifactNamePrefix-spark",
     scalaVersion := "2.13.14",
     commonSettings,
-    javaOptions ++= Seq(
+    Test / javaOptions ++= Seq(
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+      "-Duc.server.props=../../etc/conf/server.properties",
     ),
     javaCheckstyleSettings(file("dev") / "checkstyle-config.xml"),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -299,7 +299,7 @@ lazy val cli = (project in file("examples") / "cli")
   )
 
 lazy val root = (project in file("."))
-  .aggregate(client, server, cli)
+  .aggregate(client, server, cli, spark)
   .settings(
     name := s"$artifactNamePrefix",
     createTarballSettings(),

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -49,7 +49,7 @@ public class SparkIntegrationTest extends BaseCRUDTest {
         setupParquetTable(PARQUET_TABLE, new ArrayList<>(0), session);
         testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE, session);
 
-        setupParquetTable(PARQUET_TABLE_PARTITIONED, Arrays.asList("s"), session);
+        setupParquetTable(PARQUET_TABLE_PARTITIONED, List.of("s"), session);
         testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE_PARTITIONED, session);
 
         session.stop();

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class SparkIntegrationTest extends BaseCRUDTest {
 
@@ -130,9 +131,9 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
     private void createCommonResources() throws ApiException {
         // Common setup operations such as creating a catalog and schema
-        catalogOperations.createCatalog(CATALOG_NAME, "Common catalog for tables");
+        catalogOperations.createCatalog(new CreateCatalog().name(CATALOG_NAME).comment("Common catalog for tables"));
         schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(CATALOG_NAME));
-        catalogOperations.createCatalog(SPARK_CATALOG, "Spark catalog");
+        catalogOperations.createCatalog(new CreateCatalog().name(SPARK_CATALOG).comment("Spark catalog"));
         schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(SPARK_CATALOG));
     }
 
@@ -225,7 +226,7 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     }
 
     @Override
-    protected void cleanUp() {
+    public void cleanUp() {
         deleteCatalog(CATALOG_NAME);
         deleteCatalog(SPARK_CATALOG);
         try {
@@ -241,12 +242,12 @@ public class SparkIntegrationTest extends BaseCRUDTest {
         deleteTable(schemaFullName + "." + PARQUET_TABLE);
         deleteTable(schemaFullName + "." + DELTA_TABLE);
         try {
-            schemaOperations.deleteSchema(schemaFullName);
+            schemaOperations.deleteSchema(schemaFullName, Optional.of(true));
         } catch (Exception e) {
             // Ignore
         }
         try {
-            catalogOperations.deleteCatalog(catalogName);
+            catalogOperations.deleteCatalog(catalogName, Optional.of(true));
         } catch (Exception e) {
             // Ignore
         }

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/ServerPropertiesUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/ServerPropertiesUtils.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.Properties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,8 @@ import org.slf4j.LoggerFactory;
 
 public class ServerPropertiesUtils {
 
+  public static final String SERVER_PROPS_PATH = "etc/conf/server.properties";
+  public static final String SERVER_PROPS_SYSTEM_PROPERTY = "uc.server.props";
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerPropertiesUtils.class);
   @Getter private static final ServerPropertiesUtils instance = new ServerPropertiesUtils();
   private final Properties properties;
@@ -25,9 +28,13 @@ public class ServerPropertiesUtils {
 
   // Load properties from a configuration file
   private void loadProperties() {
-    try (InputStream input = Files.newInputStream(Paths.get("etc/conf/server.properties"))) {
+    String serverProps = Optional
+            .ofNullable(System.getProperty(SERVER_PROPS_SYSTEM_PROPERTY))
+            .orElse(SERVER_PROPS_PATH);
+    System.out.println(">>> serverProps: " + serverProps);
+    try (InputStream input = Files.newInputStream(Paths.get(serverProps))) {
       properties.load(input);
-      LOGGER.debug("Properties loaded successfully");
+      LOGGER.debug("Properties loaded successfully (path={})", serverProps);
       int i = 0;
       while (true) {
         String bucketPath = properties.getProperty("s3.bucketPath." + i);

--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -2,6 +2,8 @@ package io.unitycatalog.server.base;
 
 import io.unitycatalog.server.UnityCatalogServer;
 import io.unitycatalog.server.utils.TestUtils;
+
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import org.junit.After;
@@ -39,7 +41,8 @@ public abstract class BaseServerTest {
       throw new IllegalArgumentException("Auth token is required");
     }
     if (serverConfig.getServerUrl().contains("localhost")) {
-      System.out.println("Running tests on localhost..");
+      System.out.println("Running tests on localhost");
+      System.out.println("CWD: " + Paths.get(".").toAbsolutePath().normalize());
       // start the server on a random port
       int port = TestUtils.getRandomPort();
       System.setProperty("server.env", "test");


### PR DESCRIPTION
With the change, it is possible to (at least) `sbt publishLocal` and have a very rudimentary support of UC from the crew (Apache Spark 4.0.0-preview1 and Delta Lake 4.0.0rc1).

The following is going to be possible:

``` console
build/sbt clean package publishLocal
```

``` console
./bin/spark-shell \
  --conf spark.jars.ivy=$HOME/.ivy2 \
  --packages \
    io.delta:delta-spark_2.13:4.0.0rc1,io.unitycatalog:unitycatalog-spark:0.1.0-SNAPSHOT \
  --conf spark.sql.catalog.unity=io.unitycatalog.connectors.spark.UCSingleCatalog \
  --conf spark.sql.catalog.unity.uri=http://localhost:8080
```

Fixes #227