### PR TITLE
Fix the `/self` endpoint.

### DIFF
--- a/examples/cli/src/test/java/io/unitycatalog/cli/auth/CliAuthCrudTest.java
+++ b/examples/cli/src/test/java/io/unitycatalog/cli/auth/CliAuthCrudTest.java
@@ -86,6 +86,8 @@ public class CliAuthCrudTest extends BaseAuthCRUDTest {
           JsonNode localResultJson = executeCLICommand(localArgs);
         });
 
+    serverConfig.setAuthToken(token);
+
     // Test adding a user
     List<String> argsAddUser =
         List.of("user", "create", "--email", "test@localhost", "--name", "Test User");
@@ -112,7 +114,12 @@ public class CliAuthCrudTest extends BaseAuthCRUDTest {
   }
 
   @Test
-  public void testUserCrud() {
+  public void testUserCrud() throws IOException {
+    // Test with Authentication on authenticated end point
+    Path path = Path.of("etc", "conf", "token.txt");
+    String token = Files.readString(path);
+
+    serverConfig.setAuthToken(token);
     // Test creating a user
     List<String> argsAddUser =
         List.of("user", "create", "--email", "user@localhost", "--name", "Test User");
@@ -161,5 +168,7 @@ public class CliAuthCrudTest extends BaseAuthCRUDTest {
     args = addServerAndAuthParams(argsDeleteUser, serverConfig);
     responseJsonInfo = executeCLICommand(args);
     assertNotNull(responseJsonInfo);
+
+    serverConfig.setAuthToken("");
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -161,6 +161,10 @@ public class UnityCatalogServer {
       ExceptionHandlingDecorator exceptionDecorator =
           new ExceptionHandlingDecorator(new GlobalExceptionHandler());
       sb.routeDecorator().pathPrefix(basePath).build(authDecorator);
+      sb.routeDecorator()
+          .pathPrefix(controlPath)
+          .exclude(controlPath + "auth/tokens")
+          .build(authDecorator);
       sb.decorator(exceptionDecorator);
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
@@ -129,10 +129,15 @@ public class Scim2UserService {
   @Produces("application/scim+json")
   @StatusCode(200)
   public UserResource getCurrentUser() {
+    // TODO: will make this a util method in the access control PR
     ServiceRequestContext ctx = ServiceRequestContext.current();
     DecodedJWT decodedJWT = ctx.attr(AuthDecorator.DECODED_JWT_ATTR);
-    Claim sub = decodedJWT.getClaim("sub");
-    return asUserResource(USER_REPOSITORY.getUserByEmail(sub.asString()));
+    if (decodedJWT != null) {
+      Claim sub = decodedJWT.getClaim("sub");
+      return asUserResource(USER_REPOSITORY.getUserByEmail(sub.asString()));
+    } else {
+      throw new Scim2RuntimeException(new BadRequestException("No user found."));
+    }
   }
 
   @Get("/{id}")


### PR DESCRIPTION
Add some checking in currentUser() for the token before accessing it.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The `/self` endpoint relies on the acess-token JWT being in the request context. In order to do that, it needs to be intercepted by the `AuthDecorator` first, so adding that to the request pipeline, excluding `auth/tokens` which should be open.

Also made some changes to `/self` to make sure it found the token before trying to access it.

And the token exchange verifies the incoming token subject is in the user database.

Issue https://github.com/unitycatalog/unitycatalog/issues/429