### PR TITLE
Remove the ability to use SQL Warehouses in Unity Catalog AI in favor of serverless

### DIFF
--- a/ai/core/pyproject.toml
+++ b/ai/core/pyproject.toml
@@ -78,7 +78,7 @@ databricks-dev = [
   "databricks-sdk>=0.32.0",
   "databricks-connect==15.1.0",
   "pandas",
-  "ruff==0.6.4",
+  "ruff==0.9.3",
 ]
 dev = [
   "hatch",
@@ -89,7 +89,7 @@ dev = [
   # databricks-connect>=14.0.0 requires python>=3.10
   "databricks-connect",
   "pandas",
-  "ruff==0.6.4",
+  "ruff==0.9.3",
 ]
 
 [tool.ruff]
@@ -110,7 +110,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/core/src/unitycatalog/ai/core/client.py
+++ b/ai/core/src/unitycatalog/ai/core/client.py
@@ -444,8 +444,7 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
                 await self.delete_function_async(str(function_name), timeout=timeout)
             else:
                 raise ValueError(
-                    f"Function {function_name} already exists. "
-                    f"Set replace=True to overwrite it."
+                    f"Function {function_name} already exists. Set replace=True to overwrite it."
                 )
         except ServiceException:
             pass

--- a/ai/core/src/unitycatalog/ai/core/envs/databricks_env_vars.py
+++ b/ai/core/src/unitycatalog/ai/core/envs/databricks_env_vars.py
@@ -22,31 +22,6 @@ class _EnvironmentVariable:
         )
 
 
-UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT = _EnvironmentVariable(
-    "UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT",
-    "30s",
-    "The time in seconds the call will wait for the function to execute using Databricks client with warehouse_id; "
-    "the value should be set as `Ns`, where `N` can be set to 0 or to a value between 5 and 50.",
-)
-UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_ROW_LIMIT = _EnvironmentVariable(
-    "UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_ROW_LIMIT",
-    "100",
-    "Maximum number of rows of the function execution result using Databricks client with warehouse_id; "
-    "it also sets the `truncated` field in the response to indicate whether the result was trimmed due to the limit or not.",
-)
-UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_BYTE_LIMIT = _EnvironmentVariable(
-    "UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_BYTE_LIMIT",
-    "1048576",  # 1MB = 1024 * 1024
-    "Maximum byte size of the function execution result using Databricks client with warehouse_id; "
-    "If the result was truncated due to the byte limit, then `truncated` in the response is set to `true`.",
-)
-UCAI_DATABRICKS_WAREHOUSE_RETRY_TIMEOUT = _EnvironmentVariable(
-    "UCAI_DATABRICKS_WAREHOUSE_RETRY_TIMEOUT",
-    "120",
-    "Client side retry timeout for the function execution using Databricks client with warehouse_id; "
-    "if the function execution does not complete within UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT, client side will "
-    "retry to fetch the result until this timeout is reached.",
-)
 UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT = _EnvironmentVariable(
     "UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT",
     "100",

--- a/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
@@ -9,14 +9,8 @@ import pytest
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-USE_SERVERLESS = "USE_SERVERLESS"
 TEST_IN_DATABRICKS = os.environ.get("TEST_IN_DATABRICKS", "false").lower() == "true"
-WAREHOUSE_ID = os.environ.get("WAREHOUSE_ID", "warehouse_id")
 PROFILE = os.environ.get("DATABRICKS_CONFIG_PROFILE")
-
-
-def use_serverless():
-    return os.environ.get(USE_SERVERLESS, "false").lower() == "true"
 
 
 def requires_databricks(test_func):
@@ -26,17 +20,16 @@ def requires_databricks(test_func):
     )(test_func)
 
 
-# TODO: CI -- only support python 3.10, test with databricks-connect 15.1.0 + serverless
 @pytest.fixture
 def client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:
-        return DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID, profile=PROFILE)
+        return DatabricksFunctionClient(profile=PROFILE)
     else:
         with mock.patch(
             "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
             return_value=mock.Mock(),
         ):
-            return DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID)
+            return DatabricksFunctionClient()
 
 
 @pytest.fixture
@@ -46,21 +39,13 @@ def serverless_client() -> DatabricksFunctionClient:
 
 def get_client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:
-        return (
-            DatabricksFunctionClient(profile=PROFILE)
-            if use_serverless()
-            else DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID, profile=PROFILE)
-        )
+        return DatabricksFunctionClient(profile=PROFILE)
     else:
         with mock.patch(
             "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
             return_value=mock.Mock(),
         ):
-            return (
-                DatabricksFunctionClient()
-                if use_serverless()
-                else DatabricksFunctionClient(warehouse_id=WAREHOUSE_ID)
-            )
+            return DatabricksFunctionClient()
 
 
 @contextmanager

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
@@ -120,17 +120,19 @@ def create_table_function_and_cleanup(
     sql_body = (
         sql_body
         or f"""CREATE FUNCTION {func_name}(query STRING)
-RETURNS TABLE
-SELECT
-  chunked_text as page_content,
-  map('doc_uri', url, 'chunk_id', chunk_id) as metadata
-FROM
-  vector_search(
-    -- Specify your Vector Search index name here
-    index => 'catalog.schema.databricks_docs_index',
-    query => query,
-    num_results => 5
-  )
+RETURNS TABLE (
+    page_content STRING, 
+    metadata MAP<STRING, STRING>
+)
+RETURN SELECT
+      chunked_text as page_content,
+      map('doc_uri', url, 'chunk_id', chunk_id) as metadata
+    FROM
+    vector_search(
+        index => 'catalog.schema.databricks_docs_index',
+        query => query,
+        num_results => 5
+    )
 """
     )
     try:

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
@@ -125,13 +125,14 @@ RETURNS TABLE (
     metadata MAP<STRING, STRING>
 )
 RETURN SELECT
-      chunked_text as page_content,
-      map('doc_uri', url, 'chunk_id', chunk_id) as metadata
-    FROM
-    SELECT
-        'testing' as chunked_text,
-        'https://docs.databricks.com/' as url,
-        'chunk_id' as chunk_id
+      chunked_text AS page_content,
+      map('doc_uri', url, 'chunk_id', chunk_id) AS metadata
+    FROM (
+        SELECT
+            'testing' AS chunked_text,
+            'https://docs.databricks.com/' AS url,
+            '1' AS chunk_id
+    ) AS subquery_alias;
 """
     )
     try:

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
@@ -128,11 +128,10 @@ RETURN SELECT
       chunked_text as page_content,
       map('doc_uri', url, 'chunk_id', chunk_id) as metadata
     FROM
-    vector_search(
-        index => 'catalog.schema.databricks_docs_index',
-        query => query,
-        num_results => 5
-    )
+    SELECT
+        'testing' as chunked_text,
+        'https://docs.databricks.com/' as url,
+        'chunk_id' as chunk_id
 """
     )
     try:

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils.py
@@ -11,15 +11,6 @@ from databricks.sdk.service.catalog import (
 
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
-from unitycatalog.client import (
-    ColumnTypeName as OSSColumnTypeName,
-)
-from unitycatalog.client import (
-    FunctionParameterInfo as OSSFunctionParameterInfo,
-)
-from unitycatalog.client import (
-    FunctionParameterInfos as OSSFunctionParameterInfos,
-)
 
 CATALOG = "integration_testing"
 
@@ -40,24 +31,6 @@ RETRIEVER_TABLE_RETURN_PARAMS = FunctionParameterInfos(
             name="metadata",
             type_text="map<string,string>",
             type_name=ColumnTypeName.MAP,
-            type_json='{"name":"metadata","type":{"type":"map","keyType":"string","valueType":"string","valueContainsNull":true},"nullable":true,"metadata":{}}',
-            position=1,
-        ),
-    ]
-)
-RETRIEVER_TABLE_RETURN_PARAMS_OSS = OSSFunctionParameterInfos(
-    parameters=[
-        OSSFunctionParameterInfo(
-            name="page_content",
-            type_text="string",
-            type_name=OSSColumnTypeName.STRING,
-            type_json='{"name":"page_content","type":"string","nullable":true,"metadata":{}}',
-            position=0,
-        ),
-        OSSFunctionParameterInfo(
-            name="metadata",
-            type_text="map<string,string>",
-            type_name=OSSColumnTypeName.MAP,
             type_json='{"name":"metadata","type":{"type":"map","keyType":"string","valueType":"string","valueContainsNull":true},"nullable":true,"metadata":{}}',
             position=1,
         ),

--- a/ai/core/src/unitycatalog/ai/test_utils/function_utils_oss.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/function_utils_oss.py
@@ -4,8 +4,32 @@ from typing import Any, Callable, Generator, NamedTuple
 
 from unitycatalog.ai.core.client import UnitycatalogFunctionClient
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
+from unitycatalog.client import (
+    ColumnTypeName,
+    FunctionParameterInfo,
+    FunctionParameterInfos,
+)
 
 CATALOG = "integration_testing"
+
+RETRIEVER_TABLE_RETURN_PARAMS_OSS = FunctionParameterInfos(
+    parameters=[
+        FunctionParameterInfo(
+            name="page_content",
+            type_text="string",
+            type_name=ColumnTypeName.STRING,
+            type_json='{"name":"page_content","type":"string","nullable":true,"metadata":{}}',
+            position=0,
+        ),
+        FunctionParameterInfo(
+            name="metadata",
+            type_text="map<string,string>",
+            type_name=ColumnTypeName.MAP,
+            type_json='{"name":"metadata","type":{"type":"map","keyType":"string","valueType":"string","valueContainsNull":true},"nullable":true,"metadata":{}}',
+            position=1,
+        ),
+    ]
+)
 
 _logger = logging.getLogger(__name__)
 

--- a/ai/core/tests/core/databricks/function_definitions.py
+++ b/ai/core/tests/core/databricks/function_definitions.py
@@ -214,17 +214,19 @@ AS $$
 def function_with_table_retriever_output(func_name: str) -> FunctionInputOutput:
     retriever_output = 'page_content,metadata\n"# Technology partners\n## What is Databricks Partner Connect?\n",{"similarity_score": 0.010178182, "chunk_id": "0217a07ba2fec61865ce408043acf1cf", "url": "https://docs.databricks.com/partner-connect/walkthrough-fivetran.html"}\n"# Technology partners\n## What is Databricks Partner Connect?\n",{"similarity_score": 0.010178182, "chunk_id": "0217a07ba2fec61865ce408043acf1cf", "url": "https://docs.databricks.com/partner-connect/walkthrough-fivetran.html"}\n'
     sql_body = f"""CREATE FUNCTION {func_name}(query STRING)
-RETURNS TABLE
-SELECT
-  chunked_text as page_content,
-  map('doc_uri', url, 'chunk_id', chunk_id) as metadata
-FROM
-  vector_search(
-    -- Specify your Vector Search index name here
-    index => 'catalog.schema.databricks_docs_index',
-    query => query,
-    num_results => 5
-  )
+RETURNS TABLE (
+    page_content STRING, 
+    metadata MAP<STRING, STRING>
+)
+RETURN SELECT
+      chunked_text AS page_content,
+      map('doc_uri', url, 'chunk_id', chunk_id) AS metadata
+    FROM (
+        SELECT
+            'testing' AS chunked_text,
+            'https://docs.databricks.com/' AS url,
+            '1' AS chunk_id
+    ) AS subquery_alias;
 """
     return FunctionInputOutput(
         sql_body=sql_body,

--- a/ai/core/tests/core/databricks/function_definitions.py
+++ b/ai/core/tests/core/databricks/function_definitions.py
@@ -211,30 +211,6 @@ AS $$
     )
 
 
-def function_with_table_retriever_output(func_name: str) -> FunctionInputOutput:
-    retriever_output = 'page_content,metadata\n"# Technology partners\n## What is Databricks Partner Connect?\n",{"similarity_score": 0.010178182, "chunk_id": "0217a07ba2fec61865ce408043acf1cf", "url": "https://docs.databricks.com/partner-connect/walkthrough-fivetran.html"}\n"# Technology partners\n## What is Databricks Partner Connect?\n",{"similarity_score": 0.010178182, "chunk_id": "0217a07ba2fec61865ce408043acf1cf", "url": "https://docs.databricks.com/partner-connect/walkthrough-fivetran.html"}\n'
-    sql_body = f"""CREATE FUNCTION {func_name}(query STRING)
-RETURNS TABLE (
-    page_content STRING, 
-    metadata MAP<STRING, STRING>
-)
-RETURN SELECT
-      chunked_text AS page_content,
-      map('doc_uri', url, 'chunk_id', chunk_id) AS metadata
-    FROM (
-        SELECT
-            'testing' AS chunked_text,
-            'https://docs.databricks.com/' AS url,
-            '1' AS chunk_id
-    ) AS subquery_alias;
-"""
-    return FunctionInputOutput(
-        sql_body=sql_body,
-        inputs=[{"query": "What is Databricks Partner Connect?"}],
-        output=retriever_output,
-    )
-
-
 class PythonFunctionInputOutput(NamedTuple):
     func: Callable
     inputs: List[Dict[str, Any]]

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -37,6 +37,7 @@ from unitycatalog.ai.core.databricks import (
 from unitycatalog.ai.core.envs.databricks_env_vars import (
     UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT,
 )
+from unitycatalog.ai.core.utils.validation_utils import has_retriever_signature
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
     client,  # noqa: F401
@@ -99,6 +100,8 @@ def test_create_and_execute_retriever_function(serverless_client: DatabricksFunc
     with generate_func_name_and_cleanup(serverless_client, schema=SCHEMA) as func_name:
         function_sample = function_with_scalar_retriever_output(func_name)
         serverless_client.create_function(sql_function_body=function_sample.sql_body)
+        function_info = serverless_client.get_function(func_name)
+        assert has_retriever_signature(function_info)
         for input_example in function_sample.inputs:
             result = serverless_client.execute_function(
                 func_name, input_example, enable_retriever_tracing=True

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -345,7 +345,7 @@ def test_create_function_without_replace(client: DatabricksFunctionClient):
         # Attempt to create the same function again without replace
         with pytest.raises(
             Exception,
-            match=f"`{CATALOG}`.`{SCHEMA}`.`simple_func` because it already exists",
+            match=f"Cannot create the routine `{CATALOG}`.`{SCHEMA}`.`simple_func` because a routine",
         ):
             client.create_python_function(
                 func=simple_func, catalog=CATALOG, schema=SCHEMA, replace=False

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -334,7 +334,7 @@ def test_function_with_dict_of_string_to_int_return(client: DatabricksFunctionCl
     ) as func_obj:
         result = client.execute_function(func_obj.full_function_name, {"a": 3})
         # result wrapped as string is due to sql statement execution response parsing
-        assert result.value == "{'key_0': 0,'key_1': 1,'key_2': 2}"
+        assert result.value == "{'key_0': 0, 'key_1': 1, 'key_2': 2}"
 
 
 @retry_flaky_test()

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -311,7 +311,7 @@ def test_function_with_list_of_int_return(client: DatabricksFunctionClient):
     ) as func_obj:
         result = client.execute_function(func_obj.full_function_name, {"a": 3})
         # result wrapped as string is due to sql statement execution response parsing
-        assert result.value == '["0","1","2"]'
+        assert result.value == '[0, 1, 2]'
 
 
 @retry_flaky_test()
@@ -334,7 +334,7 @@ def test_function_with_dict_of_string_to_int_return(client: DatabricksFunctionCl
     ) as func_obj:
         result = client.execute_function(func_obj.full_function_name, {"a": 3})
         # result wrapped as string is due to sql statement execution response parsing
-        assert result.value == '{"key_0":"0","key_1":"1","key_2":"2"}'
+        assert result.value == "{'key_0': 0,'key_1': 1,'key_2': 2}"
 
 
 @retry_flaky_test()

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -448,7 +448,7 @@ def test_execute_python_code_integration(code: str, expected_output: str):
     [
         "MLflow is an open-source platform for managing the end-to-end machine learning lifecycle. It was developed by Databricks and is now a part of the Linux Foundation's AI Foundation.",
         "print('Hello, \"world!\"')",
-        "'return '2' + \"" '3"' "' is a valid input to this function",
+        "'return '2' + \"3\"' is a valid input to this function",
     ],
 )
 def test_string_param_passing_work(text: str):

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -1,4 +1,3 @@
-import json
 import math
 import os
 from typing import Callable, Dict, List
@@ -18,7 +17,6 @@ from tests.core.databricks.function_definitions import (
     function_with_string_input,
     function_with_struct_input,
     function_with_table_output,
-    function_with_table_retriever_output,
     function_with_timestamp_input,
     python_function_with_array_input,
     python_function_with_binary_input,
@@ -37,9 +35,7 @@ from unitycatalog.ai.core.databricks import (
 from unitycatalog.ai.core.envs.databricks_env_vars import (
     UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT,
 )
-from unitycatalog.ai.core.utils.validation_utils import has_retriever_signature
 from unitycatalog.ai.test_utils.client_utils import (
-    TEST_IN_DATABRICKS,
     client,  # noqa: F401
     get_client,
     requires_databricks,
@@ -83,36 +79,6 @@ def test_create_and_execute_function(
         for input_example in function_sample.inputs:
             result = client.execute_function(func_name, input_example)
             assert result.value == function_sample.output
-
-
-@retry_flaky_test()
-@requires_databricks
-def test_create_and_execute_retriever_function(serverless_client: DatabricksFunctionClient):
-    import mlflow
-
-    if TEST_IN_DATABRICKS:
-        import mlflow.tracking._model_registry.utils
-
-        mlflow.tracking._model_registry.utils._get_registry_uri_from_spark_session = (
-            lambda: "databricks-uc"
-        )
-
-    with generate_func_name_and_cleanup(serverless_client, schema=SCHEMA) as func_name:
-        function_sample = function_with_table_retriever_output(func_name)
-        serverless_client.create_function(sql_function_body=function_sample.sql_body)
-        function_info = serverless_client.get_function(func_name)
-        assert has_retriever_signature(function_info)
-        for input_example in function_sample.inputs:
-            result = serverless_client.execute_function(
-                func_name, input_example, enable_retriever_tracing=True
-            )
-            assert result.value == function_sample.output, result.error
-
-            trace = mlflow.get_last_active_trace()
-            assert trace is not None
-            assert trace.info.execution_time_ms is not None
-            assert trace.data.request == json.dumps(input_example)
-            assert trace.data.response == function_sample.output.replace("'", '"')
 
 
 @retry_flaky_test()

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -15,10 +15,10 @@ from tests.core.databricks.function_definitions import (
     function_with_decimal_input,
     function_with_interval_input,
     function_with_map_input,
-    function_with_scalar_retriever_output,
     function_with_string_input,
     function_with_struct_input,
     function_with_table_output,
+    function_with_table_retriever_output,
     function_with_timestamp_input,
     python_function_with_array_input,
     python_function_with_binary_input,
@@ -98,7 +98,7 @@ def test_create_and_execute_retriever_function(serverless_client: DatabricksFunc
         )
 
     with generate_func_name_and_cleanup(serverless_client, schema=SCHEMA) as func_name:
-        function_sample = function_with_scalar_retriever_output(func_name)
+        function_sample = function_with_table_retriever_output(func_name)
         serverless_client.create_function(sql_function_body=function_sample.sql_body)
         function_info = serverless_client.get_function(func_name)
         assert has_retriever_signature(function_info)

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -311,7 +311,7 @@ def test_function_with_list_of_int_return(client: DatabricksFunctionClient):
     ) as func_obj:
         result = client.execute_function(func_obj.full_function_name, {"a": 3})
         # result wrapped as string is due to sql statement execution response parsing
-        assert result.value == '[0, 1, 2]'
+        assert result.value == "[0, 1, 2]"
 
 
 @retry_flaky_test()

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 import re
 from decimal import Decimal
@@ -851,3 +852,10 @@ def test_execute_function_warnings_missing_descriptions(mock_workspace_client, m
         assert any(
             "The function mock_function does not have a description." in msg for msg in messages
         ), "Warning about missing function description was not issued."
+
+
+def test_workspace_provided_issues_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        DatabricksFunctionClient(warehouse_id="id")
+
+    assert "The argument `warehouse_id` was specified" in caplog.text

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -854,8 +854,8 @@ def test_execute_function_warnings_missing_descriptions(mock_workspace_client, m
         ), "Warning about missing function description was not issued."
 
 
-def test_workspace_provided_issues_warning(caplog):
+def test_workspace_provided_issues_warning(mock_workspace_client, caplog):
     with caplog.at_level(logging.WARNING):
-        DatabricksFunctionClient(warehouse_id="id")
+        DatabricksFunctionClient(client=mock_workspace_client, warehouse_id="id")
 
     assert "The argument `warehouse_id` was specified" in caplog.text

--- a/ai/core/tests/core/oss/test_oss_client.py
+++ b/ai/core/tests/core/oss/test_oss_client.py
@@ -540,7 +540,7 @@ async def test_list_functions(uc_client: UnitycatalogFunctionClient):
             full_data_type="LONG",
             routine_definition="return x",
             input_data={"x": 2**63 - 1},
-            expected_result=f"{2**63-1}",
+            expected_result=f"{2**63 - 1}",
             comment="test",
         ),
         FunctionObj(

--- a/ai/core/tests/core/test_callable_utils.py
+++ b/ai/core/tests/core/test_callable_utils.py
@@ -197,9 +197,9 @@ AS $$
 $$;
     """
 
-    assert (
-        sql_body.strip() == expected_sql.strip()
-    ), f"Generated SQL does not match expected SQL.\nGenerated SQL:\n{sql_body}\nExpected SQL:\n{expected_sql}"
+    assert sql_body.strip() == expected_sql.strip(), (
+        f"Generated SQL does not match expected SQL.\nGenerated SQL:\n{sql_body}\nExpected SQL:\n{expected_sql}"
+    )
 
     assert len(record) == 1
 

--- a/ai/integrations/anthropic/README.md
+++ b/ai/integrations/anthropic/README.md
@@ -88,10 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/anthropic/anthropic_databricks_example.ipynb
+++ b/ai/integrations/anthropic/anthropic_databricks_example.ipynb
@@ -165,9 +165,9 @@
    },
    "outputs": [],
    "source": [
-    "assert (\n",
-    "    \"ANTHROPIC_API_KEY\" in os.environ\n",
-    "), \"Please set the ANTHROPIC_API_KEY environment variable to your Anthropic API key\""
+    "assert \"ANTHROPIC_API_KEY\" in os.environ, (\n",
+    "    \"Please set the ANTHROPIC_API_KEY environment variable to your Anthropic API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/anthropic/anthropic_example.ipynb
+++ b/ai/integrations/anthropic/anthropic_example.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"ANTHROPIC_API_KEY\" in os.environ\n",
-    "), \"Please set the ANTHROPIC_API_KEY environment variable to your Anthropic API key\""
+    "assert \"ANTHROPIC_API_KEY\" in os.environ, (\n",
+    "    \"Please set the ANTHROPIC_API_KEY environment variable to your Anthropic API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/anthropic/pyproject.toml
+++ b/ai/integrations/anthropic/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
@@ -50,9 +50,7 @@ def mock_anthropic_tool_response(function_name, input_data, message_id):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling_with_anthropic(use_serverless, monkeypatch):
-    monkeypatch.setenv("USE_SERVERLESS", str(use_serverless))
+def test_tool_calling_with_anthropic():
     client = get_client()
     with (
         set_default_client(client),
@@ -140,9 +138,7 @@ def test_tool_calling_with_anthropic(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling_with_multiple_tools_anthropic(use_serverless, monkeypatch):
-    monkeypatch.setenv("USE_SERVERLESS", str(use_serverless))
+def test_tool_calling_with_multiple_tools_anthropic():
     client = get_client()
     with (
         set_default_client(client),
@@ -276,9 +272,7 @@ def test_tool_calling_with_multiple_tools_anthropic(use_serverless, monkeypatch)
                     )
 
 
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_anthropic_toolkit_initialization(use_serverless, monkeypatch):
-    monkeypatch.setenv("USE_SERVERLESS", str(use_serverless))
+def test_anthropic_toolkit_initialization():
     client = get_client()
 
     with pytest.raises(
@@ -309,9 +303,7 @@ def generate_function_info(parameters, catalog="catalog", schema="schema"):
     )
 
 
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_anthropic_tool_definition_generation(use_serverless, monkeypatch):
-    monkeypatch.setenv("USE_SERVERLESS", str(use_serverless))
+def test_anthropic_tool_definition_generation():
     client = get_client()
     with set_default_client(client):
         function_info = generate_function_info(

--- a/ai/integrations/autogen/README.md
+++ b/ai/integrations/autogen/README.md
@@ -96,10 +96,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="...", # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/autogen/autogen_example.ipynb
+++ b/ai/integrations/autogen/autogen_example.ipynb
@@ -42,9 +42,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/autogen/pyproject.toml
+++ b/ai/integrations/autogen/pyproject.toml
@@ -62,7 +62,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/autogen/tests/test_autogen_toolkit.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit.py
@@ -17,7 +17,6 @@ from unitycatalog.ai.autogen.toolkit import UCFunctionToolkit
 from unitycatalog.ai.core.client import FunctionExecutionResult
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
-    USE_SERVERLESS,
     get_client,
     requires_databricks,
     set_default_client,
@@ -69,10 +68,8 @@ def generate_function_info():
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
 @pytest.mark.asyncio
-async def test_toolkit_e2e(use_serverless, monkeypatch, dbx_client):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+async def test_toolkit_e2e(dbx_client):
     with (
         set_default_client(dbx_client),
         create_function_and_cleanup(dbx_client, schema=SCHEMA) as func_obj,
@@ -102,10 +99,8 @@ async def test_toolkit_e2e(use_serverless, monkeypatch, dbx_client):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
 @pytest.mark.asyncio
-async def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch, dbx_client):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+async def test_toolkit_e2e_manually_passing_client(dbx_client):
     with (
         set_default_client(dbx_client),
         create_function_and_cleanup(dbx_client, schema=SCHEMA) as func_obj,
@@ -132,10 +127,8 @@ async def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch, 
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
 @pytest.mark.asyncio
-async def test_multiple_toolkits(use_serverless, monkeypatch, dbx_client):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+async def test_multiple_toolkits(dbx_client):
     with (
         set_default_client(dbx_client),
         create_function_and_cleanup(dbx_client, schema=SCHEMA) as func_obj,
@@ -229,11 +222,7 @@ async def test_uc_function_to_autogen_tool(dbx_client):
         ("CSV", RETRIEVER_OUTPUT_CSV),
     ],
 )
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_autogen_tool_with_tracing_as_retriever(
-    use_serverless, monkeypatch, format: str, function_output: str
-):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_autogen_tool_with_tracing_as_retriever(format: str, function_output: str):
     client = get_client()
     mock_function_info = generate_function_info()
 

--- a/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
@@ -20,10 +20,10 @@ from unitycatalog.ai.test_utils.function_utils import (
     RETRIEVER_OUTPUT_CSV,
     RETRIEVER_OUTPUT_SCALAR,
     RETRIEVER_TABLE_FULL_DATA_TYPE,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
 )
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
+    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/crewai/README.md
+++ b/ai/integrations/crewai/README.md
@@ -88,9 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/crewai/crewai_oss_example.ipynb
+++ b/ai/integrations/crewai/crewai_oss_example.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/crewai/pyproject.toml
+++ b/ai/integrations/crewai/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/crewai/tests/test_crewai_toolkit.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit.py
@@ -16,7 +16,6 @@ from unitycatalog.ai.core.base import (
 )
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
-    USE_SERVERLESS,
     client,  # noqa: F401
     get_client,
     requires_databricks,
@@ -33,9 +32,7 @@ SCHEMA = os.environ.get("SCHEMA", "ucai_crewai_test")
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -56,9 +53,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e_manually_passing_client():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name], client=client)
@@ -84,9 +79,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_multiple_toolkits(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_multiple_toolkits():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -170,11 +163,7 @@ def test_uc_function_to_crewai_tool(client):
         ("CSV", RETRIEVER_OUTPUT_CSV),
     ],
 )
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_crewai_tool_with_tracing_as_retriever(
-    use_serverless, monkeypatch, format: str, function_output: str
-):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_crewai_tool_with_tracing_as_retriever(format: str, function_output: str):
     client = get_client()
     mock_function_info = generate_function_info()
 

--- a/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
@@ -13,10 +13,10 @@ from unitycatalog.ai.test_utils.function_utils import (
     RETRIEVER_OUTPUT_CSV,
     RETRIEVER_OUTPUT_SCALAR,
     RETRIEVER_TABLE_FULL_DATA_TYPE,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
 )
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
+    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/gemini/README.md
+++ b/ai/integrations/gemini/README.md
@@ -88,10 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-    cluster_id="..." # optional, only pass when you want to use cluster for function creation
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)
@@ -166,6 +163,7 @@ print(response)
 ```
 
 ### Showing Details of the Tool Call
+
 You can review the conversation history and see how the LLM decided to call the function:
 
 ```python
@@ -173,8 +171,11 @@ for content in chat.history:
     print(content.role, "->", [type(part).to_dict(part) for part in content.parts])
     print("-" * 80)
 ```
+
 ## Manually execute function calls
+
 if you prefer more control, you can manually detect and execute function calls:
+
 ```python
 from google.generativeai.types import content_types
 from unitycatalog.ai.gemini.utils import get_function_calls,generate_tool_call_messages

--- a/ai/integrations/gemini/gemini_databricks_example.ipynb
+++ b/ai/integrations/gemini/gemini_databricks_example.ipynb
@@ -165,9 +165,9 @@
    },
    "outputs": [],
    "source": [
-    "assert (\n",
-    "    \"GOOGLE_API_KEY\" in os.environ\n",
-    "), \"Please set the GOOGLE_API_KEY environment variable to your Gemini API key\""
+    "assert \"GOOGLE_API_KEY\" in os.environ, (\n",
+    "    \"Please set the GOOGLE_API_KEY environment variable to your Gemini API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/gemini/gemini_example.ipynb
+++ b/ai/integrations/gemini/gemini_example.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"GOOGLE_API_KEY\" in os.environ\n",
-    "), \"Please set the GOOGLE_API_KEY environment variable to your Gemini API key\""
+    "assert \"GOOGLE_API_KEY\" in os.environ, (\n",
+    "    \"Please set the GOOGLE_API_KEY environment variable to your Gemini API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/gemini/pyproject.toml
+++ b/ai/integrations/gemini/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -340,7 +340,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_response.prompt_feedback = mock_prompt_feedback
 
         with mock.patch(
-            "google.generativeai.generative_models.ChatSession.send_message", return_value=mock_response
+            "google.generativeai.ChatSession.send_message", return_value=mock_response
         ):
             mlflow.gemini.autolog()
 

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -326,7 +326,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_content.role = "model"
         mock_candidate = mock.MagicMock()
         mock_candidate.content = mock_content
-        mock_candidate.finishReason = "STOP"
+        mock_candidate.finishReason = 1  # STOP
         mock_candidate.index = 0
         mock_candidate.safetyRatings = [
             {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "probability": "NEGLIGIBLE"},

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -340,7 +340,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_response.prompt_feedback = mock_prompt_feedback
 
         with mock.patch(
-            "google.generativeai.GenerativeModel.generate_content", return_value=mock_response
+            "google.generativeai.GenerativeModel.send_message", return_value=mock_response
         ):
             mlflow.gemini.autolog()
 

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -233,63 +233,6 @@ def test_uc_function_to_gemini_tool(client):
         assert result == "some_string"
 
 
-# @pytest.mark.parametrize(
-#     "format,function_output",
-#     [
-#         ("SCALAR", RETRIEVER_OUTPUT_SCALAR),
-#         ("CSV", RETRIEVER_OUTPUT_CSV),
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "data_type,full_data_type,return_params",
-#     [
-#         (ColumnTypeName.TABLE_TYPE, RETRIEVER_TABLE_FULL_DATA_TYPE, RETRIEVER_TABLE_RETURN_PARAMS),
-#     ],
-# )
-# @requires_databricks
-# def test_gemini_tool_with_trace_as_retriever(
-#     format, function_output, data_type, full_data_type, return_params
-# ):
-#     client = get_client()
-#     mock_function_info = generate_function_info(
-#         name=f"test_{format}",
-#         data_type=data_type,
-#         full_data_type=full_data_type,
-#         return_params=return_params,
-#     )
-
-#     with (
-#         mock.patch(
-#             "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
-#             return_value=mock_function_info,
-#         ),
-#         mock.patch(
-#             "unitycatalog.ai.core.databricks.DatabricksFunctionClient._execute_uc_function",
-#             return_value=FunctionExecutionResult(format=format, value=function_output),
-#         ),
-#         mock.patch(
-#             "unitycatalog.ai.core.databricks.DatabricksFunctionClient.validate_input_params"
-#         ),
-#     ):
-#         import mlflow
-
-#         mlflow.gemini.autolog()
-
-#         tool = UCFunctionToolkit.uc_function_to_gemini_tool(
-#             function_name=mock_function_info.full_name, client=client
-#         )
-#         tool.fn(x="some_string")
-
-#         trace = mlflow.get_last_active_trace()
-#         assert trace is not None
-#         assert trace.data.spans[0].name == mock_function_info.full_name
-#         assert trace.info.execution_time_ms is not None
-#         assert trace.data.request == '{"x": "some_string"}'
-#         assert trace.data.response == RETRIEVER_OUTPUT_SCALAR
-
-#         mlflow.gemini.autolog(disable=True)
-
-
 @requires_databricks
 def test_gemini_tool_calling_with_trace_as_retriever():
     client = get_client()

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -315,7 +315,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_response = mock.MagicMock()
 
         mock_function_call = mock.MagicMock()
-        mock_function_call.name = "find_theaters"
+        mock_function_call.name = func_obj.full_function_name
         mock_function_call.args = {
             "query": "What are the page contents?",
         }
@@ -335,14 +335,9 @@ def test_gemini_tool_calling_with_trace_as_retriever():
             {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "probability": "NEGLIGIBLE"},
         ]
         mock_response.candidates = [mock_candidate]
-        mock_response.promptFeedback = {
-            "safetyRatings": [
-                {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "probability": "NEGLIGIBLE"},
-                {"category": "HARM_CATEGORY_HATE_SPEECH", "probability": "NEGLIGIBLE"},
-                {"category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE"},
-                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "probability": "NEGLIGIBLE"},
-            ]
-        }
+        mock_prompt_feedback = mock.MagicMock()
+        mock_prompt_feedback.block_reason = None
+        mock_response.prompt_feedback = mock_prompt_feedback
 
         with mock.patch(
             "google.generativeai.GenerativeModel.generate_content", return_value=mock_response

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -339,9 +339,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_prompt_feedback.block_reason = None
         mock_response.prompt_feedback = mock_prompt_feedback
 
-        with mock.patch(
-            "google.generativeai.ChatSession.send_message", return_value=mock_response
-        ):
+        with mock.patch("google.generativeai.ChatSession.send_message", return_value=mock_response):
             mlflow.gemini.autolog()
 
             model = GenerativeModel(model_name="gemini-2.0-flash-exp", tools=tools)

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -340,7 +340,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         mock_response.prompt_feedback = mock_prompt_feedback
 
         with mock.patch(
-            "google.generativeai.GenerativeModel.send_message", return_value=mock_response
+            "google.generativeai.generative_models.ChatSession.send_message", return_value=mock_response
         ):
             mlflow.gemini.autolog()
 

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -247,11 +247,9 @@ def test_uc_function_to_gemini_tool(client):
         (ColumnTypeName.TABLE_TYPE, RETRIEVER_TABLE_FULL_DATA_TYPE, RETRIEVER_TABLE_RETURN_PARAMS),
     ],
 )
-@pytest.mark.parametrize("use_serverless", [True, False])
 def test_crewai_tool_with_tracing_as_retriever(
-    use_serverless, monkeypatch, format, function_output, data_type, full_data_type, return_params
+    format, function_output, data_type, full_data_type, return_params
 ):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
     client = get_client()
     mock_function_info = generate_function_info(
         name=f"test_{format}",

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -14,7 +14,6 @@ from pydantic import ValidationError
 from unitycatalog.ai.core.client import FunctionExecutionResult
 from unitycatalog.ai.gemini.toolkit import GeminiTool, UCFunctionToolkit
 from unitycatalog.ai.test_utils.client_utils import (
-    USE_SERVERLESS,
     client,  # noqa: F401
     get_client,
     requires_databricks,
@@ -63,9 +62,7 @@ def test_gemini_tool_to_dict(sample_gemini_tool):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -86,9 +83,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e_manually_passing_client():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name], client=client)
@@ -110,9 +105,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_multiple_toolkits(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_multiple_toolkits():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -310,7 +310,7 @@ def test_gemini_tool_calling_with_trace_as_retriever():
         func_info = client.get_function(func_name)
         assert has_retriever_signature(func_info)
         toolkit = UCFunctionToolkit(function_names=[func_name])
-        tools = toolkit.tools
+        tools = toolkit.generate_callable_tool_list()
 
         mock_response = mock.MagicMock()
 

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -209,9 +209,9 @@ def test_convert_to_gemini_schema_with_valid_function_info():
         },
     }
 
-    assert (
-        result_schema == expected_schema
-    ), "The generated schema does not match the expected output."
+    assert result_schema == expected_schema, (
+        "The generated schema does not match the expected output."
+    )
 
 
 def test_uc_function_to_gemini_tool(client):
@@ -357,14 +357,14 @@ def test_generate_callable_tool_list(client):
 
     gemini_tool = callable_tools[0]
     tool = tools[0]
-    assert isinstance(
-        gemini_tool, CallableFunctionDeclaration
-    ), "The tool should be a CallableFunctionDeclaration."
-    assert (
-        tool.name == "catalog__schema__test_function"
-    ), "The tool's name does not match the expected name."
-    assert (
-        tool.description == "Executes Python code and returns its stdout."
-    ), "The tool's description does not match the expected description."
+    assert isinstance(gemini_tool, CallableFunctionDeclaration), (
+        "The tool should be a CallableFunctionDeclaration."
+    )
+    assert tool.name == "catalog__schema__test_function", (
+        "The tool's name does not match the expected name."
+    )
+    assert tool.description == "Executes Python code and returns its stdout.", (
+        "The tool's description does not match the expected description."
+    )
     assert "parameters" in tool.schema, "The tool's schema should include parameters."
     assert tool.schema["parameters"]["required"] == ["x"], "The required parameters do not match."

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 from databricks.sdk.service.catalog import (
-    ColumnTypeName,
     FunctionInfo,
     FunctionParameterInfo,
     FunctionParameterInfos,
@@ -16,14 +15,8 @@ from pydantic import ValidationError
 from unitycatalog.ai.core.base import FunctionExecutionResult
 from unitycatalog.ai.core.client import FunctionExecutionResult, UnitycatalogFunctionClient
 from unitycatalog.ai.gemini.toolkit import GeminiTool, UCFunctionToolkit
-from unitycatalog.ai.test_utils.function_utils import (
-    RETRIEVER_OUTPUT_CSV,
-    RETRIEVER_OUTPUT_SCALAR,
-    RETRIEVER_TABLE_FULL_DATA_TYPE,
-)
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -281,62 +281,6 @@ async def test_uc_function_to_gemini_tool(uc_client):
         assert result == "some_string"
 
 
-@pytest.mark.parametrize(
-    "format,function_output",
-    [
-        ("SCALAR", RETRIEVER_OUTPUT_SCALAR),
-        ("CSV", RETRIEVER_OUTPUT_CSV),
-    ],
-)
-@pytest.mark.parametrize(
-    "data_type,full_data_type,return_params",
-    [
-        (
-            ColumnTypeName.TABLE_TYPE,
-            RETRIEVER_TABLE_FULL_DATA_TYPE,
-            RETRIEVER_TABLE_RETURN_PARAMS_OSS,
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_crewai_tool_with_tracing_as_retriever(
-    uc_client, format, function_output, data_type, full_data_type, return_params
-):
-    mock_function_info = generate_function_info(
-        name=f"test_{format}",
-        data_type=data_type,
-        full_data_type=full_data_type,
-        return_params=return_params,
-    )
-
-    with (
-        mock.patch.object(uc_client, "get_function", return_value=mock_function_info),
-        mock.patch.object(
-            uc_client,
-            "_execute_uc_function",
-            return_value=FunctionExecutionResult(format=format, value=function_output),
-        ),
-        mock.patch.object(uc_client, "validate_input_params"),
-    ):
-        import mlflow
-
-        mlflow.gemini.autolog()
-
-        tool = UCFunctionToolkit.uc_function_to_gemini_tool(
-            function_name=mock_function_info.full_name, client=uc_client
-        )
-        tool.fn(x="some_string")
-
-        trace = mlflow.get_last_active_trace()
-        assert trace is not None
-        assert trace.data.spans[0].name == mock_function_info.full_name
-        assert trace.info.execution_time_ms is not None
-        assert trace.data.request == '{"x": "some_string"}'
-        assert trace.data.response == RETRIEVER_OUTPUT_SCALAR
-
-        mlflow.gemini.autolog(disable=True)
-
-
 @pytest.mark.asyncio
 async def test_toolkit_with_invalid_function_input(uc_client):
     """Test toolkit with invalid input parameters for function conversion."""

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -20,10 +20,10 @@ from unitycatalog.ai.test_utils.function_utils import (
     RETRIEVER_OUTPUT_CSV,
     RETRIEVER_OUTPUT_SCALAR,
     RETRIEVER_TABLE_FULL_DATA_TYPE,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
 )
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
+    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -247,9 +247,9 @@ def test_convert_to_gemini_schema_with_valid_function_info():
         },
     }
 
-    assert (
-        result_schema == expected_schema
-    ), "The generated schema does not match the expected output."
+    assert result_schema == expected_schema, (
+        "The generated schema does not match the expected output."
+    )
 
 
 @pytest.mark.asyncio
@@ -326,14 +326,14 @@ def test_generate_callable_tool_list(uc_client):
 
     gemini_tool = callable_tools[0]
     tool = tools[0]
-    assert isinstance(
-        gemini_tool, CallableFunctionDeclaration
-    ), "The tool should be a CallableFunctionDeclaration."
-    assert (
-        tool.name == "catalog__schema__test_function"
-    ), "The tool's name does not match the expected name."
-    assert (
-        tool.description == "Executes Python code and returns its stdout."
-    ), "The tool's description does not match the expected description."
+    assert isinstance(gemini_tool, CallableFunctionDeclaration), (
+        "The tool should be a CallableFunctionDeclaration."
+    )
+    assert tool.name == "catalog__schema__test_function", (
+        "The tool's name does not match the expected name."
+    )
+    assert tool.description == "Executes Python code and returns its stdout.", (
+        "The tool's description does not match the expected description."
+    )
     assert "parameters" in tool.schema, "The tool's schema should include parameters."
     assert tool.schema["parameters"]["required"] == ["x"], "The required parameters do not match."

--- a/ai/integrations/langchain/README.md
+++ b/ai/integrations/langchain/README.md
@@ -88,9 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/langchain/langchain_databricks_example.ipynb
+++ b/ai/integrations/langchain/langchain_databricks_example.ipynb
@@ -47,7 +47,8 @@
    },
    "source": [
     "#### Create a DatabricksFunctionClient\n",
-    "Use serverless client here as an example"
+    "\n",
+    "Create a client instance in order to create and execute functions using Databricks serverless"
    ]
   },
   {

--- a/ai/integrations/langchain/langchain_oss_example.ipynb
+++ b/ai/integrations/langchain/langchain_oss_example.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/langchain/langgraph_mlflow_databricks_example.ipynb
+++ b/ai/integrations/langchain/langgraph_mlflow_databricks_example.ipynb
@@ -33,7 +33,8 @@
    },
    "source": [
     "#### Create a DatabricksFunctionClient and set as default\n",
-    "Use Serverless here as an example"
+    "\n",
+    "Create a client in order to create and execute functions"
    ]
   },
   {

--- a/ai/integrations/langchain/pyproject.toml
+++ b/ai/integrations/langchain/pyproject.toml
@@ -62,7 +62,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -20,7 +20,6 @@ from unitycatalog.ai.core.base import (
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
-    USE_SERVERLESS,
     client,  # noqa: F401
     get_client,
     requires_databricks,
@@ -48,9 +47,7 @@ SCHEMA = os.environ.get("SCHEMA", "ucai_langchain_test")
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -70,9 +67,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e_manually_passing_client():
     client = get_client()
     with create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(function_names=[func_obj.full_function_name], client=client)
@@ -93,9 +88,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_tools_with_no_params(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e_tools_with_no_params():
     client = get_client()
 
     def get_weather() -> str:
@@ -123,9 +116,7 @@ def test_toolkit_e2e_tools_with_no_params(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_multiple_toolkits(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_multiple_toolkits():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -195,11 +186,7 @@ def test_uc_function_to_langchain_tool():
         ("CSV", RETRIEVER_OUTPUT_CSV),
     ],
 )
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_langchain_tool_trace_as_retriever(
-    use_serverless, monkeypatch, format: str, function_output: str
-):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_langchain_tool_trace_as_retriever(format: str, function_output: str):
     client = get_client()
     mock_function_info = generate_function_info()
 
@@ -245,10 +232,8 @@ def test_langchain_tool_trace_as_retriever(
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
 @pytest.mark.parametrize("schema", [SCHEMA, "ucai_langchain_test_star"])
-def test_langgraph_agents(monkeypatch, use_serverless, schema):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_langgraph_agents(schema):
     client = get_client()
     with create_function_and_cleanup(client, schema=schema) as func_obj:
         if schema == SCHEMA:

--- a/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
@@ -25,10 +25,10 @@ from unitycatalog.ai.test_utils.function_utils import (
     RETRIEVER_OUTPUT_CSV,
     RETRIEVER_OUTPUT_SCALAR,
     RETRIEVER_TABLE_FULL_DATA_TYPE,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
 )
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
+    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/llama_index/README.md
+++ b/ai/integrations/llama_index/README.md
@@ -88,9 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/llama_index/llama_index_databricks_example.ipynb
+++ b/ai/integrations/llama_index/llama_index_databricks_example.ipynb
@@ -164,9 +164,9 @@
    },
    "outputs": [],
    "source": [
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/llama_index/llama_index_mlflow_databricks_example.ipynb
+++ b/ai/integrations/llama_index/llama_index_mlflow_databricks_example.ipynb
@@ -100,9 +100,9 @@
     "    workspace_client.secrets.get_secret(scope=secret_scope, key=\"openai_api_key\").value\n",
     ").decode()\n",
     "\n",
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/llama_index/pyproject.toml
+++ b/ai/integrations/llama_index/pyproject.toml
@@ -57,7 +57,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
@@ -20,7 +20,6 @@ from unitycatalog.ai.core.base import (
 from unitycatalog.ai.llama_index.toolkit import UCFunctionToolkit, extract_properties
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
-    USE_SERVERLESS,
     client,  # noqa: F401
     get_client,
     requires_databricks,
@@ -127,9 +126,7 @@ def test_toolkit_creation_with_properties_argument_mocked():
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(
@@ -154,9 +151,7 @@ def test_toolkit_e2e(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_e2e_manually_passing_client():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit = UCFunctionToolkit(
@@ -180,9 +175,7 @@ def test_toolkit_e2e_manually_passing_client(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_multiple_toolkits(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_multiple_toolkits():
     client = get_client()
     with set_default_client(client), create_function_and_cleanup(client, schema=SCHEMA) as func_obj:
         toolkit1 = UCFunctionToolkit(function_names=[func_obj.full_function_name])
@@ -290,11 +283,7 @@ def test_toolkit_with_invalid_function_input(client):
         ("CSV", RETRIEVER_OUTPUT_CSV),
     ],
 )
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_toolkit_with_tracing_as_retriever(
-    use_serverless, monkeypatch, format: str, function_output: str
-):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_toolkit_with_tracing_as_retriever(format: str, function_output: str):
     client = get_client()
     mock_function_info = generate_function_info()
 

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
@@ -20,10 +20,10 @@ from unitycatalog.ai.test_utils.function_utils import (
     RETRIEVER_OUTPUT_CSV,
     RETRIEVER_OUTPUT_SCALAR,
     RETRIEVER_TABLE_FULL_DATA_TYPE,
-    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
 )
 from unitycatalog.ai.test_utils.function_utils_oss import (
     CATALOG,
+    RETRIEVER_TABLE_RETURN_PARAMS_OSS,
     create_function_and_cleanup_oss,
 )
 from unitycatalog.client import (

--- a/ai/integrations/openai/README.md
+++ b/ai/integrations/openai/README.md
@@ -88,9 +88,7 @@ Initialize a client for managing UC functions in a Databricks workspace, and set
 from unitycatalog.ai.core.client import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="..." # replace with the warehouse_id
-)
+client = DatabricksFunctionClient()
 
 # sets the default uc function client
 set_uc_function_client(client)

--- a/ai/integrations/openai/openai_example.ipynb
+++ b/ai/integrations/openai/openai_example.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "import os\n",
     "\n",
-    "assert (\n",
-    "    \"OPENAI_API_KEY\" in os.environ\n",
-    "), \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\""
+    "assert \"OPENAI_API_KEY\" in os.environ, (\n",
+    "    \"Please set the OPENAI_API_KEY environment variable to your OpenAI API key\"\n",
+    ")"
    ]
   },
   {

--- a/ai/integrations/openai/pyproject.toml
+++ b/ai/integrations/openai/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -15,6 +15,7 @@ from openai.types.chat.chat_completion_message_tool_call import Function
 from tests.helper_functions import mock_chat_completion_response, mock_choice
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
+from unitycatalog.ai.core.utils.validation_utils import has_retriever_signature
 from unitycatalog.ai.openai.toolkit import UCFunctionToolkit
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
@@ -24,6 +25,7 @@ from unitycatalog.ai.test_utils.client_utils import (
 )
 from unitycatalog.ai.test_utils.function_utils import (
     create_function_and_cleanup,
+    create_table_function_and_cleanup,
     random_func_name,
 )
 
@@ -110,9 +112,11 @@ def test_tool_calling_with_trace_as_retriever():
         )
     with (
         set_default_client(client),
-        create_function_and_cleanup(client, schema=SCHEMA) as func_obj,
+        create_table_function_and_cleanup(client, schema=SCHEMA) as func_obj,
     ):
         func_name = func_obj.full_function_name
+        func_info = client.get_function(func_name)
+        assert has_retriever_signature(func_info)
         toolkit = UCFunctionToolkit(function_names=[func_name])
         tools = toolkit.tools
 

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -133,7 +133,7 @@ def test_tool_calling_with_trace_as_retriever():
             return_value=mock_chat_completion_response(
                 function=Function(
                     arguments=json.dumps(
-                        {"code": "print([{'page_content': 'This is the page content.'}], end='')"}
+                        {"query": "What are the page contents?"}
                     ),
                     name=func_obj.tool_name,
                 ),
@@ -150,7 +150,7 @@ def test_tool_calling_with_trace_as_retriever():
 
             # execute the function based on the arguments
             result = client.execute_function(func_name, arguments, enable_retriever_tracing=True)
-            assert result.value == "[{'page_content': 'This is the page content.'}]"
+            assert result.value == "[{'page_content': 'testing', 'metadata': {'doc_uri': 'https://docs.databricks.com/', 'chunk_id': '1'}}]"
 
             trace = mlflow.get_last_active_trace()
             assert trace is not None

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -18,7 +18,6 @@ from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
 from unitycatalog.ai.openai.toolkit import UCFunctionToolkit
 from unitycatalog.ai.test_utils.client_utils import (
     TEST_IN_DATABRICKS,
-    USE_SERVERLESS,
     get_client,
     requires_databricks,
     set_default_client,
@@ -37,9 +36,7 @@ def env_setup(monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_tool_calling():
     client = get_client()
     with (
         set_default_client(client),
@@ -101,9 +98,7 @@ def test_tool_calling(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling_with_trace_as_retriever(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_tool_calling_with_trace_as_retriever():
     client = get_client()
     import mlflow
 
@@ -162,9 +157,7 @@ def test_tool_calling_with_trace_as_retriever(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling_with_multiple_choices(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_tool_calling_with_multiple_choices():
     client = get_client()
     with (
         set_default_client(client),
@@ -232,9 +225,7 @@ def test_tool_calling_with_multiple_choices(use_serverless, monkeypatch):
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_calling_work_with_non_json_schema(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_tool_calling_work_with_non_json_schema():
     func_name = random_func_name(schema=SCHEMA)
     function_name = func_name.split(".")[-1]
     sql_body = f"""CREATE FUNCTION {func_name}(start DATE, end DATE)
@@ -310,9 +301,7 @@ RETURN SELECT extract(DAYOFWEEK_ISO FROM day), day
 
 
 @requires_databricks
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_tool_choice_param(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_tool_choice_param():
     cap_func = random_func_name(schema=SCHEMA)
     sql_body1 = f"""CREATE FUNCTION {cap_func}(s STRING)
 RETURNS STRING
@@ -406,9 +395,7 @@ $$
         assert result.value == "ABC"
 
 
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_openai_toolkit_initialization(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_openai_toolkit_initialization():
     client = get_client()
     with pytest.raises(
         ValueError,
@@ -438,9 +425,7 @@ def generate_function_info(parameters: List[Dict], catalog="catalog", schema="sc
     )
 
 
-@pytest.mark.parametrize("use_serverless", [True, False])
-def test_function_definition_generation(use_serverless, monkeypatch):
-    monkeypatch.setenv(USE_SERVERLESS, str(use_serverless))
+def test_function_definition_generation():
     client = get_client()
     with set_default_client(client):
         function_info = generate_function_info(

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -150,7 +150,7 @@ def test_tool_calling_with_trace_as_retriever():
 
             # execute the function based on the arguments
             result = client.execute_function(func_name, arguments, enable_retriever_tracing=True)
-            assert result.value == 'testing,"{\'doc_uri\': \'https://docs.databricks.com/\', \'chunk_id\': \'1\'}"\n'
+            assert result.value == 'page_content,metadata\ntesting,"{\'doc_uri\': \'https://docs.databricks.com/\', \'chunk_id\': \'1\'}"\n'
 
             trace = mlflow.get_last_active_trace()
             assert trace is not None

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -132,9 +132,7 @@ def test_tool_calling_with_trace_as_retriever():
             "openai.chat.completions.create",
             return_value=mock_chat_completion_response(
                 function=Function(
-                    arguments=json.dumps(
-                        {"query": "What are the page contents?"}
-                    ),
+                    arguments=json.dumps({"query": "What are the page contents?"}),
                     name=func_obj.tool_name,
                 ),
             ),
@@ -148,16 +146,21 @@ def test_tool_calling_with_trace_as_retriever():
             tool_call = tool_calls[0]
             arguments = json.loads(tool_call.function.arguments)
 
-            # execute the function based on the arguments
             result = client.execute_function(func_name, arguments, enable_retriever_tracing=True)
-            assert result.value == 'page_content,metadata\ntesting,"{\'doc_uri\': \'https://docs.databricks.com/\', \'chunk_id\': \'1\'}"\n'
+            assert (
+                result.value
+                == "page_content,metadata\ntesting,\"{'doc_uri': 'https://docs.databricks.com/', 'chunk_id': '1'}\"\n"
+            )
 
             trace = mlflow.get_last_active_trace()
             assert trace is not None
             assert trace.data.spans[0].name == func_name
             assert trace.info.execution_time_ms is not None
             assert trace.data.request == tool_call.function.arguments
-            assert trace.data.response == '[{"page_content": "testing", "metadata": {"doc_uri": "https://docs.databricks.com/", "chunk_id": "1"}}]'
+            assert (
+                trace.data.response
+                == '[{"page_content": "testing", "metadata": {"doc_uri": "https://docs.databricks.com/", "chunk_id": "1"}}]'
+            )
 
 
 @requires_databricks

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -157,7 +157,7 @@ def test_tool_calling_with_trace_as_retriever():
             assert trace.data.spans[0].name == func_name
             assert trace.info.execution_time_ms is not None
             assert trace.data.request == tool_call.function.arguments
-            assert trace.data.response == result.value.replace("'", '"')
+            assert trace.data.response == '[{"page_content": "testing", "metadata": {"doc_uri": "https://docs.databricks.com/", "chunk_id": "1"}}]'
 
 
 @requires_databricks

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -150,7 +150,7 @@ def test_tool_calling_with_trace_as_retriever():
 
             # execute the function based on the arguments
             result = client.execute_function(func_name, arguments, enable_retriever_tracing=True)
-            assert result.value == "[{'page_content': 'testing', 'metadata': {'doc_uri': 'https://docs.databricks.com/', 'chunk_id': '1'}}]"
+            assert result.value == 'testing,"{\'doc_uri\': \'https://docs.databricks.com/\', \'chunk_id\': \'1\'}"\n'
 
             trace = mlflow.get_last_active_trace()
             assert trace is not None

--- a/ai/requirements/lint-requirements.txt
+++ b/ai/requirements/lint-requirements.txt
@@ -1,2 +1,2 @@
 yamllint==1.35.1
-ruff==0.6.4
+ruff==0.9.3

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -257,11 +257,7 @@ The `DatabricksFunctionClient` is a core component of the Unity Catalog AI Core 
 
 - **Python Version**: Python 3.10 or higher is **required** when using `databricks-connect` for serverless compute.
 - **Databricks Connect**: To create UC functions using SQL body definitions or to execute functions using serverless compute, `databricks-connect` version `15.1.0` is required. This is the only supported version that is compatible.
-- **Serverless Compute**: Function creation and execution using `databricks-connect` require serverless compute.
-- **Warehouse**: If the `warehouse_id` is not provided during client initialization, `databricks-connect` with serverless compute will be used.
-    - Classic SQL Warehouses are not supported for function execution due to excessive latency, long startup times, and noticeable overhead with executing functions.
-    Function creation can run on any Warehouse type.
-    - The SQL Warehouse must be of a serverless type for function execution. To learn more about the different warehouse types, see [the docs](https://docs.databricks.com/en/admin/sql/warehouse-types.html).
+- **Serverless Compute**: In order to create and execute functions, a serverless compute connection **is required**.
 
 ### Environment Variables for Databricks
 
@@ -269,10 +265,7 @@ You can configure the behavior of function execution using the following environ
 
 | Environment Variable                                                | Description                                                                                                                                                                     | Default Value |
 |---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT`           | Time in seconds to wait for function execution. Format: `Ns` where `N` is between 0 and 50. Setting to `0s` executes asynchronously.                                            | `30s`         |
-| `UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_ROW_LIMIT`              | Maximum number of rows in the function execution result.                                                                                                                        | `100`         |
-| `UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_BYTE_LIMIT`             | Maximum byte size of the function execution result. If exceeded, the `truncated` field in the response is set to `true`.                                                        | `1048576`     |
-| `UCAI_DATABRICKS_WAREHOUSE_RETRY_TIMEOUT`                           | Client-side retry timeout in seconds for function execution. If execution doesn't complete within `wait_timeout`, the client retries until this timeout is reached.             | `120`         |
+| `UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS`                        | Maximum number of attempts to retry refreshing the session client in case of token expiry.                                                               | `5`         |
 | `UCAI_DATABRICKS_SERVERLESS_EXECUTION_RESULT_ROW_LIMIT`             | Maximum number of rows when executing functions using serverless compute with `databricks-connect`.                                                                              | `100`         |
 
 ### Initialization
@@ -283,11 +276,9 @@ is used not only for direct interface with functions, but also is the mechanism 
 ``` python
 from ucai.core.databricks import DatabricksFunctionClient
 
-# Initialize with a warehouse ID (for executing functions using a SQL Warehouse)
-client = DatabricksFunctionClient(warehouse_id="YOUR_WAREHOUSE_ID")
-
-# Or initialize without a warehouse ID to use serverless compute with databricks-connect
+# Initialize without a warehouse ID to use serverless compute for creating, listing, deleting, retrieving, and executing functions
 client = DatabricksFunctionClient()
+
 ```
 
 ---
@@ -435,8 +426,8 @@ print(result.value)  # Outputs: HELLO WORLD
 ``` python
 from ucai.core.databricks import DatabricksFunctionClient
 
-# Initialize the client
-client = DatabricksFunctionClient(warehouse_id="YOUR_WAREHOUSE_ID")
+# Initialize the client, connecting to serverless
+client = DatabricksFunctionClient()
 
 # Define the function
 def add_numbers(a: float, b: float) -> float:
@@ -469,27 +460,6 @@ print(result.value)  # Outputs: 16.0
 
 ```
 
-### Using Environment Variables
-
-Adjust the function execution timeout value by overriding the default via the environment variable.
-
-``` python
-import os
-from ucai.core.databricks import DatabricksFunctionClient
-
-# Set the wait timeout to 50 seconds
-os.environ["UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT"] = "50s"
-
-client = DatabricksFunctionClient(warehouse_id="YOUR_WAREHOUSE_ID")
-
-# Execute your function as before
-result = client.execute_function(
-    "your_catalog.your_schema.your_function_name",
-    parameters={"param": "test"}
-)
-```
-
 ### Additional Notes
 
 - **Error Handling**: If a function execution fails, `FunctionExecutionResult` will contain an `error` attribute with details on the failure.
-- **Asynchronous Execution**: Setting UCAI_DATABRICKS_WAREHOUSE_EXECUTE_FUNCTION_WAIT_TIMEOUT to 0s will execute the function asynchronously. The call will immediately return in async mode and the result will need to be polled and fetched for its completed state when executing in async mode.

--- a/docs/ai/integrations/autogen.md
+++ b/docs/ai/integrations/autogen.md
@@ -64,10 +64,7 @@ Initialize a client for managing Unity Catalog functions in a Databricks workspa
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="your_warehouse_id",  # replace with your warehouse_id
-    cluster_id="your_cluster_id"       # optional, only pass when you want to use a cluster for function creation
-)
+client = DatabricksFunctionClient()
 
 # Set the default UC function client
 set_uc_function_client(client)

--- a/docs/ai/integrations/crewai.md
+++ b/docs/ai/integrations/crewai.md
@@ -62,10 +62,7 @@ Initialize a client for managing Unity Catalog functions in a Databricks workspa
 from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(
-    warehouse_id="your_warehouse_id",  # replace with your warehouse_id
-    cluster_id="your_cluster_id"       # optional, only pass when you want to use a cluster for function creation
-)
+client = DatabricksFunctionClient()
 
 # Set the default UC function client
 set_uc_function_client(client)

--- a/docs/ai/quickstart.md
+++ b/docs/ai/quickstart.md
@@ -35,13 +35,7 @@ pip install unitycatalog-ai[databricks]
 
 >Note: Python 3.10 or higher is required to use `unitycatalog-ai` with Databricks serverless compute for function execution.
 
-- **Serverless Compute**: For creating UC functions directly with a SQL body definition, only serverless compute is supported. You cannot run the
-function creation APIs while attached to a classic SQL Warehouse.
-
-- **SQL Warehouse**: Needed for executing UC functions.
-
-Create a serverless SQL warehouse as per [this guide](https://docs.databricks.com/en/compute/sql-warehouse/create.html). After creating the warehouse,
-note down the `warehouse id` for use within the `DatabricksFunctionClient`.
+- **Serverless Compute**: Interfacing with the DatabricksFunctionClient requires the use of serverless on Databricks. Ensure that it is enabled.
 
 ## Using a function with LangChain
 
@@ -81,14 +75,13 @@ SCHEMA = "my_schema"
 ### Client Setup - Databricks
 
 In order to be able to both create and execute a function defined within UC as a tool in LangChain, we need to initialize the UC function client.
-In this example, we're connecting to Databricks UC and specifying a `warehouse_id` that will be used for executing the functions that are
-defined as tools. When accessing functions by name, we will need to specify which catalog and schema the function resides in, so we're defining constants
+ When accessing functions by name, we will need to specify which catalog and schema the function resides in, so we're defining constants
 to store those values.
 
 ``` python
 from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 
-client = DatabricksFunctionClient(warehouse_id="YOUR_WAREHOUSE_ID")
+client = DatabricksFunctionClient()
 
 CATALOG = "my_catalog"
 SCHEMA = "my_schema"


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR removes the ability to utilize SQL Warehouses in order to simplify the CRUD and execution workflows for UC functions.
The docs, examples, tutorials, and implementations have been updated to remove the warehouse designators. 