### PR TITLE
Fix UpdateRegisteredModel and UpdateModelVersion to honor path variables

### DIFF
--- a/api/Models/UpdateModelVersion.md
+++ b/api/Models/UpdateModelVersion.md
@@ -3,8 +3,6 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **full\_name** | **String** | The full name of the registered model to update. | [optional] [default to null] |
-| **version** | **Long** | Version number of the version to update. | [optional] [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/Models/UpdateRegisteredModel.md
+++ b/api/Models/UpdateRegisteredModel.md
@@ -3,7 +3,6 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **full\_name** | **String** | The full name of the registered model to update. | [optional] [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **new\_name** | **String** | New name for the model. | [optional] [default to null] |
 

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -2083,9 +2083,6 @@ components:
     UpdateRegisteredModel:
       type: object
       properties:
-        full_name:
-          description: The full name of the registered model to update.
-          type: string
         comment:
           description: User-provided free-form text description.
           type: string
@@ -2133,13 +2130,6 @@ components:
     UpdateModelVersion:
       type: object
       properties:
-        full_name:
-          description: The full name of the registered model to update.
-          type: string
-        version:
-          description: Version number of the version to update.
-          type: integer
-          format:  int64
         comment:
           description: User-provided free-form text description.
           type: string

--- a/examples/cli/src/main/java/io/unitycatalog/cli/ModelCli.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/ModelCli.java
@@ -104,7 +104,6 @@ public class ModelCli {
     }
     UpdateRegisteredModel updateRegisteredModel =
         objectMapper.readValue(json.toString(), UpdateRegisteredModel.class);
-    updateRegisteredModel.setFullName(registeredModelFullName);
     return objectWriter.writeValueAsString(
         registeredModelsApi.updateRegisteredModel(registeredModelFullName, updateRegisteredModel));
   }

--- a/examples/cli/src/main/java/io/unitycatalog/cli/ModelVersionCli.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/ModelVersionCli.java
@@ -84,11 +84,11 @@ public class ModelVersionCli {
   private static String updateModelVersion(ModelVersionsApi modelVersionsApi, JSONObject json)
       throws JsonProcessingException, ApiException {
     String registeredModelFullName = json.getString(CliParams.FULL_NAME.getServerParam());
+    json.remove(CliParams.FULL_NAME.getServerParam());
     Long version = json.getLong(CliParams.VERSION.getServerParam());
+    json.remove(CliParams.VERSION.getServerParam());
     UpdateModelVersion updateModelVersion =
         objectMapper.readValue(json.toString(), UpdateModelVersion.class);
-    updateModelVersion.setFullName(registeredModelFullName);
-    updateModelVersion.setVersion(version);
     return objectWriter.writeValueAsString(
         modelVersionsApi.updateModelVersion(registeredModelFullName, version, updateModelVersion));
   }

--- a/examples/cli/src/test/java/io/unitycatalog/cli/model/CliModelOperations.java
+++ b/examples/cli/src/test/java/io/unitycatalog/cli/model/CliModelOperations.java
@@ -172,9 +172,9 @@ public class CliModelOperations implements ModelOperations {
                 "model_version",
                 "update",
                 "--full_name",
-                updateMv.getFullName(),
+                fullName,
                 "--version",
-                updateMv.getVersion().toString()));
+                version.toString()));
     if (updateMv.getComment() != null) {
       argsList.add("--comment");
       argsList.add(updateMv.getComment());

--- a/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
@@ -364,18 +364,18 @@ public class ModelRepository {
     return new ListRegisteredModelsResponse().registeredModels(result).nextPageToken(nextPageToken);
   }
 
-  public RegisteredModelInfo updateRegisteredModel(UpdateRegisteredModel updateRegisteredModel) {
+  public RegisteredModelInfo updateRegisteredModel(
+      String fullName, UpdateRegisteredModel updateRegisteredModel) {
     if (updateRegisteredModel.getNewName() != null) {
       ValidationUtils.validateSqlObjectName(updateRegisteredModel.getNewName());
     }
-    if (updateRegisteredModel.getFullName() == null) {
+    if (fullName == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "No three tier full name specified.");
     }
     if (updateRegisteredModel.getNewName() == null && updateRegisteredModel.getComment() == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "No updated fields defined.");
     }
 
-    String fullName = updateRegisteredModel.getFullName();
     LOGGER.info("Updating Registered Model: " + fullName);
     RegisteredModelInfo registeredModelInfo;
     String callerId = IdentityUtils.findPrincipalEmailAddress();
@@ -678,21 +678,19 @@ public class ModelRepository {
     }
   }
 
-  public ModelVersionInfo updateModelVersion(UpdateModelVersion updateModelVersion) {
-    if (updateModelVersion.getFullName() == null) {
+  public ModelVersionInfo updateModelVersion(
+      String fullName, Long version, UpdateModelVersion updateModelVersion) {
+    if (fullName == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "No model specified.");
     }
-    if (updateModelVersion.getVersion() == null || updateModelVersion.getVersion() < 1) {
+    if (version == null || version < 1) {
       throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "No valid model version specified: " + updateModelVersion.getVersion());
+          ErrorCode.INVALID_ARGUMENT, "No valid model version specified: " + version);
     }
     if (updateModelVersion.getComment() == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "No updated fields defined.");
     }
 
-    String fullName = updateModelVersion.getFullName();
-    Long version = updateModelVersion.getVersion();
     LOGGER.info("Updating Model Version: " + fullName + "/" + version);
     ModelVersionInfo modelVersionInfo;
     String callerId = IdentityUtils.findPrincipalEmailAddress();

--- a/server/src/main/java/io/unitycatalog/server/service/ModelService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ModelService.java
@@ -104,10 +104,10 @@ public class ModelService {
           (#authorize(#principal, #registered_model, OWNER) && #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
           """)
   @AuthorizeKey(METASTORE)
-  public HttpResponse updateRegisteredModel(@Param("full_name") @AuthorizeKey(REGISTERED_MODEL) String fullNameArg, UpdateRegisteredModel updateRegisteredModel) {
+  public HttpResponse updateRegisteredModel(@Param("full_name") @AuthorizeKey(REGISTERED_MODEL) String fullName, UpdateRegisteredModel updateRegisteredModel) {
     assert updateRegisteredModel != null;
     RegisteredModelInfo updateRegisteredModelResponse =
-        MODEL_REPOSITORY.updateRegisteredModel(updateRegisteredModel);
+        MODEL_REPOSITORY.updateRegisteredModel(fullName, updateRegisteredModel);
     return HttpResponse.ofJson(updateRegisteredModelResponse);
   }
 
@@ -177,11 +177,11 @@ public class ModelService {
           (#authorize(#principal, #registered_model, OWNER) && #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) && #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
           """)
   @AuthorizeKey(METASTORE)
-  public HttpResponse updateModelVersion(@Param("full_name") @AuthorizeKey(REGISTERED_MODEL) String fullName,
+  public HttpResponse updateModelVersion(@Param("full_name") @AuthorizeKey(REGISTERED_MODEL) String fullName, @Param("version") Long version,
                                          UpdateModelVersion updateModelVersion) {
     assert updateModelVersion != null;
     ModelVersionInfo updateModelVersionResponse =
-        MODEL_REPOSITORY.updateModelVersion(updateModelVersion);
+        MODEL_REPOSITORY.updateModelVersion(fullName, version, updateModelVersion);
     return HttpResponse.ofJson(updateModelVersionResponse);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/base/model/BaseModelCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/model/BaseModelCRUDTest.java
@@ -125,7 +125,7 @@ public abstract class BaseModelCRUDTest extends BaseCRUDTest {
     // Update model name without updating comment
     System.out.println("Testing update model: changing name..");
     UpdateRegisteredModel updateRegisteredModel =
-        new UpdateRegisteredModel().newName(MODEL_NEW_NAME).fullName(MODEL_FULL_NAME);
+        new UpdateRegisteredModel().newName(MODEL_NEW_NAME);
     RegisteredModelInfo updatedRegisteredModelInfo =
         modelOperations.updateRegisteredModel(MODEL_FULL_NAME, updateRegisteredModel);
     assertThat(updatedRegisteredModelInfo.getId()).isEqualTo(rmInfo.getId());
@@ -139,8 +139,7 @@ public abstract class BaseModelCRUDTest extends BaseCRUDTest {
 
     // Update model comment without updating name
     System.out.println("Testing update model: changing comment..");
-    UpdateRegisteredModel updateModel2 =
-        new UpdateRegisteredModel().comment(MODEL_NEW_COMMENT).fullName(MODEL_NEW_FULL_NAME);
+    UpdateRegisteredModel updateModel2 = new UpdateRegisteredModel().comment(MODEL_NEW_COMMENT);
     RegisteredModelInfo updatedRegisteredModelInfo2 =
         modelOperations.updateRegisteredModel(MODEL_NEW_FULL_NAME, updateModel2);
     assertThat(updatedRegisteredModelInfo.getId()).isEqualTo(updatedRegisteredModelInfo.getId());
@@ -272,8 +271,7 @@ public abstract class BaseModelCRUDTest extends BaseCRUDTest {
 
     // Update model version comment
     System.out.println("Testing update model version comment...");
-    UpdateModelVersion updateModelVersion =
-        new UpdateModelVersion().comment(MODEL_NEW_COMMENT).fullName(MODEL_FULL_NAME).version(3L);
+    UpdateModelVersion updateModelVersion = new UpdateModelVersion().comment(MODEL_NEW_COMMENT);
     ModelVersionInfo updatedModelVersionInfo =
         modelOperations.updateModelVersion(MODEL_FULL_NAME, 3L, updateModelVersion);
     assertThat(updatedModelVersionInfo.getCatalogName()).isEqualTo(mvInfo3.getCatalogName());


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fix a bug where the path variables for UpdateModelVersion and UpdateRegisteredModel were being ignored in favor of the incorrectly added variables in the request object.

- Request object has been fixed
- Path variables are passed in correctly for both handlers and used
- All existing code that relied on extraneous fields in generated code has been fixed
- All tests continue to pass