### PR TITLE
[BUILD] Push Tagged Image to DockerHub

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,9 +3,7 @@ name: unitycatalog
 services:
 
   server:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: unitycatalog/unitycatalog:latest
     ports:
       - "8080:8080"
     volumes:
@@ -23,7 +21,7 @@ services:
       - "3000:3000"
     depends_on:
       - server
-      
+
 volumes:
   # Persist docker volume across container restarts
   unitycatalog_data:


### PR DESCRIPTION
**PR Checklist**
- [x] Create UnityCatalog DockerHub profile and add DockerHub secrets to Github for workflow (CC: @dennyglee)
- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR modifies the `docker-build.yml` Github Actions workflow to enable pushing a tagged docker image, eg. `unitycatalog/unitycatalog:v0.2.0`, to DockerHub as an official resource. See issue #617 for more details.

An example of the [successfully completed workflow](https://github.com/tnightengale/unitycatalog/actions/runs/11725880001/job/32663213433) can be seen on my fork.

The workflow ran on a repush of the `v0.2.0` git tag to my fork. The resulting tagged image can be seen on my [personal DockerHub](https://hub.docker.com/repository/docker/tnightengale/unitycatalog/general). 

The `v0.2.0` tag on my fork points to the latest commit of `upstream/branch-0.2` with cherry-picked commits from #551 and this PR. 

The workflow also implements caching for Docker builds on pull requests, using the `buildcache` tag on the registry.

Running this workflow successfully will require setting up an official UnityCatalog DockerHub account, and creating and adding the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to this repository for use in the workflow. 

See the screenshot below for an example the added secrets from my fork: ![Screenshot 2024-11-07 at 10 45 36 AM (2)](https://github.com/user-attachments/assets/d51c614b-a6b9-41eb-9ee6-202c9b8b8547)