### PR TITLE
docs: add Trino docs back

### DIFF
--- a/docs/integrations/unity-catalog-trino.md
+++ b/docs/integrations/unity-catalog-trino.md
@@ -1,6 +1,6 @@
 # Unity Catalog Trino Integration
 
-### Setting up REST Catalog with Trino
+## Setting up REST Catalog with Trino
 
 After setting up Trino, REST Catalog connection can be setup by adding a `etc/catalog/iceberg.properties` file to configure Trino to use Unity Catalog's Iceberg REST API Catalog endpoint.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - Integrations:
       - Daft: integrations/unity-catalog-daft.md
       - DuckDB: integrations/unity-catalog-duckdb.md
+      - Trino: integrations/unity-catalog-trino.md
   - Deployment: deployment.md
 
 plugins:


### PR DESCRIPTION
Signed-off-by: Avril Aysha <68642378+avriiil@users.noreply.github.com>

This PR adds the Trino docs back to the Integration section.