### PR TITLE
Globally exclude `org.slf4j:slf4j-reload4j`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,9 @@ lazy val commonSettings = Seq(
     "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.23.1",
     "org.apache.logging.log4j" % "log4j-api" % "2.23.1"
   ),
+  excludeDependencies ++= Seq(
+    ExclusionRule("org.slf4j", "slf4j-reload4j")
+  ),
   resolvers += Resolver.mavenLocal,
   autoScalaLibrary := false,
   crossPaths := false,  // No scala cross building


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Run `build/sbt -J-Xmx2G test`, we can see 3 times(when test `unitiycatalog-server`, `unitiycatalog-cli`and  `unitiycatalog-spark`) logs similar to the following:

```
[error] SLF4J(W): Class path contains multiple SLF4J providers.
[error] SLF4J(W): Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@7d952499]
[error] SLF4J(W): Found provider [org.slf4j.reload4j.Reload4jServiceProvider@62592f6d]
[error] SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
[error] SLF4J(I): Actual provider is of type [org.apache.logging.slf4j.SLF4JServiceProvider@7d952499]
```

We can also see it in GA test logs, for example:

- https://github.com/unitycatalog/unitycatalog/actions/runs/11473447061/job/31927701381

<img width="731" alt="image" src="https://github.com/user-attachments/assets/cf6ee287-f670-4e88-b241-a91df9ce2087">

So this pr globally excludes the dependency `org.slf4j:slf4j-reload4j`, and there will no longer be logs similar to the one above afterwards with this pr.

