### PR TITLE
enable Delta tests and fix gs/abfs credential

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,8 @@ lazy val commonSettings = Seq(
     "org.apache.logging.log4j" % "log4j-api" % "2.23.1"
   ),
   resolvers += Resolver.mavenLocal,
+  resolvers += "Apache Spark 3.5.3 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1467/",
+  resolvers += "Delta 3.2.1 Staging" at "https://oss.sonatype.org/content/repositories/iodelta-1167",
   autoScalaLibrary := false,
   crossPaths := false,  // No scala cross building
   assembly / assemblyMergeStrategy := {
@@ -473,7 +475,7 @@ lazy val serverShaded = (project in file("server-shaded"))
     }
   )
 
-val sparkVersion = "3.5.1"
+val sparkVersion = "3.5.3"
 lazy val spark = (project in file("connectors/spark"))
   .dependsOn(client)
   .settings(
@@ -507,7 +509,7 @@ lazy val spark = (project in file("connectors/spark"))
       "org.mockito" % "mockito-junit-jupiter" % "5.12.0" % Test,
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
       "org.apache.hadoop" % "hadoop-client-runtime" % "3.4.0",
-      "io.delta" %% "delta-spark" % "3.2.0" % Test,
+      "io.delta" %% "delta-spark" % "3.2.1" % Test,
     ),
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val commonSettings = Seq(
     "org.apache.logging.log4j" % "log4j-api" % "2.23.1"
   ),
   resolvers += Resolver.mavenLocal,
+  // TODO: remove the following two resolvers once the official releases are out
   resolvers += "Apache Spark 3.5.3 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1467/",
   resolvers += "Delta 3.2.1 Staging" at "https://oss.sonatype.org/content/repositories/iodelta-1167",
   autoScalaLibrary := false,

--- a/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/connectors/spark/UCSingleCatalog.scala
@@ -181,7 +181,8 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
       val gcsCredentials = temporaryCredentials.getGcpOauthToken
       Map(
         GcsVendedTokenProvider.ACCESS_TOKEN_KEY -> gcsCredentials.getOauthToken,
-        GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY -> temporaryCredentials.getExpirationTime.toString
+        GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY -> temporaryCredentials.getExpirationTime.toString,
+        "fs.gs.impl.disable.cache" -> "true"
       )
     } else if (uri.getScheme == "abfs" || uri.getScheme == "abfss") {
       val azCredentials = temporaryCredentials.getAzureUserDelegationSas
@@ -190,6 +191,8 @@ private class UCProxy extends TableCatalog with SupportsNamespaces {
         FS_AZURE_ACCOUNT_IS_HNS_ENABLED -> "true",
         FS_AZURE_SAS_TOKEN_PROVIDER_TYPE -> "io.unitycatalog.connectors.spark.AbfsVendedTokenProvider",
         AbfsVendedTokenProvider.ACCESS_TOKEN_KEY -> azCredentials.getSasToken,
+        "fs.abfs.impl.disable.cache" -> "true",
+        "fs.abfss.impl.disable.cache" -> "true"
       )
     } else {
       Map.empty

--- a/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/connectors/spark/TableReadWriteTest.java
@@ -128,7 +128,6 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  @Disabled("Ignoring test until Delta 3.2.1 is released.")
   @ParameterizedTest
   @ValueSource(strings = {"s3", "gs", "abfs"})
   public void testCredentialDelta(String scheme) throws ApiException, IOException {
@@ -154,7 +153,6 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  @Disabled("Ignoring test until Delta 3.2.1 is released.")
   @ParameterizedTest
   @ValueSource(strings = {"s3", "gs", "abfs"})
   public void testDeleteDeltaTable(String scheme) throws ApiException, IOException {
@@ -172,7 +170,6 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  @Disabled("Ignoring test until Delta 3.2.1 is released.")
   @ParameterizedTest
   @ValueSource(strings = {"s3", "gs", "abfs"})
   public void testMergeDeltaTable(String scheme) throws ApiException, IOException {
@@ -199,7 +196,6 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  @Disabled("Ignoring test until Delta 3.2.1 is released.")
   @ParameterizedTest
   @ValueSource(strings = {"s3", "gs", "abfs"})
   public void testUpdateDeltaTable(String scheme) throws ApiException, IOException {
@@ -228,8 +224,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(tables[0].getString(1)).isEqualTo(PARQUET_TABLE);
 
     assertThatThrownBy(() -> session.sql("SHOW TABLES in a.b.c").collect())
-        .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining("a.b.c");
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Nested namespaces are not supported");
 
     session.stop();
   }
@@ -243,7 +239,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.sql("DROP TABLE " + fullName).collect();
     assertFalse(session.catalog().tableExists(fullName));
     assertThatThrownBy(() -> session.sql("DROP TABLE a.b.c.d").collect())
-        .isInstanceOf(AnalysisException.class);
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Invalid table name");
     session.stop();
   }
 
@@ -284,8 +281,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     session.stop();
   }
 
-  // TODO: enable the test after the new Delta release.
-  // @Test
+  @Test
   public void testCreateExternalDeltaTable() throws ApiException, IOException {
     SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
     String path1 = generateTableLocation(SPARK_CATALOG, DELTA_TABLE);


### PR DESCRIPTION
**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
Use the Delta 3.2.1 RC so that these ignored Delta tests can be enabled. Also fixes the gs/abfs credential support in the Delta tests, by disabling the file system cache, the same as we did for s3.