### PR TITLE
Update field sizes to support Python Functions usage

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
@@ -23,7 +23,7 @@ public class FunctionInfoDAO extends IdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 
-  @Column(name = "comment")
+  @Column(name = "comment", length = 65535)
   private String comment;
 
   @Column(name = "owner")
@@ -59,10 +59,12 @@ public class FunctionInfoDAO extends IdentifiableDAO {
   @Column(name = "parameter_style")
   private FunctionInfo.ParameterStyleEnum parameterStyle;
 
-  @Column(name = "routine_body")
+  @Lob
+  @Column(name = "routine_body", length = 16777215)
   private FunctionInfo.RoutineBodyEnum routineBody;
 
-  @Column(name = "routine_definition")
+  @Lob
+  @Column(name = "routine_definition", length = 16777215)
   private String routineDefinition;
 
   @Column(name = "sql_data_access")

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
@@ -59,8 +59,7 @@ public class FunctionInfoDAO extends IdentifiableDAO {
   @Column(name = "parameter_style")
   private FunctionInfo.ParameterStyleEnum parameterStyle;
 
-  @Lob
-  @Column(name = "routine_body", length = 16777215)
+  @Column(name = "routine_body")
   private FunctionInfo.RoutineBodyEnum routineBody;
 
   @Lob


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

By the default definitions, these field definitions that are used for functions definitions all have a limit at 255 characters. This is insufficient for most 'real-world' python functions and will impact the capabilities for ai function calling (the `routineDefinition` is a hard blocker; and the `comment` field will impact the usefulness of a defined and configured GenAI tool that is utilizing a UC function). 
The changes to these fields will enable full usage for the AI integrations. 