### PR TITLE
Reformat `ModelRepository.java` to pass javafmtCheck

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
@@ -41,7 +41,7 @@ public class ModelRepository {
     query.setParameter("schemaId", schemaId);
     query.setParameter("name", name);
     query.setMaxResults(1);
-    LOGGER.info("Finding registered model by schemaId: {} and name: {}",  schemaId, name);
+    LOGGER.info("Finding registered model by schemaId: {} and name: {}", schemaId, name);
     return query.uniqueResult(); // Returns null if no result is found
   }
 
@@ -256,7 +256,10 @@ public class ModelRepository {
             // For now, never delete.  We will implement a soft delete later.
             // UriUtils.deleteStorageLocationPath(storageLocation);
           } catch (Exception deleteErr) {
-            LOGGER.error("Unable to delete storage location {} during rollback: {}", storageLocation, deleteErr.getMessage());
+            LOGGER.error(
+                "Unable to delete storage location {} during rollback: {}",
+                storageLocation,
+                deleteErr.getMessage());
           }
           tx.rollback();
         }
@@ -586,7 +589,10 @@ public class ModelRepository {
             // For now, never delete.  We will implement a soft delete later.
             // UriUtils.deleteStorageLocationPath(storageLocation);
           } catch (Exception deleteErr) {
-            LOGGER.error("Unable to delete storage location {} during rollback: {}", storageLocation, deleteErr.getMessage());
+            LOGGER.error(
+                "Unable to delete storage location {} during rollback: {}",
+                storageLocation,
+                deleteErr.getMessage());
           }
           tx.rollback();
         }


### PR DESCRIPTION
https://github.com/unitycatalog/unitycatalog/pull/595 added javafmtCheck, but the `ModelRepository.java` file submitted by 
 https://github.com/unitycatalog/unitycatalog/pull/590 was not formatted, which resulted in a GA check error. 

- https://github.com/unitycatalog/unitycatalog/actions/runs/11300626359/job/31433764692

```
[warn] server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java isn't formatted properly!
[error] 1 file must be formatted
[error] (server / Compile / javafmtCheck) 1 file must be formatted
[error] Total time: 5 s, completed Oct 12, 2024, 8:11:48 AM
```

This pr used `build/sbt javafmt` to format the `ModelRepository.java` file in order to fix the GA(javafmtCheck) issue.
