### PR TITLE
[0.2] handle catalog and namespace properly in Iceberg REST api (#324)

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -44,7 +44,8 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
           builder
               .config(catalogConf, UCSingleCatalog.class.getName())
               .config(catalogConf + ".uri", serverConfig.getServerUrl())
-              .config(catalogConf + ".token", serverConfig.getAuthToken());
+              .config(catalogConf + ".token", serverConfig.getAuthToken())
+              .config(catalogConf + ".warehouse", catalog);
     }
     // Use fake file system for cloud storage so that we can test credentials.
     builder.config("fs.s3.impl", S3CredentialTestFileSystem.class.getName());

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
@@ -53,6 +53,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
             .config(catalogConf, UCSingleCatalog.class.getName())
             .config(catalogConf + ".uri", serverConfig.getServerUrl())
             .config(catalogConf + ".token", serverConfig.getAuthToken())
+            .config(catalogConf + ".warehouse", CATALOG_NAME)
             .config(catalogConf + ".__TEST_NO_DELTA__", "true");
     SparkSession session = builder.getOrCreate();
     setupExternalParquetTable(PARQUET_TABLE, new ArrayList<>(0));

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.*;
 import io.unitycatalog.server.base.table.TableOperations;
-import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import java.io.File;
 import java.io.IOException;
@@ -44,12 +43,14 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   public void testNoDeltaCatalog() throws IOException, ApiException {
     UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
     UCSingleCatalog.DELTA_CATALOG_LOADED().set(false);
-    SparkSession.Builder builder = SparkSession.builder()
+    SparkSession.Builder builder =
+        SparkSession.builder()
             .appName("test")
             .master("local[*]")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension");
     String catalogConf = "spark.sql.catalog.spark_catalog";
-    builder = builder
+    builder =
+        builder
             .config(catalogConf, UCSingleCatalog.class.getName())
             .config(catalogConf + ".uri", serverConfig.getServerUrl())
             .config(catalogConf + ".token", serverConfig.getAuthToken())
@@ -199,7 +200,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(row.getInt(0)).isEqualTo(1);
 
     // Path that does not exist
-    String loc3 = scheme + "://test-bucket1" + generateTableLocation(CATALOG_NAME, ANOTHER_DELTA_TABLE);
+    String loc3 =
+        scheme + "://test-bucket1" + generateTableLocation(CATALOG_NAME, ANOTHER_DELTA_TABLE);
     String t3 = CATALOG_NAME + "." + SCHEMA_NAME + "." + ANOTHER_DELTA_TABLE;
     session.sql(String.format("CREATE TABLE %s(i INT) USING delta LOCATION '%s'", t3, loc3));
     List<Row> rows = session.table(t3).collectAsList();

--- a/docs/usage/tables/uniform.md
+++ b/docs/usage/tables/uniform.md
@@ -20,7 +20,10 @@ The following is an example of the settings to configure OSS Apache Spark to rea
 "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
 "spark.sql.catalog.iceberg.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
 "spark.sql.catalog.iceberg.uri": "http://127.0.0.1:8080/api/2.1/unity-catalog/iceberg",
+"spark.sql.catalog.iceberg.warehouse": "<catalog-name>",
 "spark.sql.catalog.iceberg.token": "not_used",
 ```
 
-When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern `iceberg.<catalog-name>.<schema-name>.<table-name>` (e.g. `iceberg.unity.default.marksheet_uniform`).
+When querying Iceberg REST Catalog for Unity Catalog, tables are identified using the following pattern `iceberg.<schema-name>.<table-name>` (e.g. `iceberg.default.marksheet_uniform`).
+
+NOTE: If you want your Spark catalog name to be the same as your UC catalog name, replace `iceberg` in the above configurations with `<catalog-name>`,  then tables are identified by the following pattern `<catalog-name>.<schema-name>.<table-name>` (e.g. `unity.default.marksheet_uniform`).

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -9,6 +9,7 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import io.unitycatalog.server.utils.RESTObjectMapper;
 import lombok.SneakyThrows;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -31,7 +32,8 @@ public class IcebergRestExceptionHandler implements ExceptionHandlerFunction {
           || cause instanceof NamespaceNotEmptyException
           || cause instanceof CommitFailedException) {
         return createErrorResponse(HttpStatus.CONFLICT, cause);
-      } else if (cause instanceof IllegalArgumentException) {
+      } else if (cause instanceof IllegalArgumentException
+          || cause instanceof BadRequestException) {
         return createErrorResponse(HttpStatus.BAD_REQUEST, cause);
       } else {
         return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, cause);

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -11,18 +11,15 @@ import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
-import io.unitycatalog.server.model.CatalogInfo;
-import io.unitycatalog.server.model.ListCatalogsResponse;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
-import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.persist.utils.HibernateUtils;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.JsonUtils;
-import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,9 +28,9 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
@@ -44,6 +41,8 @@ import org.hibernate.SessionFactory;
 
 @ExceptionHandler(IcebergRestExceptionHandler.class)
 public class IcebergRestCatalogService {
+
+  private static final String PREFIX_BASE = "catalogs/";
 
   private final CatalogService catalogService;
   private final SchemaService schemaService;
@@ -70,110 +69,71 @@ public class IcebergRestCatalogService {
 
   @Get("/v1/config")
   @ProducesJson
-  public ConfigResponse config() {
-    return ConfigResponse.builder().build();
+  public ConfigResponse config(@Param("warehouse") Optional<String> catalogOpt) {
+    String catalog =
+        catalogOpt.orElseThrow(
+            () -> new BadRequestException("Must supply a proper catalog in warehouse property."));
+
+    // TODO: check catalog exists
+    // set catalog prefix
+    return ConfigResponse.builder().withOverride("prefix", PREFIX_BASE + catalog).build();
   }
 
   // Namespace APIs
 
-  @Get("/v1/namespaces")
+  @Get("/v1/catalogs/{catalog}/namespaces")
   @ProducesJson
-  public ListNamespacesResponse listNamespaces(@Param("parent") Optional<String> parent)
+  public ListNamespacesResponse listNamespaces(
+      @Param("catalog") String catalog, @Param("parent") Optional<String> parent)
       throws JsonProcessingException {
-    // List catalogs if the parent is not present
-    if (!parent.isPresent()) {
-      String respContent =
-          catalogService
-              .listCatalogs(Optional.empty(), Optional.empty())
-              .aggregate()
-              .join()
-              .contentUtf8();
-      ListCatalogsResponse resp =
-          JsonUtils.getInstance().readValue(respContent, ListCatalogsResponse.class);
-      assert resp.getCatalogs() != null;
-      List<Namespace> namespaces =
-          resp.getCatalogs().stream()
-              .map(catalogInfo -> Namespace.of(catalogInfo.getName()))
-              .collect(Collectors.toList());
-      return ListNamespacesResponse.builder().addAll(namespaces).build();
-    }
-
-    List<String> parentParts = Splitter.on(".").splitToList(parent.get());
-
-    // If parent is a catalog, then list the schemas
-    if (parentParts.size() == 1) {
-      String catalogName = parentParts.get(0);
+    List<Namespace> namespaces;
+    if (parent.isPresent() && !parent.get().isEmpty()) {
+      // nested namespaces is not supported, so child namespaces will be empty
+      namespaces = Collections.emptyList();
+    } else {
       String respContent =
           schemaService
-              .listSchemas(catalogName, Optional.of(Integer.MAX_VALUE), Optional.empty())
+              .listSchemas(catalog, Optional.of(Integer.MAX_VALUE), Optional.empty())
               .aggregate()
               .join()
               .contentUtf8();
       ListSchemasResponse resp =
           JsonUtils.getInstance().readValue(respContent, ListSchemasResponse.class);
       assert resp.getSchemas() != null;
-      List<Namespace> namespaces =
+      namespaces =
           resp.getSchemas().stream()
-              .map(schemaInfo -> Namespace.of(schemaInfo.getCatalogName(), schemaInfo.getName()))
+              .map(schemaInfo -> Namespace.of(schemaInfo.getName()))
               .collect(Collectors.toList());
-      return ListNamespacesResponse.builder().addAll(namespaces).build();
     }
 
-    // If the parent is a schema, then return an empty list of namespaces
-    if (parentParts.size() == 2) {
-      // make sure the schema exists
-      schemaService.getSchema(parent.get());
-      return ListNamespacesResponse.builder().build();
-    }
-
-    throw new IllegalArgumentException("invalid parent " + parent.get());
+    return ListNamespacesResponse.builder().addAll(namespaces).build();
   }
 
-  @Get("/v1/namespaces/{namespace}")
+  @Get("/v1/catalogs/{catalog}/namespaces/{namespace}")
   @ProducesJson
-  public GetNamespaceResponse getNamespace(@Param("namespace") String namespace)
+  public GetNamespaceResponse getNamespace(
+      @Param("catalog") String catalog, @Param("namespace") String namespace)
       throws JsonProcessingException {
-    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
 
-    // If namespace length is 1, then it is a catalog
-    if (namespaceParts.size() == 1) {
-      String catalogName = namespaceParts.get(0);
-      String resp = catalogService.getCatalog(catalogName).aggregate().join().contentUtf8();
-      CatalogInfo catalog = JsonUtils.getInstance().readValue(resp, CatalogInfo.class);
-      return GetNamespaceResponse.builder()
-          .withNamespace(Namespace.of(catalogName))
-          .setProperties(catalog.getProperties())
-          .build();
-    }
-
-    // If namespace length is 2, then it is a schema
-    if (namespaceParts.size() == 2) {
-      String catalogName = namespaceParts.get(0);
-      String schemaName = namespaceParts.get(1);
-      String schemaFullName = String.join(".", catalogName, schemaName);
-      String resp = schemaService.getSchema(schemaFullName).aggregate().join().contentUtf8();
-      return GetNamespaceResponse.builder()
-          .withNamespace(Namespace.of(catalogName, schemaName))
-          .setProperties(JsonUtils.getInstance().readValue(resp, SchemaInfo.class).getProperties())
-          .build();
-    }
-
-    // Else it's an invalid parameter
-    throw new IllegalArgumentException();
+    String schemaFullName = String.join(".", catalog, namespace);
+    String resp = schemaService.getSchema(schemaFullName).aggregate().join().contentUtf8();
+    return GetNamespaceResponse.builder()
+        .withNamespace(Namespace.of(namespace))
+        .setProperties(JsonUtils.getInstance().readValue(resp, SchemaInfo.class).getProperties())
+        .build();
   }
 
   // Table APIs
 
-  @Head("/v1/namespaces/{namespace}/tables/{table}")
+  @Head("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
   public HttpResponse tableExists(
-      @Param("namespace") String namespace, @Param("table") String table) {
-    List<String> namespaceParts = splitTwoPartNamespace(namespace);
-    String catalog = namespaceParts.get(0);
-    String schema = namespaceParts.get(1);
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table) {
     try (Session session = sessionFactory.openSession()) {
-      tableRepository.getTable(namespace + "." + table);
+      tableRepository.getTable(catalog + "." + namespace + "." + table);
       String metadataLocation =
-          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
+          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
       if (metadataLocation == null) {
         throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
       } else {
@@ -182,18 +142,17 @@ public class IcebergRestCatalogService {
     }
   }
 
-  @Get("/v1/namespaces/{namespace}/tables/{table}")
+  @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
   @ProducesJson
   public LoadTableResponse loadTable(
-      @Param("namespace") String namespace, @Param("table") String table) throws IOException {
-    List<String> namespaceParts = splitTwoPartNamespace(namespace);
-    String catalog = namespaceParts.get(0);
-    String schema = namespaceParts.get(1);
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table) {
     String metadataLocation;
     try (Session session = sessionFactory.openSession()) {
-      TableInfo tableInfo = tableRepository.getTable(namespace + "." + table);
+      tableRepository.getTable(catalog + "." + namespace + "." + table);
       metadataLocation =
-          tableRepository.getTableUniformMetadataLocation(session, catalog, schema, table);
+          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
     }
 
     if (metadataLocation == null) {
@@ -209,7 +168,7 @@ public class IcebergRestCatalogService {
         .build();
   }
 
-  @Get("/v1/namespaces/{namespace}/views/{view}")
+  @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/views/{view}")
   @ProducesJson
   public LoadViewResponse loadView(
       @Param("namespace") String namespace, @Param("view") String view) {
@@ -220,24 +179,22 @@ public class IcebergRestCatalogService {
     throw new NoSuchViewException("View does not exist: %s", namespace + "." + view);
   }
 
-  @Post("/v1/namespaces/{namespace}/tables/{table}/metrics")
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}/metrics")
   public HttpResponse reportMetrics(
       @Param("namespace") String namespace, @Param("table") String table) {
     return HttpResponse.of(HttpStatus.OK);
   }
 
-  @Get("/v1/namespaces/{namespace}/tables")
+  @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/tables")
   @ProducesJson
   public org.apache.iceberg.rest.responses.ListTablesResponse listTables(
-      @Param("namespace") String namespace) throws JsonProcessingException {
-    List<String> namespaceParts = splitTwoPartNamespace(namespace);
-    String catalog = namespaceParts.get(0);
-    String schema = namespaceParts.get(1);
+      @Param("catalog") String catalog, @Param("namespace") String namespace)
+      throws JsonProcessingException {
     AggregatedHttpResponse resp =
         tableService
             .listTables(
                 catalog,
-                schema,
+                namespace,
                 Optional.of(Integer.MAX_VALUE),
                 Optional.empty(),
                 Optional.empty(),
@@ -256,30 +213,18 @@ public class IcebergRestCatalogService {
                   tableInfo -> {
                     String metadataLocation =
                         tableRepository.getTableUniformMetadataLocation(
-                            session, catalog, schema, tableInfo.getName());
+                            session, catalog, namespace, tableInfo.getName());
                     return metadataLocation != null;
                   })
               .map(
                   tableInfo ->
                       TableIdentifier.of(
-                          tableInfo.getCatalogName(),
-                          tableInfo.getSchemaName(),
-                          tableInfo.getName()))
+                          Namespace.of(tableInfo.getSchemaName()), tableInfo.getName()))
               .collect(Collectors.toList());
     }
 
     return org.apache.iceberg.rest.responses.ListTablesResponse.builder()
         .addAll(filteredTables)
         .build();
-  }
-
-  private List<String> splitTwoPartNamespace(String namespace) {
-    List<String> namespaceParts = Splitter.on(".").splitToList(namespace);
-    if (namespaceParts.size() != 2) {
-      String errMsg = "Invalid two-part namespace " + namespace;
-      throw new IllegalArgumentException(errMsg);
-    }
-
-    return namespaceParts;
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Prior to this PR, users were required to lookup namespace and tables by supplying the uc catalog name in the namespace identifier which isn't proper and lead to problems. This PR implements the REST client flow of configuring calls to the API with a defined prefix containing the catalog name. The catalog name is now part of the API paths and broken apart from the namespace.

Client (passes warehouse parameter) -> Server Config Endpoint (response has override for URL prefix) -> Client
Subsequent calls to the API now has url prefixed with `/catalogs/{warehouse/catalog-name}`

This PR "binds" the spark catalog to a UC catalog using the client config endpoint. Users must now add to their catalog configurations something like (example in spark):

`"spark.sql.catalog.<spark-catalog-name>.warehouse": "<catalog-name>"` and now address tables like
`<spark-catalog-name>.<namespace-name>.<table-name>`

This should address
https://github.com/unitycatalog/unitycatalog/issues/182 and parts of https://github.com/unitycatalog/unitycatalog/issues/3.

---------

Signed-off-by: Alex Reid <alex.reid@databricks.com>

(cherry picked from commit 3bf4a012cfc47390bf615736671a79b9802519c4)

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
