### PR TITLE
docs: fix Daft integration guide

### DIFF
--- a/docs/integrations/unity-catalog-daft.md
+++ b/docs/integrations/unity-catalog-daft.md
@@ -9,7 +9,7 @@ This page shows you how to use Unity Catalog with Daft.
 To start, install Daft with the extra Unity Catalog dependencies using:
 
 ```sh
-pip install -U "getdaft[unity]"
+pip install -U "getdaft[unity,deltalake]"
 ```
 
 Then import Daft and the `UnityCatalog` abstraction:
@@ -76,10 +76,10 @@ unity_table = unity.load_table("unity.default.numbers")
 
 Unity Catalog tables are stored in the Delta Lake format.
 
-Simply read your table using the Daft `read_delta_lake` method:
+Simply read your table using the Daft `read_deltalake` method:
 
 ```python
-> df = daft.read_delta_lake(unity_table)
+> df = daft.read_deltalake(unity_table)
 > df.show()
 
 as_int  as_double


### PR DESCRIPTION
**Description of changes**

Updates the documentation around integration with Daft so that the guide can be followed without running into errors.

- `daft.read_delta_lake` does not exist, the right API is `daft.read_deltalake` (see the related Daft docs [here](https://www.getdaft.io/projects/docs/en/latest/api_docs/doc_gen/io_functions/daft.read_deltalake.html#daft.read_deltalake))
- Daft must be installed including extras `unity` and `deltalake`, otherwise `daft.read_deltalake` will raise `ModuleNotFoundError`
