### PR TITLE
Add uc_function_name to tools

### DIFF
--- a/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
+++ b/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
@@ -14,6 +14,9 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
 
 
 class UnityCatalogTool(StructuredTool):
+    uc_function_name: str = Field(
+        description="The full name of the function in the form of 'catalog.schema.function'",
+    )
     client_config: Dict[str, Any] = Field(
         description="Configuration of the client for managing the tool",
     )
@@ -104,6 +107,7 @@ class UCFunctionToolkit(BaseModel):
             description=function_info.comment or "",
             func=func,
             args_schema=generate_function_input_params_schema(function_info).pydantic_model,
+            uc_function_name=function_name,
             client_config=client.to_dict(),
         )
 

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -77,6 +77,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         tool = tools[0]
         assert tool.name == func_obj.tool_name
         assert tool.description == func_obj.comment
+        assert tool.uc_function_name == func_obj.full_function_name
         assert tool.client_config == client.to_dict()
         tool.args_schema(**{"code": "print(1)"})
         result = json.loads(tool.func(code="print(1)"))["value"]
@@ -99,6 +100,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         tool = tools[0]
         assert tool.name == func_obj.tool_name
         assert tool.description == func_obj.comment
+        assert tool.uc_function_name == func_obj.full_function_name
         assert tool.client_config == client.to_dict()
         tool.args_schema(**{"code": "print(1)"})
         result = json.loads(tool.func(code="print(1)"))["value"]

--- a/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
+++ b/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
@@ -23,7 +23,7 @@ class UnityCatalogTool(FunctionTool):
         uc_function_name (str): The full name of the function in the form of 'catalog.schema.function'.
         client_config (Dict[str, Any]): Configuration of the client for managing the tool.
     """
-    
+
     uc_function_name: str = Field(
         description="The full name of the function in the form of 'catalog.schema.function'",
     )
@@ -33,7 +33,13 @@ class UnityCatalogTool(FunctionTool):
     )
 
     def __init__(
-        self, fn: Callable, metadata: ToolMetadata, uc_function_name: str, client_config: Dict[str, Any], *args, **kwargs
+        self,
+        fn: Callable,
+        metadata: ToolMetadata,
+        uc_function_name: str,
+        client_config: Dict[str, Any],
+        *args,
+        **kwargs,
     ):
         """
         Initializes the UnityCatalogTool.

--- a/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
+++ b/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
@@ -20,15 +20,20 @@ class UnityCatalogTool(FunctionTool):
     A tool class that integrates Unity Catalog functions into a tool structure.
 
     Attributes:
+        uc_function_name (str): The full name of the function in the form of 'catalog.schema.function'.
         client_config (Dict[str, Any]): Configuration of the client for managing the tool.
     """
+    
+    uc_function_name: str = Field(
+        description="The full name of the function in the form of 'catalog.schema.function'",
+    )
 
     client_config: Dict[str, Any] = Field(
         description="Configuration of the client for managing the tool",
     )
 
     def __init__(
-        self, fn: Callable, metadata: ToolMetadata, client_config: Dict[str, Any], *args, **kwargs
+        self, fn: Callable, metadata: ToolMetadata, uc_function_name: str, client_config: Dict[str, Any], *args, **kwargs
     ):
         """
         Initializes the UnityCatalogTool.
@@ -36,11 +41,13 @@ class UnityCatalogTool(FunctionTool):
         Args:
             fn (Callable): The function that represents the tool's functionality.
             metadata (ToolMetadata): Metadata about the tool, including name, description, and schema.
+            uc_function_name (str): The full name of the function in the form of 'catalog.schema.function'.
             client_config (Dict[str, Any]): Configuration dictionary for the client used to manage the tool.
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
         """
         super().__init__(*args, fn=fn, metadata=metadata, **kwargs)
+        self.uc_function_name = uc_function_name
         self.client_config = client_config
 
     def __repr__(self) -> str:
@@ -177,6 +184,7 @@ class UCFunctionToolkit(BaseModel):
         return UnityCatalogTool(
             fn=func,
             metadata=metadata,
+            uc_function_name=function_name,
             client_config=client.to_dict(),
         )
 

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
@@ -138,6 +138,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
         assert tool.metadata.name == func_obj.tool_name
         assert tool.metadata.return_direct
         assert tool.metadata.description == func_obj.comment
+        assert tool.uc_function_name == func_obj.full_function_name
         assert tool.client_config == client.to_dict()
 
         input_args = {"code": "print(1)"}
@@ -164,6 +165,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         assert tool.metadata.name == func_obj.tool_name
         assert tool.metadata.return_direct
         assert tool.metadata.description == func_obj.comment
+        assert tool.uc_function_name == func_obj.full_function_name
         assert tool.client_config == client.to_dict()
         input_args = {"code": "print(1)"}
         result = json.loads(tool.fn(**input_args))["value"]


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
For these tools, we convert the original uc function name `catalog.schema.function` to `catalog__schema__function` (max length 64) to be compatible with OpenAI requirements, but sometimes we need to extract the original uc function name in the downstream usages. So saving the original uc function name directly to avoid any conversion error. 


<!-- Please state what you've changed and how it might affect the users. -->
