### PR TITLE
removed checkstyle import order configuration

### DIFF
--- a/dev/checkstyle-config.xml
+++ b/dev/checkstyle-config.xml
@@ -187,40 +187,5 @@
 
         <module name="LeftCurly"/>
         <module name="RightCurly"/>
-
-        <!--
-        We use the following import order:
-        import java.*
-        import javax.*
-        <blank line>
-        import all other imports
-        <blank line>
-        org.opencatalog
-	-->
-        <module name="ImportOrder">
-            <property name="separated" value="true"/>
-            <property name="ordered" value="true"/>
-            <property name="groups"
-                      value="java,javax,*,org.opencatalog"/>
-            <property name="option" value="under"/>
-        </module>
-
-        <!--
-        As per https://checkstyle.sourceforge.io/config_imports.html, "There is no flexibility to
-        enforce empty lines between some groups and no empty lines between other groups." However,
-        sometimes we want import X to come before import Y, yet we do not want them to be separated
-        by a blank line. This suppression is how we achieve that.
-        -->
-        <!-- org.opencatalog -->
-        <module name="SuppressionXpathSingleFilter">
-            <property name="checks" value="ImportOrder"/>
-            <property name="message" value="^'org.opencatalog\..*'.*"/>
-        </module>
-
-        <!-- java and javax -->
-        <module name="SuppressionXpathSingleFilter">
-            <property name="checks" value="ImportOrder"/>
-            <property name="message" value="^'javax\..*'.*"/>
-        </module>
     </module>
 </module>


### PR DESCRIPTION
**PR Checklist**

- [x ] A description of the changes is added to the description of this PR.
- [x ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

Removed the checkstyle configuration that related to the order and line space for import statements in the java code. This was different to the order enforced by javafmt

see: https://github.com/unitycatalog/unitycatalog/issues/98
also some discussion here: https://github.com/unitycatalog/unitycatalog/pull/289
