### PR TITLE
handle catalog and namespace properly in Iceberg REST api

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -44,7 +44,8 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
           builder
               .config(catalogConf, UCSingleCatalog.class.getName())
               .config(catalogConf + ".uri", serverConfig.getServerUrl())
-              .config(catalogConf + ".token", serverConfig.getAuthToken());
+              .config(catalogConf + ".token", serverConfig.getAuthToken())
+              .config(catalogConf + ".warehouse", catalog);
     }
     // Use fake file system for cloud storage so that we can test credentials.
     builder.config("fs.s3.impl", S3CredentialTestFileSystem.class.getName());

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
@@ -51,10 +51,11 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
             .config(catalogConf, UCSingleCatalog.class.getName())
             .config(catalogConf + ".uri", serverConfig.getServerUrl())
             .config(catalogConf + ".token", serverConfig.getAuthToken())
+            .config(catalogConf + ".warehouse", CATALOG_NAME)
             .config(catalogConf + ".__TEST_NO_DELTA__", "true");
     SparkSession session = builder.getOrCreate();
     setupExternalParquetTable(PARQUET_TABLE, new ArrayList<>(0));
-    testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE, session);
+    testTableReadWrite("spark_catalog." + SCHEMA_NAME + "." + PARQUET_TABLE, session);
     assertThat(UCSingleCatalog.DELTA_CATALOG_LOADED().get()).isEqualTo(false);
     session.close();
   }

--- a/docs/usage/tables/uniform.md
+++ b/docs/usage/tables/uniform.md
@@ -26,8 +26,10 @@ The following is an example of the settings to configure OSS Apache Spark to rea
 "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
 "spark.sql.catalog.iceberg.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
 "spark.sql.catalog.iceberg.uri": "http://127.0.0.1:8080/api/2.1/unity-catalog/iceberg",
+"spark.sql.catalog.iceberg.warehouse": "<catalog-name>",
 "spark.sql.catalog.iceberg.token": "not_used",
 ```
 
-When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern
-`iceberg.<catalog-name>.<schema-name>.<table-name>` (e.g. `iceberg.unity.default.marksheet_uniform`).
+When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern `iceberg.<schema-name>.<table-name>` (e.g. `iceberg.default.marksheet_uniform`).
+
+NOTE: If you want your Spark catalog name to be the same as your UC catalog name, replace `iceberg` in the above configurations with `<catalog-name>`,  then tables are identified by the following pattern `<catalog-name>.<schema-name>.<table-name>` (e.g. `unity.default.marksheet_uniform`).

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -9,6 +9,7 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import io.unitycatalog.server.utils.RESTObjectMapper;
 import lombok.SneakyThrows;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -31,7 +32,8 @@ public class IcebergRestExceptionHandler implements ExceptionHandlerFunction {
           || cause instanceof NamespaceNotEmptyException
           || cause instanceof CommitFailedException) {
         return createErrorResponse(HttpStatus.CONFLICT, cause);
-      } else if (cause instanceof IllegalArgumentException) {
+      } else if (cause instanceof IllegalArgumentException
+          || cause instanceof BadRequestException) {
         return createErrorResponse(HttpStatus.BAD_REQUEST, cause);
       } else {
         return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, cause);

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -14,7 +14,6 @@ import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
-import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.persist.utils.HibernateUtils;
 import io.unitycatalog.server.service.iceberg.MetadataService;

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -20,7 +20,6 @@ import io.unitycatalog.server.persist.utils.HibernateUtils;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.JsonUtils;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -80,7 +80,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
   @Test
   public void testConfig() {
-
     AggregatedHttpResponse resp =
         client.get("/v1/config?warehouse=" + TestUtils.CATALOG_NAME).aggregate().join();
     assertThat(resp.contentUtf8())
@@ -141,33 +140,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .build()
                   .toString());
     }
-    // ListNamespaces from catalog
-    /*{
-      AggregatedHttpResponse resp =
-          client.get("/v1/namespaces?parent=" + TestUtils.CATALOG_NAME).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      assertThat(
-              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), ListNamespacesResponse.class))
-          .asString()
-          .isEqualTo(
-              ListNamespacesResponse.builder()
-                  .add(Namespace.of(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME))
-                  .build()
-                  .toString());
-    }
-    // ListNamespaces from schema
-    {
-      AggregatedHttpResponse resp =
-          client
-              .get("/v1/namespaces?parent=" + TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      assertThat(
-              RESTObjectMapper.mapper().readValue(resp.contentUtf8(), ListNamespacesResponse.class))
-          .asString()
-          .isEqualTo(ListNamespacesResponse.builder().build().toString());
-    }*/
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -135,9 +135,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .build()
                   .toString());
 
-      // non-prefixed URL should result in 400
+      // non-prefixed URL should result in 404
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).isEqualTo(404);
     }
 
     // ListNamespaces
@@ -153,9 +153,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .build()
                   .toString());
 
-      // non-prefixed URL should result in 400
+      // non-prefixed URL should result in 404
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces").aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).isEqualTo(404);
     }
   }
 
@@ -277,14 +277,14 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
                   .getPath());
 
-      // non-prefixed URL should result in 400
+      // non-prefixed URL should result in 404
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/"
           + TestUtils.SCHEMA_NAME
           + "/tables/"
           + TestUtils.TABLE_NAME)
         .aggregate()
         .join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).isEqualTo(404);
     }
 
     // List uniform tables
@@ -300,9 +300,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(loadTableResponse.identifiers())
           .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
 
-      // non-prefixed URL should result in 400
+      // non-prefixed URL should result in 404
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables").aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).isEqualTo(404);
     }
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -136,7 +136,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .toString());
 
       // non-prefixed URL should result in 404
-      resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
+      resp =
+          client
+              .get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME)
+              .aggregate()
+              .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
 
@@ -278,12 +282,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .getPath());
 
       // non-prefixed URL should result in 404
-      resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/"
-          + TestUtils.SCHEMA_NAME
-          + "/tables/"
-          + TestUtils.TABLE_NAME)
-        .aggregate()
-        .join();
+      resp =
+          client
+              .get(
+                  TEST_BASE_NON_PREFIX
+                      + "/namespaces/"
+                      + TestUtils.SCHEMA_NAME
+                      + "/tables/"
+                      + TestUtils.TABLE_NAME)
+              .aggregate()
+              .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
 
@@ -301,7 +309,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
           .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
 
       // non-prefixed URL should result in 404
-      resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables").aggregate().join();
+      resp =
+          client
+              .get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables")
+              .aggregate()
+              .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
   }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Prior to this PR, users were required to lookup namespace and tables by supplying the uc catalog name in the namespace identifier which isn't proper and lead to problems. This PR implements the REST client flow of configuring calls to the API with a defined prefix containing the catalog name. The catalog name is now part of the API paths and broken apart from the namespace.

Client (passes warehouse parameter) -> Server Config Endpoint (response has override for URL prefix) -> Client
Subsequent calls to the API now has url prefixed with `/catalogs/{warehouse/catalog-name}`

This PR "binds" the spark catalog to a UC catalog using the client config endpoint. Users must now add to their catalog configurations something like (example in spark):

`"spark.sql.catalog.<spark-catalog-name>.warehouse": "<catalog-name>"` and now address tables like `<spark-catalog-name>.<namespace-name>.<table-name>`

This should address https://github.com/unitycatalog/unitycatalog/issues/182 and parts of https://github.com/unitycatalog/unitycatalog/issues/3.