### PR TITLE
Spark integration tests against cloud resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ etc/conf/*.der
 connectors/spark/etc/conf/certs.json
 connectors/spark/etc/conf/*.txt
 connectors/spark/etc/conf/*.der
+integration-tests/etc/conf/certs.json
+integration-tests/etc/conf/*.txt
+integration-tests/etc/conf/*.der
 
 # test
 .pytest_cache/

--- a/build.sbt
+++ b/build.sbt
@@ -286,6 +286,9 @@ lazy val server = (project in file("server"))
 
       //For s3 access
       "com.amazonaws" % "aws-java-sdk-s3" % "1.12.728",
+      "software.amazon.awssdk" % "sso" % "2.27.12",
+      "software.amazon.awssdk" % "ssooidc" % "2.27.12",
+
       "org.apache.httpcomponents" % "httpcore" % "4.4.16",
       "org.apache.httpcomponents" % "httpclient" % "4.5.14",
 
@@ -445,6 +448,7 @@ lazy val cli = (project in file("examples") / "cli")
       "org.fusesource.jansi" % "jansi" % "2.4.1",
       "com.amazonaws" % "aws-java-sdk-core" % "1.12.728",
       "org.apache.hadoop" % "hadoop-aws" % "3.4.0",
+      "org.apache.hadoop" % "hadoop-azure" % "3.4.0",
       "com.google.guava" % "guava" % "31.0.1-jre",
       // Test dependencies
       "org.junit.jupiter" % "junit-jupiter" % "5.10.3" % Test,
@@ -549,6 +553,39 @@ lazy val spark = (project in file("connectors/spark"))
       case DepModuleInfo("org.glassfish.hk2.external", "jakarta.inject", _) => true
       case DepModuleInfo("org.antlr", "ST4", _) => true
     }
+  )
+
+lazy val integrationTests = (project in file("integration-tests"))
+  .settings(
+    name := s"$artifactNamePrefix-integration-tests",
+    commonSettings,
+    javaOptions ++= Seq(
+      "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+    ),
+    skipReleaseSettings,
+    libraryDependencies ++= Seq(
+      "org.junit.jupiter" % "junit-jupiter" % "5.10.3" % Test,
+      "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+      "org.assertj" % "assertj-core" % "3.26.3" % Test,
+      "org.projectlombok" % "lombok" % "1.18.32" % Provided,
+      "org.apache.spark" %% "spark-sql" % "3.5.3" % Test,
+      "io.delta" %% "delta-spark" % "3.2.1" % Test,
+      "org.apache.hadoop" % "hadoop-aws" % "3.3.6" % Test,
+      "org.apache.hadoop" % "hadoop-azure" % "3.3.6" % Test,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",
+      "io.unitycatalog" %% "unitycatalog-spark" % "0.2.0" % Test,
+    ),
+    dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.0",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
+      "org.antlr" % "antlr4-runtime" % "4.9.3",
+      "org.antlr" % "antlr4" % "4.9.3",
+      "org.apache.hadoop" % "hadoop-client-api" % "3.3.6",
+    ),
+    Test / javaOptions += s"-Duser.dir=${((ThisBuild / baseDirectory).value / "integration-tests").getAbsolutePath}",
   )
 
 lazy val root = (project in file("."))

--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -50,7 +50,7 @@ Run the command from the Spark folder to start a Spark SQL shell .
     io.delta:delta-spark_2.12:3.2.0,io.unitycatalog:unitycatalog-spark:0.2.0-SNAPSHOT \
   --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
   --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
-  --conf spark.sql.catalog.puppygraph=io.unitycatalog.connectors.spark.UCSingleCatalog \
+  --conf spark.sql.catalog.puppygraph=io.unitycatalog.spark.UCSingleCatalog \
   --conf spark.sql.catalog.puppygraph.uri=http://localhost:8080
 ```
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,52 @@
+# Integration tests
+
+## Prerequisites
+
+- Run `build/sbt clean package publishLocal` to publish spark connector to local maven cache
+- These tests currently assume you have existing cloud resources set up (e.g. S3 bucket & IAM role for S3)
+ 
+## Set up catalog
+
+### Option 1: Use localhost unity catalog server
+
+First, update integration test [server.properties](./etc/conf/server.properties)
+  - For S3: Set `s3.bucketPath.0`, `s3.region.0`, `s3.awsRoleArn.0`, `s3.accessKey.0`, and `s3.secretKey.0`
+  - For GCP: Set `gcs.bucketPath.0` and `gcs.jsonKeyFilePath.0`
+  - For Azure: Set `adls.storageAccountName.0`, `adls.tenantId.0`, `adls.clientId.0`, and `adls.clientSecret.0`
+
+Next, run the UC server to test against:
+```shell
+# run from the integration-tests dir to use the testing configurations
+cd integration-tests
+../bin/start-uc-server
+```
+
+In a separate shell, ensure a catalog is created for testing:
+```
+bin/uc catalog create --name unity
+```
+
+### Option 2: Use external catalog
+
+This scenario assumes an existing unity catalog is already running externally.
+
+```shell
+export CATALOG_URI=https://<my-uc-instance/
+export CATALOG_AUTH_TOKEN=<my-access-token>
+export CATALOG_NAME=<my-catalog-name>
+```
+
+## Run the tests
+By default, tests will run against the local filesystem. To run against cloud storage, set the following *optional* environment variables:
+
+```shell
+export S3_BASE_LOCATION=s3://<my-bucket>/<optional>/<path>/
+export GS_BASE_LOCATION=gs://<my-bucket>/<optional>/<path>/
+export ABFSS_BASE_LOCATION=abfss://<container>@<account_name>.dfs.core.windows.net/<optional>/<path>/
+```
+
+Finally, run the tests:
+```shell
+build/sbt integrationTests/test
+```
+ 

--- a/integration-tests/etc/conf/server.properties
+++ b/integration-tests/etc/conf/server.properties
@@ -1,0 +1,43 @@
+server.env=test
+## Identity Provider authorization parameters
+# examples:
+# authorization=enable
+# authorization-url=https://accounts.google.com/o/oauth2/auth
+# token-url=https://oauth2.googleapis.com/token
+# client-id=111122223333-abab1212cdcd3434.apps.googleusercontent.com
+# client-secret=GOCSPX-ababfoobarcdcd-5q
+server.authorization=disable
+server.authorization-url=
+server.token-url=
+server.client-id=
+server.client-secret=
+server.redirect-port=
+
+# Define the model storage root.  Cloud storage or file based allowed.
+# If no root specified, the current working directory of the server is used.
+
+#storage-root.models=s3://my-s3-bucket/root
+#storage-root.models=abfs://file_system@account_name.dfs.core.windows.net/root
+#storage-root.models=gs://my-gc-bucket/root
+storage-root.models=file:/tmp/ucroot
+
+## S3 Storage Config (Multiple configs can be added by incrementing the index)
+s3.bucketPath.0=
+s3.region.0=
+s3.awsRoleArn.0=
+# Optional (If blank, it will use DefaultCredentialsProviderChain)
+s3.accessKey.0=
+s3.secretKey.0=
+# Test Only (If you provide a session token, it will just use those session creds, no downscoping)
+s3.sessionToken.0=
+
+## ADLS Storage Config (Multiple configs can be added by incrementing the index)
+adls.storageAccountName.0=
+adls.tenantId.0=
+adls.clientId.0=
+adls.clientSecret.0=
+
+## GCS Storage Config (Multiple configs can be added by incrementing the index)
+gcs.bucketPath.0=
+# Optional (If blank, it will use Default Application chain to find credentials)
+gcs.jsonKeyFilePath.0=

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/BaseSparkTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/BaseSparkTest.java
@@ -1,0 +1,85 @@
+package io.unitycatalog.integrationtests;
+
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class BaseSparkTest {
+    // todo: parameterize such that catalogs can be specified per cloud provider if desired
+    private static final String ServerUrl = System.getenv().getOrDefault("CATALOG_URI", "http://localhost:8080");
+    private static final String AuthToken = System.getenv().getOrDefault("CATALOG_AUTH_TOKEN", "");
+    private static final String CatalogName = System.getenv().getOrDefault("CATALOG_NAME", "unity");
+    protected static SparkSession spark;
+
+    @BeforeAll
+    public static void setup() {
+        spark = createSparkSessionWithCatalogs(CatalogName);
+    }
+
+    protected static SparkSession createSparkSessionWithCatalogs(String... catalogs) {
+        SparkSession.Builder builder =
+                SparkSession.builder()
+                        .appName("test")
+                        .master("local[*]")
+                        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+                        .config("spark.sql.catalog.spark_catalog", "io.unitycatalog.spark.UCSingleCatalog")
+                        // s3 conf
+                        .config("spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+                        // GCS conf
+                        .config("spark.hadoop.fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
+
+        for (String catalog : catalogs) {
+            String catalogConf = "spark.sql.catalog." + catalog;
+            builder =
+                    builder
+                            .config(catalogConf, "io.unitycatalog.spark.UCSingleCatalog")
+                            .config(catalogConf + ".uri", ServerUrl)
+                            .config(catalogConf + ".token", AuthToken);
+        }
+        if (catalogs.length > 0) {
+            builder.config("spark.sql.defaultCatalog", catalogs[0]);
+        }
+        return builder.getOrCreate();
+    }
+
+    protected static String getBaseLocation(LocationType locationType) throws IOException {
+        return switch (locationType) {
+            // todo: add hook to clean up temp directory
+            case FILE -> Files.createTempDirectory("uc-test-table").toFile().getAbsolutePath();
+            case S3 -> System.getenv("S3_BASE_LOCATION");
+            case GS -> System.getenv("GS_BASE_LOCATION");
+            case ABFSS -> System.getenv("ABFSS_BASE_LOCATION");
+        };
+    }
+
+    @Getter
+    public enum LocationType {
+        FILE("file://"),
+        S3(System.getenv("S3_BASE_LOCATION")),
+        GS(System.getenv("GS_BASE_LOCATION")),
+        ABFSS(System.getenv("ABFSS_BASE_LOCATION"));
+
+        private final String baseLocation;
+
+        @SneakyThrows
+        LocationType(String baseLocation) {
+            this.baseLocation = Objects.equals(baseLocation, "file://") ? Files.createTempDirectory("uc-integration-tests").toFile().getAbsolutePath()
+                    : baseLocation;
+        }
+
+        public boolean isEnabled() {
+            return this.baseLocation != null;
+        }
+    }
+
+    static List<LocationType> locationTypes() {
+        return Arrays.stream(LocationType.values()).filter(LocationType::isEnabled).toList();
+    }
+}

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkDeltaTableCRUDTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkDeltaTableCRUDTest.java
@@ -1,0 +1,135 @@
+package io.unitycatalog.integrationtests;
+
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+import java.util.List;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class SparkDeltaTableCRUDTest extends BaseSparkTest {
+    private static final String BASE_TABLE_NAME = "numbers";
+    private final String RUN_ID = UUID.randomUUID().toString();
+    private static final String SCHEMA = RandomStringUtils.randomAlphabetic(8);
+
+    static String getTableName(LocationType locationType) {
+        return format("%s_%s", BASE_TABLE_NAME, locationType.name());
+    }
+
+    @BeforeAll
+    public static void setupSchema() {
+        spark.sql(format("CREATE SCHEMA %s", SCHEMA));
+        spark.sql(format("USE %s", SCHEMA));
+    }
+
+    @AfterAll
+    public static void teardownSchema() {
+        locationTypes().forEach(locationType ->
+                spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
+        spark.sql(format("DROP SCHEMA IF EXISTS %s", SCHEMA));
+    }
+
+    private List<String> getData(String table) {
+        return spark.sql(format("SELECT * FROM %s ORDER BY as_int ASC", table)).toJSON().collectAsList();
+    }
+
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(1)
+    public void createTable(LocationType locationType) {
+        String baseLocation = getBaseLocation(locationType);
+        String location = baseLocation + "/integration/" + RUN_ID + "/numbers";
+        String table = getTableName(locationType);
+
+        spark.sql(format("CREATE TABLE %s(as_int INT, as_double DOUBLE) USING DELTA LOCATION '%s'", table, location));
+
+        assertThat(getData(table))
+                .as("Data after CREATE should be empty")
+                .isEqualTo(List.of());
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(2)
+    public void insert(LocationType locationType) {
+        String table = getTableName(locationType);
+        spark.sql(format("INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)", table));
+
+        assertThat(getData(table))
+                .as("Data after INSERT")
+                .isEqualTo(List.of(
+                        "{\"as_int\":0,\"as_double\":0.0}",
+                        "{\"as_int\":1,\"as_double\":1.5}",
+                        "{\"as_int\":42,\"as_double\":244.25}",
+                        "{\"as_int\":539,\"as_double\":425.66102859000944}"
+                ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(3)
+    public void merge(LocationType locationType) {
+        String table = getTableName(locationType);
+        spark.sql(format("""
+                MERGE INTO %s target
+                USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5) AS mock_data(as_int, as_double)) source
+                ON source.as_int = target.as_int
+                WHEN MATCHED THEN DELETE
+                WHEN NOT MATCHED THEN INSERT *
+                """, table));
+
+        assertThat(getData(table))
+                .as("Data after MERGE")
+                .isEqualTo(List.of(
+                        "{\"as_int\":0,\"as_double\":0.0}",
+                        "{\"as_int\":3,\"as_double\":3.75}",
+                        "{\"as_int\":5,\"as_double\":2.5}",
+                        "{\"as_int\":42,\"as_double\":244.25}",
+                        "{\"as_int\":539,\"as_double\":425.66102859000944}"
+                ));
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(4)
+    public void delete(LocationType locationType) {
+        String table = getTableName(locationType);
+        spark.sql(format("DELETE FROM %s WHERE as_int < 20", table));
+
+        assertThat(getData(table))
+                .as("Data after DELETE")
+                .isEqualTo(List.of(
+                        "{\"as_int\":42,\"as_double\":244.25}",
+                        "{\"as_int\":539,\"as_double\":425.66102859000944}"
+                ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(5)
+    public void update(LocationType locationType) {
+        String table = getTableName(locationType);
+        spark.sql(format("UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table));
+
+        assertThat(getData(table))
+                .as("Data after UPDATE")
+                .isEqualTo(List.of(
+                        "{\"as_int\":42,\"as_double\":63.0}",
+                        "{\"as_int\":539,\"as_double\":425.66102859000944}"
+                ));
+    }
+}

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkParquetTableCRUDTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkParquetTableCRUDTest.java
@@ -1,0 +1,120 @@
+package io.unitycatalog.integrationtests;
+
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.spark.SparkUnsupportedOperationException;
+import org.apache.spark.sql.AnalysisException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class SparkParquetTableCRUDTest extends BaseSparkTest {
+    private static final String BASE_TABLE_NAME = "numbers";
+    private final String RUN_ID = UUID.randomUUID().toString();
+    private static final String SCHEMA = RandomStringUtils.randomAlphabetic(8);
+
+    static String getTableName(LocationType locationType) {
+        return format("%s_%s", BASE_TABLE_NAME, locationType.name());
+    }
+
+    @BeforeAll
+    public static void setupSchema() {
+        spark.sql(format("CREATE SCHEMA %s", SCHEMA));
+        spark.sql(format("USE %s", SCHEMA));
+    }
+
+    @AfterAll
+    public static void teardownSchema() {
+        locationTypes().forEach(locationType ->
+                spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
+        spark.sql(format("DROP SCHEMA IF EXISTS %s", SCHEMA));
+    }
+
+    private List<String> getData(String table) {
+        return spark.sql(format("SELECT * FROM %s ORDER BY as_int ASC", table)).toJSON().collectAsList();
+    }
+
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(1)
+    public void createTable(LocationType locationType) {
+        String baseLocation = getBaseLocation(locationType);
+        String location = baseLocation + "/integration/" + RUN_ID + "/numbers";
+        String table = getTableName(locationType);
+
+        spark.sql(format("CREATE TABLE %s(as_int INT, as_double DOUBLE) USING PARQUET LOCATION '%s'", table, location));
+
+        assertThat(getData(table))
+                .as("Data after CREATE should be empty")
+                .isEqualTo(List.of());
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(2)
+    public void insert(LocationType locationType) {
+        String table = getTableName(locationType);
+        spark.sql(format("INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)", table));
+
+        assertThat(getData(table))
+                .as("Data after INSERT")
+                .isEqualTo(List.of(
+                        "{\"as_int\":0,\"as_double\":0.0}",
+                        "{\"as_int\":1,\"as_double\":1.5}",
+                        "{\"as_int\":42,\"as_double\":244.25}",
+                        "{\"as_int\":539,\"as_double\":425.66102859000944}"
+                ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(3)
+    public void merge(LocationType locationType) {
+        String table = getTableName(locationType);
+        assertThatThrownBy(() -> spark.sql(format("""
+                MERGE INTO %s target
+                USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5) AS mock_data(as_int, as_double)) source
+                ON source.as_int = target.as_int
+                WHEN MATCHED THEN DELETE
+                WHEN NOT MATCHED THEN INSERT *
+                """, table)))
+                .isInstanceOf(SparkUnsupportedOperationException.class)
+                .hasMessageContaining("MERGE INTO TABLE is not supported temporarily");
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(4)
+    public void delete(LocationType locationType) {
+        String table = getTableName(locationType);
+        assertThatThrownBy(() -> spark.sql(format("DELETE FROM %s WHERE as_int < 20", table)))
+                .isInstanceOf(AnalysisException.class)
+                .hasMessageContaining("does not support DELETE");
+    }
+
+    @ParameterizedTest
+    @MethodSource("locationTypes")
+    @Order(5)
+    public void update(LocationType locationType) {
+        String table = getTableName(locationType);
+
+        assertThatThrownBy(() -> spark.sql(format("UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table)))
+                .isInstanceOf(SparkUnsupportedOperationException.class)
+                .hasMessageContaining("UPDATE TABLE is not supported temporarily");
+    }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds spark integration tests that a user can manually run to test basic spark functionality against local FS and against S3/GCP/Azure cloud buckets.

Out of scope and/or Followup items:

- It'd be nice to add a dimension for testing multiple catalog endpoints as well (or at least parameterize so that different catalog conf could be used for different clouds)
- Shared/ project specific cloud resources (this will require provisioning buckets / secrets management for this project specifically)
    - Github actions automation 
