### PR TITLE
Fix client execution issue for SparkSession references

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -91,11 +91,12 @@ def _try_get_spark_session_in_dbr() -> Any:
 
         if not isinstance(spark, SparkSession):
             _logger.warning(
-                "Current spark session in the active Databricks runtime is not a "
-                "pyspark.sql.connect.session.SparkSession instance, it's probably "
-                "because you're not using a Serverless compute. To use the full "
-                "functionalities of this package please switch to a Serverless cluster, "
-                "check https://docs.databricks.com/en/compute/serverless/index.html#connect-to-serverless-compute "
+                "Current SparkSession in the active environment is not a "
+                "pyspark.sql.connect.session.SparkSession instance. Classic runtime does not support "
+                "all functionalities of the unitycatalog-ai framework. To use the full "
+                "capabilities of unitycatalog-ai, execute your code using a client that is attached to "
+                "a Serverless runtime cluster. To learn more about serverless, see the guide at: "
+                "https://docs.databricks.com/en/compute/serverless/index.html#connect-to-serverless-compute "
                 "for more details."
             )
         return spark

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -695,7 +695,12 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     format="CSV", value=csv_buffer.getvalue(), truncated=truncated
                 )
         except Exception as e:
-            error = f"Failed to execute function with command `{sql_command}`; Error: {e}"
+            sql_command_msg = (
+                f"spark.sql({sql_command.sql_query}" + f", args={sql_command.args})"
+                if sql_command.args
+                else ")"
+            )
+            error = f"Failed to execute function with command `{sql_command_msg}`\nError: {e}"
             return FunctionExecutionResult(error=error)
 
     @override


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
If the client is run on non-serverless computes, we should warn the user as some of the functionalities might not work well. 
Non-dbconnect sparkSession doesn't contain `is_stopped` attribute.
After this PR:
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/06a24a88-1c92-42e8-b267-3adc1e458bc1">
Also updated the exception catch in serverless to include result part, as the calculation happens when collect is called.

https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/11813567109 passed
<!-- Please state what you've changed and how it might affect the users. -->
