### PR TITLE
always request READ credentials

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -152,9 +152,11 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
     val tableId = t.getTableId
     val credential: AwsCredentials = temporaryTableCredentialsApi
       .generateTemporaryTableCredentials(
-        // TODO: at this time, we don't know if the table will be read or written. We should get
-        //       credential in a later phase.
-        new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ_WRITE)
+        // TODO: at this time, we don't know if the table will be read or written. For now we always
+        //       request READ credentials as the server doesn't distinguish between READ and
+        //       READ_WRITE credentials as of today. When loading a table, Spark should tell if it's
+        //       for read or write, we can request the proper credential after fixing Spark.
+        new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ)
       )
       .getAwsTempCredentials
     val extraSerdeProps = if (uri.getScheme == "s3") {


### PR DESCRIPTION
**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

Due to the Spark limitation, when UC loads a table, we don't know if Spark will use this table for read or write. For now, we simply request `READ_WRITE` credentials, but this won't work for certain UC servers that don't allow external writing, such as Databricks UC.

In this PR, we change it to always request READ credentials, as the current UC server doesn't distinguish between READ and READ_WRITE credentials. After we fix the Spark limitation, we can request the proper credentials.