### PR TITLE
docs: remove redundant publish cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Unity Catalog can be built using [sbt](https://www.scala-sbt.org/).
 To build UC (incl. [Spark Integration](./connectors/spark) module), run the following command:
 
 ```shell
-build/sbt clean package publishLocal spark/publishLocal
+build/sbt clean package publishLocal
 ```
 
 Refer to [sbt docs](https://www.scala-sbt.org/1.x/docs/) for more commands.

--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -14,7 +14,7 @@ This document walks through how to use [PuppyGraph](https://www.puppygraph.com) 
 Run the command From the cloned repository root directory
 
 ```shell
-build/sbt clean package publishLocal spark/publishLocal
+build/sbt clean package publishLocal
 ```
 
 ## Run the Unity Catalog Server


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Tiny docs update: 
`build/sbt clean package publishLocal` covers the spark subproject (and others), so adding a specific `spark/publishLocal` is not necessary