### PR TITLE
[DOCS] Remove broken link (404) from PuppyGraph docs

### DIFF
--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -192,4 +192,3 @@ You can also use [Web UI](https://docs.puppygraph.com/user-interface/puppygraph-
 ## See Also
 
 - [Querying Unity Catalog Data as a Graph](https://docs.puppygraph.com/getting-started/querying-unity-catalog-data-as-a-graph)
-- [The Internals of Unity Catalog | Spark Connector](https://books.japila.pl/unity-catalog-internals/spark-connector/)


### PR DESCRIPTION
This PR removes a broken link from the Puppygraph integration docs.