### PR TITLE
[SPARK] CreateTable should return from loadTable for Spark 3.5

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -226,7 +226,7 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
     val format: String = properties.get("provider")
     createTable.setDataSourceFormat(convertDatasourceFormat(format))
     tablesApi.createTable(createTable)
-    null
+    loadTable(ident)
   }
 
   private def convertDatasourceFormat(format: String): DataSourceFormat = {


### PR DESCRIPTION
CreateTable should return from loadTable for Spark 3.5. We cannot return null until Spark 4.0