### PR TITLE
docs: add clickable index feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ theme:
     - content.code.copy
     - navigation.footer
     - navigation.expand
+    - navigation.indexes
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
This adds the `navigation.indexes` feature so that top-level directories in the nav bar can be clickable and point to overview pages.

Make the section header clickable by adding an `index.md` file to the directory. Also make sure to add the `index.md` to the `nav` in the `mkdocs.yml` file.

usage:

```
nav:
  - Section:
    - section/index.md 
    - Page 1: section/page-1.md
    ...
    - Page n: section/page-n.md
```