### PR TITLE
Add client retry logic for Databricks Unity Catalog AI Client

### DIFF
--- a/unitycatalog-ai/src/ucai/core/envs/databricks_env_vars.py
+++ b/unitycatalog-ai/src/ucai/core/envs/databricks_env_vars.py
@@ -52,3 +52,8 @@ UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT = _EnvironmentVariable(
     "100",
     "Maximum number of rows of the function execution result using Databricks client with serverless.",
 )
+UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS = _EnvironmentVariable(
+    "UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS",
+    "5",
+    "Maximum number of attempts to retry refreshing the session client in case of token expiry.",
+)


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR adds client-based retry for temporary auth credentials expiry to the DatabricksFunctionClient. 
