### PR TITLE
strip trailing slash from downscoped path for Azure vended credential

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
@@ -63,8 +63,10 @@ public class AzureCredentialVendor {
     // azure supports only downscoping to a single location for now
     // azure wants only the path
     String path = URI.create(context.getLocations().get(0)).getPath();
-    // remove any preceding forward slashes
-    path = path.replaceAll("^/+", "");
+    // remove any preceding forward slashes or trailing forward slashes
+    // hadoop ABFS strips trailing slash when preforming some operations so we need to vend
+    // a cred for path without trailing slash
+    path = path.replaceAll("^/+|/*$", "");
 
     String sasToken =
         new DataLakeSasImplUtil(sasSignatureValues, locationParts.container(), path, true)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Azure Hadoop FS strips trailing slash when performing operations, so in order to make that work we need to vend a credential for the table path without a trailing slash.
