### PR TITLE
[README] Add increasing JVM heap size in commands for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ Refer to [sbt docs](https://www.scala-sbt.org/1.x/docs/) for more commands.
   ```
 - To compile and execute tests, run the following:
   ```sh
-  build/sbt clean test
+  build/sbt -J-Xmx2G clean test
   ```
 - To execute tests with coverage, run the following:
   ```sh
-  build/sbt jacoco 
+  build/sbt -J-Xmx2G jacoco
   ```
 - To update the API specification, just update the `api/all.yaml` and then run the following:
   ```sh


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Heap size when running tests was increased in the CI workflow in PR #274 Without this increase, the example commands for running tests given in the README fail with `java.lang.OutOfMemoryError: Java heap space`.

This PR adds the same heap size increase to the commands for running tests in the README.

Fixes #385