### PR TITLE
Mark some properties in the all.yaml file as required

### DIFF
--- a/api/Models/CatalogInfo.md
+++ b/api/Models/CatalogInfo.md
@@ -3,12 +3,12 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | Name of catalog. | [optional] [default to null] |
+| **name** | **String** | Name of catalog. | [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this catalog was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this catalog was last modified, in epoch milliseconds. | [optional] [default to null] |
-| **id** | **String** | Unique identifier for the catalog. | [optional] [default to null] |
+| **id** | **String** | Unique identifier for the catalog. | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/Models/CreateFunction.md
+++ b/api/Models/CreateFunction.md
@@ -20,7 +20,7 @@
 | **security\_type** | **String** | Function security type. | [default to null] |
 | **specific\_name** | **String** | Specific name of the function; Reserved for future use. | [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
-| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [default to null] |
+| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [optional] [default to null] |
 | **external\_language** | **String** | External language of the function. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/Models/FunctionInfo.md
+++ b/api/Models/FunctionInfo.md
@@ -3,28 +3,28 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | Name of function, relative to parent schema. | [optional] [default to null] |
-| **catalog\_name** | **String** | Name of parent catalog. | [optional] [default to null] |
-| **schema\_name** | **String** | Name of parent schema relative to its parent catalog. | [optional] [default to null] |
-| **input\_params** | [**FunctionParameterInfos**](FunctionParameterInfos.md) |  | [optional] [default to null] |
-| **data\_type** | [**ColumnTypeName**](ColumnTypeName.md) |  | [optional] [default to null] |
-| **full\_data\_type** | **String** | Pretty printed function data type. | [optional] [default to null] |
+| **name** | **String** | Name of function, relative to parent schema. | [default to null] |
+| **catalog\_name** | **String** | Name of parent catalog. | [default to null] |
+| **schema\_name** | **String** | Name of parent schema relative to its parent catalog. | [default to null] |
+| **input\_params** | [**FunctionParameterInfos**](FunctionParameterInfos.md) |  | [default to null] |
+| **data\_type** | [**ColumnTypeName**](ColumnTypeName.md) |  | [default to null] |
+| **full\_data\_type** | **String** | Pretty printed function data type. | [default to null] |
 | **return\_params** | [**FunctionParameterInfos**](FunctionParameterInfos.md) |  | [optional] [default to null] |
-| **routine\_body** | **String** | Function language. When **EXTERNAL** is used, the language of the routine function should be specified in the __external_language__ field,  and the __return_params__ of the function cannot be used (as **TABLE** return type is not supported), and the __sql_data_access__ field must be **NO_SQL**.  | [optional] [default to null] |
-| **routine\_definition** | **String** | Function body. | [optional] [default to null] |
+| **routine\_body** | **String** | Function language. When **EXTERNAL** is used, the language of the routine function should be specified in the __external_language__ field,  and the __return_params__ of the function cannot be used (as **TABLE** return type is not supported), and the __sql_data_access__ field must be **NO_SQL**.  | [default to null] |
+| **routine\_definition** | **String** | Function body. | [default to null] |
 | **routine\_dependencies** | [**DependencyList**](DependencyList.md) |  | [optional] [default to null] |
-| **parameter\_style** | **String** | Function parameter style. **S** is the value for SQL. | [optional] [default to null] |
-| **is\_deterministic** | **Boolean** | Whether the function is deterministic. | [optional] [default to null] |
-| **sql\_data\_access** | **String** | Function SQL data access. | [optional] [default to null] |
-| **is\_null\_call** | **Boolean** | Function null call. | [optional] [default to null] |
-| **security\_type** | **String** | Function security type. | [optional] [default to null] |
-| **specific\_name** | **String** | Specific name of the function; Reserved for future use. | [optional] [default to null] |
+| **parameter\_style** | **String** | Function parameter style. **S** is the value for SQL. | [default to null] |
+| **is\_deterministic** | **Boolean** | Whether the function is deterministic. | [default to null] |
+| **sql\_data\_access** | **String** | Function SQL data access. | [default to null] |
+| **is\_null\_call** | **Boolean** | Function null call. | [default to null] |
+| **security\_type** | **String** | Function security type. | [default to null] |
+| **specific\_name** | **String** | Specific name of the function; Reserved for future use. | [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
-| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [optional] [default to null] |
+| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [default to null] |
 | **full\_name** | **String** | Full name of function, in form of __catalog_name__.__schema_name__.__function__name__ | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this function was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this function was last updated, in epoch milliseconds. | [optional] [default to null] |
-| **function\_id** | **String** | Id of Function, relative to parent schema. | [optional] [default to null] |
+| **function\_id** | **String** | Id of Function, relative to parent schema. | [default to null] |
 | **external\_language** | **String** | External language of the function. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/Models/FunctionInfo.md
+++ b/api/Models/FunctionInfo.md
@@ -20,7 +20,7 @@
 | **security\_type** | **String** | Function security type. | [default to null] |
 | **specific\_name** | **String** | Specific name of the function; Reserved for future use. | [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
-| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [default to null] |
+| **properties** | **String** | JSON-serialized key-value pair map, encoded (escaped) as a string. | [optional] [default to null] |
 | **full\_name** | **String** | Full name of function, in form of __catalog_name__.__schema_name__.__function__name__ | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this function was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this function was last updated, in epoch milliseconds. | [optional] [default to null] |

--- a/api/Models/SchemaInfo.md
+++ b/api/Models/SchemaInfo.md
@@ -3,14 +3,14 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | Name of schema, relative to parent catalog. | [optional] [default to null] |
-| **catalog\_name** | **String** | Name of parent catalog. | [optional] [default to null] |
+| **name** | **String** | Name of schema, relative to parent catalog. | [default to null] |
+| **catalog\_name** | **String** | Name of parent catalog. | [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
 | **full\_name** | **String** | Full name of schema, in form of __catalog_name__.__schema_name__. | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this schema was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this schema was last modified, in epoch milliseconds. | [optional] [default to null] |
-| **schema\_id** | **String** | Unique identifier for the schema. | [optional] [default to null] |
+| **schema\_id** | **String** | Unique identifier for the schema. | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/Models/TableInfo.md
+++ b/api/Models/TableInfo.md
@@ -3,18 +3,18 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | Name of table, relative to parent schema. | [optional] [default to null] |
-| **catalog\_name** | **String** | Name of parent catalog. | [optional] [default to null] |
-| **schema\_name** | **String** | Name of parent schema relative to its parent catalog. | [optional] [default to null] |
-| **table\_type** | [**TableType**](TableType.md) |  | [optional] [default to null] |
-| **data\_source\_format** | [**DataSourceFormat**](DataSourceFormat.md) |  | [optional] [default to null] |
-| **columns** | [**List**](ColumnInfo.md) | The array of __ColumnInfo__ definitions of the table&#39;s columns. | [optional] [default to null] |
+| **name** | **String** | Name of table, relative to parent schema. | [default to null] |
+| **catalog\_name** | **String** | Name of parent catalog. | [default to null] |
+| **schema\_name** | **String** | Name of parent schema relative to its parent catalog. | [default to null] |
+| **table\_type** | [**TableType**](TableType.md) |  | [default to null] |
+| **data\_source\_format** | [**DataSourceFormat**](DataSourceFormat.md) |  | [default to null] |
+| **columns** | [**List**](ColumnInfo.md) | The array of __ColumnInfo__ definitions of the table&#39;s columns. | [default to null] |
 | **storage\_location** | **String** | Storage root URL for table (for **MANAGED**, **EXTERNAL** tables) | [optional] [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this table was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this table was last modified, in epoch milliseconds. | [optional] [default to null] |
-| **table\_id** | **String** | Unique identifier for the table. | [optional] [default to null] |
+| **table\_id** | **String** | Unique identifier for the table. | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/Models/VolumeInfo.md
+++ b/api/Models/VolumeInfo.md
@@ -3,15 +3,15 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **catalog\_name** | **String** | The name of the catalog where the schema and the volume are | [optional] [default to null] |
-| **schema\_name** | **String** | The name of the schema where the volume is | [optional] [default to null] |
-| **name** | **String** | The name of the volume | [optional] [default to null] |
+| **catalog\_name** | **String** | The name of the catalog where the schema and the volume are | [default to null] |
+| **schema\_name** | **String** | The name of the schema where the volume is | [default to null] |
+| **name** | **String** | The name of the volume | [default to null] |
 | **comment** | **String** | The comment attached to the volume | [optional] [default to null] |
 | **created\_at** | **Long** | Time at which this volume was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this volume was last modified, in epoch milliseconds. | [optional] [default to null] |
-| **volume\_id** | **String** | Unique identifier for the volume | [optional] [default to null] |
-| **volume\_type** | [**VolumeType**](VolumeType.md) |  | [optional] [default to null] |
-| **storage\_location** | **String** | The storage location of the volume | [optional] [default to null] |
+| **volume\_id** | **String** | Unique identifier for the volume | [default to null] |
+| **volume\_type** | [**VolumeType**](VolumeType.md) |  | [default to null] |
+| **storage\_location** | **String** | The storage location of the volume | [default to null] |
 | **full\_name** | **String** | Full name of volume, in form of __catalog_name__.__schema_name__.__volume_name__. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -790,38 +790,45 @@ components:
       type: object
       properties:
         catalog_name:
-          type: string
           description: The name of the catalog where the schema and the volume are
+          type: string
         schema_name:
-          type: string
           description: The name of the schema where the volume is
-        name:
           type: string
+        name:
           description: The name of the volume
+          type: string
         comment:
+          description: The comment attached to the volume
           type: string
           maxLength: 65536
           minLength: 1
-          description: The comment attached to the volume
         created_at:
-          type: integer
-          format: int64
           description: Time at which this volume was created, in epoch milliseconds.
-        updated_at:
           type: integer
           format: int64
+        updated_at:
           description: Time at which this volume was last modified, in epoch milliseconds.
+          type: integer
+          format: int64
         volume_id:
-          type: string
           description: Unique identifier for the volume
+          type: string
         "volume_type":
           "$ref": "#/components/schemas/VolumeType"
         storage_location:
-          type: string
           description: The storage location of the volume
-        full_name:
           type: string
+        full_name:
           description: Full name of volume, in form of __catalog_name__.__schema_name__.__volume_name__.
+          type: string
+      required:
+        - catalog_name
+        - schema_name
+        - name
+        - volume_id
+        - volume_type
+        - storage_location
     ColumnTypeName:
       description: Name of type (INT, STRUCT, MAP, etc.).
       type: string
@@ -943,6 +950,14 @@ components:
         table_id:
           description: Unique identifier for the table.
           type: string
+      required:
+        - name
+        - catalog_name
+        - schema_name
+        - table_type
+        - data_source_format
+        - columns
+        - table_id
     CreateTable:
       type: object
       properties:
@@ -1020,6 +1035,10 @@ components:
         schema_id:
           description: Unique identifier for the schema.
           type: string
+      required:
+        - name
+        - catalog_name
+        - schema_id
     CreateSchema:
       type: object
       properties:
@@ -1083,6 +1102,9 @@ components:
         id:
           description: Unique identifier for the catalog.
           type: string
+      required:
+        - name
+        - id
     CreateCatalog:
       type: object
       properties:
@@ -1133,12 +1155,6 @@ components:
         - IN
     FunctionParameterInfo:
       type: object
-      required:
-        - name
-        - type_text
-        - type_name
-        - type_json
-        - position
       properties:
         name:
           description: Name of parameter.
@@ -1176,6 +1192,12 @@ components:
         comment:
           description: User-provided free-form text description.
           type: string
+      required:
+        - name
+        - type_text
+        - type_name
+        - type_json
+        - position
     FunctionParameterInfos:
       type: object
       properties:
@@ -1230,22 +1252,6 @@ components:
             "$ref": "#/components/schemas/Dependency"
     CreateFunction:
       type: object
-      required:
-        - name
-        - catalog_name
-        - schema_name
-        - input_params
-        - data_type
-        - full_data_type
-        - routine_body
-        - routine_definition
-        - parameter_style
-        - is_deterministic
-        - sql_data_access
-        - is_null_call
-        - security_type
-        - specific_name
-        - properties
       properties:
         name:
           description: Name of function, relative to parent schema.
@@ -1316,6 +1322,22 @@ components:
         external_language:
           description: External language of the function.
           type: string
+      required:
+        - name
+        - catalog_name
+        - schema_name
+        - input_params
+        - data_type
+        - full_data_type
+        - routine_body
+        - routine_definition
+        - parameter_style
+        - is_deterministic
+        - sql_data_access
+        - is_null_call
+        - security_type
+        - specific_name
+        - properties
     FunctionInfo:
       type: object
       properties:
@@ -1401,6 +1423,23 @@ components:
         external_language:
           description: External language of the function.
           type: string
+      required:
+        - name
+        - catalog_name
+        - schema_name
+        - input_params
+        - data_type
+        - full_data_type
+        - routine_body
+        - routine_definition
+        - parameter_style
+        - is_deterministic
+        - sql_data_access
+        - is_null_call
+        - security_type
+        - specific_name
+        - properties
+        - function_id
     ListFunctionsResponse:
       type: object
       properties:

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1337,7 +1337,6 @@ components:
         - is_null_call
         - security_type
         - specific_name
-        - properties
     FunctionInfo:
       type: object
       properties:
@@ -1438,7 +1437,6 @@ components:
         - is_null_call
         - security_type
         - specific_name
-        - properties
         - function_id
     ListFunctionsResponse:
       type: object


### PR DESCRIPTION
**Description of changes**
Resolves #280.

Marked some properties in the all.yaml file as required and updated the related API documents. The updating strategy is as follows:

 - Update the properties marked as `required` in the `FooInfo` schema, by referring to the properties marked as `required` in `CreateFoo` schema.
 - In addition to the above, update the property corresponding to its `id` to required in `FooInfo`.

Verified that it works in the local environment and does not break backward compatibility. It is also possible to consider making all properties defined as required nullable as another implementation approach, but this was not adopted.
