### PR TITLE
[DOCKER] UC server container displays welcome message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ EOF
 # Define the shell used within the container
 SHELL ["/bin/bash", "-i", "-c", "-o", "pipefail"]
 
-ENV SERVER_JAR="${unitycatalog_jars}/unitycatalog-server-${unitycatalog_version}.jar"
 ENV UC_SERVER_BIN="${unitycatalog_home}/${unitycatalog_bin}/start-uc-server"
 
 RUN <<-EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG sbt_args="-J-Xmx2G"
 ARG unitycatalog_version="0.2.0-SNAPSHOT"
 ARG jars_directory="server/target/jars"
 
-FROM eclipse-temurin:22-jdk-alpine AS package_server
+FROM eclipse-temurin:17-jdk-alpine AS package_server
 
 ARG unitycatalog_repo
 ARG sbt_args
@@ -46,7 +46,7 @@ RUN build/sbt ${sbt_args} server/package
 # Copy the jar files into a single directory
 RUN ./docker/copy_jars_from_classpath.sh ${jars_directory}
 
-FROM eclipse-temurin:22-jre-alpine AS build_uc
+FROM eclipse-temurin:17-jdk-alpine AS build_uc
 
 ARG unitycatalog_uid
 ARG unitycatalog_home

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ ARG unitycatalog_user_basedir="${unitycatalog_home}/${unitycatalog_user_home}"
 ARG sbt_args="-J-Xmx2G"
 # FIXME Pass it from the outside
 ARG unitycatalog_version="0.2.0-SNAPSHOT"
-ARG server_assembly_jar="${unitycatalog_repo}/${unitycatalog_jar}/unitycatalog-server-assembly-${unitycatalog_version}.jar"
 ARG jars_directory="server/target/jars"
 
 FROM eclipse-temurin:22-jdk-alpine AS package_server
@@ -60,7 +59,6 @@ ARG unitycatalog_user_name
 ARG unitycatalog_user_home
 ARG unitycatalog_user_basedir
 ARG sbt_args
-ARG server_assembly_jar
 ARG unitycatalog_version
 ARG jars_directory
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,8 @@ Before you can build the Docker image, install the following tools:
 
 > [!NOTE]
 >
-> `build-uc-server-docker` runs the entire sbt build while creating the Docker image. 
+> `build-uc-server-docker` runs `sbt server/package` build while creating the Docker image.
+> That gives all the required jars files part of the image.
 
 `build-uc-server-docker` creates an image named `unitycatalog` with the version from [version.sbt](../version.sbt).
 
@@ -28,8 +29,8 @@ docker images unitycatalog
 ```
 
 ```text
-REPOSITORY     TAG              IMAGE ID       CREATED              SIZE
-unitycatalog   0.2.0-SNAPSHOT   8b68b233813b   About a minute ago   427MB
+REPOSITORY     TAG              IMAGE ID       CREATED          SIZE
+unitycatalog   0.2.0-SNAPSHOT   de48dd1c2789   12 minutes ago   2.47GB
 ```
 
 ## Running Unity Catalog Server Container
@@ -41,28 +42,23 @@ Once the Docker image of Unity Catalog's Localhost Reference Server is built, yo
 ```
 
 ```text
-Container unitycatalog does not exist. Creating it...
-fbf8a0d2fc6a82f81134c4c50fb4c777399e7095706cb65ff6fe0c158ec43ef4
-The container unitycatalog is running with the following parameters:
-{
-  "Command": "\"/bin/bash bin/start…\"",
-  "CreatedAt": "2024-08-26 18:10:48 +0200 CEST",
-  "ID": "fbf8a0d2fc6a",
-  "Image": "unitycatalog:0.2.0-SNAPSHOT",
-  "Labels": "",
-  "LocalVolumes": "1",
-  "Mounts": "3e4bcb63d68a91…",
-  "Names": "unitycatalog",
-  "Networks": "bridge",
-  "Ports": "0.0.0.0:8081->8081/tcp",
-  "RunningFor": "Less than a second ago",
-  "Size": "32.8kB (virtual 427MB)",
-  "State": "running",
-  "Status": "Up Less than a second"
-}
+❤️ Starting unitycatalog:0.2.0-SNAPSHOT.
+💡 Use Ctrl+C to stop and remove the container.
+###################################################################
+#  _    _       _ _            _____      _        _              #
+# | |  | |     (_) |          / ____|    | |      | |             #
+# | |  | |_ __  _| |_ _   _  | |     __ _| |_ __ _| | ___   __ _  #
+# | |  | | '_ \| | __| | | | | |    / _` | __/ _` | |/ _ \ / _` | #
+# | |__| | | | | | |_| |_| | | |___| (_| | || (_| | | (_) | (_| | #
+#  \____/|_| |_|_|\__|\__, |  \_____\__,_|\__\__,_|_|\___/ \__, | #
+#                      __/ |                                __/ | #
+#                     |___/               v0.2.0-SNAPSHOT  |___/  #
+###################################################################
 ```
 
 `start-uc-server-docker` starts the Unity Catalog server to listen to `8081`.
+
+In another terminal, execute the following command to learn more about the container.
 
 ```bash
 docker container ls --filter name=unitycatalog --no-trunc --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.Ports}}'
@@ -108,6 +104,8 @@ unitycatalog-cli   0.2.0-SNAPSHOT   52502d16934f   About a minute ago   1.48GB
 
 > [!NOTE]
 > In case you run into the following build exception, restart the CLI docker image build.
+> This is likely due to Java 22 used to build the image (and execute the sbt build). 
+>
 > ```text
 > ❯ ./docker/bin/build-uc-cli-docker
 > ...
@@ -116,7 +114,7 @@ unitycatalog-cli   0.2.0-SNAPSHOT   52502d16934f   About a minute ago   1.48GB
 > [error] (cli / Compile / compileIncremental) Failed to find name hashes for io.unitycatalog.cli.utils.CliUtils
 > ```
 
-## Access Unity Catalog Localhost Reference Server
+## Access Unity Catalog Server
 
 [start-uc-cli-docker](./bin/start-uc-cli-docker) uses the `unitycatalog-cli` image to run Unity Catalog CLI in a Docker container.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,14 @@ Before you can build the Docker image, install the following tools:
 
 ## Building Unity Catalog Server Image
 
+> [!NOTE]
+>
+> On [Mac computers with Apple silicon](https://support.apple.com/en-us/116943), you may want to change [DOCKER_DEFAULT_PLATFORM](https://docs.docker.com/reference/cli/docker/#environment-variables) environment variable before building the images as follows:
+>
+> ```bash
+> export DOCKER_DEFAULT_PLATFORM=linux/amd64
+> ```
+
 [build-uc-server-docker](./bin/build-uc-server-docker) builds the Docker image of Unity Catalog Localhost Reference Server.
 
 ```bash
@@ -29,8 +37,8 @@ docker images unitycatalog
 ```
 
 ```text
-REPOSITORY     TAG              IMAGE ID       CREATED          SIZE
-unitycatalog   0.2.0-SNAPSHOT   de48dd1c2789   12 minutes ago   2.47GB
+REPOSITORY     TAG              IMAGE ID       CREATED         SIZE
+unitycatalog   0.2.0-SNAPSHOT   5771da356693   7 minutes ago   2.58GB
 ```
 
 ## Running Unity Catalog Server Container
@@ -66,7 +74,7 @@ docker container ls --filter name=unitycatalog --no-trunc --format 'table {{.ID}
 
 ```text
 CONTAINER ID                                                       IMAGE                         COMMAND                           PORTS
-fbf8a0d2fc6a82f81134c4c50fb4c777399e7095706cb65ff6fe0c158ec43ef4   unitycatalog:0.2.0-SNAPSHOT   "/bin/bash bin/start-uc-server"   0.0.0.0:8081->8081/tcp
+1e15b648d6c2669eb83ac12991323ca288e27d9201c4ecbc8dc15ea2bfa6c389   unitycatalog:0.2.0-SNAPSHOT   "/bin/bash bin/start-uc-server"   0.0.0.0:8081->8081/tcp
 ```
 
 Use the regular non-dockerized Unity Catalog CLI to access the server and list the catalogs.
@@ -98,21 +106,9 @@ docker images unitycatalog-cli
 ```
 
 ```text
-REPOSITORY         TAG              IMAGE ID       CREATED              SIZE
-unitycatalog-cli   0.2.0-SNAPSHOT   52502d16934f   About a minute ago   1.48GB
+REPOSITORY         TAG              IMAGE ID       CREATED          SIZE
+unitycatalog-cli   0.2.0-SNAPSHOT   c13a37c4e91e   13 seconds ago   1.62GB
 ```
-
-> [!NOTE]
-> In case you run into the following build exception, restart the CLI docker image build.
-> This is likely due to Java 22 used to build the image (and execute the sbt build). 
->
-> ```text
-> ❯ ./docker/bin/build-uc-cli-docker
-> ...
-> [error] java.lang.RuntimeException: Failed to find name hashes for io.unitycatalog.cli.utils.CliUtils
-> ...
-> [error] (cli / Compile / compileIncremental) Failed to find name hashes for io.unitycatalog.cli.utils.CliUtils
-> ```
 
 ## Access Unity Catalog Server
 

--- a/docker/bin/build-uc-cli-docker
+++ b/docker/bin/build-uc-cli-docker
@@ -12,7 +12,7 @@ echo "Changing directory to $project_dir"
 cd "$project_dir" || exit
 
 if [[ -r "$docker_file" ]]; then
-    echo "Building $image_tag from Dockerfile $docker_file"
+    echo "Building $image_tag using the build definition from $docker_file"
     docker buildx build \
       --progress=plain \
       --no-cache \

--- a/docker/bin/build-uc-server-docker
+++ b/docker/bin/build-uc-server-docker
@@ -5,14 +5,14 @@ script_dir=$(dirname "$0")
 project_dir=$(dirname "$(dirname "$(realpath "$script_dir")")")
 docker_file="Dockerfile"
 container_name="unitycatalog"
-container_version=$(< "$project_dir/version.sbt" cut -d '"' -f2)
+container_version=$(cut -d '"' -f2 "$project_dir/version.sbt")
 image_tag=$container_name:$container_version
 
 echo "Changing directory to $project_dir"
 cd "$project_dir" || exit
 
 if [[ -r "$docker_file" ]]; then
-    echo "Building $image_tag from Dockerfile $docker_file"
+    echo "Building $image_tag using the build definition from $docker_file"
     docker buildx build \
       --progress=plain \
       --no-cache \

--- a/docker/bin/start-uc-server-docker
+++ b/docker/bin/start-uc-server-docker
@@ -3,27 +3,13 @@
 script_dir=$(dirname "$0")
 project_dir=$(dirname "$(dirname "$(realpath "$script_dir")")")
 container_name="unitycatalog"
-container_version=$(< "$project_dir/version.sbt" cut -d '"' -f2)
+container_version=$(cut -d '"' -f2 "$project_dir/version.sbt")
 
-container_details=$(docker container ls -a -q --filter "name=$container_name")
-container_running=$(docker ps -q --filter "name=$container_name")
-
-if [ -z "$container_details" ]; then
-    echo "Container $container_name does not exist. Creating it..."
-    docker run \
-       --tty \
-       --publish 8081:8081 \
-       --detach \
-       --name "$container_name" \
-       "$container_name:$container_version"
-else
-    if [ -n "$container_running" ]; then
-        echo "Container $container_name already running, skipping."
-    else
-        echo "Container $container_name already exists, starting it."
-        docker start $container_name
-    fi
-fi
-
-echo "The container $container_name is running with the following parameters:"
-docker ps --format '{{json .}}' | jq -r --arg CONTAINER_NAME "$container_name" 'select(.Names == $CONTAINER_NAME)'
+echo "❤️ Starting $container_name:$container_version."
+echo "💡 Use Ctrl+C to stop and remove the container."
+docker run \
+   --rm \
+   --tty \
+   --publish 8081:8081 \
+   --name "$container_name" \
+   "$container_name:$container_version"

--- a/docker/copy_jars_from_classpath.sh
+++ b/docker/copy_jars_from_classpath.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+JARS_DIR="server/target/jars"
+if [ "$1" != "" ]; then
+  JARS_DIR="$1"
+fi
+
+echo "Creating $JARS_DIR directory"
+mkdir -p "$JARS_DIR"
+
+ONE_SINGLE_CLASSPATH_LINE=$(< server/target/classpath)
+
+IFS=':' read -ra JARS <<< "$ONE_SINGLE_CLASSPATH_LINE"
+for jar_file in "${JARS[@]}"
+do
+  # -R recursively copies two classes directories into one classes output directory
+  # happily, -R works with files too
+  cp -R "$jar_file" "$JARS_DIR"
+done

--- a/uc-cli.dockerfile
+++ b/uc-cli.dockerfile
@@ -23,7 +23,7 @@ ARG cli_assembly_jar="${unitycatalog_repo}/${unitycatalog_jar}/unitycatalog-cli-
 # Building the Uber-Jar #
 #########################
 
-FROM eclipse-temurin:22-jdk-alpine AS assemble_cli
+FROM eclipse-temurin:17-jdk-alpine AS assemble_cli
 
 ARG unitycatalog_repo
 ARG sbt_args
@@ -50,7 +50,7 @@ RUN build/sbt ${sbt_args} cli/assembly
 # Running the UC server #
 #########################
 
-FROM eclipse-temurin:22-jre-alpine AS build_cli
+FROM eclipse-temurin:17-jdk-alpine AS build_cli
 
 ARG unitycatalog_uid
 ARG unitycatalog_home


### PR DESCRIPTION
This PR changes how the UC server docker image is built (uses the faster `sbt server/package`) and copies the jars required to start it (to `jars` directory).

After https://github.com/unitycatalog/unitycatalog/commit/4b7aaa319bfad76dde4d30c9fdd5128895bf98d1, I thought I'd work on changes that would make the behaviour of the UC server when started consistent regardless whether it's in or outside Docker container (namely the welcome message at the start and no warnings).

A Dockerized UC runs in the foreground and containers are removed once stopped.
