### PR TITLE
Adds support for uniform iceberg metadata in CreateTable request

### DIFF
--- a/api/Models/CreateTable.md
+++ b/api/Models/CreateTable.md
@@ -12,6 +12,7 @@
 | **storage\_location** | **String** | Storage root URL for table (for **MANAGED**, **EXTERNAL** tables) | [optional] [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+| **uniform_iceberg_metadata_location** | **String** | Path of icebegrg metadata location. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/Models/TableInfo.md
+++ b/api/Models/TableInfo.md
@@ -15,6 +15,7 @@
 | **created\_at** | **Long** | Time at which this table was created, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_at** | **Long** | Time at which this table was last modified, in epoch milliseconds. | [optional] [default to null] |
 | **table\_id** | **String** | Unique identifier for the table. | [optional] [default to null] |
+| **uniform_iceberg_metadata_location** | **String** | Path of icebegrg metadata location. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -943,6 +943,9 @@ components:
         table_id:
           description: Unique identifier for the table.
           type: string
+        uniform_iceberg_metadata_location:
+          description: icebegrg metadata location 
+          type: string
     CreateTable:
       type: object
       properties:
@@ -972,6 +975,9 @@ components:
           type: string
         properties:
           $ref: '#/components/schemas/SecurablePropertiesMap'
+        uniform_iceberg_metadata_location:
+          description: icebegrg metadata location 
+          type: string
       required:
         - name
         - catalog_name

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -121,6 +121,7 @@ public class TableRepository {
             .storageLocation(FileUtils.convertRelativePathToURI(createTable.getStorageLocation()))
             .comment(createTable.getComment())
             .properties(createTable.getProperties())
+            .uniformIcebergMetadataLocation(createTable.getUniformIcebergMetadataLocation())
             .createdAt(System.currentTimeMillis());
     String fullName = getTableFullName(tableInfo);
     LOGGER.debug("Creating table: " + fullName);

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -74,6 +74,10 @@ public class TableInfoDAO extends IdentifiableDAO {
         .dataSourceFormat(tableInfo.getDataSourceFormat().toString())
         .url(tableInfo.getStorageLocation())
         .columns(ColumnInfoDAO.fromList(tableInfo.getColumns()))
+        .uniformIcebergMetadataLocation(
+            tableInfo.getUniformIcebergMetadataLocation() != null
+                ? tableInfo.getUniformIcebergMetadataLocation()
+                : null)
         .build();
   }
 
@@ -86,6 +90,7 @@ public class TableInfoDAO extends IdentifiableDAO {
             .dataSourceFormat(DataSourceFormat.valueOf(dataSourceFormat))
             .storageLocation(FileUtils.convertRelativePathToURI(url))
             .comment(comment)
+            .uniformIcebergMetadataLocation(uniformIcebergMetadataLocation)
             .createdAt(createdAt != null ? createdAt.getTime() : null)
             .updatedAt(updatedAt != null ? updatedAt.getTime() : null);
     if (fetchColumns) {


### PR DESCRIPTION
**Description of changes**
Adds support for uniform icebegr metadat in CreateTable request. This PR closes [this issue](https://github.com/unitycatalog/unitycatalog/issues/312#issuecomment-2268292893).

This PR adds `uniform_iceberg_metadata_location` field in `CreateTable` and `TableInfo` object which is then passed on `TableInfoDAO`

