### PR TITLE
Fix UC function schema when no params are needed

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -5,7 +5,7 @@ import os
 from hashlib import md5
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import Field, create_model
 
 from unitycatalog.ai.core.utils.config import JSON_SCHEMA_TYPE, UC_LIST_FUNCTIONS_MAX_RESULTS
 from unitycatalog.ai.core.utils.pydantic_utils import (
@@ -239,8 +239,11 @@ def generate_function_input_params_schema(
     """
     if not isinstance(function_info, supported_function_info_types()):
         raise TypeError(f"Unsupported function info type: {type(function_info)}")
+    params_name = (
+        f"{function_info.catalog_name}__{function_info.schema_name}__{function_info.name}__params"
+    )
     if function_info.input_params is None:
-        return PydanticFunctionInputParams(pydantic_model=BaseModel, strict=strict)
+        return PydanticFunctionInputParams(pydantic_model=create_model(params_name), strict=strict)
     param_infos = function_info.input_params.parameters
     if param_infos is None:
         raise ValueError("Function input parameters are None.")
@@ -251,10 +254,7 @@ def generate_function_input_params_schema(
             pydantic_field.pydantic_type,
             Field(default=pydantic_field.default, description=pydantic_field.description),
         )
-    model = create_model(
-        f"{function_info.catalog_name}__{function_info.schema_name}__{function_info.name}__params",
-        **fields,
-    )
+    model = create_model(params_name, **fields)
     return PydanticFunctionInputParams(pydantic_model=model, strict=pydantic_field.strict)
 
 

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -381,7 +381,7 @@ def test_create_function_without_replace(client: DatabricksFunctionClient):
         # Attempt to create the same function again without replace
         with pytest.raises(
             Exception,
-            match=f"Cannot create the function `{CATALOG}`.`{SCHEMA}`.`simple_func` because it already exists",
+            match=f"`{CATALOG}`.`{SCHEMA}`.`simple_func` because it already exists",
         ):
             client.create_python_function(
                 func=simple_func, catalog=CATALOG, schema=SCHEMA, replace=False

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -28,6 +28,7 @@ from unitycatalog.ai.test_utils.client_utils import (
 from unitycatalog.ai.test_utils.function_utils import (
     CATALOG,
     create_function_and_cleanup,
+    create_python_function_and_cleanup,
 )
 
 try:
@@ -70,7 +71,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
     monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
     client = get_client()
-    with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
+    with create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name], client=client)
         tools = toolkit.tools
         assert len(tools) == 1
@@ -89,10 +90,17 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
 @requires_databricks
 @pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
+def test_toolkit_e2e_tools_with_no_params(use_serverless, monkeypatch):
     monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
     client = get_client()
-    with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
+
+    def get_weather() -> str:
+        """
+        Get the weather.
+        """
+        return "sunny"
+
+    with create_python_function_and_cleanup(client, schema=SCHEMA, func=get_weather) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name], client=client)
         tools = toolkit.tools
         assert len(tools) == 1
@@ -100,9 +108,9 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
         assert tool.name == func_obj.tool_name
         assert tool.description == func_obj.comment
         assert tool.client_config == client.to_dict()
-        tool.args_schema(**{"code": "print(1)"})
-        result = json.loads(tool.func(code="print(1)"))["value"]
-        assert result == "1\n"
+        tool.args_schema()
+        result = json.loads(tool.func())["value"]
+        assert result == "sunny"
 
         toolkit = UCFunctionToolkit(function_names=[f"{CATALOG}.{SCHEMA}.*"], client=client)
         assert len(toolkit.tools) >= 1


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
With the latest langchain version, if the UC function has no params then the schema is not correctly parsed. We should use `create_model` instead of `BaseModel`, added test for this.

Test validation: https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/11567043081/job/32198004224

<!-- Please state what you've changed and how it might affect the users. -->
