### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,9 @@ COPY --from=base --parents \
     $HOME/.cache/ \
     /
 
-RUN apk add gcompat
-
 # Create a service user with read and execute permissions and write permissions of the ./etc directory
 RUN <<EOF
-apk add --no-cache bash
+apk add --no-cache bash gcompat
 addgroup -S $USER
 adduser -S -G $USER $USER
 chmod -R 550 $HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 ARG HOME="/home/unitycatalog"
 ARG ALPINE_VERSION="3.20"
+ARG PYTHON_VERSION="3.11"
 
 # Build stage, using Amazon Corretto jdk 17 on alpine with arm64 support
 FROM amazoncorretto:17-alpine${ALPINE_VERSION}-jdk as base
@@ -15,8 +16,8 @@ COPY --parents build/ project/ examples/ server/ api/ clients/python/ version.sb
 
 RUN apk add --no-cache bash && ./build/sbt -info clean package
 
-# Small runtime image
-FROM alpine:${ALPINE_VERSION} as runtime
+# Small Python runtime image
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} as runtime
 
 # Specific JAVA_HOME from Amazon Corretto
 ARG JAVA_HOME="/usr/lib/jvm/default-jvm"
@@ -38,6 +39,8 @@ COPY --from=base --parents \
     $HOME/target/ \
     $HOME/.cache/ \
     /
+
+RUN apk add gcompat
 
 # Create a service user with read and execute permissions and write permissions of the ./etc directory
 RUN <<EOF


### PR DESCRIPTION
**PR Checklist**

- [ x ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
alpine image does not contain a lib compat package.
To make a command `bin/uc table get --full_name unity.default.numbers` works a **gcompat** package need to be installed.

Unity catalog Function need a python.
Therefore a suggestion to use a python3.11-alpine docker image as runtime will be the best choice.


<!-- Please state what you've changed and how it might affect the users. -->
