### PR TITLE
Fix credential support by disabling FileSystem cache

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -161,7 +161,9 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
         "fs.s3a.access.key" -> credential.getAccessKeyId,
         "fs.s3a.secret.key" -> credential.getSecretAccessKey,
         "fs.s3a.session.token" -> credential.getSessionToken,
-        "fs.s3a.path.style.access" -> "true"
+        "fs.s3a.path.style.access" -> "true",
+        "fs.s3.impl.disable.cache" -> "true",
+        "fs.s3a.impl.disable.cache" -> "true"
       )
     } else {
       Map.empty

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/CredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/CredentialTestFileSystem.java
@@ -1,12 +1,16 @@
 package io.unitycatalog.connectors.spark;
 
 import java.io.IOException;
+import java.net.URI;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.util.Progressable;
 
 // A wrapper over the local file system to test UC table credentials.
 public class CredentialTestFileSystem extends RawLocalFileSystem {
+
+  public static boolean credentialCheckEnabled = true;
 
   @Override
   protected void checkPath(Path path) {
@@ -71,7 +75,9 @@ public class CredentialTestFileSystem extends RawLocalFileSystem {
   private Path toLocalPath(Path f) {
     Configuration conf = getConf();
     String host = f.toUri().getHost();
-    if ("test-bucket0".equals(host)) {
+    if (!credentialCheckEnabled) {
+      // Do nothing
+    } else if ("test-bucket0".equals(host)) {
       assert "accessKey0".equals(conf.get("fs.s3a.access.key"));
       assert "secretKey0".equals(conf.get("fs.s3a.secret.key"));
       assert "sessionToken0".equals(conf.get("fs.s3a.session.token"));

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -329,9 +329,14 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     } else {
       partitionClause = String.format(" PARTITIONED BY (%s)", String.join(", ", partitionColumns));
     }
+
+    // Temporarily disable the credential check when setting up the external Delta location which
+    // does not involve Unity Catalog at all.
+    CredentialTestFileSystem.credentialCheckEnabled = false;
     session.sql(
         String.format("CREATE TABLE delta.`%s`(i INT, s STRING) USING delta", location)
             + partitionClause);
+    CredentialTestFileSystem.credentialCheckEnabled = true;
 
     setupTables(catalogName, tableName, DataSourceFormat.DELTA, location, partitionColumns, false);
   }


### PR DESCRIPTION
**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
The credential support is implemented by setting hadoop conf for different table scans. This means we can't reuse FileSystem instance as it may mess up credentials. This PR explicit disables the cache.