### PR TITLE
Refactoring Tests Related to Spark Integration

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
@@ -1,0 +1,151 @@
+package io.unitycatalog.connectors.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.*;
+import io.unitycatalog.server.base.BaseCRUDTest;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import org.apache.spark.network.util.JavaUtils;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
+
+  protected static final String SPARK_CATALOG = "spark_catalog";
+  protected static final String PARQUET_TABLE = "test_parquet";
+
+  @Test
+  public void testCreateSchema() throws ApiException {
+    SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
+    session.catalog().setCurrentCatalog(CATALOG_NAME);
+    session.sql("CREATE DATABASE my_test_database;");
+    assertTrue(session.catalog().databaseExists("my_test_database"));
+    session.sql(String.format("DROP DATABASE %s.my_test_database;", CATALOG_NAME));
+    assertFalse(session.catalog().databaseExists("my_test_database"));
+
+    session.catalog().setCurrentCatalog(SPARK_CATALOG);
+    session.sql("CREATE DATABASE my_test_database;");
+    assertTrue(session.catalog().databaseExists("my_test_database"));
+    session.sql(String.format("DROP DATABASE %s.my_test_database;", SPARK_CATALOG));
+    assertFalse(session.catalog().databaseExists("my_test_database"));
+    session.stop();
+  }
+
+  @Test
+  public void testSetCurrentDB() throws ApiException {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.catalog().setCurrentCatalog(SPARK_CATALOG);
+    // TODO: We need to apply a fix on Spark side to use v2 session catalog handle
+    // `setCurrentDatabase` when the catalog name is `spark_catalog`.
+    // session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.stop();
+  }
+
+  @Test
+  public void testListNamespace() throws IOException, ApiException {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
+    Row row = session.sql("SHOW NAMESPACES").collectAsList().get(0);
+    assertThat(row.getString(0)).isEqualTo(SCHEMA_NAME);
+    assertThatThrownBy(() -> session.sql("SHOW NAMESPACES IN a.b.c").collect())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Multi-layer namespace is not supported in Unity Catalog");
+    session.stop();
+  }
+
+  @Test
+  public void testLoadNamespace() throws IOException, ApiException {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
+
+    Row[] rows = (Row[]) session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
+    assertThat(rows).hasSize(2);
+    assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
+    assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);
+    assertThat(rows[1].getString(0)).isEqualTo("Namespace Name");
+    assertThat(rows[1].getString(1)).isEqualTo(SCHEMA_NAME);
+
+    assertThatThrownBy(() -> session.sql("DESC NAMESPACE NonExist").collect())
+        .isInstanceOf(NoSuchNamespaceException.class);
+
+    session.stop();
+  }
+
+  private SchemaOperations schemaOperations;
+
+  private void createCommonResources() throws ApiException {
+    // Common setup operations such as creating a catalog and schema
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(CATALOG_NAME));
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(SPARK_CATALOG).comment("Spark catalog"));
+    schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(SPARK_CATALOG));
+  }
+
+  protected SparkSession createSparkSessionWithCatalogs(String... catalogs) {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension");
+    for (String catalog : catalogs) {
+      String catalogConf = "spark.sql.catalog." + catalog;
+      builder =
+          builder
+              .config(catalogConf, UCSingleCatalog.class.getName())
+              .config(catalogConf + ".uri", serverConfig.getServerUrl())
+              .config(catalogConf + ".token", serverConfig.getAuthToken());
+    }
+    // Use fake file system for s3:// so that we can test credentials.
+    builder.config("fs.s3.impl", CredentialTestFileSystem.class.getName());
+    return builder.getOrCreate();
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    schemaOperations = new SdkSchemaOperations(createApiClient(serverConfig));
+    cleanUp();
+    try {
+      createCommonResources();
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(createApiClient(serverConfig));
+  }
+
+  @Override
+  public void cleanUp() {
+    try {
+      catalogOperations.deleteCatalog(SPARK_CATALOG, Optional.of(true));
+    } catch (Exception e) {
+      // Ignore
+    }
+    super.cleanUp();
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
@@ -21,7 +21,7 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
 
   private SchemaOperations schemaOperations;
 
-  private void createCommonResources() throws ApiException {
+  protected void createCommonResources() throws ApiException {
     // Common setup operations such as creating a catalog and schema
     catalogOperations.createCatalog(
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
@@ -1,10 +1,6 @@
 package io.unitycatalog.connectors.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.*;
@@ -12,83 +8,16 @@ import io.unitycatalog.server.base.BaseCRUDTest;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
-import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
-import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.utils.TestUtils;
-import java.io.File;
-import java.io.IOException;
 import java.util.*;
-import org.apache.spark.network.util.JavaUtils;
-import org.apache.spark.sql.AnalysisException;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
 
   protected static final String SPARK_CATALOG = "spark_catalog";
-  protected static final String PARQUET_TABLE = "test_parquet";
-
-  @Test
-  public void testCreateSchema() throws ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
-    session.catalog().setCurrentCatalog(CATALOG_NAME);
-    session.sql("CREATE DATABASE my_test_database;");
-    assertTrue(session.catalog().databaseExists("my_test_database"));
-    session.sql(String.format("DROP DATABASE %s.my_test_database;", CATALOG_NAME));
-    assertFalse(session.catalog().databaseExists("my_test_database"));
-
-    session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    session.sql("CREATE DATABASE my_test_database;");
-    assertTrue(session.catalog().databaseExists("my_test_database"));
-    session.sql(String.format("DROP DATABASE %s.my_test_database;", SPARK_CATALOG));
-    assertFalse(session.catalog().databaseExists("my_test_database"));
-    session.stop();
-  }
-
-  @Test
-  public void testSetCurrentDB() throws ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, TestUtils.CATALOG_NAME);
-    session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
-    session.catalog().setCurrentDatabase(SCHEMA_NAME);
-    session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    // TODO: We need to apply a fix on Spark side to use v2 session catalog handle
-    // `setCurrentDatabase` when the catalog name is `spark_catalog`.
-    // session.catalog().setCurrentDatabase(SCHEMA_NAME);
-    session.stop();
-  }
-
-  @Test
-  public void testListNamespace() throws IOException, ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
-    Row row = session.sql("SHOW NAMESPACES").collectAsList().get(0);
-    assertThat(row.getString(0)).isEqualTo(SCHEMA_NAME);
-    assertThatThrownBy(() -> session.sql("SHOW NAMESPACES IN a.b.c").collect())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Multi-layer namespace is not supported in Unity Catalog");
-    session.stop();
-  }
-
-  @Test
-  public void testLoadNamespace() throws IOException, ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
-
-    Row[] rows = (Row[]) session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
-    assertThat(rows).hasSize(2);
-    assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
-    assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);
-    assertThat(rows[1].getString(0)).isEqualTo("Namespace Name");
-    assertThat(rows[1].getString(1)).isEqualTo(SCHEMA_NAME);
-
-    assertThatThrownBy(() -> session.sql("DESC NAMESPACE NonExist").collect())
-        .isInstanceOf(NoSuchNamespaceException.class);
-
-    session.stop();
-  }
 
   private SchemaOperations schemaOperations;
 

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
@@ -21,7 +21,7 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
 
   private SchemaOperations schemaOperations;
 
-  protected void createCommonResources() throws ApiException {
+  private void createCommonResources() throws ApiException {
     // Common setup operations such as creating a catalog and schema
     catalogOperations.createCatalog(
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
@@ -58,7 +58,7 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
   public void testLoadSchema() {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
-    Row[] rows = session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
+    Row[] rows = (Row[]) session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
     assertThat(rows).hasSize(2);
     assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
     assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
@@ -46,9 +46,9 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
   @Test
   public void testListSchema() {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
-    Row row = session.sql("SHOW NAMESPACES").collectAsList().get(0);
+    Row row = session.sql("SHOW SCHEMAS").collectAsList().get(0);
     assertThat(row.getString(0)).isEqualTo(SCHEMA_NAME);
-    assertThatThrownBy(() -> session.sql("SHOW NAMESPACES IN a.b.c").collect())
+    assertThatThrownBy(() -> session.sql("SHOW SCHEMAS IN a.b.c").collect())
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageContaining("Multi-layer namespace is not supported in Unity Catalog");
     session.stop();
@@ -58,7 +58,7 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
   public void testLoadSchema() {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
-    Row[] rows = (Row[]) session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
+    Row[] rows = (Row[]) session.sql("DESC SCHEMA " + SCHEMA_NAME).collect();
     assertThat(rows).hasSize(2);
     assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
     assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/SchemaOperationsTest.java
@@ -1,0 +1,73 @@
+package io.unitycatalog.connectors.spark;
+
+import io.unitycatalog.server.utils.TestUtils;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.junit.jupiter.api.Test;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SchemaOperationsTest extends BaseSparkIntegrationTest {
+  @Test
+  public void testCreateSchema() {
+    SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
+    session.catalog().setCurrentCatalog(CATALOG_NAME);
+    session.sql("CREATE DATABASE my_test_database;");
+    assertTrue(session.catalog().databaseExists("my_test_database"));
+    session.sql(String.format("DROP DATABASE %s.my_test_database;", CATALOG_NAME));
+    assertFalse(session.catalog().databaseExists("my_test_database"));
+
+    session.catalog().setCurrentCatalog(SPARK_CATALOG);
+    session.sql("CREATE DATABASE my_test_database;");
+    assertTrue(session.catalog().databaseExists("my_test_database"));
+    session.sql(String.format("DROP DATABASE %s.my_test_database;", SPARK_CATALOG));
+    assertFalse(session.catalog().databaseExists("my_test_database"));
+    session.stop();
+  }
+
+  @Test
+  public void testSetCurrentDB() {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
+    session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.catalog().setCurrentCatalog(SPARK_CATALOG);
+    // TODO: We need to apply a fix on Spark side to use v2 session catalog handle
+    // `setCurrentDatabase` when the catalog name is `spark_catalog`.
+    // session.catalog().setCurrentDatabase(SCHEMA_NAME);
+    session.stop();
+  }
+
+  @Test
+  public void testListSchema() {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
+    Row row = session.sql("SHOW NAMESPACES").collectAsList().get(0);
+    assertThat(row.getString(0)).isEqualTo(SCHEMA_NAME);
+    assertThatThrownBy(() -> session.sql("SHOW NAMESPACES IN a.b.c").collect())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Multi-layer namespace is not supported in Unity Catalog");
+    session.stop();
+  }
+
+  @Test
+  public void testLoadSchema() {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
+
+    Row[] rows = session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
+    assertThat(rows).hasSize(2);
+    assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
+    assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);
+    assertThat(rows[1].getString(0)).isEqualTo("Namespace Name");
+    assertThat(rows[1].getString(1)).isEqualTo(SCHEMA_NAME);
+
+    assertThatThrownBy(() -> session.sql("DESC NAMESPACE NonExist").collect())
+        .isInstanceOf(NoSuchNamespaceException.class);
+
+    session.stop();
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -43,7 +43,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE, session);
 
     setupExternalParquetTable(PARQUET_TABLE_PARTITIONED, Arrays.asList("s"));
-    testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE_PARTITIONED, session);
+    testTableReadWrite(
+        SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE_PARTITIONED, session);
 
     session.stop();
   }
@@ -79,18 +80,18 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList()).isEmpty();
     session.sql("INSERT INTO " + tableName1 + " SELECT 1");
     assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList())
-            .first()
-            .extracting(row -> row.get(0))
-            .isEqualTo(1);
+        .first()
+        .extracting(row -> row.get(0))
+        .isEqualTo(1);
 
     // Test CTAS
     String path2 = new File(dataDir, "test_delta_path2").getCanonicalPath();
     String tableName2 = String.format("delta.`%s`", path2);
     session.sql(String.format("CREATE TABLE %s USING delta AS SELECT 1 AS i", tableName2));
     assertThat(session.sql("SELECT * FROM " + tableName2).collectAsList())
-            .first()
-            .extracting(row -> row.get(0))
-            .isEqualTo(1);
+        .first()
+        .extracting(row -> row.get(0))
+        .isEqualTo(1);
 
     session.stop();
   }
@@ -110,10 +111,10 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     testTableReadWrite(t2, session);
 
     Row row =
-            session
-                    .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
-                    .collectAsList()
-                    .get(0);
+        session
+            .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
+            .collectAsList()
+            .get(0);
     assertThat(row.getInt(0)).isEqualTo(1);
 
     session.stop();
@@ -133,7 +134,11 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     String t2 = CATALOG_NAME + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     testTableReadWrite(t2, session);
 
-    Row row = session.sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2)).collectAsList().get(0);
+    Row row =
+        session
+            .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
+            .collectAsList()
+            .get(0);
     assertThat(row.getInt(0)).isEqualTo(1);
 
     session.stop();
@@ -170,9 +175,9 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.sql("INSERT INTO " + t2 + " SELECT 2, 'b'");
 
     session.sql(
-            String.format(
-                    "MERGE INTO %s USING %s ON %s.i = %s.i WHEN NOT MATCHED THEN INSERT *",
-                    t1, t2, t1, t2));
+        String.format(
+            "MERGE INTO %s USING %s ON %s.i = %s.i WHEN NOT MATCHED THEN INSERT *",
+            t1, t2, t1, t2));
     List<Row> rows = session.sql("SELECT * FROM " + t1).collectAsList();
     assertThat(2 == rows.size());
 
@@ -206,8 +211,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(tables[0].getString(1)).isEqualTo(PARQUET_TABLE);
 
     assertThatThrownBy(() -> session.sql("SHOW TABLES in a.b.c").collect())
-            .isInstanceOf(AnalysisException.class)
-            .hasMessageContaining("a.b.c");
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageContaining("a.b.c");
 
     session.stop();
   }
@@ -221,26 +226,26 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.sql("DROP TABLE " + fullName).collect();
     assertFalse(session.catalog().tableExists(fullName));
     assertThatThrownBy(() -> session.sql("DROP TABLE a.b.c.d").collect())
-            .isInstanceOf(AnalysisException.class);
+        .isInstanceOf(AnalysisException.class);
     session.stop();
   }
 
   private void setupExternalParquetTable(String tableName, List<String> partitionColumns)
-          throws IOException, ApiException {
+      throws IOException, ApiException {
     String location = generateTableLocation(SPARK_CATALOG, tableName);
     setupExternalParquetTable(tableName, location, partitionColumns);
   }
 
   private void setupExternalParquetTable(
-          String tableName, String location, List<String> partitionColumns)
-          throws IOException, ApiException {
+      String tableName, String location, List<String> partitionColumns)
+      throws IOException, ApiException {
     setupTables(
-            SPARK_CATALOG, tableName, DataSourceFormat.PARQUET, location, partitionColumns, false);
+        SPARK_CATALOG, tableName, DataSourceFormat.PARQUET, location, partitionColumns, false);
   }
 
   private void setupExternalDeltaTable(
-          String catalogName, String tableName, List<String> partitionColumns, SparkSession session)
-          throws IOException, ApiException {
+      String catalogName, String tableName, List<String> partitionColumns, SparkSession session)
+      throws IOException, ApiException {
     String location = generateTableLocation(catalogName, tableName);
     setupExternalDeltaTable(catalogName, tableName, location, partitionColumns, session);
   }
@@ -268,12 +273,12 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   private void setupExternalDeltaTable(
-          String catalogName,
-          String tableName,
-          String location,
-          List<String> partitionColumns,
-          SparkSession session)
-          throws IOException, ApiException {
+      String catalogName,
+      String tableName,
+      String location,
+      List<String> partitionColumns,
+      SparkSession session)
+      throws IOException, ApiException {
     // The Delta path can't be empty, need to initialize before read.
     String partitionClause;
     if (partitionColumns.isEmpty()) {
@@ -282,8 +287,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
       partitionClause = String.format(" PARTITIONED BY (%s)", String.join(", ", partitionColumns));
     }
     session.sql(
-            String.format("CREATE TABLE delta.`%s`(i INT, s STRING) USING delta", location)
-                    + partitionClause);
+        String.format("CREATE TABLE delta.`%s`(i INT, s STRING) USING delta", location)
+            + partitionClause);
 
     setupTables(catalogName, tableName, DataSourceFormat.DELTA, location, partitionColumns, false);
   }
@@ -296,43 +301,42 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(row.getString(1)).isEqualTo("a");
   }
 
-
   private void setupTables(
-          String catalogName,
-          String tableName,
-          DataSourceFormat format,
-          String location,
-          List<String> partitionColumns,
-          boolean isManaged)
-          throws IOException, ApiException {
+      String catalogName,
+      String tableName,
+      DataSourceFormat format,
+      String location,
+      List<String> partitionColumns,
+      boolean isManaged)
+      throws IOException, ApiException {
     Integer partitionIndex1 = partitionColumns.indexOf("i");
     if (partitionIndex1 == -1) partitionIndex1 = null;
     Integer partitionIndex2 = partitionColumns.indexOf("s");
     if (partitionIndex2 == -1) partitionIndex2 = null;
 
     ColumnInfo c1 =
-            new ColumnInfo()
-                    .name("i")
-                    .typeText("INTEGER")
-                    .typeJson("{\"type\": \"integer\"}")
-                    .typeName(ColumnTypeName.INT)
-                    .typePrecision(10)
-                    .typeScale(0)
-                    .position(0)
-                    .partitionIndex(partitionIndex1)
-                    .comment("Integer column")
-                    .nullable(true);
+        new ColumnInfo()
+            .name("i")
+            .typeText("INTEGER")
+            .typeJson("{\"type\": \"integer\"}")
+            .typeName(ColumnTypeName.INT)
+            .typePrecision(10)
+            .typeScale(0)
+            .position(0)
+            .partitionIndex(partitionIndex1)
+            .comment("Integer column")
+            .nullable(true);
 
     ColumnInfo c2 =
-            new ColumnInfo()
-                    .name("s")
-                    .typeText("STRING")
-                    .typeJson("{\"type\": \"string\"}")
-                    .typeName(ColumnTypeName.STRING)
-                    .position(1)
-                    .partitionIndex(partitionIndex2)
-                    .comment("String column")
-                    .nullable(true);
+        new ColumnInfo()
+            .name("s")
+            .typeText("STRING")
+            .typeJson("{\"type\": \"string\"}")
+            .typeName(ColumnTypeName.STRING)
+            .position(1)
+            .partitionIndex(partitionIndex2)
+            .comment("String column")
+            .nullable(true);
     TableType tableType;
     if (isManaged) {
       tableType = TableType.MANAGED;
@@ -340,14 +344,14 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
       tableType = TableType.EXTERNAL;
     }
     CreateTable createTableRequest =
-            new CreateTable()
-                    .name(tableName)
-                    .catalogName(catalogName)
-                    .schemaName(SCHEMA_NAME)
-                    .columns(Arrays.asList(c1, c2))
-                    .comment(COMMENT)
-                    .tableType(tableType)
-                    .dataSourceFormat(format);
+        new CreateTable()
+            .name(tableName)
+            .catalogName(catalogName)
+            .schemaName(SCHEMA_NAME)
+            .columns(Arrays.asList(c1, c2))
+            .comment(COMMENT)
+            .tableType(tableType)
+            .dataSourceFormat(format);
     if (!isManaged) {
       createTableRequest = createTableRequest.storageLocation(location);
     }

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -1,37 +1,30 @@
 package io.unitycatalog.connectors.spark;
 
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.*;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import org.apache.spark.network.util.JavaUtils;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static io.unitycatalog.server.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.model.*;
-import io.unitycatalog.server.base.BaseCRUDTest;
-import io.unitycatalog.server.base.ServerConfig;
-import io.unitycatalog.server.base.catalog.CatalogOperations;
-import io.unitycatalog.server.base.schema.SchemaOperations;
-import io.unitycatalog.server.base.table.TableOperations;
-import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
-import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
-import io.unitycatalog.server.sdk.tables.SdkTableOperations;
-import io.unitycatalog.server.utils.TestUtils;
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import org.apache.spark.network.util.JavaUtils;
-import org.apache.spark.sql.AnalysisException;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+public class TableReadWriteTest extends BaseSparkIntegrationTest {
 
-public class SparkIntegrationTest extends BaseCRUDTest {
-
-  private static final String SPARK_CATALOG = "spark_catalog";
-  private static final String PARQUET_TABLE = "test_parquet";
   private static final String ANOTHER_PARQUET_TABLE = "test_parquet_another";
   private static final String PARQUET_TABLE_PARTITIONED = "test_parquet_partitioned";
   private static final String DELTA_TABLE = "test_delta";
@@ -40,42 +33,23 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   private final File dataDir = new File(System.getProperty("java.io.tmpdir"), "spark_test");
 
-  @Test
-  public void testCreateSchema() throws ApiException {
-    createCommonResources();
-    SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
-    session.catalog().setCurrentCatalog(CATALOG_NAME);
-    session.sql("CREATE DATABASE my_test_database;");
-    assertTrue(session.catalog().databaseExists("my_test_database"));
-    session.sql(String.format("DROP DATABASE %s.my_test_database;", CATALOG_NAME));
-    assertFalse(session.catalog().databaseExists("my_test_database"));
-
-    session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    session.sql("CREATE DATABASE my_test_database;");
-    assertTrue(session.catalog().databaseExists("my_test_database"));
-    session.sql(String.format("DROP DATABASE %s.my_test_database;", SPARK_CATALOG));
-    assertFalse(session.catalog().databaseExists("my_test_database"));
-    session.stop();
-  }
+  private TableOperations tableOperations;
 
   @Test
   public void testParquetReadWrite() throws IOException, ApiException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
     // Spark only allow `spark_catalog` to return built-in file source tables.
     setupExternalParquetTable(PARQUET_TABLE, new ArrayList<>(0));
     testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE, session);
 
     setupExternalParquetTable(PARQUET_TABLE_PARTITIONED, Arrays.asList("s"));
-    testTableReadWrite(
-        SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE_PARTITIONED, session);
+    testTableReadWrite(SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE_PARTITIONED, session);
 
     session.stop();
   }
 
   @Test
   public void testDeltaReadWrite() throws IOException, ApiException {
-    createCommonResources();
     // Test both `spark_catalog` and other catalog names.
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
 
@@ -96,7 +70,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testDeltaPathTable() throws IOException, ApiException {
-    createCommonResources();
     // We must replace the `spark_catalog` in order to support Delta path tables.
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
@@ -106,25 +79,24 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList()).isEmpty();
     session.sql("INSERT INTO " + tableName1 + " SELECT 1");
     assertThat(session.sql("SELECT * FROM " + tableName1).collectAsList())
-        .first()
-        .extracting(row -> row.get(0))
-        .isEqualTo(1);
+            .first()
+            .extracting(row -> row.get(0))
+            .isEqualTo(1);
 
     // Test CTAS
     String path2 = new File(dataDir, "test_delta_path2").getCanonicalPath();
     String tableName2 = String.format("delta.`%s`", path2);
     session.sql(String.format("CREATE TABLE %s USING delta AS SELECT 1 AS i", tableName2));
     assertThat(session.sql("SELECT * FROM " + tableName2).collectAsList())
-        .first()
-        .extracting(row -> row.get(0))
-        .isEqualTo(1);
+            .first()
+            .extracting(row -> row.get(0))
+            .isEqualTo(1);
 
     session.stop();
   }
 
   @Test
   public void testCredentialParquet() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
     String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, PARQUET_TABLE);
@@ -138,10 +110,10 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     testTableReadWrite(t2, session);
 
     Row row =
-        session
-            .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
-            .collectAsList()
-            .get(0);
+            session
+                    .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
+                    .collectAsList()
+                    .get(0);
     assertThat(row.getInt(0)).isEqualTo(1);
 
     session.stop();
@@ -149,7 +121,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testCredentialDelta() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
 
     String loc0 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
@@ -162,11 +133,7 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     String t2 = CATALOG_NAME + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     testTableReadWrite(t2, session);
 
-    Row row =
-        session
-            .sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2))
-            .collectAsList()
-            .get(0);
+    Row row = session.sql(String.format("SELECT l.i FROM %s l JOIN %s r ON l.i = r.i", t1, t2)).collectAsList().get(0);
     assertThat(row.getInt(0)).isEqualTo(1);
 
     session.stop();
@@ -174,7 +141,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testDeleteDeltaTable() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
     String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
@@ -191,7 +157,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testMergeDeltaTable() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
 
     String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
@@ -205,9 +170,9 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     session.sql("INSERT INTO " + t2 + " SELECT 2, 'b'");
 
     session.sql(
-        String.format(
-            "MERGE INTO %s USING %s ON %s.i = %s.i WHEN NOT MATCHED THEN INSERT *",
-            t1, t2, t1, t2));
+            String.format(
+                    "MERGE INTO %s USING %s ON %s.i = %s.i WHEN NOT MATCHED THEN INSERT *",
+                    t1, t2, t1, t2));
     List<Row> rows = session.sql("SELECT * FROM " + t1).collectAsList();
     assertThat(2 == rows.size());
 
@@ -216,7 +181,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testUpdateDeltaTable() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
     String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
@@ -233,7 +197,6 @@ public class SparkIntegrationTest extends BaseCRUDTest {
 
   @Test
   public void testShowTables() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
     setupExternalParquetTable(PARQUET_TABLE, new ArrayList<>(0));
 
@@ -243,15 +206,14 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     assertThat(tables[0].getString(1)).isEqualTo(PARQUET_TABLE);
 
     assertThatThrownBy(() -> session.sql("SHOW TABLES in a.b.c").collect())
-        .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining("a.b.c");
+            .isInstanceOf(AnalysisException.class)
+            .hasMessageContaining("a.b.c");
 
     session.stop();
   }
 
   @Test
   public void testDropTable() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
     setupExternalParquetTable(PARQUET_TABLE, new ArrayList<>(0));
     String fullName = String.join(".", SPARK_CATALOG, SCHEMA_NAME, PARQUET_TABLE);
@@ -259,51 +221,28 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     session.sql("DROP TABLE " + fullName).collect();
     assertFalse(session.catalog().tableExists(fullName));
     assertThatThrownBy(() -> session.sql("DROP TABLE a.b.c.d").collect())
-        .isInstanceOf(AnalysisException.class);
+            .isInstanceOf(AnalysisException.class);
     session.stop();
   }
 
-  @Test
-  public void testSetCurrentDB() throws ApiException {
-    createCommonResources();
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, TestUtils.CATALOG_NAME);
-    session.catalog().setCurrentCatalog(TestUtils.CATALOG_NAME);
-    session.catalog().setCurrentDatabase(SCHEMA_NAME);
-    session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    // TODO: We need to apply a fix on Spark side to use v2 session catalog handle
-    // `setCurrentDatabase` when the catalog name is `spark_catalog`.
-    // session.catalog().setCurrentDatabase(SCHEMA_NAME);
-    session.stop();
+  private void setupExternalParquetTable(String tableName, List<String> partitionColumns)
+          throws IOException, ApiException {
+    String location = generateTableLocation(SPARK_CATALOG, tableName);
+    setupExternalParquetTable(tableName, location, partitionColumns);
   }
 
-  @Test
-  public void testListNamespace() throws IOException, ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
-    createCommonResources();
-    Row row = session.sql("SHOW NAMESPACES").collectAsList().get(0);
-    assertThat(row.getString(0)).isEqualTo(SCHEMA_NAME);
-    assertThatThrownBy(() -> session.sql("SHOW NAMESPACES IN a.b.c").collect())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Multi-layer namespace is not supported in Unity Catalog");
-    session.stop();
+  private void setupExternalParquetTable(
+          String tableName, String location, List<String> partitionColumns)
+          throws IOException, ApiException {
+    setupTables(
+            SPARK_CATALOG, tableName, DataSourceFormat.PARQUET, location, partitionColumns, false);
   }
 
-  @Test
-  public void testLoadNamespace() throws IOException, ApiException {
-    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
-    createCommonResources();
-
-    Row[] rows = (Row[]) session.sql("DESC NAMESPACE " + SCHEMA_NAME).collect();
-    assertThat(rows).hasSize(2);
-    assertThat(rows[0].getString(0)).isEqualTo("Catalog Name");
-    assertThat(rows[0].getString(1)).isEqualTo(SPARK_CATALOG);
-    assertThat(rows[1].getString(0)).isEqualTo("Namespace Name");
-    assertThat(rows[1].getString(1)).isEqualTo(SCHEMA_NAME);
-
-    assertThatThrownBy(() -> session.sql("DESC NAMESPACE NonExist").collect())
-        .isInstanceOf(NoSuchNamespaceException.class);
-
-    session.stop();
+  private void setupExternalDeltaTable(
+          String catalogName, String tableName, List<String> partitionColumns, SparkSession session)
+          throws IOException, ApiException {
+    String location = generateTableLocation(catalogName, tableName);
+    setupExternalDeltaTable(catalogName, tableName, location, partitionColumns, session);
   }
 
   @Test
@@ -328,73 +267,13 @@ public class SparkIntegrationTest extends BaseCRUDTest {
     return new File(new File(dataDir, catalogName), tableName).getCanonicalPath();
   }
 
-  private void testTableReadWrite(String tableFullName, SparkSession session) {
-    assertThat(session.sql("SELECT * FROM " + tableFullName).collectAsList()).isEmpty();
-    session.sql("INSERT INTO " + tableFullName + " SELECT 1, 'a'");
-    Row row = session.sql("SELECT * FROM " + tableFullName).collectAsList().get(0);
-    assertThat(row.getInt(0)).isEqualTo(1);
-    assertThat(row.getString(1)).isEqualTo("a");
-  }
-
-  private SchemaOperations schemaOperations;
-  private TableOperations tableOperations;
-
-  private void createCommonResources() throws ApiException {
-    // Common setup operations such as creating a catalog and schema
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(CATALOG_NAME));
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(SPARK_CATALOG).comment("Spark catalog"));
-    schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(SPARK_CATALOG));
-  }
-
-  private SparkSession createSparkSessionWithCatalogs(String... catalogs) {
-    SparkSession.Builder builder =
-        SparkSession.builder()
-            .appName("test")
-            .master("local[*]")
-            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension");
-    for (String catalog : catalogs) {
-      String catalogConf = "spark.sql.catalog." + catalog;
-      builder =
-          builder
-              .config(catalogConf, UCSingleCatalog.class.getName())
-              .config(catalogConf + ".uri", serverConfig.getServerUrl())
-              .config(catalogConf + ".token", serverConfig.getAuthToken());
-    }
-    // Use fake file system for s3:// so that we can test credentials.
-    builder.config("fs.s3.impl", CredentialTestFileSystem.class.getName());
-    return builder.getOrCreate();
-  }
-
-  private void setupExternalParquetTable(String tableName, List<String> partitionColumns)
-      throws IOException, ApiException {
-    String location = generateTableLocation(SPARK_CATALOG, tableName);
-    setupExternalParquetTable(tableName, location, partitionColumns);
-  }
-
-  private void setupExternalParquetTable(
-      String tableName, String location, List<String> partitionColumns)
-      throws IOException, ApiException {
-    setupTables(
-        SPARK_CATALOG, tableName, DataSourceFormat.PARQUET, location, partitionColumns, false);
-  }
-
   private void setupExternalDeltaTable(
-      String catalogName, String tableName, List<String> partitionColumns, SparkSession session)
-      throws IOException, ApiException {
-    String location = generateTableLocation(catalogName, tableName);
-    setupExternalDeltaTable(catalogName, tableName, location, partitionColumns, session);
-  }
-
-  private void setupExternalDeltaTable(
-      String catalogName,
-      String tableName,
-      String location,
-      List<String> partitionColumns,
-      SparkSession session)
-      throws IOException, ApiException {
+          String catalogName,
+          String tableName,
+          String location,
+          List<String> partitionColumns,
+          SparkSession session)
+          throws IOException, ApiException {
     // The Delta path can't be empty, need to initialize before read.
     String partitionClause;
     if (partitionColumns.isEmpty()) {
@@ -403,48 +282,57 @@ public class SparkIntegrationTest extends BaseCRUDTest {
       partitionClause = String.format(" PARTITIONED BY (%s)", String.join(", ", partitionColumns));
     }
     session.sql(
-        String.format("CREATE TABLE delta.`%s`(i INT, s STRING) USING delta", location)
-            + partitionClause);
+            String.format("CREATE TABLE delta.`%s`(i INT, s STRING) USING delta", location)
+                    + partitionClause);
 
     setupTables(catalogName, tableName, DataSourceFormat.DELTA, location, partitionColumns, false);
   }
 
+  private void testTableReadWrite(String tableFullName, SparkSession session) {
+    assertThat(session.sql("SELECT * FROM " + tableFullName).collectAsList()).isEmpty();
+    session.sql("INSERT INTO " + tableFullName + " SELECT 1, 'a'");
+    Row row = session.sql("SELECT * FROM " + tableFullName).collectAsList().get(0);
+    assertThat(row.getInt(0)).isEqualTo(1);
+    assertThat(row.getString(1)).isEqualTo("a");
+  }
+
+
   private void setupTables(
-      String catalogName,
-      String tableName,
-      DataSourceFormat format,
-      String location,
-      List<String> partitionColumns,
-      boolean isManaged)
-      throws IOException, ApiException {
+          String catalogName,
+          String tableName,
+          DataSourceFormat format,
+          String location,
+          List<String> partitionColumns,
+          boolean isManaged)
+          throws IOException, ApiException {
     Integer partitionIndex1 = partitionColumns.indexOf("i");
     if (partitionIndex1 == -1) partitionIndex1 = null;
     Integer partitionIndex2 = partitionColumns.indexOf("s");
     if (partitionIndex2 == -1) partitionIndex2 = null;
 
     ColumnInfo c1 =
-        new ColumnInfo()
-            .name("i")
-            .typeText("INTEGER")
-            .typeJson("{\"type\": \"integer\"}")
-            .typeName(ColumnTypeName.INT)
-            .typePrecision(10)
-            .typeScale(0)
-            .position(0)
-            .partitionIndex(partitionIndex1)
-            .comment("Integer column")
-            .nullable(true);
+            new ColumnInfo()
+                    .name("i")
+                    .typeText("INTEGER")
+                    .typeJson("{\"type\": \"integer\"}")
+                    .typeName(ColumnTypeName.INT)
+                    .typePrecision(10)
+                    .typeScale(0)
+                    .position(0)
+                    .partitionIndex(partitionIndex1)
+                    .comment("Integer column")
+                    .nullable(true);
 
     ColumnInfo c2 =
-        new ColumnInfo()
-            .name("s")
-            .typeText("STRING")
-            .typeJson("{\"type\": \"string\"}")
-            .typeName(ColumnTypeName.STRING)
-            .position(1)
-            .partitionIndex(partitionIndex2)
-            .comment("String column")
-            .nullable(true);
+            new ColumnInfo()
+                    .name("s")
+                    .typeText("STRING")
+                    .typeJson("{\"type\": \"string\"}")
+                    .typeName(ColumnTypeName.STRING)
+                    .position(1)
+                    .partitionIndex(partitionIndex2)
+                    .comment("String column")
+                    .nullable(true);
     TableType tableType;
     if (isManaged) {
       tableType = TableType.MANAGED;
@@ -452,14 +340,14 @@ public class SparkIntegrationTest extends BaseCRUDTest {
       tableType = TableType.EXTERNAL;
     }
     CreateTable createTableRequest =
-        new CreateTable()
-            .name(tableName)
-            .catalogName(catalogName)
-            .schemaName(SCHEMA_NAME)
-            .columns(Arrays.asList(c1, c2))
-            .comment(COMMENT)
-            .tableType(tableType)
-            .dataSourceFormat(format);
+            new CreateTable()
+                    .name(tableName)
+                    .catalogName(catalogName)
+                    .schemaName(SCHEMA_NAME)
+                    .columns(Arrays.asList(c1, c2))
+                    .comment(COMMENT)
+                    .tableType(tableType)
+                    .dataSourceFormat(format);
     if (!isManaged) {
       createTableRequest = createTableRequest.storageLocation(location);
     }
@@ -470,23 +358,11 @@ public class SparkIntegrationTest extends BaseCRUDTest {
   @Override
   public void setUp() {
     super.setUp();
-    schemaOperations = new SdkSchemaOperations(createApiClient(serverConfig));
     tableOperations = new SdkTableOperations(createApiClient(serverConfig));
-    cleanUp();
-  }
-
-  @Override
-  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
-    return new SdkCatalogOperations(createApiClient(serverConfig));
   }
 
   @Override
   public void cleanUp() {
-    try {
-      catalogOperations.deleteCatalog(SPARK_CATALOG, Optional.of(true));
-    } catch (Exception e) {
-      // Ignore
-    }
     super.cleanUp();
     try {
       JavaUtils.deleteRecursively(dataDir);

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -28,6 +28,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   private static final String ANOTHER_PARQUET_TABLE = "test_parquet_another";
   private static final String PARQUET_TABLE_PARTITIONED = "test_parquet_partitioned";
   private static final String DELTA_TABLE = "test_delta";
+  private static final String PARQUET_TABLE = "test_parquet";
   private static final String ANOTHER_DELTA_TABLE = "test_delta_another";
   private static final String DELTA_TABLE_PARTITIONED = "test_delta_partitioned";
 
@@ -70,7 +71,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Test
-  public void testDeltaPathTable() throws IOException, ApiException {
+  public void testDeltaPathTable() throws IOException {
     // We must replace the `spark_catalog` in order to support Delta path tables.
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -253,7 +253,6 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
 
   @Test
   public void testCreateExternalParquetTable() throws ApiException, IOException {
-    createCommonResources();
     SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME);
     String path = generateTableLocation(CATALOG_NAME, PARQUET_TABLE);
     String fullTableName = CATALOG_NAME + "." + SCHEMA_NAME + "." + PARQUET_TABLE;


### PR DESCRIPTION
To facilitate future expansion, we are splitting the current mixed Spark Integration tests into the following parts:

- BaseSparkIntegrationTest abstract class: This includes the basic Spark Catalog session creation, default setup, cleanup functions, and serves as the base class for all Spark integration tests.
- SchemaOperationsTest: This tests schema-related operations such as create, delete, and list.
- TableReadWriteTest: This tests table-related operations, including read/write operations.
