### PR TITLE
Update the create table API spec to clarify only external table creation is supported

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -271,12 +271,12 @@ paths:
     post:
       operationId: createTable
       summary: |
-        Create a table.
+        Create a table. Only external table creation is supported.
         WARNING: This API is experimental and will change in future versions.
       tags:
         - Tables
       description: |
-        Creates a new table instance.
+        Creates a new external table instance.
         WARNING: This API is experimental and will change in future versions.
       requestBody:
         content:
@@ -285,7 +285,7 @@ paths:
               $ref: '#/components/schemas/CreateTable'
       responses:
         '200':
-          description: The new table was successfully created.
+          description: The new external table was successfully created.
           content:
             application/json:
               schema:
@@ -1278,7 +1278,7 @@ components:
           items:
             $ref: '#/components/schemas/ColumnInfo'
         storage_location:
-          description: Storage root URL for table (for **MANAGED**, **EXTERNAL** tables)
+          description: Storage root URL for external table
           type: string
         comment:
           description: User-provided free-form text description.
@@ -1292,6 +1292,7 @@ components:
         - table_type
         - data_source_format
         - columns
+        - storage_location
     ListTablesResponse:
       type: object
       properties:

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -142,7 +142,7 @@ public class TableRepository {
           throw new BaseException(
               ErrorCode.INVALID_ARGUMENT, "MANAGED table creation is not supported yet.");
         }
-        // assuming external table
+        // only external table creation is supported at this time
         if (tableInfo.getStorageLocation() == null) {
           throw new BaseException(
               ErrorCode.INVALID_ARGUMENT, "Storage location is required for external table");


### PR DESCRIPTION
Update the create table API spec to clarify only external table creation is supported. The `createTable` method in `TableRepository` already ensures only external tables are created.

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
