### PR TITLE
Test setCurrentCatalog and setCurrentDatabase

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -184,7 +184,7 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     session.catalog().setCurrentCatalog(SPARK_CATALOG);
     // TODO: We need to apply a fix on Spark side to used v2 session catalog handle
     // set current database when the catalog name is "spark_catalog".
-    session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    // session.catalog().setCurrentDatabase(SCHEMA_NAME);
     session.stop();
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -175,6 +175,19 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     session.stop();
   }
 
+  @Test
+  public void testSetCurrentDB() throws ApiException {
+    createCommonResources();
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.catalog().setCurrentCatalog(SPARK_CATALOG);
+    // TODO: We need to apply a fix on Spark side to used v2 session catalog handle
+    // set current database when the catalog name is "spark_catalog".
+    session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.stop();
+  }
+
   private String generateTableLocation(String catalogName, String tableName) throws IOException {
     return new File(new File(dataDir, catalogName), tableName).getCanonicalPath();
   }

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SparkIntegrationTest.java
@@ -182,8 +182,8 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
     session.catalog().setCurrentDatabase(SCHEMA_NAME);
     session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    // TODO: We need to apply a fix on Spark side to used v2 session catalog handle
-    // set current database when the catalog name is "spark_catalog".
+    // TODO: We need to apply a fix on Spark side to use v2 session catalog handle
+    // `setCurrentDatabase` when the catalog name is `spark_catalog`.
     // session.catalog().setCurrentDatabase(SCHEMA_NAME);
     session.stop();
   }


### PR DESCRIPTION
**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

Test setCurrentCatalog and setCurrentDatabase. Note that we identified a Spark issue that needs a fix on Spark side to support `spark_catalog` override in UC.