### PR TITLE
Downgrade the clients and Spark connector to Java 11 for better Spark compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,6 @@ lazy val commonSettings = Seq(
   Compile / compile / javacOptions ++= Seq(
     "-Xlint:deprecation",
     "-Xlint:unchecked",
-    "-source", "17",
-    "-target", "17",
     "-g:source,lines,vars",
   ),
   libraryDependencies ++= Seq(
@@ -109,6 +107,9 @@ lazy val client = (project in file("target/clients/java"))
     name := s"$artifactNamePrefix-client",
     commonSettings,
     javaOnlyReleaseSettings,
+    Compile / compile / javacOptions ++= Seq(
+      "--release", "11",
+    ),
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -178,6 +179,11 @@ lazy val server = (project in file("server"))
     javaOnlyReleaseSettings,
     javafmtCheckSettings,
     javaCheckstyleSettings(file("dev") / "checkstyle-config.xml"),
+    Compile / compile / javacOptions ++= Seq(
+      "--release", "17",
+      "-processor",
+      "lombok.launch.AnnotationProcessorHider$AnnotationProcessor"
+    ),
     libraryDependencies ++= Seq(
       "com.linecorp.armeria" %  "armeria" % "1.28.4",
       // Netty dependencies
@@ -227,11 +233,6 @@ lazy val server = (project in file("server"))
       "commons-cli" % "commons-cli" % "1.7.0"
     ),
 
-    Compile / compile / javacOptions ++= Seq(
-      "-processor",
-      "lombok.launch.AnnotationProcessorHider$AnnotationProcessor"
-    ),
-
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "io" / "unitycatalog" / "server" / "utils" / "VersionUtils.java"
       IO.write(file,
@@ -257,6 +258,9 @@ lazy val serverModels = (project in file("server") / "target" / "models")
     name := s"$artifactNamePrefix-servermodels",
     commonSettings,
     (Compile / compile) := ((Compile / compile) dependsOn generate).value,
+    Compile / compile / javacOptions ++= Seq(
+      "--release", "17",
+    ),
     libraryDependencies ++= Seq(
       "jakarta.annotation" % "jakarta.annotation-api" % "3.0.0" % Provided,
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
@@ -294,6 +298,9 @@ lazy val cli = (project in file("examples") / "cli")
     skipReleaseSettings,
     javafmtCheckSettings,
     javaCheckstyleSettings(file("dev") / "checkstyle-config.xml"),
+    Compile / compile / javacOptions ++= Seq(
+      "--release", "17",
+    ),
     libraryDependencies ++= Seq(
       "commons-cli" % "commons-cli" % "1.7.0",
       "org.json" % "json" % "20240303",
@@ -364,6 +371,9 @@ lazy val spark = (project in file("connectors/spark"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
     ),
     javaCheckstyleSettings(file("dev/checkstyle-config.xml")),
+    Compile / compile / javacOptions ++= Seq(
+      "--release", "11",
+    ),
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",


### PR DESCRIPTION

**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This changes the Java language version to 11 for the Clients module and the Spark Connector. See Issue https://github.com/unitycatalog/unitycatalog/issues/351