### PR TITLE
[DRAFT] Set and check nonce during authentication sequence.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -184,6 +184,8 @@ lazy val client = (project in file("target/clients/java"))
       "com.google.code.findbugs" % "jsr305" % "3.0.2",
       "jakarta.annotation" % "jakarta.annotation-api" % "3.0.0" % Provided,
 
+      "com.auth0" % "java-jwt" % "4.4.0",
+
       // Test dependencies
       "org.junit.jupiter" % "junit-jupiter" % "5.10.3" % Test,
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

This fixes a potential replay attack by setting a `nonce` value and validating the `nonce` is returned in the id-token.