### PR TITLE
Handle invalid function definitions gracefully

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/utils/validation_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/validation_utils.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, List, NamedTuple
 
 from unitycatalog.ai.core.utils.type_utils import is_time_type
 
@@ -140,3 +140,17 @@ def validate_function_name_length(function_name: str) -> None:
             f"The maximum length of a function name is {OSS_MAX_FUNCTION_NAME_LENGTH}. "
             f"The name supplied is {name_length} characters long."
         )
+
+
+def check_wildcard_function_name_listing(function_names: List[str]) -> None:
+    """
+    Checks if the function names contain wildcard characters and raises an error if they do.
+
+    Args:
+        function_names: The list of function names to check.
+    """
+    for function_name in function_names:
+        if "*" in function_name:
+            raise ValueError(
+                f"Function names with wildcard characters '*' are not supported: {function_name}"
+            )

--- a/ai/integrations/anthropic/src/unitycatalog/ai/anthropic/toolkit.py
+++ b/ai/integrations/anthropic/src/unitycatalog/ai/anthropic/toolkit.py
@@ -9,6 +9,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 
 class AnthropicTool(BaseModel):
@@ -64,6 +65,8 @@ class UCFunctionToolkit(BaseModel):
         Validates the toolkit, ensuring the client is properly set and function names are processed.
         """
         self.client = validate_or_set_default_client(self.client)
+
+        check_wildcard_function_name_listing(self.function_names)
 
         self.tools_dict = process_function_names(
             function_names=self.function_names,

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
@@ -20,6 +20,14 @@ from unitycatalog.ai.test_utils.client_utils import (
 )
 from unitycatalog.ai.test_utils.function_utils import create_function_and_cleanup
 
+try:
+    # v2
+    from pydantic_core._pydantic_core import ValidationError
+except ImportError:
+    # v1
+    from pydantic.error_wrappers import ValidationError
+
+
 SCHEMA = os.environ.get("SCHEMA", "ucai_core_test")
 
 
@@ -350,3 +358,11 @@ def test_anthropic_tool_definition_generation(use_serverless, monkeypatch):
                 "required": [],
             },
         }
+
+
+def test_toolkit_prohibits_wildcard_functions():
+    client = get_client()
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])

--- a/ai/integrations/autogen/src/unitycatalog/ai/autogen/toolkit.py
+++ b/ai/integrations/autogen/src/unitycatalog/ai/autogen/toolkit.py
@@ -14,6 +14,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 # Ensure the version of autogen is compatible
 if version.parse(autogen_version) >= version.parse("0.4.0"):
@@ -116,6 +117,8 @@ class UCFunctionToolkit(BaseModel):
 
         if not self.function_names:
             raise ValueError("Cannot create tool instances without function_names being provided.")
+
+        check_wildcard_function_name_listing(self.function_names)
 
         self.tools_dict = process_function_names(
             function_names=self.function_names,

--- a/ai/integrations/autogen/tests/test_toolkit.py
+++ b/ai/integrations/autogen/tests/test_toolkit.py
@@ -241,7 +241,7 @@ def test_register_with_agents(client):
     function_names = ["catalog.schema.function"]
 
     # Create a realistic FunctionInfo object
-    function_info = FunctionInfo(
+    FunctionInfo(
         catalog_name="catalog",
         schema_name="schema",
         name="function",
@@ -271,3 +271,11 @@ def test_register_with_agents(client):
             tool.register_function.assert_called_once_with(
                 callers=mock_callers, executors=mock_executors
             )
+
+
+def test_toolkit_prohibits_wildcard_functions():
+    client = get_client()
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])

--- a/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
+++ b/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
@@ -12,6 +12,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 _logger = logging.getLogger(__name__)
 
@@ -99,6 +100,8 @@ class UCFunctionToolkit(BaseModel):
 
         if not self.function_names:
             raise ValueError("Cannot create tool instances without function_names being provided.")
+
+        check_wildcard_function_name_listing(self.function_names)
 
         self.tools_dict = process_function_names(
             function_names=self.function_names,

--- a/ai/integrations/crewai/tests/test_toolkit.py
+++ b/ai/integrations/crewai/tests/test_toolkit.py
@@ -203,3 +203,11 @@ def test_toolkit_crewai_kwarg_passthrough(client):
         assert tool.cache_function()
         assert tool.result_as_answer
         assert tool.description_updated
+
+
+def test_toolkit_prohibits_wildcard_functions():
+    client = get_client()
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])

--- a/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
+++ b/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
@@ -11,6 +11,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 
 class UnityCatalogTool(StructuredTool):
@@ -47,6 +48,9 @@ class UCFunctionToolkit(BaseModel):
         values["client"] = client
 
         function_names = values["function_names"]
+
+        check_wildcard_function_name_listing(function_names)
+
         tools_dict = values.get("tools_dict", {})
 
         values["tools_dict"] = process_function_names(

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -228,3 +228,10 @@ def test_toolkit_fields_validation(client):
 
     with pytest.raises(ValidationError, match=r"instance of BaseFunctionClient expected"):
         UCFunctionToolkit(client=test_tool, function_names=[])
+
+
+def test_toolkit_prohibits_wildcard_functions(client):
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])

--- a/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
+++ b/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
@@ -13,6 +13,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 
 class UnityCatalogTool(FunctionTool):
@@ -105,6 +106,8 @@ class UCFunctionToolkit(BaseModel):
 
         if not self.function_names:
             raise ValueError("Cannot create tool instances without function_names being provided.")
+
+        check_wildcard_function_name_listing(self.function_names)
 
         self.tools_dict = process_function_names(
             function_names=self.function_names,

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
@@ -505,3 +505,10 @@ def test_toolkit_with_invalid_function_input_mocked():
         mock_client.execute_function.assert_called_once_with(
             function_name="catalog.schema.test_function", parameters=invalid_inputs
         )
+
+
+def test_toolkit_prohibits_wildcard_functions(client):
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])

--- a/ai/integrations/openai/src/unitycatalog/ai/openai/toolkit.py
+++ b/ai/integrations/openai/src/unitycatalog/ai/openai/toolkit.py
@@ -11,6 +11,7 @@ from unitycatalog.ai.core.utils.function_processing_utils import (
     get_tool_name,
     process_function_names,
 )
+from unitycatalog.ai.core.utils.validation_utils import check_wildcard_function_name_listing
 
 
 class UCFunctionToolkit(BaseModel):
@@ -34,6 +35,8 @@ class UCFunctionToolkit(BaseModel):
     @model_validator(mode="after")
     def validate_toolkit(self) -> "UCFunctionToolkit":
         self.client = validate_or_set_default_client(self.client)
+
+        check_wildcard_function_name_listing(self.function_names)
 
         self.tools_dict = process_function_names(
             function_names=self.function_names,

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -27,6 +27,13 @@ from unitycatalog.ai.test_utils.function_utils import (
     random_func_name,
 )
 
+try:
+    # v2
+    from pydantic_core._pydantic_core import ValidationError
+except ImportError:
+    # v1
+    from pydantic.error_wrappers import ValidationError
+
 SCHEMA = os.environ.get("SCHEMA", "ucai_openai_test")
 
 
@@ -421,3 +428,11 @@ def test_function_definition_generation(use_serverless, monkeypatch):
                 },
             },
         }
+
+
+def test_toolkit_prohibits_wildcard_functions():
+    client = get_client()
+    with pytest.raises(
+        ValidationError, match=r"Function names with wildcard characters '\*' are not supported"
+    ):
+        UCFunctionToolkit(client=client, function_names=["catalog.schema.*"])


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The error that is raised at a Toolkit invocation time for invalid (wildcard defined) functions within the function_names list is a very vague and difficult to troubleshoot pydantic field validation error that requires knowledge of the integration's implementation in order to troubleshoot. 
This PR fixes this for the integration toolkits by explicitly defining why the failure is occurring from within the model validation logic post-field-validation.