### PR TITLE
Bugfix: Fix getting child element on UI

### DIFF
--- a/ui/src/components/layouts/DetailsLayout.tsx
+++ b/ui/src/components/layouts/DetailsLayout.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb, Col, Flex, Grid, Row } from 'antd';
 import { BreadcrumbItemType } from 'antd/es/breadcrumb/Breadcrumb';
 import React, { ReactNode } from 'react';
-import { getChildOnDisplayName } from '../../utils/getChildOnDisplayName';
+import { getChildOnType } from '../../utils/getChildOnType';
 
 interface DetailsLayoutProps {
   title: ReactNode;
@@ -14,8 +14,8 @@ const { useBreakpoint } = Grid;
 function DetailsLayout({ title, breadcrumbs, children }: DetailsLayoutProps) {
   const screens = useBreakpoint();
 
-  const contentChild = getChildOnDisplayName(children, 'Content');
-  const asideChild = getChildOnDisplayName(children, 'Aside');
+  const contentChild = getChildOnType(children, Content);
+  const asideChild = getChildOnType(children, Aside);
 
   return (
     <Flex vertical gap="middle" style={{ flexGrow: 1 }}>

--- a/ui/src/utils/getChildOnType.ts
+++ b/ui/src/utils/getChildOnType.ts
@@ -1,14 +1,12 @@
 import React from 'react';
 
-export function getChildOnDisplayName(
+export function getChildOnType(
   children: React.ReactNode[] | React.ReactNode,
-  displayName: string,
+  type: React.JSXElementConstructor<any>,
 ) {
   return React.Children.toArray(children).find((child) => {
     if (React.isValidElement(child)) {
-      return typeof child.type === 'function'
-        ? child.type.name === displayName
-        : false;
+      return child.type === type;
     }
     return false;
   });


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

While displayName works in dev, it gets minified for production builds. What this means is that no children are matched to the displayName so nothing is actually rendered.

Matching on the actual type works both in dev and prod builds.
