### PR TITLE
Formate usage documentation pages via markdownlint

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,19 +1,19 @@
 # Unity Catalog CLI
 
-The CLI tool allows users to interact with a Unity Catalog server to create and manage catalogs, schemas, tables across 
+The CLI tool allows users to interact with a Unity Catalog server to create and manage catalogs, schemas, tables across
 different formats (DELTA, UNIFORM, PARQUET, JSON, and CSV), volumes with unstructured data, and functions.
 
 !!! note "Specify token for authenticated access"
 
-    For all the following commands, you will need to provide an authentication token when executng these commands.  For example, in the following section, to run the catalog list command, you would specify:
+    For all the following commands, you will need to provide an authentication token when executng these commands.
+    For example, in the following section, to run the catalog list command, you would specify:
 
     ```bash
     bin/uc --auth_token $token catalog list
     ```
 
-    where $token is the authentication token provided by an identity provider.  For more information on how to support both authentication and authorization, please refer to the [auth](../server/auth.md).
-
-
+    where $token is the authentication token provided by an identity provider. For more information on how to support
+    both authentication and authorization, please refer to the [auth](../server/auth.md).
 
 ## 1. Catalog Management CLI Usage
 
@@ -46,8 +46,9 @@ bin/uc catalog create --name <name> [--comment <comment>] [--properties <propert
 
 - `name`: The name of the catalog.
 - `comment`: *\[Optional\]* The description of the catalog.
-- `properties`:  *\[Optional\]* The properties of the catalog in JSON format (e.g., `'{"key1": "value1", "key2": "value2"}'`).
-  Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
+- `properties`:  *\[Optional\]* The properties of the catalog in JSON format
+    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the
+    properties string or just use single quotes(`''`) around the same.
 
 Example:
 
@@ -64,8 +65,9 @@ bin/uc catalog update --name <name> [--new_name <new_name>] [--comment <comment>
 - `name`: The name of the existing catalog.
 - `new_name`: *\[Optional\]* The new name of the catalog.
 - `comment`: *\[Optional\]* The new description of the catalog.
-- `properties`:  *\[Optional\]* The new properties of the catalog in JSON format (e.g., `'{"key1": "value1", "key2": "value2"}'`).
-  Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
+- `properties`:  *\[Optional\]* The new properties of the catalog in JSON format
+    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the
+    properties string or just use single quotes(`''`) around the same.
 
 ***Note:** At least one of the optional parameters must be specified.*
 
@@ -117,8 +119,9 @@ bin/uc schema create --catalog <catalog> --name <name> [--comment <comment>] [--
 - `catalog`: The name of the catalog.
 - `name`: The name of the schema.
 - `comment`: *\[Optional\]*  The description of the schema.
-- `properties`:  *\[Optional\]* The properties of the schema in JSON format (e.g., `'{"key1": "value1", "key2": "value2"}'`).
-  Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
+- `properties`:  *\[Optional\]* The properties of the schema in JSON format
+    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the
+    properties string or just use single quotes(`''`) around the same.
 
 Example:
 
@@ -132,12 +135,13 @@ bin/uc schema create --catalog my_catalog --name my_schema --comment "My Schema"
 bin/uc schema update --full_name <full_name> [--new_name <new_name>] [--comment <comment>] [--properties <properties>]
 ```
 
-- `full_name`: The full name of the existing schema. 
-  The full name is the concatenation of the catalog name and schema name separated by a dot (e.g., `catalog_name.schema_name`).
+- `full_name`: The full name of the existing schema. The full name is the concatenation of the catalog name and schema
+    name separated by a dot (e.g., `catalog_name.schema_name`).
 - `new_name`: *\[Optional\]* The new name of the schema.
 - `comment`: *\[Optional\]* The new description of the schema.
-- `properties`:  *\[Optional\]* The new properties of the schema in JSON format (e.g., `'{"key1": "value1", "key2": "value2"}'`).
-  Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
+- `properties`:  *\[Optional\]* The new properties of the schema in JSON format
+    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the
+    properties string or just use single quotes(`''`) around the same.
 
 ***Note:** At least one of the optional parameters must be specified.*
 
@@ -189,27 +193,30 @@ bin/uc table create --full_name <full_name> --columns <columns> --storage_locati
 ```
 
 - `full_name`: The full name of the table, which is a concatenation of the catalog name,
-  schema name, and table name separated by dots (e.g., `catalog_name.schema_name.table_name`).
+    schema name, and table name separated by dots (e.g., `catalog_name.schema_name.table_name`).
 - `columns`: The columns of the table in SQL-like format `"column_name column_data_type"`.
-  Supported data types include `BOOLEAN`, `BYTE`, `SHORT`, `INT`, `LONG`, `FLOAT`, `DOUBLE`, `DATE`, `TIMESTAMP`,
-  `TIMESTAMP_NTZ`, `STRING`, `BINARY`, `DECIMAL`. Separate multiple columns with a comma
-  (e.g., `"id INT, name STRING"`).
-- `format`: *\[Optional\]* The format of the data source. Supported values are `DELTA`, `PARQUET`, `ORC`, `JSON`, `CSV`, `AVRO`, and `TEXT`.
-  If not specified the default format is `DELTA`.
+    Supported data types include `BOOLEAN`, `BYTE`, `SHORT`, `INT`, `LONG`, `FLOAT`, `DOUBLE`, `DATE`, `TIMESTAMP`,
+    `TIMESTAMP_NTZ`, `STRING`, `BINARY`, `DECIMAL`. Separate multiple columns with a comma
+    (e.g., `"id INT, name STRING"`).
+- `format`: *\[Optional\]* The format of the data source. Supported values are `DELTA`, `PARQUET`, `ORC`, `JSON`,
+    `CSV`, `AVRO`, and `TEXT`. If not specified the default format is `DELTA`.
 - `storage_location`: The storage location associated with the table. It is a mandatory field for `EXTERNAL` tables.
-- `properties`:  *\[Optional\]* The properties of the table in JSON format (e.g., `'{"key1": "value1", "key2": "value2"}'`).
-  Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
+- `properties`:  *\[Optional\]* The properties of the table in JSON format
+    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the
+    properties string or just use single quotes(`''`) around the same.
 
 Example:
 
-- Create an external DELTA table with columns `id` and `name` in the schema `my_schema` of catalog `my_catalog` with storage location `/path/to/storage`:
+- Create an external DELTA table with columns `id` and `name` in the schema `my_schema` of catalog `my_catalog` with
+    storage location `/path/to/storage`:
 
 ```sh
 bin/uc table create --full_name my_catalog.my_schema.my_table --columns "id INT, name STRING" --storage_location "/path/to/storage"
 ```
 
-When running against UC server, the storage location can be a local path(absolute path) or an S3 path. 
-When S3 path is provided, the [server configuration](../server/configuration.md) will vend temporary credentials to access the S3 bucket and server properties must be set up accordingly.
+When running against UC server, the storage location can be a local path(absolute path) or an S3 path.
+When S3 path is provided, the [server configuration](../server/configuration.md) will vend temporary credentials to
+access the S3 bucket and server properties must be set up accordingly.
 
 ### 3.4 Read a DELTA Table
 
@@ -279,10 +286,11 @@ bin/uc volume create --full_name <catalog>.<schema>.<volume> --storage_location 
 - `schema`: The name of the schema.
 - `volume`: The name of the volume.
 - `storage_location`: The storage location associated with the volume. When running against UC OSS server,
-  the storage location can be a local path(absolute path) or an S3 path.
-  When S3 path is provided, the [server configuration](../server/configuration.md) will vend temporary credentials to access the S3 bucket and server properties must be set up accordingly.
-  When running against Databricks Unity Catalog, the storage location for EXTERNAL volume can only be an S3 location which
-  has been configured as an `external location` in your Databricks workspace.
+    the storage location can be a local path(absolute path) or an S3 path. When S3 path is provided, the
+    [server configuration](../server/configuration.md) will vend temporary credentials to access the S3 bucket and
+    server properties must be set up accordingly. When running against Databricks Unity Catalog, the storage location
+    for EXTERNAL volume can only be an S3 location which has been configured as an `external location` in your
+    Databricks workspace.
 - `comment`: *\[Optional\]* The description of the volume.
 
 Example:
@@ -323,9 +331,9 @@ bin/uc volume read --full_name <catalog>.<schema>.<volume> [--path <path>]
 - `schema`: The name of the schema.
 - `volume`: The name of the volume.
 - `path`: *\[Optional\]* The path relative to the volume root.
-  If no path is provided, the volume root is read.
-  If the final path is a directory, the contents of the directory are listed(`ls`).
-  If the final path is a file, the contents of the file are displayed(`cat`).
+    If no path is provided, the volume root is read.
+    If the final path is a directory, the contents of the directory are listed(`ls`).
+    If the final path is a file, the contents of the file are displayed(`cat`).
 
 ### 4.6 Write Sample Data to a Volume
 
@@ -380,11 +388,14 @@ bin/uc function get --full_name <catalog>.<schema>.<function_name>
 bin/uc function create --full_name <catalog>.<schema>.<function_name> --input_params <input_params> --data_type <data_type> --def <definition> [--comment <comment>] [--language <language>]
 ```
 
-- `full_name`: The full name of the function, which is a concatenation of the catalog name, schema name, and function name separated by dots (e.g., `catalog_name.schema_name.function_name`).
+- `full_name`: The full name of the function, which is a concatenation of the catalog name, schema name, and function
+    name separated by dots (e.g., `catalog_name.schema_name.function_name`).
 - `input_params`: The input parameters to the function in SQL-like format `"param_name param_data_type"`.
-  Multiple input parameters should be separated by a comma (e.g., `"param1 INT, param2 STRING"`).
-- `data_type`: The data type of the function. Either a type_name (for e.g. `INT`,`DOUBLE`, `BOOLEAN`, `DATE`), or `TABLE_TYPE` if this is a table valued function.
-- `def`: The definition of the function. The definition should be a valid SQL statement or a python routine with the function logic and return statement.
+    Multiple input parameters should be separated by a comma (e.g., `"param1 INT, param2 STRING"`).
+- `data_type`: The data type of the function. Either a type_name (for e.g. `INT`,`DOUBLE`, `BOOLEAN`, `DATE`), or
+    `TABLE_TYPE` if this is a table valued function.
+- `def`: The definition of the function. The definition should be a valid SQL statement or a python routine with the
+    function logic and return statement.
 - `comment`: *\[Optional\]* The description of the function.
 - `language`: *\[Optional\]*  The language of the function. If not specified, the default value is `PYTHON`.
 
@@ -402,11 +413,12 @@ bin/uc function create --full_name my_catalog.my_schema.my_function --input_para
 bin/uc function call --full_name <catalog>.<schema>.<function_name> --input_params <input_params>
 ```
 
-- `full_name`: The full name of the function, which is a concatenation of the catalog name, schema name, and function name separated by dots (e.g., `catalog_name.schema_name.function_name`).
+- `full_name`: The full name of the function, which is a concatenation of the catalog name, schema name, and function
+    name separated by dots (e.g., `catalog_name.schema_name.function_name`).
 - `input_params` : The value of input parameters to the function separated by a comma (e.g., `"param1,param2"`).
 
-This is an experimental feature and only supported for python functions that take in primitive types as input parameters.
-It runs the functions using the python engine script at `etc/data/function/python_engine.py`.
+This is an experimental feature and only supported for python functions that take in primitive types as input
+parameters. It runs the functions using the python engine script at `etc/data/function/python_engine.py`.
 
 Example:
 
@@ -428,7 +440,8 @@ bin/uc function delete --full_name <catalog>.<schema>.<function_name>
 
 ## 6. Registered model and model version management
 
-Please refer to [MLflow documentation](https://mlflow.org/docs/latest/index.html) to learn how to use MLflow to create, register, update, use, and delete registered models and model versions.
+Please refer to [MLflow documentation](https://mlflow.org/docs/latest/index.html) to learn how to use MLflow to create,
+register, update, use, and delete registered models and model versions.
 
 ## 7. CLI Server Configuration
 
@@ -436,19 +449,20 @@ By default, the CLI tool is configured to interact with a local reference server
 The CLI can be configured to talk to Databricks Unity Catalog by one of the following methods:
 
 - Include the following params in CLI commands:
-  - `--server <server_url>`: The URL of the Unity Catalog server.
-  - `--auth_token <auth_token>`: The PAT(Personal Authorization Token) token obtained from Databricks' Workspace.
+    - `--server <server_url>`: The URL of the Unity Catalog server.
+    - `--auth_token <auth_token>`: The PAT(Personal Authorization Token) token obtained from Databricks' Workspace.
 - Set the following properties in the CLI configuration file located at `examples/cli/src/main/resources/application.properties`:
-  - `server`: The URL of the Unity Catalog server.
-  - `auth_token`: The PAT(Personal Authorization Token) token obtained from Databricks' Workspace.
+    - `server`: The URL of the Unity Catalog server.
+    - `auth_token`: The PAT(Personal Authorization Token) token obtained from Databricks' Workspace.
 
 Each parameter can be configured either from the CLI or the configuration file, independently of each other.
 The CLI will prioritize the values provided from the CLI over the configuration file.
 
 !!! feedback "Different look for users CLI commands"
 
-    We're trying out a different look for the CLI commands - which do you prefer - the format above this or the format below?  Chime in UC GitHub discussion [529](https://github.com/unitycatalog/unitycatalog/discussions/529) and let us know!
-
+    We're trying out a different look for the CLI commands - which do you prefer - the format above this or the format
+    below? Chime in UC GitHub discussion [529](https://github.com/unitycatalog/unitycatalog/discussions/529) and let
+    us know!
 
 ## 8. Manage Users
 
@@ -473,7 +487,6 @@ bin/uc create [options]
     -- external_id: The identity provider's id for the user
     -- output: To indicate CLI output format preference. Supported values are json and jsonPretty.
 
-
 ### 8.2 Delete User
 
 ```bash title="Usage"
@@ -489,7 +502,6 @@ bin/uc user delete [options]
     --server UC Server to connect to. Default is reference server.
     --auth_token PAT token to authorize uc requests.
     --output To indicate CLI output format preference. Supported values are json and jsonPretty.
-
 
 ### 8.3 Get User
 
@@ -507,7 +519,6 @@ bin/uc user get [options]
     --auth_token PAT token to authorize uc requests.
     --output To indicate CLI output format preference. Supported values are json and jsonPretty.
 
-
 ### 8.4 List Users
 
 ```bash title="Usage"
@@ -516,7 +527,7 @@ bin/uc user list [options]
 
 *Required Params:*
 
-    None  
+    None
 
 *Optional Params:*
 
@@ -527,18 +538,15 @@ bin/uc user list [options]
     --start_index Specifies the index (starting at 1) of the first result.
     --count Desired number of results per page
 
-
 ### 8.5 Update User
 
 ```bash title="Usage"
 bin/uc user update [options]
 ```
 
-
 *Required Params:*
 
     --id The unique id of the user
-
 
 *Optional Params:*
 
@@ -550,10 +558,14 @@ bin/uc user update [options]
     --email The email address for the user
 
 ## 9. Metastore Management CLI Usage
-This section outlines the usage of the `bin/uc` script to handle operations related to the metastore of the UC OSS server.
+
+This section outlines the usage of the `bin/uc` script to handle operations related to the metastore of the
+UC OSS server.
 
 ### 9.1 Get Metastore Information
-Gets information about the metastore hosted by this Unity Catalog service (currently the service hosts only one metastore)
+
+Gets information about the metastore hosted by this Unity Catalog service
+(currently the service hosts only one metastore)
 
 ```sh
 bin/uc metastore get

--- a/docs/usage/functions.md
+++ b/docs/usage/functions.md
@@ -19,9 +19,11 @@ Let's look at how this works.
 
 We'll use a local Unity Catalog server to get started. The default local UC server comes with some sample data.
 
-> If this is your first time spinning up a UC server, you might want to check out the [Quickstart](../quickstart.md) first.
+> If this is your first time spinning up a UC server, you might want to check out the [Quickstart](../quickstart.md)
+    first.
 
-Spin up a local UC server by running the following code in a terminal from the root directory of your local `unitycatalog` repository:
+Spin up a local UC server by running the following code in a terminal from the root directory of your local
+`unitycatalog` repository:
 
 ```sh
 bin/start-uc-server
@@ -39,7 +41,7 @@ bin/uc function list --catalog unity --schema default
 
 You should see something that looks like:
 
-```
+```console
 ┌────────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┐
 │    NAME    │CATALOG_│SCHEMA_N│INPUT_PA│DATA_TYP│FULL_DAT│RETURN_P│ROUTINE_│ROUTINE_│ROUTINE_│PARAMETE│IS_DETER│SQL_DATA│IS_NULL_│SECURITY│SPECIFIC│COMMENT │PROPERTI│FULL_NAM│CREATED_│UPDATED_│FUNCTION│EXTERNAL│
 │            │  NAME  │  AME   │  RAMS  │   E    │ A_TYPE │ ARAMS  │  BODY  │DEFINITI│DEPENDEN│R_STYLE │MINISTIC│_ACCESS │  CALL  │ _TYPE  │ _NAME  │        │   ES   │   E    │   AT   │   AT   │  _ID   │_LANGUAG│
@@ -59,7 +61,7 @@ bin/uc function get --full_name unity.default.sum
 
 You should see something that looks like:
 
-```
+```console
 ┌────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │        KEY         │                                               VALUE                                                │
 ├────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -120,9 +122,10 @@ You should see something that looks like:
 └────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-The `routine definition` is probably most helpful here: `t = x + y + z\nreturn t `
+The `routine definition` is probably most helpful here: `t = x + y + z\nreturn t`
 
-It looks like this functions takes in 3 arguments and returns their sum. The `DATA_TYPE` field tells us that the output should be of `INT` data type.
+It looks like this functions takes in 3 arguments and returns their sum. The `DATA_TYPE` field tells us that the
+output should be of `INT` data type.
 
 ## Calling Functions from Unity Catalog
 
@@ -148,7 +151,8 @@ We'll start with a basic example using only scalar values.
 
 Suppose you want to register the following function to Unity Catalog: `c = a * b`
 
-To do so, define a new Function by its full name, specify the data type of the output, the input parameters and their data types, and define the function.
+To do so, define a new Function by its full name, specify the data type of the output, the input parameters and their
+data types, and define the function.
 
 ```sh
 bin/uc function create --full_name unity.default.my_function \
@@ -158,7 +162,6 @@ bin/uc function create --full_name unity.default.my_function \
 This should output something like:
 
 ```sh
-
 ┌────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │        KEY         │                                               VALUE                                                │
 ├────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -216,8 +219,9 @@ This should output something like:
 └────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-You can also store more complex functions. For example, you can import Python modules and use them in your function. Note if you have multiple lines in complex functions, you must insert "\n"
-to separate lines in the function definition. Otherwise, the function will return "invalid syntax" error when it is called.
+You can also store more complex functions. For example, you can import Python modules and use them in your function.
+Note if you have multiple lines in complex functions, you must insert "\n" to separate lines in the function
+definition. Otherwise, the function will return "invalid syntax" error when it is called.
 
 Let's take the example below of a function that uses the Numpy library to simulate a random roll of dice:
 
@@ -248,8 +252,9 @@ This will simulate rolling a single die with 6 sides.
 
 Required Parameters:
 
-- `--full_name`: The full name of the table. The full name is the concatenation of the catalog name, schema name, and table/volume name separated by a dot. For example, catalog_name.schema_name.table_name.
-- `--input_params`: The input parameters of the function, 
+- `--full_name`: The full name of the table. The full name is the concatenation of the catalog name, schema name, and
+    table/volume name separated by a dot. For example, catalog_name.schema_name.table_name.
+- `--input_params`: The input parameters of the function,
 - `--data_type`: The data type of the function.
 
 Optional Parameters:

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -3,36 +3,37 @@
 This page shows you how to use Unity Catalog to store, access, and govern Registered Models and Model Versions.
 
 Registered Models are logical containers for ML models within Unity Catalog.  A registered model is comprised of any
-number of Model Versions which represent different iterations of the model that you with to keep track of from within Unity Catalog.
-
+number of Model Versions which represent different iterations of the model that you with to keep track of from within
+Unity Catalog.
 
 ## How Unity Catalog and MLflow work together
+
 The following diagram shows how Unity Catalog and MLflow work together from tracking to governance.
 
 ![Unity Catalog and MLflow](../assets/images/unitycatalog-and-mlflow.png)
 
-The MLflow client connects both MLflow and Unity Catalog services (via `port:5000` and `port:8080` respectively).  
+The MLflow client connects both MLflow and Unity Catalog services (via `port:5000` and `port:8080` respectively).
 
-1. When you are running your training runs with MLflow, the metrics generated in those training runs are stored within MLflow.
+1. When you are running your training runs with MLflow, the metrics generated in those training runs are stored within
+    MLflow.
 2. For those same training runs, models are often generated, and those models are also stored within MLflow.
 3. Once you have decided which model you want to register, you can register and store that model into Unity Catalog.
-
 
 ## Setting up MLflow and Unity Catalog
 
 !!! warning "Prerequisites"
     For Unity Catalog MLflow Integration, ensure you are using MLflow version >= 2.16.1 and Unity Catalog >= 0.2.
 
-
 ### Spin up Unity Catalog
 
 We will use a local Unity Catalog server to get started.
 
 !!! question "First time working with Unity Catalog?"
-     If this is your first time spinning up a UC server, you might want to check out the [Quickstart](../quickstart.md) first.
+     If this is your first time spinning up a UC server, you might want to check out the
+    [Quickstart](../quickstart.md) first.
 
-
-Spin up a local UC server by running the following code in a terminal from the root directory of your local `unitycatalog` repository:
+Spin up a local UC server by running the following code in a terminal from the root directory of your local
+`unitycatalog` repository:
 
 ```sh
 bin/start-uc-server
@@ -44,13 +45,15 @@ bin/start-uc-server
 pip install mlflow
 ```
 
-The installation of MLflow includes the MLflow CLI tool, so you can start a local MLflow server with UI by running the command below in your terminal:
+The installation of MLflow includes the MLflow CLI tool, so you can start a local MLflow server with UI by running the
+command below in your terminal:
 
 ```bash
 mlflow ui
 ```
 
-It will generate logs with the IP address of the newly started tracking server which can be used in your MLflow python workloads, for example:
+It will generate logs with the IP address of the newly started tracking server which can be used in your MLflow Python
+workloads, for example:
 
 ```py
 import mlflow
@@ -59,19 +62,17 @@ mlflow.set_tracking_uri("http://127.0.0.1:5000") # (1)
 mlflow.set_registry_uri("uc:http://127.0.0.1:8080") # (2)
 ```
 
-1.  Here we are specifying the MLflow tracking server to store training metrics and models.
+1. Here we are specifying the MLflow tracking server to store training metrics and models.
+2. Here we are specifying that we register our ML model in Unity Catalog.
 
-2.  Here we are specifying that we register our ML model in Unity Catalog.
-
-
-
-At this point, your MLflow environment is ready for use with the newly started MLflow tracking server and the Unity Catalog server acting as your model registry.
+At this point, your MLflow environment is ready for use with the newly started MLflow tracking server and the
+Unity Catalog server acting as your model registry.
 
 You can quickly train a test model and validate that the Unity Catalog MLflow integration is fully working.
 
-## Train and register a sample model 
+## Train and register a sample model
 
-The following code snippet creates a scikit-learn model and registers the model into Unity Catalog. 
+The following code snippet creates a scikit-learn model and registers the model into Unity Catalog.
 
 ```py
 import os
@@ -103,12 +104,12 @@ with mlflow.start_run():
     )
 ```
 
-1.  `clf` is a Random Forest Classifier and it is being trained from training data (`X_train`, `Y_train`) from the Iris dataset.
-
-2.  The `artifact_path` contains the model we just trained and it is common to have multiple training runs with multiple models generated and stored with MLflow.
-
-3.  Because we had earlier specified `mlflow.set_registry_uri("uc:http://127.0.0.1:8080")`, the MLflow client will register the model to Unity Catalog.
-
+1. `clf` is a Random Forest Classifier and it is being trained from training data (`X_train`, `Y_train`) from the Iris
+    dataset.
+2. The `artifact_path` contains the model we just trained and it is common to have multiple training runs with
+    multiple models generated and stored with MLflow.
+3. Because we had earlier specified `mlflow.set_registry_uri("uc:http://127.0.0.1:8080")`, the MLflow client will
+    register the model to Unity Catalog.
 
 Upon successful registration of the model, you should see the following output.
 
@@ -121,28 +122,34 @@ Created version '1' of model 'unity.default.iris'.
 2024/09/24 20:51:29 INFO mlflow.tracking._tracking_service.client: 🧪 View experiment at: http://127.0.0.1:5000/#/experiments/0.
 ```
 
-The results can be seen in the Unity Catalog UI at [http://localhost:3000](http://localhost:3000).  For more information, dive deeper into the [Unity Catalog UI](./ui.md).  
+The results can be seen in the Unity Catalog UI at [http://localhost:3000](http://localhost:3000). For more
+information, dive deeper into the [Unity Catalog UI](./ui.md).  
 
+![UC UI Models](../assets/images/uc_ui_models.png)
 
-![](../assets/images/uc_ui_models.png)
+---
 
-<hr/>
+As you can see in the UI, there is an implied hierarchy of a three-part naming convention within Unity Catalog that is
+applicable to data and AI assets. The hierarchy of `catalog -> schema -> asset` plays out as the `unity` catalog,
+`default` schema, and `iris` asset (in this case ML model).  
 
-As you can see in the UI, there is an implied hierarchy of a three-part naming convention within Unity Catalog that is applicable to data and AI assets.  The hierarchy of `catalog -> schema -> asset` plays out as the `unity` catalog, `default` schema, and `iris` asset (in this case ML model).  
+![Unity Catalog Model Hierarchy](../assets/images/unitycatalog-model-hierarchy.png)
 
-![](../assets/images/unitycatalog-model-hierarchy.png)
+This convention allows us to apply governance to these assets (e.g., models, tables, volumes, and functions) in a
+similar fashion. You can also see the training run(s) and model(s) in the MLflow UI at
+[http://127.0.0.1:5000/](http://127.0.0.1:5000/).  
 
-This convention allows us to apply governance to these assets (e.g., models, tables, volumes, and functions) in a similar fashion. You can also see the training run(s) and model(s) in the MLflow UI at [http://127.0.0.1:5000/](http://127.0.0.1:5000/).  
+![MLflow Unity Catalog Model View 2.0](../assets/images/mlflow-unitycatalog-model-view-2.0.gif)
 
-![](../assets/images/mlflow-unitycatalog-model-view-2.0.gif)
-
-<hr/>
+---
 
 !!! note "MLflow Guides"
-    Please see the [MLflow quickstart guides](https://mlflow.org/docs/latest/getting-started/index.html) and the [MLflow python API](https://mlflow.org/docs/latest/python_api/index.html) to learn how to use the MLflow client to train, register, and use models from with the Unity Catalog server.
+    Please see the [MLflow quickstart guides](https://mlflow.org/docs/latest/getting-started/index.html) and the
+    [MLflow python API](https://mlflow.org/docs/latest/python_api/index.html) to learn how to use the MLflow client to
+    train, register, and use models from with the Unity Catalog server.
 
+## Load the sample model
 
-## Load the sample model 
 In a new terminal, you can load your recently registered model using the following code snippet.
 
 ```py
@@ -171,11 +178,11 @@ result["predicted_class"] = predictions
 result[:4]
 ```
 
-1.  Here we are specifying that we are loading our ML model from Unity Catalog.
+1. Here we are specifying that we are loading our ML model from Unity Catalog.
+2. We are loading the ML model `unity.default.iris`, version `1` from the Unity Catalog model registry.
 
-2.  We are loading the ML model `unity.default.iris`, version `1` from the Unity Catalog model registry.
-
-This code snippet uses the `unity.default.iris` model to predict the class (`predicted_class`) using the test dataset (`X_test`) and compares it to the actual class (`actual_class`) from the Iris dataset. 
+This code snippet uses the `unity.default.iris` model to predict the class (`predicted_class`) using the test dataset
+(`X_test`) and compares it to the actual class (`actual_class`) from the Iris dataset.
 
 ```bash
      sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  actual_class  predicted_class
@@ -185,12 +192,9 @@ This code snippet uses the `unity.default.iris` model to predict the class (`pre
 78                 6.0               2.9                4.5               1.5             1                1
 ```
 
-
-!!! tip 
-    The UC CLI also has support for interacting with models in the Unity Catalog server.  It is recommended that you interact with models in Unity Catalog using the MLflow client.  
-
-
-
+!!! tip
+    The UC CLI also has support for interacting with models in the Unity Catalog server. It is recommended that you
+    interact with models in Unity Catalog using the MLflow client.
 
 ## Inspecting Registered Models and Model Versions
 
@@ -234,7 +238,8 @@ bin/uc registered_model get --full_name unity.default.iris
 ```
 
 which would return something similar to this:
-```
+
+```console
 ┌──────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                 KEY                  │                                                                VALUE                                                                 │
 ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -270,7 +275,7 @@ bin/uc model_version get --full_name unity.default.iris --version 1
 
 which would return something similar to:
 
-```
+```console
 ┌──────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                 KEY                  │                                                                                    VALUE                                                                                    │
 ├──────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -315,7 +320,7 @@ bin/uc registered_model update --full_name unity.default.iris --new_name iris2 -
 
 which will return the updated metadata of the registered model:
 
-```
+```console
 ┌──────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                 KEY                  │                                                                VALUE                                                                 │
 ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -351,7 +356,7 @@ bin/uc model_version --full_name unity.default.iris2 --version 1 --comment "New 
 
 which will return the updated model version metadata:
 
-```
+```console
 ┌──────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                 KEY                  │                                                                                    VALUE                                                                                    │
 ├──────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -397,6 +402,6 @@ bin/uc model_version delete --full_name unity.default.iris2 --version 1
 
 and
 
-```bash title="Delete registered model" 
+```bash title="Delete registered model"
 bin/uc registered_model delete --full_name unity.default.iris2
 ```

--- a/docs/usage/ui.md
+++ b/docs/usage/ui.md
@@ -1,20 +1,21 @@
 # Unity Catalog UI
 
-The Unity Catalog UI allows you to interact with a Unity Catalog server to view or create data and AI assets.  
+The Unity Catalog UI allows you to interact with a Unity Catalog server to view or create data and AI assets.
 
 ![UC UI](../assets/images/ui/uc-ui-expanded.png)
 
 ## Start Unity Catalog UI locally
 
-To use the Unity Catalog UI, start a new terminal and ensure you have already started the UC server (e.g., `./bin/start-uc-server`)
+To use the Unity Catalog UI, start a new terminal and ensure you have already started the UC server
+(e.g., `./bin/start-uc-server`)
 
 !!! warning "Prerequisites"
-    The Unity Catalog UI requires both [Node](https://nodejs.org/en/download/package-manager) and [Yarn](https://classic.yarnpkg.com/lang/en/docs/install).
-
+    The Unity Catalog UI requires both [Node](https://nodejs.org/en/download/package-manager) and
+    [Yarn](https://classic.yarnpkg.com/lang/en/docs/install).
 
 To start the UI locally, run the following commands to start `yarn`
 
-```
+```sh
 cd /ui
 yarn install
 yarn start
@@ -27,14 +28,15 @@ yarn start
 The following steps show how you can create, describe, and delete UC catalogs.
 
 === "1. List and create catalogs"
-    
-    After clicking the top **Catalog** button, you will see your list of catalogs.  To create a catalog, click the **Create Catalog** button to the right.
+
+    After clicking the top **Catalog** button, you will see your list of catalogs.  To create a catalog, click the
+    **Create Catalog** button to the right.
 
     ![](../assets/images/ui/uc-ui-catalog-create-1.png)
     
 
 === "2. Create catalog dialog"
-    
+
     Specify the name and include any comments when creating your catalog.
 
     ![](../assets/images/ui/uc-ui-catalog-create-2.png)
@@ -45,22 +47,22 @@ The following steps show how you can create, describe, and delete UC catalogs.
 
     ![](../assets/images/ui/uc-ui-catalog-delete.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
-
+---
 
 ### Schemas
 
 The following steps show how you can create, describe, and delete UC schemas.
 
 === "1. List and create schemas"
-    
-    After clicking on any catalog, the main dialog contains the list of available schemas.  Click the **Create Schemas** button to the right to create a new schema.
+
+    After clicking on any catalog, the main dialog contains the list of available schemas.  Click the
+    **Create Schemas** button to the right to create a new schema.
 
     ![](../assets/images/ui/uc-ui-schema-create-1.png)
     
 
 === "2. Create schemas dialog"
-    
+
     Specify the name and include any comments when creating your schema.
 
     ![](../assets/images/ui/uc-ui-schema-create-2.png)
@@ -71,49 +73,47 @@ The following steps show how you can create, describe, and delete UC schemas.
 
     ![](../assets/images/ui/uc-ui-schema-delete.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
-
-
-
+---
 
 ### Tables
 
 The following steps show how you can view your UC table metadata and descriptions.
 
 === "1. View tables in schema (1)"
-    
+
     Click on the schema (e.g., `unity.demo`) to view its tables.
 
     ![](../assets/images/ui/uc-ui-tables-1.png)
     
 === "2. View tables in schema (2)"
-    
+
     Click on the schema (e.g., `unity.default`) to view its tables.
 
     ![](../assets/images/ui/uc-ui-tables-2.png)
 
 === "3. View table metadata"
 
-    Click on any table (e.g., `unity.default.marksheet`) to view its metadata.  You also have the option to delete the table via the *three horizontal dots* on the right.
+    Click on any table (e.g., `unity.default.marksheet`) to view its metadata.  You also have the option to delete the
+    table via the *three horizontal dots* on the right.
 
     ![](../assets/images/ui/uc-ui-tables-3.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
-
+---
 
 ### Volumes
 
 The following steps show how you can view your UC volume metadata and descriptions.
 
 === "1. Traverse to volumes"
-    
+
     Using the left-hand nav bar, click on *catalog > schema* (e.g., `unity` > `default`) to view the available volumes.
 
     ![](../assets/images/ui/uc-ui-volumes-1.png)
     
 === "2. View volume metadata"
-    
-    Click on the volume (e.g., `unity.default.txt_files`) to view its metadata.  You have the option to delete it by click on the *three horizontal dots* to the right. 
+
+    Click on the volume (e.g., `unity.default.txt_files`) to view its metadata.  You have the option to delete it by
+    click on the *three horizontal dots* to the right.
 
     ![](../assets/images/ui/uc-ui-volumes-2.png)
 
@@ -123,35 +123,36 @@ The following steps show how you can view your UC volume metadata and descriptio
 
     ![](../assets/images/ui/uc-ui-volumes-3.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
-
+---
 
 ### Functions
 
 The following steps show how you can view your UC functions metadata and descriptions.
 
 === "1. Traverse to functions"
-    
-    Using the left-hand nav bar, click on *catalog > schema* (e.g., `unity` > `default`) to view the available functions.
+
+    Using the left-hand nav bar, click on *catalog > schema* (e.g., `unity` > `default`) to view the available
+    functions.
 
     ![](../assets/images/ui/uc-ui-functions-1.png)
     
 === "2. View functions metadata"
-    
-    Click on the volume (e.g., `unity.default.lowercase`) to view its metadata.  You have the option to delete it by click on the *three horizontal dots* to the right. 
+
+    Click on the volume (e.g., `unity.default.lowercase`) to view its metadata.  You have the option to delete it by
+    click on the *three horizontal dots* to the right.
 
     ![](../assets/images/ui/uc-ui-functions-2.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
-
+---
 
 ### Models
 
 The following steps show how you can list, describe and delete your UC models.
 
 === "1. List and create models"
-    
-    After clicking on any *schema > models*, the main dialog contains the list of available models.  Click the **horizontal three dots** button to the right to create a new model.
+
+    After clicking on any *schema > models*, the main dialog contains the list of available models.  Click the
+    **horizontal three dots** button to the right to create a new model.
 
     ![](../assets/images/ui/uc-ui-models-1.png)
 
@@ -179,9 +180,7 @@ The following steps show how you can list, describe and delete your UC models.
 
     ![](../assets/images/ui/uc-ui-model-delete.png)
 
-
-
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
+---
 
 ### Model Versions
 
@@ -217,4 +216,4 @@ The following steps show how you can view your UC model versions and their metad
 
     ![](../assets/images/ui/uc-ui-model-version-delete.png)
 
-<hr style="height:2px;border-width:0;color:gray;background-color:lightgrey">
+---

--- a/docs/usage/volumes.md
+++ b/docs/usage/volumes.md
@@ -42,7 +42,8 @@ bin/uc volume read --full_name unity.default.json_files --path c.json
 
 ![UC Volume read file](../assets/images/uc_volume_read_file.png)
 
-Voilà! You have read the content of a file stored in a volume. We can also list the contents of any subdirectory. For example:
+Voilà! You have read the content of a file stored in a volume. We can also list the contents of any subdirectory.
+For example:
 
 ```sh
 bin/uc volume read --full_name unity.default.json_files --path dir1


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Update the formatting of the `usage` documentation pages by using markdownlint. User-facing changes have been kept minimal.

Resolves #682