### PR TITLE
[SPARK] Support gcs reads using vended credentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,7 +398,7 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
       "org.antlr" % "antlr4-runtime" % "4.9.3",
       "org.antlr" % "antlr4" % "4.9.3",
-      "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2", // todo: compileOnly?
+      "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2" % Provided,
     ),
     libraryDependencies ++= Seq(
       // Test dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -398,6 +398,7 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
       "org.antlr" % "antlr4-runtime" % "4.9.3",
       "org.antlr" % "antlr4" % "4.9.3",
+      "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2", // todo: compileOnly?
     ),
     libraryDependencies ++= Seq(
       // Test dependencies

--- a/connectors/spark/etc/conf/server.properties
+++ b/connectors/spark/etc/conf/server.properties
@@ -8,3 +8,7 @@ s3.bucketPath.1=s3://test-bucket1
 s3.accessKey.1=accessKey1
 s3.secretKey.1=secretKey1
 s3.sessionToken.1=sessionToken1
+gcs.bucketPath.0=gs://test-bucket0
+gcs.jsonKeyFilePath.0=testing://0
+gcs.bucketPath.1=gs://test-bucket1
+gcs.jsonKeyFilePath.1=testing://1

--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/GcsVendedTokenProvider.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/GcsVendedTokenProvider.java
@@ -1,0 +1,36 @@
+package io.unitycatalog.connectors.spark;
+
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.time.Instant;
+
+public class GcsVendedTokenProvider implements AccessTokenProvider {
+    protected static final String ACCESS_TOKEN_KEY = "fs.gs.auth.access.token.credential";
+    protected static final String ACCESS_TOKEN_EXPIRATION_KEY = "fs.gs.auth.access.token.expiration";
+    private Configuration conf;
+
+    @Override
+    public AccessToken getAccessToken() {
+        return new AccessToken(
+                conf.get(ACCESS_TOKEN_KEY),
+                Instant.ofEpochMilli(Long.parseLong(conf.get(ACCESS_TOKEN_EXPIRATION_KEY)))
+        );
+    }
+
+    @Override
+    public void refresh() throws IOException {
+        throw new IOException("Temporary token, not refreshable");
+    }
+
+    @Override
+    public void setConf(Configuration configuration) {
+        conf = configuration;
+    }
+
+    @Override
+    public Configuration getConf() {
+        return conf;
+    }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/BaseSparkIntegrationTest.java
@@ -45,8 +45,9 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
               .config(catalogConf + ".uri", serverConfig.getServerUrl())
               .config(catalogConf + ".token", serverConfig.getAuthToken());
     }
-    // Use fake file system for s3:// so that we can test credentials.
-    builder.config("fs.s3.impl", CredentialTestFileSystem.class.getName());
+    // Use fake file system for cloud storage so that we can test credentials.
+    builder.config("fs.s3.impl", S3CredentialTestFileSystem.class.getName());
+    builder.config("fs.gs.impl", GCSCredentialTestFileSystem.class.getName());
     return builder.getOrCreate();
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/GCSCredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/GCSCredentialTestFileSystem.java
@@ -1,0 +1,32 @@
+package io.unitycatalog.connectors.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+public class GCSCredentialTestFileSystem extends CredentialTestFileSystem {
+  @Override
+  void checkCredentials(Path f) {
+    Configuration conf = getConf();
+    String host = f.toUri().getHost();
+    if (credentialCheckEnabled) {
+      if ("test-bucket0".equals(host)) {
+        assertThat(conf.get(GcsVendedTokenProvider.ACCESS_TOKEN_KEY)).isEqualTo("testing://0");
+        assertThat(conf.get(GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY))
+            .isEqualTo("253370790000000");
+      } else if ("test-bucket1".equals(host)) {
+        assertThat(conf.get(GcsVendedTokenProvider.ACCESS_TOKEN_KEY)).isEqualTo("testing://1");
+        assertThat(conf.get(GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY))
+            .isEqualTo("253370790000000");
+      } else {
+        throw new RuntimeException("invalid path: " + f);
+      }
+    }
+  }
+
+  @Override
+  String scheme() {
+    return "gs:";
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/S3CredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/S3CredentialTestFileSystem.java
@@ -1,0 +1,32 @@
+package io.unitycatalog.connectors.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+public class S3CredentialTestFileSystem extends CredentialTestFileSystem {
+  @Override
+  void checkCredentials(Path f) {
+    Configuration conf = getConf();
+    String host = f.toUri().getHost();
+    if (credentialCheckEnabled) {
+      if ("test-bucket0".equals(host)) {
+        assertThat(conf.get("fs.s3a.access.key")).isEqualTo("accessKey0");
+        assertThat(conf.get("fs.s3a.secret.key")).isEqualTo("secretKey0");
+        assertThat(conf.get("fs.s3a.session.token")).isEqualTo("sessionToken0");
+      } else if ("test-bucket1".equals(host)) {
+        assertThat(conf.get("fs.s3a.access.key")).isEqualTo("accessKey1");
+        assertThat(conf.get("fs.s3a.secret.key")).isEqualTo("secretKey1");
+        assertThat(conf.get("fs.s3a.session.token")).isEqualTo("sessionToken1");
+      } else {
+        throw new RuntimeException("invalid path: " + f);
+      }
+    }
+  }
+
+  @Override
+  String scheme() {
+    return "s3:";
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -25,6 +25,8 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TableReadWriteTest extends BaseSparkIntegrationTest {
 
@@ -100,16 +102,18 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  @Test
-  public void testCredentialParquet() throws ApiException, IOException {
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gs"})
+  public void testCredentialParquet(String scheme) throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
-    String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, PARQUET_TABLE);
+    String loc1 = scheme + "://test-bucket0" + generateTableLocation(SPARK_CATALOG, PARQUET_TABLE);
     setupExternalParquetTable(PARQUET_TABLE, loc1, new ArrayList<>(0));
     String t1 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + PARQUET_TABLE;
     testTableReadWrite(t1, session);
 
-    String loc2 = "s3://test-bucket1" + generateTableLocation(SPARK_CATALOG, ANOTHER_PARQUET_TABLE);
+    String loc2 =
+        scheme + "://test-bucket1" + generateTableLocation(SPARK_CATALOG, ANOTHER_PARQUET_TABLE);
     setupExternalParquetTable(ANOTHER_PARQUET_TABLE, loc2, new ArrayList<>(0));
     String t2 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + ANOTHER_PARQUET_TABLE;
     testTableReadWrite(t2, session);
@@ -125,16 +129,17 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Disabled("Ignoring test until Delta 3.2.1 is released.")
-  @Test
-  public void testCredentialDelta() throws ApiException, IOException {
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gs"})
+  public void testCredentialDelta(String scheme) throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
 
-    String loc0 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
+    String loc0 = scheme + "://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
     setupExternalDeltaTable(SPARK_CATALOG, DELTA_TABLE, loc0, new ArrayList<>(0), session);
     String t1 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     testTableReadWrite(t1, session);
 
-    String loc1 = "s3://test-bucket1" + generateTableLocation(CATALOG_NAME, DELTA_TABLE);
+    String loc1 = scheme + "://test-bucket1" + generateTableLocation(CATALOG_NAME, DELTA_TABLE);
     setupExternalDeltaTable(CATALOG_NAME, DELTA_TABLE, loc1, new ArrayList<>(0), session);
     String t2 = CATALOG_NAME + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     testTableReadWrite(t2, session);
@@ -150,11 +155,12 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Disabled("Ignoring test until Delta 3.2.1 is released.")
-  @Test
-  public void testDeleteDeltaTable() throws ApiException, IOException {
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gs"})
+  public void testDeleteDeltaTable(String scheme) throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
-    String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
+    String loc1 = scheme + "://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
     setupExternalDeltaTable(SPARK_CATALOG, DELTA_TABLE, loc1, new ArrayList<>(0), session);
     String t1 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     testTableReadWrite(t1, session);
@@ -167,16 +173,18 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Disabled("Ignoring test until Delta 3.2.1 is released.")
-  @Test
-  public void testMergeDeltaTable() throws ApiException, IOException {
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gs"})
+  public void testMergeDeltaTable(String scheme) throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
 
-    String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
+    String loc1 = scheme + "://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
     setupExternalDeltaTable(SPARK_CATALOG, DELTA_TABLE, loc1, new ArrayList<>(0), session);
     String t1 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     session.sql("INSERT INTO " + t1 + " SELECT 1, 'a'");
 
-    String loc2 = "s3://test-bucket1" + generateTableLocation(CATALOG_NAME, ANOTHER_DELTA_TABLE);
+    String loc2 =
+        scheme + "://test-bucket1" + generateTableLocation(CATALOG_NAME, ANOTHER_DELTA_TABLE);
     setupExternalDeltaTable(CATALOG_NAME, ANOTHER_DELTA_TABLE, loc2, new ArrayList<>(0), session);
     String t2 = CATALOG_NAME + "." + SCHEMA_NAME + "." + ANOTHER_DELTA_TABLE;
     session.sql("INSERT INTO " + t2 + " SELECT 2, 'b'");
@@ -192,11 +200,12 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Disabled("Ignoring test until Delta 3.2.1 is released.")
-  @Test
-  public void testUpdateDeltaTable() throws ApiException, IOException {
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "gs"})
+  public void testUpdateDeltaTable(String scheme) throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG);
 
-    String loc1 = "s3://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
+    String loc1 = scheme + "://test-bucket0" + generateTableLocation(SPARK_CATALOG, DELTA_TABLE);
     setupExternalDeltaTable(SPARK_CATALOG, DELTA_TABLE, loc1, new ArrayList<>(0), session);
     String t1 = SPARK_CATALOG + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     session.sql("INSERT INTO " + t1 + " SELECT 1, 'a'");

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileUtils.java
@@ -216,7 +216,7 @@ public class FileUtils {
     if (url == null) {
       return null;
     }
-    if (url.startsWith("s3://")) {
+    if (url.startsWith("s3://") || url.startsWith("gs://")) {
       return url;
     } else {
       return adjustFileUri(createURI(url)).toString();

--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -12,6 +12,7 @@ import com.google.common.base.CharMatcher;
 import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import java.net.URI;
+import java.sql.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +37,13 @@ public class GcpCredentialVendor {
 
     GoogleCredentials creds;
     if (serviceAccountKeyJsonFilePath != null && !serviceAccountKeyJsonFilePath.isEmpty()) {
+      if (serviceAccountKeyJsonFilePath.startsWith("testing://")) {
+        // allow pass-through of a dummy value for integration testing
+        return AccessToken.newBuilder()
+            .setTokenValue(serviceAccountKeyJsonFilePath)
+            .setExpirationTime(Date.valueOf("9999-01-01"))
+            .build();
+      }
       creds =
           ServiceAccountCredentials.fromStream(
               Files.localInput(serviceAccountKeyJsonFilePath).newStream());

--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -13,6 +13,7 @@ import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import java.net.URI;
 import java.sql.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class GcpCredentialVendor {
         // allow pass-through of a dummy value for integration testing
         return AccessToken.newBuilder()
             .setTokenValue(serviceAccountKeyJsonFilePath)
-            .setExpirationTime(Date.valueOf("9999-01-01"))
+            .setExpirationTime(Date.from(Instant.ofEpochMilli(253370790000000L)))
             .build();
       }
       creds =


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Updates the spark connector to support vended credentials for google cloud storage buckets.  

We use the `com.google.cloud.hadoop.util.AccessTokenProvider` interface to pass the vended credential properties stored in the hadoop conf -- see [google's gcs-connector documentation](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/7257fb4de55d83f14d4820fe00672b732d959987/gcs/CONFIGURATION.md#authentication) for more details. 

Example spark conf (assumes that the [gcs connector jar](https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v3.0.2/gcs-connector-3.0.2-shaded.jar) is included in the spark jars/packages as well):
```
spark.hadoop.fs.AbstractFileSystem.gs.impl 	com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS
spark.hadoop.fs.gs.auth.type 			ACCESS_TOKEN_PROVIDER
spark.hadoop.fs.gs.auth.access.token.provider 	io.unitycatalog.connectors.spark.GcsVendedTokenProvider
```


