### PR TITLE
Fix execute_function string parsing with serverless

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -657,7 +657,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         try:
             result = self.spark.sql(sqlQuery=sql_command.sql_query, args=sql_command.args or None)
         except Exception as e:
-            error = f"Failed to execute function with command {sql_command}; Error: {e}"
+            error = f"Failed to execute function with command `{sql_command}`; Error: {e}"
             return FunctionExecutionResult(error=error)
         if is_scalar(function_info):
             return FunctionExecutionResult(format="SCALAR", value=str(result.collect()[0][0]))

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -22,9 +22,6 @@ from unitycatalog.ai.core.envs.databricks_env_vars import (
 )
 from unitycatalog.ai.core.paged_list import PagedList
 from unitycatalog.ai.core.utils.callable_utils import generate_sql_function_body
-from unitycatalog.ai.core.utils.function_processing_utils import (
-    sanitize_string_inputs_of_function_params,
-)
 from unitycatalog.ai.core.utils.type_utils import (
     column_type_to_python_type,
     convert_timedelta_to_interval_str,
@@ -879,9 +876,6 @@ def get_execute_function_sql_command(
                     ):
                         param_value = float(param_value)
                     arg_clause += f":{param_info.name}"
-                    # Handle all other types as string types and santitize escape characters
-                    # since this is likely a code block being executed
-                    param_value = sanitize_string_inputs_of_function_params(param_value)
                     params_dict[param_info.name] = param_value
                 args.append(arg_clause)
         sql_query += ",".join(args)

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -143,7 +143,10 @@ def retry_on_session_expiration(func):
     def wrapper(self, *args, **kwargs):
         for attempt in range(1, max_attempts + 1):
             try:
-                return func(self, *args, **kwargs)
+                result = func(self, *args, **kwargs)
+                if isinstance(result, FunctionExecutionResult) and result.error:
+                    raise Exception(result.error)
+                return result
             except Exception as e:
                 error_message = str(e)
                 if SESSION_EXCEPTION_MESSAGE in error_message:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -833,10 +833,10 @@ def get_execute_function_sql_command(
             f"SELECT * FROM `{function.catalog_name}`.`{function.schema_name}`.`{function.name}`("
         )
 
+    params_dict: dict[str, Any] = {}
     if parameters and function.input_params and function.input_params.parameters:
         args: List[str] = []
         use_named_args = False
-        params_dict: dict[str, Any] = {}
 
         for param_info in function.input_params.parameters:
             if param_info.name not in parameters:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -144,7 +144,12 @@ def retry_on_session_expiration(func):
         for attempt in range(1, max_attempts + 1):
             try:
                 result = func(self, *args, **kwargs)
-                if isinstance(result, FunctionExecutionResult) and result.error:
+                # for non-seession related error in the result, we should directly return the result
+                if (
+                    isinstance(result, FunctionExecutionResult)
+                    and result.error
+                    and SESSION_EXCEPTION_MESSAGE in result.error
+                ):
                     raise Exception(result.error)
                 return result
             except Exception as e:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -657,7 +657,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
         _logger.info("Using databricks connect to execute functions with serverless compute.")
         self.set_default_spark_session()
         sql_command = get_execute_function_sql_command(function_info, parameters)
-        result = self.spark.sql(sqlQuery=sql_command)
+        try:
+            result = self.spark.sql(sqlQuery=sql_command)
+        except Exception as e:
+            error = f"Failed to execute function with command {sql_command}; Error: {e}"
+            return FunctionExecutionResult(error=error)
         if is_scalar(function_info):
             return FunctionExecutionResult(format="SCALAR", value=str(result.collect()[0][0]))
         else:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -144,7 +144,7 @@ def retry_on_session_expiration(func):
         for attempt in range(1, max_attempts + 1):
             try:
                 result = func(self, *args, **kwargs)
-                # for non-seession related error in the result, we should directly return the result
+                # for non-session related error in the result, we should directly return the result
                 if (
                     isinstance(result, FunctionExecutionResult)
                     and result.error

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -1,4 +1,3 @@
-import ast
 import decimal
 import json
 import logging
@@ -283,63 +282,3 @@ def supported_function_info_types():
         pass
 
     return types
-
-
-def is_python_code(code_str: str) -> bool:
-    """Check if the provided string is valid Python code."""
-    try:
-        ast.parse(code_str)
-        return True
-    except SyntaxError:
-        return False
-
-
-def convert_quoting_to_sql_safe_format(string_value: str) -> str:
-    """
-    Convert a string to a SQL-safe format by escaping single quotes.
-
-    Args:
-        string_value: The string to be converted.
-
-    Returns:
-        str: The SQL-safe string.
-    """
-    has_single_quote = "'" in string_value
-    has_double_quote = '"' in string_value
-
-    if not has_single_quote and not has_double_quote:
-        return string_value
-
-    if has_single_quote and not has_double_quote:
-        string_value = string_value.replace("'", '"')
-    elif has_single_quote and has_double_quote:
-        raise ValueError(
-            "The argument passed in has been detected as Python code that contains both single and double quotes. "
-            "This is not supported. Code must use only one style of quotation. Please fix the code and try again."
-        )
-    return string_value
-
-
-def sanitize_string_inputs_of_function_params(param_value: Any) -> str:
-    """
-    Sanitize string inputs of function parameters to allow for code block submission.
-
-    Args:
-        param_value: The value of the parameter to sanitize.
-
-    Returns:
-        A sanitized string of the argument value.
-    """
-
-    if isinstance(param_value, str) and is_python_code(param_value):
-        # Escape single quotes, backslashes, and control characters that would otherwise break Python code execution
-        parsed = (
-            param_value.replace("\\", "\\\\")
-            .replace("\r", "\\r")
-            .replace("\n", "\\n")
-            .replace("\t", "\\t")
-        )
-        quotes_parsed = convert_quoting_to_sql_safe_format(parsed)
-    else:
-        quotes_parsed = param_value
-    return str(quotes_parsed)

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
@@ -86,7 +86,9 @@ def create_python_function_and_cleanup(
 ) -> Generator[FunctionObj, None, None]:
     func_name = f"{CATALOG}.{schema}.{func.__name__}"
     try:
-        func_info = client.create_python_function(func=func, catalog=CATALOG, schema=schema)
+        func_info = client.create_python_function(
+            func=func, catalog=CATALOG, schema=schema, replace=True
+        )
         yield FunctionObj(
             full_function_name=func_name,
             comment=func_info.comment,

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -21,7 +21,6 @@ from databricks.sdk.service.catalog import (
 from unitycatalog.ai.core.databricks import (
     DatabricksFunctionClient,
     extract_function_name,
-    get_execute_function_sql_command,
     retry_on_session_expiration,
 )
 from unitycatalog.ai.core.envs.databricks_env_vars import UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS
@@ -696,73 +695,6 @@ def create_mock_function_info():
             ]
         ),
     )
-
-
-test_cases_string_inputs = [
-    (
-        {"a": 1, "b": "test"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','test')",
-    ),
-    # String with single quotes
-    (
-        {"a": 1, "b": "O'Reilly"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','O'Reilly')",
-    ),
-    # String with backslashes
-    (
-        {"a": 1, "b": "C:\\Program Files\\App"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','C:\\Program Files\\App')",
-    ),
-    # String with newlines
-    (
-        {"a": 1, "b": "Line1\nLine2"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Line1\\nLine2')",
-    ),
-    # String with tabs
-    (
-        {"a": 1, "b": "Column1\tColumn2"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Column1\tColumn2')",
-    ),
-    # String with various special characters
-    (
-        {"a": 1, "b": "Special chars: !@#$%^&*()_+-=[]{}|;':,./<>?"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Special chars: !@#$%^&*()_+-=[]{}|;':,./<>?')",
-    ),
-    # String with Unicode characters
-    (
-        {"a": 1, "b": "Unicode test: ü, é, 漢字"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Unicode test: ü, é, 漢字')",
-    ),
-    # String with double quotes
-    (
-        {"a": 1, "b": 'He said, "Hello"'},
-        """SELECT `catalog`.`schema`.`mock_function`('1',\'He said, "Hello"\')""",
-    ),
-    # String with backslashes and quotes
-    (
-        {"a": 1, "b": "Path: C:\\User\\'name'\\\"docs\""},
-        "SELECT `catalog`.`schema`.`mock_function`('1','Path: C:\\User\\'name'\\\"docs\"')",
-    ),
-    # String with code-like content (simulating GenAI code)
-    (
-        {"a": 1, "b": "def func():\n    print('Hello, world!')"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','def func():\\n    print(\"Hello, world!\")')",
-    ),
-    # String with multiline code and special characters
-    (
-        {"a": 1, "b": "if a > 0:\n    print('Positive')\nelse:\n    print('Non-positive')"},
-        "SELECT `catalog`.`schema`.`mock_function`('1','if a > 0:\\n    print(\"Positive\")\\nelse:\\n    print(\"Non-positive\")')",
-    ),
-]
-
-
-@pytest.mark.parametrize("parameters, expected_sql", test_cases_string_inputs)
-def test_get_execute_function_sql_command_string_inputs(parameters, expected_sql):
-    function_info = create_mock_function_info()
-
-    sql_command = get_execute_function_sql_command(function_info, parameters)
-
-    assert sql_command.replace("\r\n", "\n") == expected_sql.replace("\r\n", "\n")
 
 
 def test_execute_function_with_mock_string_input(

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -547,7 +547,7 @@ def test_execute_function_success(mock_workspace_client, mock_spark_session, moc
     assert not result.truncated
 
     expected_sql = "SELECT `catalog`.`schema`.`function_name`()"
-    mock_spark_session.sql.assert_called_with(sqlQuery=expected_sql)
+    mock_spark_session.sql.assert_called_with(sqlQuery=expected_sql, args=None)
 
 
 def test_execute_function_with_retry(mock_workspace_client, mock_spark_session, mock_function_info):
@@ -584,7 +584,7 @@ def test_execute_function_with_retry(mock_workspace_client, mock_spark_session, 
 
         client.refresh_client_and_session.assert_called_once()
         expected_sql = "SELECT `catalog`.`schema`.`function_name`()"
-        mock_spark_session.sql.assert_called_with(sqlQuery=expected_sql)
+        mock_spark_session.sql.assert_called_with(sqlQuery=expected_sql, args=None)
         assert mock_spark_session.sql.call_count == 2
         assert client.refresh_client_and_session.call_count == 1
 

--- a/ai/core/tests/core/test_utils.py
+++ b/ai/core/tests/core/test_utils.py
@@ -1,8 +1,5 @@
 import datetime
 import decimal
-import math
-import sys
-from io import StringIO
 from typing import Dict, List, Optional, Tuple, Union
 
 import pytest
@@ -16,7 +13,6 @@ from pydantic import BaseModel
 from unitycatalog.ai.core.utils.function_processing_utils import (
     FullFunctionName,
     generate_function_input_params_schema,
-    sanitize_string_inputs_of_function_params,
     uc_type_json_to_pydantic_type,
 )
 from unitycatalog.ai.core.utils.type_utils import (
@@ -435,98 +431,3 @@ def test_generate_function_input_params_schema_with_non_ascii_chars():
     )
     pydantic_model = generate_function_input_params_schema(function_info).pydantic_model
     pydantic_model(**{"x": 123})
-
-
-def unescape_sql_string(value: str) -> str:
-    """
-    Unescapes a string as it would be when parsed by the SQL engine.
-    """
-    # Replace doubled backslashes with single backslash
-    unescaped = value.replace("\\\\", "\\")
-    # Replace double single quotes with a single quote
-    unescaped = unescaped.replace("''", "'")
-    # Replace escaped newlines, and tabs
-    unescaped = unescaped.replace("\\n", "\n").replace("\\t", "\t")
-    return unescaped
-
-
-# Mocking the UDF execution environment
-def mock_execute_function(code: str) -> str:
-    """
-    Mocks the execution of the user-defined function that executes the provided code string.
-    """
-    sys_stdout = sys.stdout
-    redirected_output = StringIO()
-    sys.stdout = redirected_output
-    exec(code)
-    sys.stdout = sys_stdout
-    return redirected_output.getvalue()
-
-
-# Test cases
-test_cases = [
-    # Simple print statement
-    ("print('Hello, world!')", "Hello, world!\n"),
-    # Code with double quotes
-    ('print("He said, \\"Hi!\\"")', 'He said, "Hi!"\n'),
-    # Code with backslashes
-    (r"print('C:\\path\\into\\dir')", "C:\\path\\into\\dir\n"),
-    # Multi-line code with newlines
-    ("for i in range(3):\n    print(i)", "0\n1\n2\n"),
-    # Code with tabs and indents
-    ("def greet(name):\n    print(f'Hello, {name}!')\ngreet('Alice')", "Hello, Alice!\n"),
-    # Code with special characters
-    ("print('Special chars: !@#$%^&*()')", "Special chars: !@#$%^&*()\n"),
-    # Unicode characters
-    ("print('Unicode test: ü, é, 漢字')", "Unicode test: ü, é, 漢字\n"),
-    # Code with comments
-    ("# This is a comment\nprint('Comment test')", "Comment test\n"),
-    # Code raising an exception
-    (
-        "try:\n    raise ValueError('Test error')\nexcept Exception as e:\n    print(f'Caught an error: {e}')",
-        "Caught an error: Test error\n",
-    ),
-    # Code with triple quotes
-    ('print("""Triple quote test""")', "Triple quote test\n"),
-    # Code with raw strings
-    ("print('Raw string: \\\\n new line')", "Raw string:  new line\n"),
-    # Empty code string
-    ("", ""),
-    # Code with carriage return
-    ("print('Line1\\\\rLine2')", "Line1\\rLine2\n"),
-    # Code with encoding declarations (Note: encoding declarations should be in the first or second line)
-    ("# -*- coding: utf-8 -*-\nprint('Encoding test')", "Encoding test\n"),
-    # Code importing a standard library
-    ("import math\nprint(math.pi)", f"{math.pi}\n"),
-    # Code with nested functions
-    (
-        "def outer():\n    def inner():\n        return 'Nested'\n    return inner()\nprint(outer())",
-        "Nested\n",
-    ),
-    # Code with list comprehensions
-    ("squares = [x**2 for x in range(5)]\nprint(squares)", "[0, 1, 4, 9, 16]\n"),
-    # Code with multi-line strings
-    ("multi_line = '''Line1\nLine2\nLine3'''\nprint(multi_line)", "Line1\nLine2\nLine3\n"),
-]
-
-
-@pytest.mark.parametrize("code_input, expected_output", test_cases)
-def test_code_execution(code_input: str, expected_output: str):
-    escaped_code = sanitize_string_inputs_of_function_params(code_input)
-    code_to_execute = unescape_sql_string(escaped_code)
-    output = mock_execute_function(code_to_execute)
-    assert output == expected_output
-
-
-@pytest.mark.parametrize(
-    "code_input",
-    [
-        "print('Hello, \"world!\"')",
-        'return \'2\' + """3"""',
-    ],
-)
-def test_rejected_code_execution(code_input: str):
-    with pytest.raises(
-        ValueError, match="The argument passed in has been detected as Python code that contains"
-    ):
-        sanitize_string_inputs_of_function_params(code_input)


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Update the logic of serverless execution to pass arguments using `:` prefix by SQL literals. Wrap the exception to provide better error message when failing. 
Drop the previous sanitization logic as we no longer need it :) SQL side can deal with the single+double quotes combination correctly.
Updated tests.


<!-- Please state what you've changed and how it might affect the users. -->
