### PR TITLE
[SPARK] Workaround for read_write credential

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -149,12 +149,23 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
     }.toArray
     val uri = CatalogUtils.stringToURI(t.getStorageLocation)
     val tableId = t.getTableId
-    val temporaryCredentials = temporaryTableCredentialsApi
-      .generateTemporaryTableCredentials(
-        // TODO: at this time, we don't know if the table will be read or written. We should get
-        //       credential in a later phase.
-        new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ_WRITE)
-      )
+    val temporaryCredentials = {
+      try {
+        temporaryTableCredentialsApi
+          .generateTemporaryTableCredentials(
+            // TODO: at this time, we don't know if the table will be read or written. For now we always
+            //       request READ credentials as the server doesn't distinguish between READ and
+            //       READ_WRITE credentials as of today. When loading a table, Spark should tell if it's
+            //       for read or write, we can request the proper credential after fixing Spark.
+            new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ_WRITE)
+          )
+      } catch {
+        case e: ApiException => temporaryTableCredentialsApi
+          .generateTemporaryTableCredentials(
+            new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ)
+          )
+      }
+    }
     val extraSerdeProps = if (uri.getScheme == "s3") {
       val awsCredentials = temporaryCredentials.getAwsTempCredentials
       Map(

--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -154,7 +154,7 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
         temporaryTableCredentialsApi
           .generateTemporaryTableCredentials(
             // TODO: at this time, we don't know if the table will be read or written. For now we always
-            //       request READ credentials as the server doesn't distinguish between READ and
+            //       request READ_WRITE credentials as the server doesn't distinguish between READ and
             //       READ_WRITE credentials as of today. When loading a table, Spark should tell if it's
             //       for read or write, we can request the proper credential after fixing Spark.
             new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ_WRITE)


### PR DESCRIPTION
at this time, we don't know if the table will be read or written. For now we always equest READ credentials as the server doesn't distinguish between READ and READ_WRITE credentials as of today. When loading a table, Spark should tell if it's for read or write, we can request the proper credential after fixing Spark.