### PR TITLE
Fixing build.sbt to generate controlApi jar 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -543,7 +543,7 @@ lazy val spark = (project in file("connectors/spark"))
   )
 
 lazy val root = (project in file("."))
-  .aggregate(serverModels, client, server, cli, spark)
+  .aggregate(serverModels, client, server, cli, spark, controlApi, controlModels, apiDocs)
   .settings(
     name := s"$artifactNamePrefix",
     createTarballSettings(),


### PR DESCRIPTION
Fixing the build.sbt file to generate the controlApi jar. 

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR modifies the .root aggregate method in the build.sbt file to enable the generation of additional JAR files. These changes were necessary because `build/sbt clean package publishLocal spark/publishLocal` command which was used to generate the spark connector jar had a dependency on the controlAPi jar.
