### PR TITLE
add condition for listing objects in gcs cred downscoping

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -69,10 +69,21 @@ public class GcpCredentialVendor {
 
               String resource =
                   format("//storage.googleapis.com/projects/_/buckets/%s", locationUri.getHost());
-              String expr =
+
+              // for reading/writing objects
+              String resourceNameStartsWithExpr =
                   format(
                       "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
                       locationUri.getHost(), path);
+
+              // for listing objects
+              String objectListPrefixStartsWithExpr =
+                  format(
+                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s')",
+                      path);
+
+              String combinedExpr =
+                  resourceNameStartsWithExpr + " || " + objectListPrefixStartsWithExpr;
 
               boundaryBuilder.addRule(
                   CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
@@ -80,7 +91,7 @@ public class GcpCredentialVendor {
                       .setAvailabilityCondition(
                           CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition
                               .newBuilder()
-                              .setExpression(expr)
+                              .setExpression(combinedExpr)
                               .build())
                       .setAvailableResource(resource)
                       .build());


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

UC Spark Connector uses hadoop fs which does bucket/directory listings. This adds a condition to the credential access boundary in the GCS cred downscoping to allow listing objects on the prefix that is the table path.
