### PR TITLE
docs: add table index

### DIFF
--- a/docs/usage/tables/index.md
+++ b/docs/usage/tables/index.md
@@ -1,6 +1,6 @@
 # Tables
 
-This page shows you how to use Unity Catalog to store, access and govern Tables.
+This section shows you how to use Unity Catalog to store, access and govern Tables.
 
 Use Unity Catalog with:
 

--- a/docs/usage/tables/index.md
+++ b/docs/usage/tables/index.md
@@ -1,0 +1,8 @@
+# Tables
+
+This page shows you how to use Unity Catalog to store, access and govern Tables.
+
+Use Unity Catalog with:
+
+- [Delta Lake tables](deltalake.md)
+- [Uniform Tables](uniform.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Usage:
       - CLI: usage/cli.md
       - Tables:
+          - usage/tables/index.md
           - UniForm: usage/tables/uniform.md
           - Delta Lake: usage/tables/deltalake.md
       - Volumes: usage/volumes.md
@@ -33,6 +34,7 @@ theme:
     - content.code.copy
     - navigation.footer
     - navigation.expand
+    - navigation.indexes
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
This PR adds an index.md as overview page for the Tables docs.

The `toc` is a manual implementation. It will be great to have this automized using `[TOC]` at some point but I couldn't get this to work.

context: https://github.com/squidfunk/mkdocs-material/discussions/5200