### PR TITLE
Formate usage/tables documentation pages via markdownlint

### DIFF
--- a/docs/usage/tables/formats.md
+++ b/docs/usage/tables/formats.md
@@ -1,16 +1,20 @@
 # Table Formats
 
-This page explains how you can work with various table storage format tables in your Unity Catalog. It will also explain the advantages and drawbacks of working with these storage formats including Parquet, ORC, JSON, CSV, Avro, and TEXT.  
+This page explains how you can work with various table storage format tables in your Unity Catalog. It will also
+explain the advantages and drawbacks of working with these storage formats including Parquet, ORC, JSON, CSV, Avro,
+and TEXT.
 
 ## Set up Unity Catalog
 
-To follow along, make sure you have a local instance of Unity Catalog running by launching the following command from a terminal window:
+To follow along, make sure you have a local instance of Unity Catalog running by launching the following command from
+a terminal window:
 
 ```bash
 bin/start-uc-server
 ```
 
-This local UC server will come with some sample data pre-loaded.  To list all of the tables in your local Unity Catalog, use:
+This local UC server will come with some sample data pre-loaded. To list all of the tables in your local
+Unity Catalog, use:
 
 ```bash
 bin/uc table list --catalog unity --schema default
@@ -30,12 +34,12 @@ bin/uc table list --catalog unity --schema default
 └─────────────────┴──────────────┴─────┴────────────────────────────────────┘
 ```
 
-
 As you can see, there are currently four (4) Delta tables pre-loaded in this catalog.  
 
+## Create a table using a different storage format
 
-## Create a table using a different storage format 
-To create a table storage format table such as Parquet, ORC, Avro, CSV, JSON, or TEXT, use the `bin/uc table create ...` command with the `--format ` flag.
+To create a table storage format table such as Parquet, ORC, Avro, CSV, JSON, or TEXT, use the
+`bin/uc table create ...` command with the `--format` flag.
 
 The following creates a new table in the `path/to/storage` LOCATION two colummns: `some_numbers` and `some_letters`
 
@@ -43,8 +47,8 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format PARQUET
     ```
 
@@ -52,8 +56,8 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format JSON
     ```
     
@@ -61,8 +65,8 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format CSV
     ```
 
@@ -70,8 +74,8 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format ORC
     ```
 
@@ -79,8 +83,8 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format AVRO
     ```
       
@@ -88,17 +92,18 @@ The following creates a new table in the `path/to/storage` LOCATION two colummns
 
     ```bash
     bin/uc table create --full_name unity.default.test \
-       --columns "some_numbers INT, some_letters STRING"  \
-       --storage_location /path/to/storage \ 
+       --columns "some_numbers INT, some_letters STRING" \
+       --storage_location /path/to/storage \
        --format TEXT
     ```
 
-
 !!! Note "Setting your /path/to/storage"
-    You will need to manually set the `/path/to/storage` to the correct storage location. If you don't know where Unity Catalog is storing your files, then take a look at the metadata of an existing table using `bin/uc table get --full_name <catalog.schema.table>` to see its storage location. 
+    You will need to manually set the `/path/to/storage` to the correct storage location. If you don't know where
+    Unity Catalog is storing your files, then take a look at the metadata of an existing table using
+    `bin/uc table get --full_name <catalog.schema.table>` to see its storage location.
 
-
-After you run the `table create` command, your output should look similar to the following *abridged* output of a JSON table:
+After you run the `table create` command, your output should look similar to the following *abridged* output of a JSON
+table:
 
 ```console
 ┌───────────────────┬───────────────────────────────────────────────┐
@@ -132,22 +137,26 @@ After you run the `table create` command, your output should look similar to the
 This command has multiple parameters:
 
 | Parameter | Description |
-| --------- | ----------- | 
-| `full_name` | The full name of the table, which is a concatenation of the catalog name, schema name, and table name separated by dots (e.g., catalog_name.schema_name.table_name). | 
+| --------- | ----------- |
+| `full_name` | The full name of the table, which is a concatenation of the catalog name, schema name, and table name separated by dots (e.g., catalog_name.schema_name.table_name). |
 | `columns` |  The columns of the table in SQL-like format "column_name column_data_type". Supported data types include `BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, DATE, TIMESTAMP, TIMESTAMP_NTZ, STRING, BINARY, DECIMAL`. Separate multiple columns with a comma (e.g., "`id INT, name STRING`") |
 | `format` | [Optional] The format of the data source. Supported values are DELTA, PARQUET, ORC, JSON, CSV, AVRO, and TEXT. If not specified the default format is DELTA. |
 | `storage_location` | The storage location associated with the table. It is a mandatory field for EXTERNAL tables. |
 | `properties` |  [Optional] The properties of the entity in JSON format (e.g., '{"key1": "value1", "key2": "value2"}'). Make sure to either escape the double quotes(\") inside the properties string or just use single quotes('') around the same. |
 
+## Challenges using table storage formats
 
-## Challenges using table storage formats 
-While popular, each table storage format (e.g., Parquet, ORC, JSON, CSV, Avro, TEXT, etc.) has their own set of distinct advantages.But the challenges when working with these formats include:
+While popular, each table storage format (e.g., Parquet, ORC, JSON, CSV, Avro, TEXT, etc.) has their own set of
+distinct advantages. But the challenges when working with these formats include:
 
 - No ACID transactions for these data lakes meaning it's easier to accidentally corrupt your data
 - It is not easy to delete rows from these tables
 - These table storage foramts do not offer DML transactions
 - They lack advanced features from schema evolution and enforcement to deletion vectors to change data feed
-- Slow file listing overhead when working with cloud object stores such as AWS S3, Azure ADLSgen2, and Google Cloud Storage
+- Slow file listing overhead when working with cloud object stores such as AWS S3, Azure ADLSgen2, and
+    Google Cloud Storage
 - Potentialy expensive footer reads to gather statistics for file skipping
 
-Open table formats like Apache Iceberg and Delta Lake are specifically designed to overcome these challenges. Storing your data in a lakehouse format is almost always more advantageous than storing it in traditional table storage formats.
+Open table formats like Apache Iceberg and Delta Lake are specifically designed to overcome these challenges. Storing
+your data in a lakehouse format is almost always more advantageous than storing it in traditional table storage
+formats.

--- a/docs/usage/tables/uniform.md
+++ b/docs/usage/tables/uniform.md
@@ -1,21 +1,27 @@
 # Unity Catalog with UniForm tables
 
-UniForm tables are Delta tables with both Delta Lake and Iceberg metadata.  UniForm tables can easily be read by Delta or Iceberg clients.
+UniForm tables are Delta tables with both Delta Lake and Iceberg metadata. UniForm tables can easily be read by Delta
+or Iceberg clients.
 
-UniForm makes it easy for all engines to read Delta tables, even engines that only have Iceberg connectors and don't have Delta Lake connectors.
+UniForm makes it easy for all engines to read Delta tables, even engines that only have Iceberg connectors and don't
+have Delta Lake connectors.
 
 ## Read Delta Uniform tables via Iceberg REST Catalog
 
 Delta Tables with Uniform enabled can be accessed via Iceberg REST Catalog. The Iceberg REST Catalog is served at
 `http://127.0.0.1:8080/api/2.1/unity-catalog/iceberg/`.
 
-A pre-populated Delta Uniform table can be prepared by running `cp -r etc/data/external/unity/default/tables/marksheet_uniform /tmp/marksheet_uniform`.
+A pre-populated Delta Uniform table can be prepared by running
+
+```sh
+cp -r etc/data/external/unity/default/tables/marksheet_uniform /tmp/marksheet_uniform
+```
 
 ## Setting up REST Catalog with Apache Spark
 
 The following is an example of the settings to configure OSS Apache Spark to read UniForm as Iceberg:
 
-```
+```console
 "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
 "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
 "spark.sql.catalog.iceberg.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
@@ -23,4 +29,5 @@ The following is an example of the settings to configure OSS Apache Spark to rea
 "spark.sql.catalog.iceberg.token": "not_used",
 ```
 
-When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern `iceberg.<catalog-name>.<schema-name>.<table-name>` (e.g. `iceberg.unity.default.marksheet_uniform`).
+When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern
+`iceberg.<catalog-name>.<schema-name>.<table-name>` (e.g. `iceberg.unity.default.marksheet_uniform`).


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Update the formatting of the `usage/tables` documentation pages by using markdownlint. User-facing changes have been kept minimal.

Resolves #675