### PR TITLE
docs: typo fix in UI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,11 @@ To quit DuckDB, press `Ctrl`+`D` (if your platform supports it), press `Ctrl`+`C
 To use the Unity Catalog UI, start a new terminal and ensure you have already started the UC server (e.g., `./bin/start-uc-server`)
 
 ```
-cd /ui
+cd ui/
 yarn install
 yarn start
 open localhost:3000
 ```
-
-
 
 ## CLI tutorial
 


### PR DESCRIPTION
typo fix in UI instruction + clarification that `yarn start` will automatically open browser window