### PR TITLE
Add h/help option for unity catalog server

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -44,18 +44,12 @@ import io.unitycatalog.server.service.credential.CredentialOperations;
 import io.unitycatalog.server.service.iceberg.FileIOFactory;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
+import io.unitycatalog.server.utils.OptionParser;
 import io.unitycatalog.server.utils.RESTObjectMapper;
 import io.unitycatalog.server.utils.VersionUtils;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,46 +202,16 @@ public class UnityCatalogServer {
   }
 
   public static void main(String[] args) {
-    int port = 8080;
-    Options options = new Options();
-    options.addOption(
-        Option.builder("p")
-            .longOpt("port")
-            .hasArg()
-            .desc("Port number to run the server on. Default is 8080.")
-            .type(Integer.class)
-            .build());
-    options.addOption(
-        Option.builder("v")
-            .longOpt("version")
-            .hasArg(false)
-            .desc("Display the version of the Unity Catalog server")
-            .build());
-    CommandLineParser parser = new DefaultParser();
-    try {
-      CommandLine cmd = parser.parse(options, args);
-      if (cmd.hasOption("v")) {
-        System.out.println(VersionUtils.VERSION);
-        return;
-      }
-      if (cmd.hasOption("p")) {
-        port = cmd.getParsedOptionValue("p");
-      }
-    } catch (ParseException e) {
-      System.out.println();
-      System.out.println("Parsing Failed. Reason: " + e.getMessage());
-      System.out.println();
-      HelpFormatter formatter = new HelpFormatter();
-      formatter.printHelp("bin/start-uc-server", options);
-      return;
-    }
+    OptionParser options = new OptionParser();
+    options.parse(args);
     // Start Unity Catalog server
-    UnityCatalogServer unityCatalogServer = new UnityCatalogServer(port + 1);
+    UnityCatalogServer unityCatalogServer = new UnityCatalogServer(options.getPort() + 1);
     unityCatalogServer.printArt();
     unityCatalogServer.start();
     // Start URL transcoder
     Vertx vertx = Vertx.vertx();
-    Verticle transcodeVerticle = new URLTranscoderVerticle(port, port + 1);
+    Verticle transcodeVerticle =
+        new URLTranscoderVerticle(options.getPort(), options.getPort() + 1);
     vertx.deployVerticle(transcodeVerticle);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/OptionParser.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/OptionParser.java
@@ -1,0 +1,68 @@
+package io.unitycatalog.server.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.cli.*;
+
+@Setter
+@Getter
+public class OptionParser {
+  private int port = 8080;
+
+  private final Options options = new Options();
+
+  public OptionParser() {
+    options.addOption(
+        Option.builder("p")
+            .longOpt("port")
+            .hasArg()
+            .desc("Port number to run the server on. Default is 8080.")
+            .type(Integer.class)
+            .build());
+    options.addOption(
+        Option.builder("v")
+            .longOpt("version")
+            .hasArg(false)
+            .desc("Display the version of the Unity Catalog server")
+            .build());
+    options.addOption("h", "help", false, "Print help message.");
+  }
+
+  private void printHelpAndExit(int code) {
+    new HelpFormatter().printHelp("bin/start-uc-server", options);
+    exit(code);
+  }
+
+  @VisibleForTesting
+  protected void exit(int code) {
+    System.exit(code);
+  }
+
+  /**
+   * Parse the command line arguments
+   *
+   * @param args the command line arguments
+   */
+  public void parse(String[] args) {
+    CommandLineParser parser = new DefaultParser();
+    try {
+      CommandLine cmd = parser.parse(options, args);
+      if (cmd.hasOption("h")) {
+        printHelpAndExit(0);
+      }
+      if (cmd.hasOption("v")) {
+        System.out.println(VersionUtils.VERSION);
+        exit(0);
+      }
+      if (cmd.hasOption("p")) {
+        setPort(cmd.getParsedOptionValue("p"));
+      }
+    } catch (ParseException e) {
+      System.out.println();
+      System.out.println("Parsing Failed. Reason: " + e.getMessage());
+      System.out.println();
+      printHelpAndExit(-1);
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/OptionParserTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/OptionParserTest.java
@@ -1,0 +1,78 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OptionParserTest {
+
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+  @Setter
+  @Getter
+  class NoExitOptionsParser extends OptionParser {
+    int exitCode = -128;
+
+    @Override
+    protected void exit(int code) {
+      setExitCode(code);
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    System.setOut(new PrintStream(out));
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.setOut(System.out);
+  }
+
+  @Test
+  void testParseCLIOptions() {
+    OptionParser optionParser = new OptionParser();
+    optionParser.parse(new String[] {"-p", "8081"});
+    assertThat(optionParser.getPort()).isEqualTo(8081);
+  }
+
+  @Test
+  void testParseCLIOptionsWithVersion() {
+    NoExitOptionsParser optionParser = new NoExitOptionsParser();
+    optionParser.parse(new String[] {"-v"});
+    assertThat(optionParser.getExitCode()).isEqualTo(0);
+    assertThat(out.toString().trim()).isEqualTo(VersionUtils.VERSION);
+  }
+
+  private void verifyHelpMessage() {
+    assertThat(out.toString()).contains("bin/start-uc-server");
+    assertThat(out.toString())
+        .contains("-p,--port <arg>   Port number to run the server on. Default is 8080.");
+    assertThat(out.toString())
+        .contains("-v,--version      Display the version of the Unity Catalog server");
+    assertThat(out.toString()).contains("-h,--help         Print help message.");
+  }
+
+  @Test
+  void testParseCLIOptionsWithHelp() {
+    NoExitOptionsParser optionParser = new NoExitOptionsParser();
+    optionParser.parse(new String[] {"-h"});
+    assertThat(optionParser.getExitCode()).isEqualTo(0);
+    verifyHelpMessage();
+  }
+
+  @Test
+  void testParseCLIOptionsWithInvalidOption() {
+    NoExitOptionsParser optionParser = new NoExitOptionsParser();
+    optionParser.parse(new String[] {"-x"});
+    assertThat(optionParser.getExitCode()).isEqualTo(-1);
+    assertThat(out.toString()).contains("Parsing Failed. Reason: Unrecognized option: -x");
+    verifyHelpMessage();
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR adds `h/help` option for `bin/start-uc-server` to print the usage guide

```
 bin/start-uc-server -v
0.2.0-SNAPSHOT
  bin/start-uc-server -h
usage: bin/start-uc-server
 -h,--help         Print help message.
 -p,--port <arg>   Port number to run the server on. Default is 8080.
 -v,--version      Display the version of the Unity Catalog server
```

