### PR TITLE
Fix broken link to Spark Connector in PuppyGraph integration

### DIFF
--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -192,4 +192,4 @@ You can also use [Web UI](https://docs.puppygraph.com/user-interface/puppygraph-
 ## See Also
 
 - [Querying Unity Catalog Data as a Graph](https://docs.puppygraph.com/getting-started/querying-unity-catalog-data-as-a-graph)
-- [The Internals of Unity Catalog | Spark Integration](https://books.japila.pl/unity-catalog-internals/spark-integration/)
+- [The Internals of Unity Catalog | Spark Connector](https://books.japila.pl/unity-catalog-internals/spark-connector/)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fix the broken link in the docs pointing to the Spark Integration instead of the Spark Connector in the PuppyGraph integration documentation page.

Resolves #564
