### PR TITLE
Add access control to temporary credentials endpoints.

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -140,9 +140,9 @@ public class UnityCatalogServer {
     TemporaryTableCredentialsService temporaryTableCredentialsService =
         new TemporaryTableCredentialsService(credentialOperations);
     TemporaryVolumeCredentialsService temporaryVolumeCredentialsService =
-        new TemporaryVolumeCredentialsService(credentialOperations);
+        new TemporaryVolumeCredentialsService(authorizer, credentialOperations);
     TemporaryModelVersionCredentialsService temporaryModelVersionCredentialsService =
-        new TemporaryModelVersionCredentialsService(credentialOperations);
+        new TemporaryModelVersionCredentialsService(authorizer, credentialOperations);
     TemporaryPathCredentialsService temporaryPathCredentialsService =
         new TemporaryPathCredentialsService(credentialOperations);
     sb.service("/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"))

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -138,7 +138,7 @@ public class UnityCatalogServer {
     ModelService modelService = new ModelService(authorizer);
     // TODO: combine these into a single service in a follow-up PR
     TemporaryTableCredentialsService temporaryTableCredentialsService =
-        new TemporaryTableCredentialsService(credentialOperations);
+        new TemporaryTableCredentialsService(authorizer, credentialOperations);
     TemporaryVolumeCredentialsService temporaryVolumeCredentialsService =
         new TemporaryVolumeCredentialsService(authorizer, credentialOperations);
     TemporaryModelVersionCredentialsService temporaryModelVersionCredentialsService =

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/KeyMapperUtil.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/KeyMapperUtil.java
@@ -1,0 +1,181 @@
+package io.unitycatalog.server.auth.decorator;
+
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.FUNCTION;
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+import static io.unitycatalog.server.model.SecurableType.TABLE;
+import static io.unitycatalog.server.model.SecurableType.VOLUME;
+
+import io.unitycatalog.server.model.CatalogInfo;
+import io.unitycatalog.server.model.FunctionInfo;
+import io.unitycatalog.server.model.RegisteredModelInfo;
+import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.SecurableType;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.VolumeInfo;
+import io.unitycatalog.server.persist.CatalogRepository;
+import io.unitycatalog.server.persist.FunctionRepository;
+import io.unitycatalog.server.persist.MetastoreRepository;
+import io.unitycatalog.server.persist.ModelRepository;
+import io.unitycatalog.server.persist.SchemaRepository;
+import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.VolumeRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class KeyMapperUtil {
+  public static Map<SecurableType, Object> mapResourceKeys(
+      Map<SecurableType, Object> resourceKeys) {
+    Map<SecurableType, Object> resourceIds = new HashMap<>();
+
+    if (resourceKeys.containsKey(CATALOG)
+        && resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(TABLE)) {
+      String fullName =
+          resourceKeys.get(CATALOG)
+              + "."
+              + resourceKeys.get(SCHEMA)
+              + "."
+              + resourceKeys.get(TABLE);
+      TableInfo table = TableRepository.getInstance().getTable(fullName);
+      resourceIds.put(TABLE, UUID.fromString(table.getTableId()));
+    }
+
+    // If only TABLE is specified, assuming its value is a full table name (including catalog and
+    // schema)
+    if (!resourceKeys.containsKey(CATALOG)
+        && !resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(TABLE)) {
+      String fullName = (String) resourceKeys.get(TABLE);
+      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
+      TableInfo table =
+          fullName.contains(".")
+              ? TableRepository.getInstance().getTable(fullName)
+              : TableRepository.getInstance().getTableById(fullName);
+      String fullSchemaName = table.getCatalogName() + "." + table.getSchemaName();
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(table.getCatalogName());
+      resourceIds.put(TABLE, UUID.fromString(table.getTableId()));
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(CATALOG)
+        && resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(VOLUME)) {
+      String fullName =
+          resourceKeys.get(CATALOG)
+              + "."
+              + resourceKeys.get(SCHEMA)
+              + "."
+              + resourceKeys.get(VOLUME);
+      VolumeInfo volume = VolumeRepository.getInstance().getVolume(fullName);
+      resourceIds.put(VOLUME, UUID.fromString(volume.getVolumeId()));
+    }
+
+    // If only VOLUME is specified, assuming its value is a full volume name (including catalog and
+    // schema)
+    if (!resourceKeys.containsKey(CATALOG)
+        && !resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(VOLUME)) {
+      String fullName = (String) resourceKeys.get(VOLUME);
+      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
+      VolumeInfo volume =
+          (fullName.contains("."))
+              ? VolumeRepository.getInstance().getVolume(fullName)
+              : VolumeRepository.getInstance().getVolumeById(fullName);
+      String fullSchemaName = volume.getCatalogName() + "." + volume.getSchemaName();
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(volume.getCatalogName());
+      resourceIds.put(VOLUME, UUID.fromString(volume.getVolumeId()));
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(CATALOG)
+        && resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(FUNCTION)) {
+      String fullName =
+          resourceKeys.get(CATALOG)
+              + "."
+              + resourceKeys.get(SCHEMA)
+              + "."
+              + resourceKeys.get(FUNCTION);
+      FunctionInfo function = FunctionRepository.getInstance().getFunction(fullName);
+      resourceIds.put(FUNCTION, UUID.fromString(function.getFunctionId()));
+    }
+
+    // If only FUNCTION is specified, assuming its value is a full volume name (including catalog
+    // and schema)
+    if (!resourceKeys.containsKey(CATALOG)
+        && !resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(FUNCTION)) {
+      String fullName = (String) resourceKeys.get(FUNCTION);
+      FunctionInfo function = FunctionRepository.getInstance().getFunction(fullName);
+      String fullSchemaName = function.getCatalogName() + "." + function.getSchemaName();
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(function.getCatalogName());
+      resourceIds.put(FUNCTION, UUID.fromString(function.getFunctionId()));
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(CATALOG)
+        && resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(REGISTERED_MODEL)) {
+      String fullName =
+          resourceKeys.get(CATALOG)
+              + "."
+              + resourceKeys.get(SCHEMA)
+              + "."
+              + resourceKeys.get(REGISTERED_MODEL);
+      RegisteredModelInfo model = ModelRepository.getInstance().getRegisteredModel(fullName);
+      resourceIds.put(REGISTERED_MODEL, UUID.fromString(model.getId()));
+    }
+
+    // If only REGISTERED_MODEL is specified, assuming its value is a full volume name (including
+    // catalog and schema)
+    if (!resourceKeys.containsKey(CATALOG)
+        && !resourceKeys.containsKey(SCHEMA)
+        && resourceKeys.containsKey(REGISTERED_MODEL)) {
+      String fullName = (String) resourceKeys.get(REGISTERED_MODEL);
+      RegisteredModelInfo model = ModelRepository.getInstance().getRegisteredModel(fullName);
+      String fullSchemaName = model.getCatalogName() + "." + model.getSchemaName();
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(model.getCatalogName());
+      resourceIds.put(REGISTERED_MODEL, UUID.fromString(model.getId()));
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA)) {
+      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA);
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullName);
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+    }
+
+    // if only SCHEMA is specified, assuming its value is a full schema name (including catalog)
+    if (!resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA)) {
+      String fullName = (String) resourceKeys.get(SCHEMA);
+      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullName);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(schema.getCatalogName());
+      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(CATALOG)) {
+      String fullName = (String) resourceKeys.get(CATALOG);
+      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(fullName);
+      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
+    }
+
+    if (resourceKeys.containsKey(METASTORE)) {
+      resourceIds.put(METASTORE, MetastoreRepository.getInstance().getMetastoreId());
+    }
+
+    return resourceIds;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -18,20 +18,7 @@ import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeKeys;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.model.CatalogInfo;
-import io.unitycatalog.server.model.FunctionInfo;
-import io.unitycatalog.server.model.RegisteredModelInfo;
-import io.unitycatalog.server.model.SchemaInfo;
 import io.unitycatalog.server.model.SecurableType;
-import io.unitycatalog.server.model.TableInfo;
-import io.unitycatalog.server.model.VolumeInfo;
-import io.unitycatalog.server.persist.CatalogRepository;
-import io.unitycatalog.server.persist.FunctionRepository;
-import io.unitycatalog.server.persist.MetastoreRepository;
-import io.unitycatalog.server.persist.ModelRepository;
-import io.unitycatalog.server.persist.SchemaRepository;
-import io.unitycatalog.server.persist.TableRepository;
-import io.unitycatalog.server.persist.VolumeRepository;
 import io.unitycatalog.server.utils.IdentityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,13 +37,6 @@ import java.util.UUID;
 import static io.unitycatalog.server.auth.decorator.KeyLocator.Source.PARAM;
 import static io.unitycatalog.server.auth.decorator.KeyLocator.Source.PAYLOAD;
 import static io.unitycatalog.server.auth.decorator.KeyLocator.Source.SYSTEM;
-import static io.unitycatalog.server.model.SecurableType.CATALOG;
-import static io.unitycatalog.server.model.SecurableType.FUNCTION;
-import static io.unitycatalog.server.model.SecurableType.METASTORE;
-import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
-import static io.unitycatalog.server.model.SecurableType.SCHEMA;
-import static io.unitycatalog.server.model.SecurableType.TABLE;
-import static io.unitycatalog.server.model.SecurableType.VOLUME;
 
 /**
  * Armeria access control Decorator.
@@ -192,7 +172,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
   private void checkAuthorization(UUID principal, String expression, Map<SecurableType, Object> resourceKeys) {
     LOGGER.debug("resourceKeys = {}", resourceKeys);
 
-    Map<SecurableType, Object> resourceIds = mapResourceKeys(resourceKeys);
+    Map<SecurableType, Object> resourceIds = KeyMapperUtil.mapResourceKeys(resourceKeys);
 
     if (!resourceIds.keySet().containsAll(resourceKeys.keySet())) {
       LOGGER.warn("Some resource keys have unresolved ids.");
@@ -203,114 +183,6 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     if (!evaluator.evaluate(principal, expression, resourceIds)) {
       throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
     }
-  }
-
-  private Map<SecurableType, Object> mapResourceKeys(Map<SecurableType, Object> resourceKeys) {
-    Map<SecurableType, Object> resourceIds = new HashMap<>();
-
-    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(TABLE)) {
-      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA) + "." + resourceKeys.get(TABLE);
-      TableInfo table = TableRepository.getInstance().getTable(fullName);
-      resourceIds.put(TABLE, UUID.fromString(table.getTableId()));
-    }
-
-    // If only TABLE is specified, assuming its value is a full table name (including catalog and schema)
-    if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(TABLE)) {
-      String fullName = (String) resourceKeys.get(TABLE);
-      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
-      TableInfo table = fullName.contains(".") ?
-        TableRepository.getInstance().getTable(fullName):TableRepository.getInstance().getTableById(fullName);
-      String fullSchemaName = table.getCatalogName() + "." + table.getSchemaName();
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(table.getCatalogName());
-      resourceIds.put(TABLE, UUID.fromString(table.getTableId()));
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(VOLUME)) {
-      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA) + "." + resourceKeys.get(VOLUME);
-      VolumeInfo volume = VolumeRepository.getInstance().getVolume(fullName);
-      resourceIds.put(VOLUME, UUID.fromString(volume.getVolumeId()));
-    }
-
-    // If only VOLUME is specified, assuming its value is a full volume name (including catalog and schema)
-    if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(VOLUME)) {
-      String fullName = (String) resourceKeys.get(VOLUME);
-      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
-      VolumeInfo volume = (fullName.contains(".")) ?
-              VolumeRepository.getInstance().getVolume(fullName): VolumeRepository.getInstance().getVolumeById(fullName);
-      String fullSchemaName = volume.getCatalogName() + "." + volume.getSchemaName();
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(volume.getCatalogName());
-      resourceIds.put(VOLUME, UUID.fromString(volume.getVolumeId()));
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(FUNCTION)) {
-      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA) + "." + resourceKeys.get(FUNCTION);
-      FunctionInfo function = FunctionRepository.getInstance().getFunction(fullName);
-      resourceIds.put(FUNCTION, UUID.fromString(function.getFunctionId()));
-    }
-
-    // If only FUNCTION is specified, assuming its value is a full volume name (including catalog and schema)
-    if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(FUNCTION)) {
-      String fullName = (String) resourceKeys.get(FUNCTION);
-      FunctionInfo function = FunctionRepository.getInstance().getFunction(fullName);
-      String fullSchemaName = function.getCatalogName() + "." + function.getSchemaName();
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(function.getCatalogName());
-      resourceIds.put(FUNCTION, UUID.fromString(function.getFunctionId()));
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(REGISTERED_MODEL)) {
-      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA) + "." + resourceKeys.get(REGISTERED_MODEL);
-      RegisteredModelInfo model = ModelRepository.getInstance().getRegisteredModel(fullName);
-      resourceIds.put(REGISTERED_MODEL, UUID.fromString(model.getId()));
-    }
-
-    // If only REGISTERED_MODEL is specified, assuming its value is a full volume name (including catalog and schema)
-    if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(REGISTERED_MODEL)) {
-      String fullName = (String) resourceKeys.get(REGISTERED_MODEL);
-      RegisteredModelInfo model = ModelRepository.getInstance().getRegisteredModel(fullName);
-      String fullSchemaName = model.getCatalogName() + "." + model.getSchemaName();
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(model.getCatalogName());
-      resourceIds.put(REGISTERED_MODEL, UUID.fromString(model.getId()));
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-
-    if (resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA)) {
-      String fullName = resourceKeys.get(CATALOG) + "." + resourceKeys.get(SCHEMA);
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullName);
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-    }
-
-    // if only SCHEMA is specified, assuming its value is a full schema name (including catalog)
-    if (!resourceKeys.containsKey(CATALOG) && resourceKeys.containsKey(SCHEMA)) {
-      String fullName = (String) resourceKeys.get(SCHEMA);
-      SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullName);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(schema.getCatalogName());
-      resourceIds.put(SCHEMA, UUID.fromString(schema.getSchemaId()));
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-    if (resourceKeys.containsKey(CATALOG)) {
-      String fullName = (String) resourceKeys.get(CATALOG);
-      CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(fullName);
-      resourceIds.put(CATALOG, UUID.fromString(catalog.getId()));
-    }
-
-    if (resourceKeys.containsKey(METASTORE)) {
-      resourceIds.put(METASTORE, MetastoreRepository.getInstance().getMetastoreId());
-    }
-
-    return resourceIds;
   }
 
   private static String findAuthorizeExpression(Method method) {

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -217,7 +217,9 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     // If only TABLE is specified, assuming its value is a full table name (including catalog and schema)
     if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(TABLE)) {
       String fullName = (String) resourceKeys.get(TABLE);
-      TableInfo table = TableRepository.getInstance().getTable(fullName);
+      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
+      TableInfo table = fullName.contains(".") ?
+        TableRepository.getInstance().getTable(fullName):TableRepository.getInstance().getTableById(fullName);
       String fullSchemaName = table.getCatalogName() + "." + table.getSchemaName();
       SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
       CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(table.getCatalogName());
@@ -235,7 +237,9 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     // If only VOLUME is specified, assuming its value is a full volume name (including catalog and schema)
     if (!resourceKeys.containsKey(CATALOG) && !resourceKeys.containsKey(SCHEMA) && resourceKeys.containsKey(VOLUME)) {
       String fullName = (String) resourceKeys.get(VOLUME);
-      VolumeInfo volume = VolumeRepository.getInstance().getVolume(fullName);
+      // If the full name contains a dot, we assume it's a full name, otherwise we assume it's an id
+      VolumeInfo volume = (fullName.contains(".")) ?
+              VolumeRepository.getInstance().getVolume(fullName): VolumeRepository.getInstance().getVolumeById(fullName);
       String fullSchemaName = volume.getCatalogName() + "." + volume.getSchemaName();
       SchemaInfo schema = SchemaRepository.getInstance().getSchema(fullSchemaName);
       CatalogInfo catalog = CatalogRepository.getInstance().getCatalog(volume.getCatalogName());

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.persist;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.*;
+import io.unitycatalog.server.persist.dao.CatalogInfoDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
@@ -46,7 +47,20 @@ public class TableRepository {
         if (tableInfoDAO == null) {
           throw new BaseException(ErrorCode.NOT_FOUND, "Table not found: " + tableId);
         }
+        SchemaInfoDAO schemaInfoDAO = session.get(SchemaInfoDAO.class, tableInfoDAO.getSchemaId());
+        if (schemaInfoDAO == null) {
+          throw new BaseException(
+              ErrorCode.NOT_FOUND, "Schema not found: " + tableInfoDAO.getSchemaId());
+        }
+        CatalogInfoDAO catalogInfoDAO =
+            session.get(CatalogInfoDAO.class, schemaInfoDAO.getCatalogId());
+        if (catalogInfoDAO == null) {
+          throw new BaseException(
+              ErrorCode.NOT_FOUND, "Catalog not found: " + schemaInfoDAO.getCatalogId());
+        }
         TableInfo tableInfo = tableInfoDAO.toTableInfo(true);
+        tableInfo.setSchemaName(schemaInfoDAO.getName());
+        tableInfo.setCatalogName(catalogInfoDAO.getName());
         tx.commit();
         return tableInfo;
       } catch (Exception e) {

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
@@ -86,10 +86,7 @@ public class TemporaryModelVersionCredentialsService {
         // This should be replaced with more direct annotations and syntax in the future.
 
         String readExpression = """
-          #authorize(#principal, #metastore, OWNER) ||
-          #authorize(#principal, #catalog, OWNER) ||
-          (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
-          (#authorizeAny(#principal, #registered_model, OWNER, EXECUTE) && #authorize(#principal, #schema, USE_SCHEMA) && #authorize(#principal, #catalog, USE_CATALOG))
+          #authorizeAny(#principal, #registered_model, OWNER, EXECUTE) && #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
           """;
 
         String writeExpression = """

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
@@ -3,6 +3,8 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
+import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
+import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryPathCredential;
 import io.unitycatalog.server.model.PathOperation;
@@ -12,6 +14,7 @@ import io.unitycatalog.server.service.credential.CredentialOperations;
 import java.util.Collections;
 import java.util.Set;
 
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
@@ -24,6 +27,8 @@ public class TemporaryPathCredentialsService {
     }
 
     @Post("")
+    @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+    @AuthorizeKey(METASTORE)
     public HttpResponse generateTemporaryPathCredential(
         GenerateTemporaryPathCredential generateTemporaryPathCredential) {
         return HttpResponse.ofJson(

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
@@ -3,20 +3,34 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
+import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
+import io.unitycatalog.server.auth.decorator.KeyMapperUtil;
+import io.unitycatalog.server.auth.decorator.UnityAccessEvaluator;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
+import io.unitycatalog.server.model.GenerateTemporaryModelVersionCredential;
 import io.unitycatalog.server.model.GenerateTemporaryTableCredential;
+import io.unitycatalog.server.model.ModelVersionOperation;
+import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.model.TableOperation;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.CredentialOperations;
+import io.unitycatalog.server.utils.IdentityUtils;
+import lombok.SneakyThrows;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.TABLE;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
@@ -26,22 +40,19 @@ public class TemporaryTableCredentialsService {
 
   private static final TableRepository TABLE_REPOSITORY = TableRepository.getInstance();
 
+  private final UnityAccessEvaluator evaluator;
   private final CredentialOperations credentialOps;
 
-  public TemporaryTableCredentialsService(CredentialOperations credentialOps) {
+  @SneakyThrows
+  public TemporaryTableCredentialsService(UnityCatalogAuthorizer authorizer, CredentialOperations credentialOps) {
+    this.evaluator = new UnityAccessEvaluator(authorizer);
     this.credentialOps = credentialOps;
   }
 
   @Post("")
-  @AuthorizeExpression("""
-          #authorize(#principal, #metastore, OWNER) ||
-          #authorize(#principal, #catalog, OWNER) ||
-          (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
-          (#authorize(#principal, #schema, USE_SCHEMA) && #authorize(#principal, #catalog, USE_CATALOG) && #authorizeAny(#principal, #table, OWNER, SELECT))
-          """)
-  @AuthorizeKey(METASTORE)
-  public HttpResponse generateTemporaryTableCredential(
-      @AuthorizeKey(value=TABLE, key="table_id") GenerateTemporaryTableCredential generateTemporaryTableCredential) {
+  public HttpResponse generateTemporaryTableCredential(GenerateTemporaryTableCredential generateTemporaryTableCredential) {
+    authorizeForOperation(generateTemporaryTableCredential);
+
     String tableId = generateTemporaryTableCredential.getTableId();
     TableInfo tableInfo = TABLE_REPOSITORY.getTableById(tableId);
     return HttpResponse.ofJson(credentialOps
@@ -56,4 +67,32 @@ public class TemporaryTableCredentialsService {
       case UNKNOWN_TABLE_OPERATION -> Collections.emptySet();
     };
   }
+
+  private void authorizeForOperation(GenerateTemporaryTableCredential generateTemporaryTableCredential) {
+
+    // TODO: This is a short term solution to conditional expression evaluation based on additional request parameters.
+    // This should be replaced with more direct annotations and syntax in the future.
+
+    String readExpression = """
+          #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) && #authorizeAny(#principal, #table, OWNER, SELECT)
+          """;
+
+    // TODO: add MODIFY to the expression
+    String writeExpression = """
+          #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) && #authorize(#principal, #table, OWNER)
+          """;
+
+    String authorizeExpression =
+            generateTemporaryTableCredential.getOperation() ==  TableOperation.READ ?
+                    readExpression : writeExpression;
+
+    Map<SecurableType, Object> resourceKeys = KeyMapperUtil.mapResourceKeys(
+            Map.of(METASTORE, "metastore",
+                    TABLE, generateTemporaryTableCredential.getTableId()));
+
+    if (!evaluator.evaluate(IdentityUtils.findPrincipalId(), authorizeExpression, resourceKeys)) {
+      throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
+    }
+  }
+
 }

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
@@ -3,6 +3,8 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
+import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
+import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.server.model.TableInfo;
@@ -14,6 +16,8 @@ import io.unitycatalog.server.service.credential.CredentialOperations;
 import java.util.Collections;
 import java.util.Set;
 
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.TABLE;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
@@ -29,8 +33,15 @@ public class TemporaryTableCredentialsService {
   }
 
   @Post("")
+  @AuthorizeExpression("""
+          #authorize(#principal, #metastore, OWNER) ||
+          #authorize(#principal, #catalog, OWNER) ||
+          (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
+          (#authorize(#principal, #schema, USE_SCHEMA) && #authorize(#principal, #catalog, USE_CATALOG) && #authorizeAny(#principal, #table, OWNER, SELECT))
+          """)
+  @AuthorizeKey(METASTORE)
   public HttpResponse generateTemporaryTableCredential(
-      GenerateTemporaryTableCredential generateTemporaryTableCredential) {
+      @AuthorizeKey(value=TABLE, key="table_id") GenerateTemporaryTableCredential generateTemporaryTableCredential) {
     String tableId = generateTemporaryTableCredential.getTableId();
     TableInfo tableInfo = TABLE_REPOSITORY.getTableById(tableId);
     return HttpResponse.ofJson(credentialOps

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
@@ -71,14 +71,14 @@ public class TemporaryVolumeCredentialsService {
     // This should be replaced with more direct annotations and syntax in the future.
 
     String readExpression = """
-          #authorize(#principal, #metastore, OWNER) ||
-          #authorize(#principal, #catalog, OWNER) ||
-          (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
-          (#authorize(#principal, #schema, USE_SCHEMA) && #authorize(#principal, #catalog, USE_CATALOG) && #authorizeAny(#principal, #volume, OWNER, READ_VOLUME))
+          #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) && #authorizeAny(#principal, #volume, OWNER, READ_VOLUME)
           """;
 
+    // TODO: add WRITE_VOLUME to the expression
     String writeExpression = """
-          (#authorize(#principal, #volume, OWNER) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) && #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA))
+          #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+          #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
+          (#authorize(#principal, #schema, OWNER) || #authorizeAll(#principal, #volume, READ_VOLUME))
           """;
 
     String authorizeExpression =

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
@@ -78,7 +78,7 @@ public class TemporaryVolumeCredentialsService {
     String writeExpression = """
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
-          (#authorize(#principal, #schema, OWNER) || #authorizeAll(#principal, #volume, READ_VOLUME))
+          #authorize(#principal, #volume, OWNER)
           """;
 
     String authorizeExpression =


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This is a follow on to the overall access control feature to add access control to the credential vending endpoints. The access control rules for credential vending follows the same rules as getting the entity.

This resolve Issue https://github.com/unitycatalog/unitycatalog/issues/501