### PR TITLE
Adjust parameter input sanitization to only apply locally to strings

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -1,3 +1,4 @@
+import ast
 import decimal
 import json
 import logging
@@ -284,6 +285,41 @@ def supported_function_info_types():
     return types
 
 
+def is_python_code(code_str: str) -> bool:
+    """Check if the provided string is valid Python code."""
+    try:
+        ast.parse(code_str)
+        return True
+    except SyntaxError:
+        return False
+
+
+def convert_quoting_to_sql_safe_format(string_value: str) -> str:
+    """
+    Convert a string to a SQL-safe format by escaping single quotes.
+
+    Args:
+        string_value: The string to be converted.
+
+    Returns:
+        str: The SQL-safe string.
+    """
+    has_single_quote = "'" in string_value
+    has_double_quote = '"' in string_value
+
+    if not has_single_quote and not has_double_quote:
+        return string_value
+
+    if has_single_quote and not has_double_quote:
+        string_value = string_value.replace("'", '"')
+    elif has_single_quote and has_double_quote:
+        raise ValueError(
+            "The argument passed in has been detected as Python code that contains both single and double quotes. "
+            "This is not supported. Code must use only one style of quotation. Please fix the code and try again."
+        )
+    return string_value
+
+
 def sanitize_string_inputs_of_function_params(param_value: Any) -> str:
     """
     Sanitize string inputs of function parameters to allow for code block submission.
@@ -295,15 +331,15 @@ def sanitize_string_inputs_of_function_params(param_value: Any) -> str:
         A sanitized string of the argument value.
     """
 
-    if isinstance(param_value, str):
+    if isinstance(param_value, str) and is_python_code(param_value):
         # Escape single quotes, backslashes, and control characters that would otherwise break Python code execution
         parsed = (
-            param_value.replace("'", "''")
-            .replace("\\", "\\\\")
+            param_value.replace("\\", "\\\\")
             .replace("\r", "\\r")
             .replace("\n", "\\n")
             .replace("\t", "\\t")
         )
-        param_value = f"""{parsed}"""
-
-    return str(param_value)
+        quotes_parsed = convert_quoting_to_sql_safe_format(parsed)
+    else:
+        quotes_parsed = param_value
+    return str(quotes_parsed)

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -284,29 +284,26 @@ def supported_function_info_types():
     return types
 
 
-def sanitize_string_inputs_of_function_params(function_params: Dict[str, Any]) -> Dict[str, Any]:
+def sanitize_string_inputs_of_function_params(param_value: Any) -> str:
     """
-    Sanitize string inputs of function parameters to prevent injection attacks.
+    Sanitize string inputs of function parameters to allow for code block submission.
 
     Args:
-        function_params: A dictionary of function parameters.
+        param_value: The value of the parameter to sanitize.
 
     Returns:
-        A sanitized dictionary of function parameters.
+        A sanitized string of the argument value.
     """
-    sanitized_params = {}
-    for key, value in function_params.items():
-        if isinstance(value, str):
-            # Escape single quotes, backslashes, and control characters that would otherwise break Python code execution
-            parsed = (
-                value.replace("'", "''")
-                .replace("\\", "\\\\")
-                .replace("\r", "\\r")
-                .replace("\n", "\\n")
-                .replace("\t", "\\t")
-            )
-            sanitized_params[key] = f"""{parsed}"""
 
-        else:
-            sanitized_params[key] = value
-    return sanitized_params
+    if isinstance(param_value, str):
+        # Escape single quotes, backslashes, and control characters that would otherwise break Python code execution
+        parsed = (
+            param_value.replace("'", "''")
+            .replace("\\", "\\\\")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+        )
+        param_value = f"""{parsed}"""
+
+    return str(param_value)

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -386,3 +386,81 @@ def test_create_function_without_replace(client: DatabricksFunctionClient):
             client.create_python_function(
                 func=simple_func, catalog=CATALOG, schema=SCHEMA, replace=False
             )
+
+
+integration_test_cases = [
+    ("\nprint('Hello World!')", "Hello World!"),
+    ("def greet(name='Bob'):\n    return f'Hello {name}!'\nprint(greet())", "Hello Bob!"),
+    ("for i in range(5):\n\tif i % 2 == 0:\n\t\tprint(i)", "0\n2\n4"),
+    (
+        """def calculate_sum(numbers):
+\t\ttotal = 0
+\t\tfor num in numbers:
+\t\t\ttotal += num
+\t\treturn total
+print(calculate_sum([1, 2, 3, 4, 5]))""",
+        "15",
+    ),
+]
+
+
+@requires_databricks
+@pytest.mark.parametrize("code, expected_output", integration_test_cases)
+def test_execute_python_code_integration(
+    client: DatabricksFunctionClient, code: str, expected_output: str
+):
+    def python_exec(code: str) -> str:
+        """
+        Execute the provided Python code and return the output.
+        """
+        import sys
+        from io import StringIO
+
+        sys_stdout = sys.stdout
+        redirected_output = StringIO()
+        sys.stdout = redirected_output
+
+        exec(code)
+        sys.stdout = sys_stdout
+        return redirected_output.getvalue()
+
+    function_full_name = f"{CATALOG}.{SCHEMA}.python_exec"
+
+    with create_python_function_and_cleanup(client, func=python_exec, schema=SCHEMA):
+        result = client.execute_function(
+            function_name=function_full_name, parameters={"code": code}
+        )
+
+        assert result.error is None, f"Function execution failed with error: {result.error}"
+
+        assert result.value == expected_output
+
+
+@requires_databricks
+def test_execute_invalid_format_python_code(client: DatabricksFunctionClient):
+    def python_exec(code: str) -> str:
+        """
+        Execute the provided Python code and return the output.
+        """
+        import sys
+        from io import StringIO
+
+        sys_stdout = sys.stdout
+        redirected_output = StringIO()
+        sys.stdout = redirected_output
+
+        exec(code)
+        sys.stdout = sys_stdout
+        return redirected_output.getvalue()
+
+    function_full_name = f"{CATALOG}.{SCHEMA}.python_exec"
+
+    with create_python_function_and_cleanup(client, func=python_exec, schema=SCHEMA):
+        invalid_code = "print(\"Hello 'world'\")"
+        with pytest.raises(
+            ValueError,
+            match="The argument passed in has been detected as Python code that contains",
+        ):
+            client.execute_function(
+                function_name=function_full_name, parameters={"code": invalid_code}
+            )

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -709,12 +709,12 @@ test_cases_string_inputs = [
     # String with single quotes
     (
         {"a": 1, "b": "O'Reilly"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','O''Reilly')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','O'Reilly')",
     ),
     # String with backslashes
     (
         {"a": 1, "b": "C:\\Program Files\\App"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','C:\\\\Program Files\\\\App')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','C:\\Program Files\\App')",
     ),
     # String with newlines
     (
@@ -724,12 +724,12 @@ test_cases_string_inputs = [
     # String with tabs
     (
         {"a": 1, "b": "Column1\tColumn2"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Column1\\tColumn2')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','Column1\tColumn2')",
     ),
     # String with various special characters
     (
         {"a": 1, "b": "Special chars: !@#$%^&*()_+-=[]{}|;':,./<>?"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Special chars: !@#$%^&*()_+-=[]{}|;'':,./<>?')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','Special chars: !@#$%^&*()_+-=[]{}|;':,./<>?')",
     ),
     # String with Unicode characters
     (
@@ -744,17 +744,17 @@ test_cases_string_inputs = [
     # String with backslashes and quotes
     (
         {"a": 1, "b": "Path: C:\\User\\'name'\\\"docs\""},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Path: C:\\\\User\\\\''name''\\\\\"docs\"')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','Path: C:\\User\\'name'\\\"docs\"')",
     ),
     # String with code-like content (simulating GenAI code)
     (
         {"a": 1, "b": "def func():\n    print('Hello, world!')"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','def func():\\n    print(''Hello, world!'')')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','def func():\\n    print(\"Hello, world!\")')",
     ),
     # String with multiline code and special characters
     (
         {"a": 1, "b": "if a > 0:\n    print('Positive')\nelse:\n    print('Non-positive')"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','if a > 0:\\n    print(''Positive'')\\nelse:\\n    print(''Non-positive'')')",
+        "SELECT `catalog`.`schema`.`mock_function`('1','if a > 0:\\n    print(\"Positive\")\\nelse:\\n    print(\"Non-positive\")')",
     ),
 ]
 

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -796,8 +796,7 @@ def test_execute_function_with_mock_string_input(
         "b": "def func():\n    print('Hello, world!')",
     }
 
-    sanitized_parameters = sanitize_string_inputs_of_function_params(parameters)
-    sanitized_b = sanitized_parameters["b"]
+    sanitized_b = sanitize_string_inputs_of_function_params(parameters["b"])
 
     expected_sql = f"SELECT `catalog`.`schema`.`mock_function`('1','{sanitized_b}')"
 
@@ -805,18 +804,18 @@ def test_execute_function_with_mock_string_input(
 
     client.set_default_spark_session = MagicMock()
     client.spark = mock_spark_session
-
     client.get_function = MagicMock(return_value=mock_function_info)
 
     mock_result = MagicMock()
-    mock_result.collect.return_value = [[f"1-{parameters['b']}"]]
+    mock_result.collect.return_value = [[f"1-{sanitized_b}"]]
     mock_spark_session.sql.return_value = mock_result
 
     result = client.execute_function("catalog.schema.mock_function", parameters=parameters)
 
     mock_spark_session.sql.assert_called_once_with(sqlQuery=expected_sql)
 
-    assert result.value == f"1-{parameters['b']}"
+    expected_result = f"1-{sanitized_b}"
+    assert result.value == expected_result
 
 
 def test_execute_function_with_genai_code_input(
@@ -852,8 +851,7 @@ greet("World")"""
         "b": genai_code,
     }
 
-    sanitized_parameters = sanitize_string_inputs_of_function_params(parameters)
-    sanitized_b = sanitized_parameters["b"]
+    sanitized_b = sanitize_string_inputs_of_function_params(parameters["b"])
 
     expected_sql = f"SELECT `catalog`.`schema`.`mock_function`('1','{sanitized_b}')"
 

--- a/ai/core/tests/core/test_utils.py
+++ b/ai/core/tests/core/test_utils.py
@@ -516,7 +516,7 @@ test_cases = [
 
 @pytest.mark.parametrize("code_input, expected_output", test_cases)
 def test_code_execution(code_input: str, expected_output: str):
-    escaped_code = sanitize_string_inputs_of_function_params({"code": code_input})
-    code_to_execute = unescape_sql_string(escaped_code["code"])
+    escaped_code = sanitize_string_inputs_of_function_params(code_input)
+    code_to_execute = unescape_sql_string(escaped_code)
     output = mock_execute_function(code_to_execute)
     assert output == expected_output

--- a/ai/core/tests/core/test_utils.py
+++ b/ai/core/tests/core/test_utils.py
@@ -465,51 +465,47 @@ def mock_execute_function(code: str) -> str:
 
 # Test cases
 test_cases = [
-    # 1. Simple print statement
+    # Simple print statement
     ("print('Hello, world!')", "Hello, world!\n"),
-    # 2. Code with single quotes
-    ("print('It\\'s a sunny day')", "It's a sunny day\n"),
-    # 3. Code with double quotes
+    # Code with double quotes
     ('print("He said, \\"Hi!\\"")', 'He said, "Hi!"\n'),
-    # 4. Code with backslashes
+    # Code with backslashes
     (r"print('C:\\path\\into\\dir')", "C:\\path\\into\\dir\n"),
-    # 5. Multi-line code with newlines
+    # Multi-line code with newlines
     ("for i in range(3):\n    print(i)", "0\n1\n2\n"),
-    # 6. Code with tabs and indents
+    # Code with tabs and indents
     ("def greet(name):\n    print(f'Hello, {name}!')\ngreet('Alice')", "Hello, Alice!\n"),
-    # 7. Code with special characters
+    # Code with special characters
     ("print('Special chars: !@#$%^&*()')", "Special chars: !@#$%^&*()\n"),
-    # 8. Unicode characters
+    # Unicode characters
     ("print('Unicode test: ü, é, 漢字')", "Unicode test: ü, é, 漢字\n"),
-    # 9. Code with comments
+    # Code with comments
     ("# This is a comment\nprint('Comment test')", "Comment test\n"),
-    # 10. Code raising an exception
+    # Code raising an exception
     (
         "try:\n    raise ValueError('Test error')\nexcept Exception as e:\n    print(f'Caught an error: {e}')",
         "Caught an error: Test error\n",
     ),
-    # 11. Code with triple quotes
+    # Code with triple quotes
     ('print("""Triple quote test""")', "Triple quote test\n"),
-    # 12. Code with raw strings
+    # Code with raw strings
     ("print('Raw string: \\\\n new line')", "Raw string:  new line\n"),
-    # 13. Empty code string
+    # Empty code string
     ("", ""),
-    # 14. Code with carriage return
+    # Code with carriage return
     ("print('Line1\\\\rLine2')", "Line1\\rLine2\n"),
-    # 15. Code with multiple special characters
-    (r"print('Mix: \\\\ \\\' \\\" \\\\n \\\\t')", """Mix: \\\\ \\\' \\" \\ \\\\\t\n"""),
-    # 16. Code with encoding declarations (Note: encoding declarations should be in the first or second line)
+    # Code with encoding declarations (Note: encoding declarations should be in the first or second line)
     ("# -*- coding: utf-8 -*-\nprint('Encoding test')", "Encoding test\n"),
-    # 17. Code importing a standard library
+    # Code importing a standard library
     ("import math\nprint(math.pi)", f"{math.pi}\n"),
-    # 18. Code with nested functions
+    # Code with nested functions
     (
         "def outer():\n    def inner():\n        return 'Nested'\n    return inner()\nprint(outer())",
         "Nested\n",
     ),
-    # 19. Code with list comprehensions
+    # Code with list comprehensions
     ("squares = [x**2 for x in range(5)]\nprint(squares)", "[0, 1, 4, 9, 16]\n"),
-    # 20. Code with multi-line strings
+    # Code with multi-line strings
     ("multi_line = '''Line1\nLine2\nLine3'''\nprint(multi_line)", "Line1\nLine2\nLine3\n"),
 ]
 
@@ -520,3 +516,17 @@ def test_code_execution(code_input: str, expected_output: str):
     code_to_execute = unescape_sql_string(escaped_code)
     output = mock_execute_function(code_to_execute)
     assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "code_input",
+    [
+        "print('Hello, \"world!\"')",
+        'return \'2\' + """3"""',
+    ],
+)
+def test_rejected_code_execution(code_input: str):
+    with pytest.raises(
+        ValueError, match="The argument passed in has been detected as Python code that contains"
+    ):
+        sanitize_string_inputs_of_function_params(code_input)


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This change adjusts the SQL sanitization logic for string input parameters (arguments) to UC function calls to only apply locally in order to prevent valid SQL string command objects that are wrapped in single quotes from being converted to double-single-quote wrapping, which is invalid as a SQL statement. 