### PR TITLE
Permission  for GH token to publish swagger GH pages

### DIFF
--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Prepare deployment directory for Swagger UI
         run: |
             set +x
-            mkdir docs
+            ls -ltr  ./swagger-ui
+            mkdir -p ./docs
             mv ./swagger-ui/* ./docs/
             ls -ltr  ./docs
 

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -19,9 +19,14 @@ jobs:
           output: ./swagger-ui/swagger-docs
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare deployment directory for Swagger UI
+          run: |
+            mkdir -p swagger-docs
+            mv swagger-ui/* ./swagger-docs/
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./swagger-ui/swagger-docs
+          publish_dir: ./swagger-docs
           keep_files: true

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -20,7 +20,7 @@ jobs:
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI
-          run: |
+        run: |
             mkdir -p swagger-docs
             mv swagger-ui/* ./swagger-docs/
 

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -3,7 +3,7 @@ name: Publish Swagger Docs
 on:
   push:
     branches:
-      - temp
+      - main
 
 jobs:
   build:

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -21,13 +21,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI
         run: |
-            mkdir -p swagger-docs
-            mv swagger-ui/* ./swagger-docs/
-            touch ./swagger-docs/.nojekyll
+            mkdir -p docs
+            mv swagger-ui/* ./docs/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./swagger-docs
+          publish_dir: ./docs
           keep_files: true

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,12 +16,13 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: ./swagger-ui
+          output: swagger-ui
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI
         run: |
-            mkdir -p docs
+            set +x
+            mkdir -p ./docs
             mv swagger-ui/* ./docs/
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: swagger-ui
+          keep_files: true

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
       - uses: actions/checkout@v4
       - name: Generate Swagger UI

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
             mkdir -p swagger-docs
             mv swagger-ui/* ./swagger-docs/
+            touch swagger-docs/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,21 +16,17 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: ./swagger-ui/
+          output: ./swagger-ui/swagger-docs
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI
         run: |
-            set +x
-            ls -ltr  ./swagger-ui
-            mkdir -p ./docs
-            mv ./swagger-ui/* ./docs/
-            ls -ltr  ./docs
+            mkdir -p swagger-docs
+            mv swagger-ui/* ./swagger-docs/
 
       - name: Deploy to GitHub Pages
-
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./swagger-docs
           keep_files: true

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: swagger-ui
+          output: ./swagger-ui/swagger-docs
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: swagger-ui
+          publish_dir: ./swagger-ui/swagger-docs
           keep_files: true

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             mkdir -p swagger-docs
             mv swagger-ui/* ./swagger-docs/
-            touch swagger-docs/.nojekyll
+            touch ./swagger-docs/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -3,7 +3,7 @@ name: Publish Swagger Docs
 on:
   push:
     branches:
-      - main
+      - temp
 
 jobs:
   build:

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,15 +16,15 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: swagger-ui
+          output: ./swagger-ui/
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI
         run: |
             set +x
-            mkdir -p ./docs
-            mv swagger-ui/* ./docs/
-            ls -ltr  .
+            mkdir docs
+            mv ./swagger-ui/* ./docs/
+            ls -ltr  ./docs
 
       - name: Deploy to GitHub Pages
 

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: ./swagger-ui/swagger-docs
+f          output: ./swagger-ui
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
-f          output: ./swagger-ui
+          output: ./swagger-ui
           spec-file: ./api/all.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare deployment directory for Swagger UI

--- a/.github/workflows/publish-swagger-docs.yml
+++ b/.github/workflows/publish-swagger-docs.yml
@@ -24,8 +24,10 @@ jobs:
             set +x
             mkdir -p ./docs
             mv swagger-ui/* ./docs/
+            ls -ltr  .
 
       - name: Deploy to GitHub Pages
+
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
By default, the `GITHUB_TOKEN` used in GitHub Actions has read-only access to the repository. However, publishing to GitHub Pages requires write permissions to create and update the `gh-pages` branch.

This PR addresses the permission issue by explicitly granting the necessary write permissions to the GitHub Actions workflow.

Changes Made
- Added `permissions` configuration to the workflow file
- Specified `contents: write`  and `pages: write`  to allow modification of repository contents
- This change enables the creation and updating of the `gh-pages` branch
