### PR TITLE
Patch FunctionInfo to support python callables

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
@@ -23,7 +23,7 @@ public class FunctionInfoDAO extends IdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 
-  @Column(name = "comment")
+  @Column(name = "comment", length = 65535)
   private String comment;
 
   @Column(name = "owner")
@@ -62,7 +62,8 @@ public class FunctionInfoDAO extends IdentifiableDAO {
   @Column(name = "routine_body")
   private FunctionInfo.RoutineBodyEnum routineBody;
 
-  @Column(name = "routine_definition")
+  @Lob
+  @Column(name = "routine_definition", length = 16777215)
   private String routineDefinition;
 
   @Column(name = "sql_data_access")


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This change allows for realistic python callable descriptions (`comment`) and function bodies (`routine_definition`) to be written to the UC server. Otherwise, the default of maximum 255 characters is not sufficient for any meaningful use of this service for real-world python functions. 