### PR TITLE
Send non empty data as part of expired cookie in the header

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -66,6 +66,7 @@ public class AuthService {
   private final JwksOperations jwksOperations;
 
   private static final String COOKIE = "cookie";
+  private static final String EMPTY_RESPONSE = "{}";
 
   public AuthService(SecurityContext securityContext) {
     this.securityContext = securityContext;
@@ -190,9 +191,10 @@ public class AuthService {
                       .add(HttpHeaderNames.SET_COOKIE, expiredCookie.toSetCookieHeader())
                       .contentType(MediaType.JSON)
                       .build();
-              return HttpResponse.of(headers, HttpData.ofUtf8("{}"));
+              // Armeria requires a non-empty response payload, so an empty JSON is sent
+              return HttpResponse.of(headers, HttpData.ofUtf8(EMPTY_RESPONSE));
             })
-        .orElse(HttpResponse.of(HttpStatus.OK));
+        .orElse(HttpResponse.of(HttpStatus.OK, MediaType.JSON, EMPTY_RESPONSE));
   }
 
   private static void verifyPrincipal(DecodedJWT decodedJWT) {

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -185,9 +185,12 @@ public class AuthService {
             authorizationCookie -> {
               Cookie expiredCookie = createCookie(AuthDecorator.UC_TOKEN_KEY, "", "/", "PT0S");
               ResponseHeaders headers =
-                  ResponseHeaders.of(
-                      HttpStatus.OK, HttpHeaderNames.SET_COOKIE, expiredCookie.toSetCookieHeader());
-              return HttpResponse.of(headers);
+                  ResponseHeaders.builder()
+                      .status(HttpStatus.OK)
+                      .add(HttpHeaderNames.SET_COOKIE, expiredCookie.toSetCookieHeader())
+                      .contentType(MediaType.JSON)
+                      .build();
+              return HttpResponse.of(headers, HttpData.ofUtf8("{}"));
             })
         .orElse(HttpResponse.of(HttpStatus.OK));
   }

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -1,0 +1,62 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+import com.linecorp.armeria.common.auth.AuthToken;
+import io.unitycatalog.server.base.BaseServerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AuthServiceTest extends BaseServerTest {
+
+  private static final String LOGOUT_ENDPOINT = "/api/1.0/unity-control/auth/logout";
+  private WebClient client;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    String uri = serverConfig.getServerUrl();
+    String token = serverConfig.getAuthToken();
+    client = WebClient.builder(uri).auth(AuthToken.ofOAuth2(token)).build();
+  }
+
+  @Test
+  public void testLogout() {
+
+    // Logout with cookie should return status as 200 and  empty json content
+    RequestHeaders headersWithCookie = buildRequestHeader(true);
+
+    AggregatedHttpResponse response = client.execute(headersWithCookie).aggregate().join();
+    assertEquals(HttpStatus.OK, response.status());
+    assertThat(response.contentUtf8()).isEqualTo("{}");
+
+    // Logout without cookie should return 200 status
+    RequestHeaders headersWithoutCookie = buildRequestHeader(false);
+    response = client.execute(headersWithoutCookie).aggregate().join();
+    assertEquals(HttpStatus.OK, response.status());
+    assertThat(response.contentUtf8()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  public RequestHeaders buildRequestHeader(boolean includeCookie) {
+    RequestHeadersBuilder builder =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(LOGOUT_ENDPOINT)
+            .contentType(MediaType.JSON);
+
+    if (includeCookie) {
+      builder.add(HttpHeaderNames.COOKIE, "UC_TOKEN=1234");
+    }
+
+    return builder.build();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -20,6 +20,8 @@ public class AuthServiceTest extends BaseServerTest {
 
   private static final String LOGOUT_ENDPOINT = "/api/1.0/unity-control/auth/logout";
   private WebClient client;
+  private static final String EMPTY_RESPONSE = "{}";
+
 
   @BeforeEach
   public void setUp() {
@@ -37,13 +39,13 @@ public class AuthServiceTest extends BaseServerTest {
 
     AggregatedHttpResponse response = client.execute(headersWithCookie).aggregate().join();
     assertEquals(HttpStatus.OK, response.status());
-    assertThat(response.contentUtf8()).isEqualTo("{}");
+    assertThat(response.contentUtf8()).isEqualTo(EMPTY_RESPONSE);
 
     // Logout without cookie should return 200 status
     RequestHeaders headersWithoutCookie = buildRequestHeader(false);
     response = client.execute(headersWithoutCookie).aggregate().join();
     assertEquals(HttpStatus.OK, response.status());
-    assertThat(response.contentUtf8()).isEqualTo(HttpStatus.OK.toString());
+    assertThat(response.contentUtf8()).isEqualTo(EMPTY_RESPONSE);
   }
 
   public RequestHeaders buildRequestHeader(boolean includeCookie) {


### PR DESCRIPTION

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Logout endpoint was implemented to expire cookie as part of the task https://github.com/unitycatalog/unitycatalog/pull/593 and changes are pushed as part of PR https://github.com/unitycatalog/unitycatalog/pull/678 but when the endpoint was called it gets hung indefinitely , On further investigation non empty data needs to be send as part of the header when we expire the cookie. This PR has the fix for the same.