### PR TITLE
docs: add trino docs back

### DIFF
--- a/docs/integrations/unity-catalog-trino.md
+++ b/docs/integrations/unity-catalog-trino.md
@@ -1,0 +1,19 @@
+# Unity Catalog Trino Integration
+
+## Setting up REST Catalog with Trino
+
+After setting up Trino, REST Catalog connection can be setup by adding a `etc/catalog/iceberg.properties` file to configure Trino to use Unity Catalog's Iceberg REST API Catalog endpoint.
+
+```
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=http://127.0.0.1:8080/api/2.1/unity-catalog/iceberg
+iceberg.rest-catalog.security=OAUTH2
+iceberg.rest-catalog.oauth2.token=not_used
+```
+
+Once your properties file is configured, you can run the Trino CLI and issue a SQL query against the Delta UniForm table:
+
+```sql
+SELECT * FROM iceberg."unity.default".marksheet_uniform
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_author: unitycatalog
 
 nav:
   - Home: index.md
-  - Getting Started: 
+  - Getting Started:
       - Quickstart: quickstart.md
       - Docker Compose: docker_compose.md
   - Usage:
@@ -31,6 +31,7 @@ nav:
       - DuckDB: integrations/unity-catalog-duckdb.md
       - PuppyGraph: integrations/unity-catalog-puppygraph.md
       - SpiceAI: integrations/unity-catalog-spiceai.md
+      - Trino: integrations/unity-catalog-trino.md
       - XTable: integrations/unity-catalog-xtable.md
   - Deployment: deployment.md
 


### PR DESCRIPTION
This PR adds the trino docs back to the integration section

Signed-off-by: Avril Aysha <68642378+avriiil@users.noreply.github.com>
