### PR TITLE
Use AssertJ to provide more informative test failure messages 

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.util.*;
 
 import static io.unitycatalog.server.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,8 +94,7 @@ public class SparkIntegrationTest extends BaseCRUDTest {
         String path1 = new File(dataDir, "test_delta_path1").getCanonicalPath();
         String tableName1 = String.format("delta.`%s`", path1);
         session.sql(String.format("CREATE TABLE %s(i INT) USING delta", tableName1));
-        assertTrue(
-                session.sql("SELECT * FROM " + tableName1).collectAsList().isEmpty());
+        assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList()).isEmpty();
         session.sql("INSERT INTO " + tableName1 + " SELECT 1");
         assertEquals(1,
                 session.sql("SELECT * FROM " + tableName1).collectAsList().get(0).getInt(0));

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -96,15 +96,19 @@ public class SparkIntegrationTest extends BaseCRUDTest {
         session.sql(String.format("CREATE TABLE %s(i INT) USING delta", tableName1));
         assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList()).isEmpty();
         session.sql("INSERT INTO " + tableName1 + " SELECT 1");
-        assertEquals(1,
-                session.sql("SELECT * FROM " + tableName1).collectAsList().get(0).getInt(0));
+        assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList())
+            .first()
+            .extracting(row -> row.get(0))
+            .isEqualTo(1);
 
         // Test CTAS
         String path2 = new File(dataDir, "test_delta_path2").getCanonicalPath();
         String tableName2 = String.format("delta.`%s`", path2);
         session.sql(String.format("CREATE TABLE %s USING delta AS SELECT 1 AS i", tableName2));
-        assertEquals(1,
-                session.sql("SELECT * FROM " + tableName2).collectAsList().get(0).getInt(0));
+        assertThat(session.sql("SELECT * FROM " + tableName2).collectAsList())
+            .first()
+            .extracting(row -> row.get(0))
+            .isEqualTo(1);
 
         session.stop();
     }

--- a/server/src/test/java/io/unitycatalog/server/base/catalog/BaseCatalogCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/catalog/BaseCatalogCRUDTest.java
@@ -1,19 +1,20 @@
 package io.unitycatalog.server.base.catalog;
 
 import static io.unitycatalog.server.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.CatalogInfo;
 import io.unitycatalog.client.model.CreateCatalog;
 import io.unitycatalog.client.model.UpdateCatalog;
 import io.unitycatalog.server.base.BaseCRUDTest;
+
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 public abstract class BaseCatalogCRUDTest extends BaseCRUDTest {
@@ -26,12 +27,17 @@ public abstract class BaseCatalogCRUDTest extends BaseCRUDTest {
   }
 
   protected void assertCatalogExists(List<CatalogInfo> catalogList, String name, String comment) {
-    assertTrue(catalogList.stream()
-        .anyMatch(c -> Objects.equals(c.getName(), name) && Objects.equals(c.getComment(), comment)));
+    assertThat(catalogList)
+        .extracting(CatalogInfo::getName, CatalogInfo::getComment)
+        .as("Catalog list should contain a catalog with name '%s' and comment '%s'", name, comment)
+        .containsAnyOf(tuple(name, comment));
   }
 
   protected void assertCatalogNotExists(List<CatalogInfo> catalogList, String name) {
-    assertFalse(catalogList.stream().anyMatch(c -> Objects.equals(c.getName(), name)));
+    assertThat(catalogList)
+        .as("Catalog with name '%s' should not exist", name)
+        .extracting(CatalogInfo::getName)
+        .doesNotContain(name);
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/base/schema/BaseSchemaCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/schema/BaseSchemaCRUDTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class BaseSchemaCRUDTest extends BaseCRUDTest {
 
@@ -97,11 +96,9 @@ public abstract class BaseSchemaCRUDTest extends BaseCRUDTest {
     System.out.println("Testing delete schema..");
     schemaOperations.deleteSchema(
         TestUtils.CATALOG_NEW_NAME + "." + TestUtils.SCHEMA_NEW_NAME, Optional.of(false));
-    assertFalse(
-        TestUtils.contains(
-            schemaOperations.listSchemas(TestUtils.CATALOG_NEW_NAME),
-            updatedSchemaInfo,
-            (schema) -> schema.getName().equals(TestUtils.SCHEMA_NEW_NAME)));
+    assertThat(schemaOperations.listSchemas(TestUtils.CATALOG_NEW_NAME))
+        .as("Schema with schema name '%s' exists", TestUtils.CATALOG_NEW_COMMENT)
+        .noneSatisfy(schema -> assertThat(schema.getName()).isEqualTo(TestUtils.SCHEMA_NEW_NAME));
 
     // Delete parent entity when schema exists
     SchemaInfo schemaInfo2 =

--- a/server/src/test/java/io/unitycatalog/server/base/schema/BaseSchemaCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/schema/BaseSchemaCRUDTest.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,7 +51,7 @@ public abstract class BaseSchemaCRUDTest extends BaseCRUDTest {
     // List schemas
     System.out.println("Testing list schemas..");
     Iterable<SchemaInfo> schemaList = schemaOperations.listSchemas(TestUtils.CATALOG_NAME);
-    assertTrue(TestUtils.contains(schemaList, schemaInfo, (schema) -> schema.equals(schemaInfo)));
+    assertThat(schemaList).contains(schemaInfo);
 
     // Get schema
     System.out.println("Testing get schema..");

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
@@ -70,9 +70,10 @@ public abstract class BaseTableCRUDTest extends BaseCRUDTest {
     assertEquals(tableInfo, tableInfo2);
 
     Collection<ColumnInfo> columnInfos2 = tableInfo2.getColumns();
-    assertEquals(2, columnInfos2.size());
-    assertEquals(1, columnInfos2.stream().filter(c -> c.getName().equals("as_int")).count());
-    assertEquals(1, columnInfos2.stream().filter(c -> c.getName().equals("as_string")).count());
+    assertThat(columnInfos2).hasSize(2)
+        .extracting(ColumnInfo::getName)
+        .as("Table should contain two colums with names '%s' and '%s'", "as_int", "as_string")
+        .containsOnlyOnce("as_int", "as_string");
 
     // Create multiple tables
     List<TableInfo> createdTables = createMultipleTestingTables(111);
@@ -81,7 +82,7 @@ public abstract class BaseTableCRUDTest extends BaseCRUDTest {
     System.out.println("Testing list tables with pagination..");
     Iterable<TableInfo> tableInfosWithPagination =
         tableOperations.listTables(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME);
-    assertEquals(100, TestUtils.getSize(tableInfosWithPagination));
+    assertThat(tableInfosWithPagination).hasSize(100);
 
     // List tables with result sorted by name
     System.out.println("Testing list tables sorted by name");

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
@@ -1,10 +1,10 @@
 package io.unitycatalog.server.base.table;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.*;
@@ -89,10 +89,7 @@ public abstract class BaseTableCRUDTest extends BaseCRUDTest {
         tableOperations.listTables(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME);
     List<TableInfo> sortedTableList = new ArrayList<>();
     tableInfosSortedByName.forEach(sortedTableList::add);
-    for (int i = 1; i < sortedTableList.size(); i++) {
-      assertTrue(
-          sortedTableList.get(i - 1).getName().compareTo(sortedTableList.get(i).getName()) <= 0);
-    }
+    assertThat(sortedTableList).isSortedAccordingTo(Comparator.comparing(TableInfo::getName));
 
     // Clean up created tables
     System.out.println("Cleaning up created tables..");

--- a/server/src/test/java/io/unitycatalog/server/base/volume/BaseVolumeCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/volume/BaseVolumeCRUDTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.*;
@@ -78,14 +77,9 @@ public abstract class BaseVolumeCRUDTest extends BaseCRUDTest {
     // List volumes
     System.out.println("Testing list volumes..");
     Iterable<VolumeInfo> volumeInfos = volumeOperations.listVolumes(CATALOG_NAME, SCHEMA_NAME);
-    assertTrue(
-        contains(
-            volumeInfos,
-            volumeInfo,
-            (volume) -> {
-              assertThat(volume.getName()).isNotNull();
-              return volume.getName().equals(VOLUME_NAME);
-            }));
+    assertThat(volumeInfos)
+        .as("Volume with name '%s' should exist", VOLUME_NAME)
+        .anySatisfy(volume -> assertThat(volume.getName()).isNotNull().isEqualTo(VOLUME_NAME));
 
     // Get volume
     System.out.println("Testing get volume..");
@@ -165,14 +159,9 @@ public abstract class BaseVolumeCRUDTest extends BaseCRUDTest {
     Iterable<VolumeInfo> volumeInfosManaged =
         volumeOperations.listVolumes(CATALOG_NAME, SCHEMA_NAME);
     assertEquals(1, getSize(volumeInfosManaged));
-    assertTrue(
-        contains(
-            volumeInfosManaged,
-            managedVolumeInfo,
-            (volume) -> {
-              assertThat(volume.getName()).isNotNull();
-              return volume.getName().equals(VOLUME_NAME);
-            }));
+    assertThat(volumeInfosManaged)
+        .as("Volume with name '%s' should exist", VOLUME_NAME)
+        .anySatisfy(volume -> assertThat(volume.getName()).isNotNull().isEqualTo(VOLUME_NAME));
 
     // NOW Update the schema name
     schemaOperations.updateSchema(


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.

**Description of changes**
Resolves #260.

Use AssertJ to ensure that test failure messages are informative, as suggested by @nastra's [comment]https://github.com/unitycatalog/unitycatalog/pull/256#discussion_r1683894084.
* Replace boolean assertions on collections
* Migrate away from using `TestUtils#contains()` in combination with boolean assertions on collection elements
* Replace size/count checks on collection elements
* Use AssertJ's fluent API to replace equality checks on Spark query row values

If there are any concerns or suggestions for further improvements regarding the changes introduced in commit  [`9d45725`](https://github.com/unitycatalog/unitycatalog/commit/9d457252c38fd85762720645010a6bcd7d57f29f), please feel free to share.