### PR TITLE
Refactor ServerPropertiesUtils (to be ServerProperties)

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -183,7 +183,7 @@ public class UnityCatalogServer {
         icebergResponseConverter);
 
     // TODO: eventually might want to make this secure-by-default.
-    if (enableAuthorization) {
+    if (authorizationEnabled) {
       LOGGER.info("Authorization enabled.");
 
       // Note: Decorators are applied in reverse order.

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -22,7 +22,7 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.ExceptionHandlingDecorator;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.security.SecurityConfiguration;
 import io.unitycatalog.server.security.SecurityContext;
 import io.unitycatalog.server.service.AuthDecorator;
@@ -110,13 +110,12 @@ public class UnityCatalogServer {
     // Credentials Service
     CredentialOperations credentialOperations = new CredentialOperations();
 
-    ServerPropertiesUtils serverPropertiesUtils = ServerPropertiesUtils.getInstance();
-    String authorization = serverPropertiesUtils.getProperty("server.authorization", "disable");
-    boolean enableAuthorization = authorization.equalsIgnoreCase("enable");
+    ServerProperties serverProperties = ServerProperties.getInstance();
+    boolean authorizationEnabled = serverProperties.isAuthorizationEnabled();
 
     UnityCatalogAuthorizer authorizer = null;
     try {
-      if (enableAuthorization) {
+      if (authorizationEnabled) {
         authorizer = new JCasbinAuthorizer();
         UnityAccessUtil.initializeAdmin(authorizer);
       } else {

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileUtils.java
@@ -20,12 +20,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.stream.Stream;
+
+import io.unitycatalog.server.utils.ServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FileUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
-  private static final ServerPropertiesUtils properties = ServerPropertiesUtils.getInstance();
+  private static final ServerProperties properties = ServerProperties.getInstance();
 
   private FileUtils() {}
 
@@ -119,10 +121,10 @@ public class FileUtils {
   private static URI modifyS3Directory(URI parsedUri, boolean createOrDelete) {
     String bucketName = parsedUri.getHost();
     String path = parsedUri.getPath().substring(1); // Remove leading '/'
-    String accessKey = ServerPropertiesUtils.getInstance().getProperty("aws.s3.accessKey");
-    String secretKey = ServerPropertiesUtils.getInstance().getProperty("aws.s3.secretKey");
-    String sessionToken = ServerPropertiesUtils.getInstance().getProperty("aws.s3.sessionToken");
-    String region = ServerPropertiesUtils.getInstance().getProperty("aws.region");
+    String accessKey = properties.getProperty("aws.s3.accessKey");
+    String secretKey = properties.getProperty("aws.s3.secretKey");
+    String sessionToken = properties.getProperty("aws.s3.sessionToken");
+    String region = properties.getProperty("aws.region");
 
     BasicSessionCredentials sessionCredentials =
         new BasicSessionCredentials(accessKey, secretKey, sessionToken);

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateUtils.java
@@ -6,6 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
+import io.unitycatalog.server.utils.ServerProperties;
 import lombok.Getter;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -19,11 +21,11 @@ public class HibernateUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(HibernateUtils.class);
 
   @Getter private static final SessionFactory sessionFactory;
-  private static final ServerPropertiesUtils properties;
+  private static final ServerProperties properties;
   @Getter private static final Properties hibernateProperties = new Properties();
 
   static {
-    properties = ServerPropertiesUtils.getInstance();
+    properties = ServerProperties.getInstance();
     sessionFactory = createSessionFactory();
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/UriUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/UriUtils.java
@@ -21,12 +21,14 @@ import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import io.unitycatalog.server.utils.ServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UriUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(UriUtils.class);
-  private static final ServerPropertiesUtils properties = ServerPropertiesUtils.getInstance();
+  private static final ServerProperties properties = ServerProperties.getInstance();
 
   private enum Operation {
     CREATE,

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -16,7 +16,7 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.OAuthInvalidRequestException;
 import io.unitycatalog.server.persist.UserRepository;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.security.SecurityContext;
 import io.unitycatalog.server.utils.JwksOperations;
@@ -128,9 +128,8 @@ public class AuthService {
           ErrorCode.INVALID_ARGUMENT, "Actor tokens not currently supported");
     }
 
-    String authorization =
-        ServerPropertiesUtils.getInstance().getProperty("server.authorization", "disable");
-    if (!authorization.equals("enable")) {
+    boolean authorizationEnabled = ServerProperties.getInstance().isAuthorizationEnabled();
+    if (!authorizationEnabled) {
       throw new OAuthInvalidRequestException(
           ErrorCode.INVALID_ARGUMENT, "Authorization is disabled");
     }

--- a/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
@@ -230,9 +230,9 @@ public class Scim2UserService {
   private HttpResponse handleExceptionDuringPatch(Exception ex) {
     if (ex instanceof ScimException) {
       throw new Scim2RuntimeException((ScimException) ex);
-    } else   {
+    } else {
       throw new Scim2RuntimeException(
-          new ServerErrorException("Problem with patch operation",ex.getMessage(), ex));
+          new ServerErrorException("Problem with patch operation", ex.getMessage(), ex));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
@@ -2,7 +2,7 @@ package io.unitycatalog.server.service.credential.aws;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import java.time.Duration;
 import java.util.Map;
@@ -24,7 +24,7 @@ public class AwsCredentialVendor {
   private final Map<String, S3StorageConfig> s3Configurations;
 
   public AwsCredentialVendor() {
-    this.s3Configurations = ServerPropertiesUtils.getInstance().getS3Configurations();
+    this.s3Configurations = ServerProperties.getInstance().getS3Configurations();
   }
 
   public Credentials vendAwsCredentials(CredentialContext context) {

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
@@ -2,9 +2,11 @@ package io.unitycatalog.server.service.credential.aws;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class S3StorageConfig {
   private final String bucketPath;
   private final String region;

--- a/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
@@ -13,7 +13,7 @@ import com.azure.storage.file.datalake.implementation.util.DataLakeSasImplUtil;
 import com.azure.storage.file.datalake.models.UserDelegationKey;
 import com.azure.storage.file.datalake.sas.DataLakeServiceSasSignatureValues;
 import com.azure.storage.file.datalake.sas.PathSasPermission;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import java.net.URI;
 import java.time.OffsetDateTime;
@@ -25,7 +25,7 @@ public class AzureCredentialVendor {
   private final Map<String, ADLSStorageConfig> adlsConfigurations;
 
   public AzureCredentialVendor() {
-    this.adlsConfigurations = ServerPropertiesUtils.getInstance().getAdlsConfigurations();
+    this.adlsConfigurations = ServerProperties.getInstance().getAdlsConfigurations();
   }
 
   public AzureCredential vendAzureCredential(CredentialContext context) {

--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -11,7 +11,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.base.CharMatcher;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import java.io.IOException;
 import java.net.URI;
@@ -31,7 +31,7 @@ public class GcpCredentialVendor {
   private final Map<String, String> gcsConfigurations;
 
   public GcpCredentialVendor() {
-    this.gcsConfigurations = ServerPropertiesUtils.getInstance().getGcsConfigurations();
+    this.gcsConfigurations = ServerProperties.getInstance().getGcsConfigurations();
   }
 
   @SneakyThrows

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
@@ -2,7 +2,7 @@ package io.unitycatalog.server.service.iceberg;
 
 import com.google.auth.oauth2.AccessToken;
 import io.unitycatalog.server.exception.BaseException;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.CredentialOperations;
 import io.unitycatalog.server.service.credential.aws.S3StorageConfig;
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,7 +83,7 @@ public class FileIOFactory {
   protected S3FileIO getS3FileIO(URI tableLocationUri) {
     CredentialContext context = getCredentialContextFromTableLocation(tableLocationUri);
     S3StorageConfig s3StorageConfig =
-      ServerPropertiesUtils.getInstance().getS3Configurations().get(context.getStorageBase());
+      ServerProperties.getInstance().getS3Configurations().get(context.getStorageBase());
 
     S3FileIO s3FileIO =
         new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(context), s3StorageConfig.getRegion()));

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -1,7 +1,7 @@
 package io.unitycatalog.server.service.iceberg;
 
 import com.google.auth.oauth2.AccessToken;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.CredentialOperations;
 import io.unitycatalog.server.service.credential.aws.S3StorageConfig;
@@ -15,7 +15,6 @@ import org.apache.iceberg.gcp.GCPProperties;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,7 +30,7 @@ public class TableConfigService {
   private final Map<String, S3StorageConfig> s3Configurations;
 
   public TableConfigService(CredentialOperations credentialOperations) {
-    this.s3Configurations = ServerPropertiesUtils.getInstance().getS3Configurations();
+    this.s3Configurations = ServerProperties.getInstance().getS3Configurations();
     this.credentialOperations = credentialOperations;
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -1,4 +1,4 @@
-package io.unitycatalog.server.persist.utils;
+package io.unitycatalog.server.utils;
 
 import io.unitycatalog.server.service.credential.aws.S3StorageConfig;
 import io.unitycatalog.server.service.credential.azure.ADLSStorageConfig;
@@ -14,37 +14,32 @@ import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ServerPropertiesUtils {
+public class ServerProperties {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ServerPropertiesUtils.class);
-  @Getter private static final ServerPropertiesUtils instance = new ServerPropertiesUtils();
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerProperties.class);
+  @Getter private static final ServerProperties instance = new ServerProperties();
   private final Properties properties;
 
-  private ServerPropertiesUtils() {
+  public static final String SERVER_PROPERTIES_FILE = "etc/conf/server.properties";
+
+  private ServerProperties() {
     properties = new Properties();
     loadProperties();
   }
 
   // Load properties from a configuration file
   private void loadProperties() {
-    Path path = Paths.get("etc/conf/server.properties");
+    Path path = Paths.get(SERVER_PROPERTIES_FILE);
     if (!path.toFile().exists()) {
-      LOGGER.error("Properties file not found: {}", path);
+      LOGGER.error("Server properties file not found: {}", path);
       return;
     }
     try (InputStream input = Files.newInputStream(path)) {
       properties.load(input);
-      LOGGER.debug("Properties loaded successfully");
+      LOGGER.debug("Server properties loaded successfully: {}", path);
     } catch (IOException ex) {
       LOGGER.error("Exception during loading properties", ex);
     }
-  }
-
-  // Get a property value by key
-  public String getProperty(String key) {
-    if (System.getProperty(key) != null) return System.getProperty(key);
-    if (System.getenv().containsKey(key)) return System.getenv(key);
-    return properties.getProperty(key);
   }
 
   public Map<String, S3StorageConfig> getS3Configurations() {
@@ -124,10 +119,34 @@ public class ServerPropertiesUtils {
     return adlsConfigMap;
   }
 
-  // Get a property value by key with a default value
-  public String getProperty(String key, String defaultValue) {
+  /**
+   * Get a property value by key.
+   * <p>
+   * The key can be one of the following (in that order)
+   * before looking it up in the server properties:
+   * <ol>
+   *     <li>System property</li>
+   *     <li>Environment variable</li>
+   * </ol>
+   * </p>
+   */
+  public String getProperty(String key) {
     if (System.getProperty(key) != null) return System.getProperty(key);
     if (System.getenv().containsKey(key)) return System.getenv(key);
-    return properties.getProperty(key, defaultValue);
+    return properties.getProperty(key);
+  }
+
+  /**
+   * Get a property value by key with a default value
+   * @see Properties#getProperty(String key, String defaultValue)
+   */
+  public String getProperty(String key, String defaultValue) {
+    String val = getProperty(key);
+    return (val == null) ? defaultValue : val;
+  }
+
+  public boolean isAuthorizationEnabled() {
+    String authorization = instance.getProperty("server.authorization", "disable");
+    return authorization.equalsIgnoreCase("enable");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CredentialOperationsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CredentialOperationsTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.model.AwsCredentials;
 import io.unitycatalog.server.model.TemporaryCredentials;
-import io.unitycatalog.server.persist.utils.ServerPropertiesUtils;
+import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.service.credential.aws.S3StorageConfig;
 import io.unitycatalog.server.service.credential.azure.ADLSStorageConfig;
 import java.util.Map;
@@ -23,7 +23,8 @@ import software.amazon.awssdk.services.sts.model.StsException;
 
 @ExtendWith(MockitoExtension.class)
 public class CredentialOperationsTest {
-  @Mock ServerPropertiesUtils serverPropertiesUtils;
+  @Mock
+  ServerProperties serverProperties;
   CredentialOperations credentialsOperations;
 
   @Test
@@ -33,11 +34,11 @@ public class CredentialOperationsTest {
     final String SESSION_TOKEN = "sessionToken";
     final String S3_REGION = "us-west-2";
     final String ROLE_ARN = "roleArn";
-    try (MockedStatic<ServerPropertiesUtils> mockedStatic =
-        mockStatic(ServerPropertiesUtils.class)) {
-      mockedStatic.when(ServerPropertiesUtils::getInstance).thenReturn(serverPropertiesUtils);
+    try (MockedStatic<ServerProperties> mockedStatic =
+        mockStatic(ServerProperties.class)) {
+      mockedStatic.when(ServerProperties::getInstance).thenReturn(serverProperties);
       // Test session key is available
-      when(serverPropertiesUtils.getS3Configurations())
+      when(serverProperties.getS3Configurations())
           .thenReturn(
               Map.of(
                   "s3://storageBase",
@@ -58,7 +59,7 @@ public class CredentialOperationsTest {
                   .sessionToken(SESSION_TOKEN));
 
       // Test when sts client is called
-      when(serverPropertiesUtils.getS3Configurations())
+      when(serverProperties.getS3Configurations())
           .thenReturn(
               Map.of(
                   "s3://storageBase",
@@ -82,11 +83,11 @@ public class CredentialOperationsTest {
     final String CLIENT_ID = "clientId";
     final String CLIENT_SECRET = "clientSecret";
     final String TENANT_ID = "tenantId";
-    try (MockedStatic<ServerPropertiesUtils> mockedStatic =
-        mockStatic(ServerPropertiesUtils.class)) {
-      mockedStatic.when(ServerPropertiesUtils::getInstance).thenReturn(serverPropertiesUtils);
+    try (MockedStatic<ServerProperties> mockedStatic =
+        mockStatic(ServerProperties.class)) {
+      mockedStatic.when(ServerProperties::getInstance).thenReturn(serverProperties);
       // Test mode used
-      when(serverPropertiesUtils.getAdlsConfigurations())
+      when(serverProperties.getAdlsConfigurations())
           .thenReturn(Map.of("uctest", ADLSStorageConfig.builder().testMode(true).build()));
       credentialsOperations = new CredentialOperations();
       TemporaryCredentials azureTemporaryCredentials =
@@ -96,7 +97,7 @@ public class CredentialOperationsTest {
       assertThat(azureTemporaryCredentials.getAzureUserDelegationSas().getSasToken()).isNotNull();
 
       // Use datalake service client
-      when(serverPropertiesUtils.getAdlsConfigurations())
+      when(serverProperties.getAdlsConfigurations())
           .thenReturn(
               Map.of(
                   "uctest",
@@ -119,11 +120,11 @@ public class CredentialOperationsTest {
   public void testGenerateGcpTemporaryCredentials() {
     final String PROJECT_ID = "projectId";
     final String PRIVATE_KEY_ID = "privateKeyId";
-    try (MockedStatic<ServerPropertiesUtils> mockedStatic =
-        mockStatic(ServerPropertiesUtils.class)) {
-      mockedStatic.when(ServerPropertiesUtils::getInstance).thenReturn(serverPropertiesUtils);
+    try (MockedStatic<ServerProperties> mockedStatic =
+        mockStatic(ServerProperties.class)) {
+      mockedStatic.when(ServerProperties::getInstance).thenReturn(serverProperties);
       // Test mode used
-      when(serverPropertiesUtils.getGcsConfigurations())
+      when(serverProperties.getGcsConfigurations())
           .thenReturn(Map.of("gs://uctest", "testing://test"));
       credentialsOperations = new CredentialOperations();
       TemporaryCredentials gcpTemporaryCredentials =
@@ -132,7 +133,7 @@ public class CredentialOperationsTest {
       assertThat(gcpTemporaryCredentials.getGcpOauthToken().getOauthToken()).isNotNull();
 
       // Use default creds
-      when(serverPropertiesUtils.getGcsConfigurations()).thenReturn(Map.of("gs://uctest", ""));
+      when(serverProperties.getGcsConfigurations()).thenReturn(Map.of("gs://uctest", ""));
       credentialsOperations = new CredentialOperations();
       assertThatThrownBy(
               () ->


### PR DESCRIPTION
As agreed with @alexreid-db, `ServerPropertiesUtils` should really be in `io.unitycatalog.server.utils` package.

The other changes are mainly as follows:

1. No need for `Utils` suffix
2. Added `isAuthorizationEnabled` method
3. Javadoc