### PR TITLE
skip maven release for python client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,7 @@ lazy val pythonClient = (project in file("clients/python/target"))
     // name of the generation step. See `openApiPackageName` for the actual Python package name
     name := s"$artifactNamePrefix-python-client",
     commonSettings,
+    skipReleaseSettings,
     (Compile / compile) := ((Compile / compile) dependsOn generate).value,
 
     // OpenAPI generation specs


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
Currently, there are no release settings configured for the python client which cause the `build/sbt release` command to fail. Skipping python client release in maven since there needs to be a separate flow to publish to pypi