### PR TITLE
Fix the broken link to the Docker README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You have to ensure that your local environment has the following:
 - Ensure the `JAVA_HOME` environment variable your terminal is configured to point to JDK17+.
 - Compile the project using `build/sbt package`
 
-> If you prefer to run this using the Unity Catalog Dockerized Environment, please refer to the Docker [README.md](./docker/readme.md)
+> If you prefer to run this using the Unity Catalog Dockerized Environment, please refer to the Docker [README.md](./docker/README.md)
 
 ### Run the UC Server
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixed the Docker [README.md](https://github.com/unitycatalog/unitycatalog/blob/main/docker/README.md) link present in UC QuickStart [Prerequisites](https://github.com/unitycatalog/unitycatalog?tab=readme-ov-file#prerequisites).
