### PR TITLE
[DOCS] Fix inconsistent table in quickstart md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -204,7 +204,7 @@ Let's try creating a new table.
 
 ```sh
 bin/uc table create --full_name unity.default.mytable \
---columns "col1 int, col2 double" --storage_location /tmp/uc/my_table
+--columns "col1 int, col2 double" --storage_location /tmp/uc/mytable
 ```
 
 ```console
@@ -272,7 +272,7 @@ bin/uc table delete --full_name unity.default.mytable
 ```
 
 > Note, while you have deleted the table from Unity Catalog, the underlying file system may still have the files (i.e.,
-check the /tmp/uc/my_table/ folder).  
+check the /tmp/uc/mytable/ folder).  
 
 ## Interact with the Unity Catalog UI
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

In pquickstart docs](https://docs.unitycatalog.io/quickstart/), example table names are not consistent.
change my_table to `mytable`
