### PR TITLE
[MINOR] Remove duplicate + no publics in interface

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -201,10 +201,6 @@ public class UnityCatalogServer {
           .pathPrefix(controlPath)
           .exclude(controlPath + "auth/tokens")
           .build(authDecorator);
-      sb.routeDecorator()
-          .pathPrefix(controlPath)
-          .exclude(controlPath + "auth/tokens")
-          .build(authDecorator);
 
       ExceptionHandlingDecorator exceptionDecorator =
           new ExceptionHandlingDecorator(new GlobalExceptionHandler());

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -16,29 +16,29 @@ import java.util.UUID;
  * relationships.
  */
 public interface UnityCatalogAuthorizer {
-  public boolean grantAuthorization(UUID principal, UUID resource, Privileges action);
+  boolean grantAuthorization(UUID principal, UUID resource, Privileges action);
 
-  public boolean revokeAuthorization(UUID principal, UUID resource, Privileges action);
+  boolean revokeAuthorization(UUID principal, UUID resource, Privileges action);
 
-  public boolean clearAuthorizationsForPrincipal(UUID principal);
+  boolean clearAuthorizationsForPrincipal(UUID principal);
 
-  public boolean clearAuthorizationsForResource(UUID resource);
+  boolean clearAuthorizationsForResource(UUID resource);
 
-  public boolean addHierarchyChild(UUID parent, UUID child);
+  boolean addHierarchyChild(UUID parent, UUID child);
 
-  public boolean removeHierarchyChild(UUID parent, UUID child);
+  boolean removeHierarchyChild(UUID parent, UUID child);
 
-  public boolean removeHierarchyChildren(UUID resource);
+  boolean removeHierarchyChildren(UUID resource);
 
-  public UUID getHierarchyParent(UUID resource);
+  UUID getHierarchyParent(UUID resource);
 
-  public boolean authorize(UUID principal, UUID resource, Privileges action);
+  boolean authorize(UUID principal, UUID resource, Privileges action);
 
-  public boolean authorizeAny(UUID principal, UUID resource, Privileges... actions);
+  boolean authorizeAny(UUID principal, UUID resource, Privileges... actions);
 
-  public boolean authorizeAll(UUID principal, UUID resource, Privileges... actions);
+  boolean authorizeAll(UUID principal, UUID resource, Privileges... actions);
 
-  public List<Privileges> listAuthorizations(UUID principal, UUID resource);
+  List<Privileges> listAuthorizations(UUID principal, UUID resource);
 
-  public Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
+  Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
 }

--- a/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
@@ -88,6 +88,7 @@ public class PermissionService {
     return getAuthorization(TABLE, name);
   }
 
+  @Get("/function/{name}")
   public HttpResponse getFunctionAuthorization(
       @Param("name") String name) {
     return getAuthorization(FUNCTION, name);


### PR DESCRIPTION
This is a follow-up to f9a9bf1f84cb4c7fa03ecb569ae19f306a7cd85b:

1. Removes a code duplication
2. `@Get("/function/{name}")`
3. Removes `public` qualifiers in `UnityCatalogAuthorizer` interface

/cc @creechy 