### PR TITLE
allow configuration for server port

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,10 @@ lazy val server = (project in file("server"))
       "com.adobe.testing" % "s3mock-junit5" % "2.11.0" % Test
         exclude("ch.qos.logback", "logback-classic")
         exclude("org.apache.logging.log4j", "log4j-to-slf4j"),
-      "javax.xml.bind" % "jaxb-api" % "2.3.1" % Test
+      "javax.xml.bind" % "jaxb-api" % "2.3.1" % Test,
+
+      // CLI dependencies
+      "commons-cli" % "commons-cli" % "1.7.0"
     ),
 
     Compile / compile / javacOptions ++= Seq(

--- a/docs/usage/server.md
+++ b/docs/usage/server.md
@@ -10,6 +10,22 @@ The server can be started by issuing the below command from the project root dir
 bin/start-uc-server
 ```
 
+### Running the Server on a Specific Port
+
+To run the server on a specific port, use the `-p` or `--port` option followed by the port number:
+
+```sh
+bin/start-uc-server -p <port_number>
+```
+
+or
+
+```commandline
+bin/start-uc-server --port <port_number>
+```
+
+If no port is specified, the server defaults to port **8080**.
+
 ## Configuration
 
 The server config file is at the location `etc/conf/server.properties` (relative to the project root).

--- a/docs/usage/server.md
+++ b/docs/usage/server.md
@@ -20,7 +20,7 @@ bin/start-uc-server -p <port_number>
 
 or
 
-```commandline
+```sh
 bin/start-uc-server --port <port_number>
 ```
 

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -93,7 +93,19 @@ public class UnityCatalogServer {
   public static void main(String[] args) {
     int port = 8080;
     if (args.length > 0) {
-      port = Integer.parseInt(args[0]);
+      if ("-p".equals(args[0]) || "--port".equals(args[0])) {
+        if (args.length > 1) {
+          try {
+            port = Integer.parseInt(args[1]);
+          } catch (NumberFormatException e) {
+            System.err.println("Invalid port number: " + args[1]);
+            return;
+          }
+        } else {
+          System.err.println("No port number provided after " + args[0]);
+          return;
+        }
+      }
     }
     // Start Unity Catalog server
     UnityCatalogServer unityCatalogServer = new UnityCatalogServer(port + 1);

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -26,6 +26,7 @@ import io.vertx.core.Vertx;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.cli.*;
 
 public class UnityCatalogServer {
   private static final Logger LOGGER = LoggerFactory.getLogger(UnityCatalogServer.class);
@@ -92,23 +93,32 @@ public class UnityCatalogServer {
 
   public static void main(String[] args) {
     int port = 8080;
-    if (args.length > 0) {
-      if ("-p".equals(args[0]) || "--port".equals(args[0])) {
-        if (args.length > 1) {
-          try {
-            port = Integer.parseInt(args[1]);
-          } catch (NumberFormatException e) {
-            System.err.println("Invalid port number: " + args[1]);
-            return;
-          }
-        } else {
-          System.err.println("No port number provided after " + args[0]);
-          return;
-        }
-      } else {
-        System.err.println("Invalid argument: " + args[0] + ". Please use -p or --port to specify the port number.");
-        return;
+    // Create Options object
+    Options options = new Options();
+
+    // Add port option
+    options.addOption("p", "port", true, "Port number to run the server on. Default is 8080.");
+    CommandLineParser parser = new DefaultParser();
+    try {
+      // Parse the command line arguments
+      CommandLine cmd = parser.parse(options, args);
+
+      // Check if port option is provided
+      if (cmd.hasOption("p")) {
+        port = Integer.parseInt(cmd.getOptionValue("p"));
       }
+    } catch (ParseException e) {
+      System.out.println();
+      System.out.println("Error parsing command line arguments: " + e.getMessage());
+      System.out.println();
+
+      // Automatically generate the help statement
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("bin/start-uc-server", options);
+      return;
+    } catch (NumberFormatException e) {
+      System.out.println("Invalid port number: " + e.getMessage() + ". Please enter a valid integer.");
+      return;
     }
     // Start Unity Catalog server
     UnityCatalogServer unityCatalogServer = new UnityCatalogServer(port + 1);

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -105,6 +105,9 @@ public class UnityCatalogServer {
           System.err.println("No port number provided after " + args[0]);
           return;
         }
+      } else {
+        System.err.println("Invalid argument: " + args[0] + ". Please use -p or --port to specify the port number.");
+        return;
       }
     }
     // Start Unity Catalog server

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -94,22 +94,25 @@ public class UnityCatalogServer {
   public static void main(String[] args) {
     int port = 8080;
     Options options = new Options();
-    options.addOption("p", "port", true, "Port number to run the server on. Default is 8080.");
+    options.addOption(
+            Option.builder("p")
+                    .longOpt("port")
+                    .hasArg()
+                    .desc("Port number to run the server on. Default is 8080.")
+                    .type(Integer.class)
+                    .build());
     CommandLineParser parser = new DefaultParser();
     try {
       CommandLine cmd = parser.parse(options, args);
       if (cmd.hasOption("p")) {
-        port = Integer.parseInt(cmd.getOptionValue("p"));
+        port = cmd.getParsedOptionValue("p");
       }
     } catch (ParseException e) {
       System.out.println();
-      System.out.println("Error parsing command line arguments: " + e.getMessage());
+      System.out.println("Parsing Failed. Reason: " + e.getMessage());
       System.out.println();
       HelpFormatter formatter = new HelpFormatter();
       formatter.printHelp("bin/start-uc-server", options);
-      return;
-    } catch (NumberFormatException e) {
-      System.out.println("Invalid port number: " + e.getMessage() + ". Please enter a valid integer.");
       return;
     }
     // Start Unity Catalog server

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -93,17 +93,11 @@ public class UnityCatalogServer {
 
   public static void main(String[] args) {
     int port = 8080;
-    // Create Options object
     Options options = new Options();
-
-    // Add port option
     options.addOption("p", "port", true, "Port number to run the server on. Default is 8080.");
     CommandLineParser parser = new DefaultParser();
     try {
-      // Parse the command line arguments
       CommandLine cmd = parser.parse(options, args);
-
-      // Check if port option is provided
       if (cmd.hasOption("p")) {
         port = Integer.parseInt(cmd.getOptionValue("p"));
       }
@@ -111,8 +105,6 @@ public class UnityCatalogServer {
       System.out.println();
       System.out.println("Error parsing command line arguments: " + e.getMessage());
       System.out.println();
-
-      // Automatically generate the help statement
       HelpFormatter formatter = new HelpFormatter();
       formatter.printHelp("bin/start-uc-server", options);
       return;


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Added checks for flags -p and --port to configure the port while starting the UC server. The default is 8080.

Usage:
```sh
bin/start-uc-server -p <port_number>
or
bin/start-uc-server --port <port_number>
```

~~The previous method of specifying the port ```bin/start-uc-server <port_number>``` will print the error message: "Invalid argument: <port_number>. Please use -p or --port to specify the port number."~~

Updated the code to utilize [Apache Commons CLI](https://commons.apache.org/proper/commons-cli/).
<!-- Please state what you've changed and how it might affect the users. -->
Fixes #250 