### PR TITLE
Update log4j version due to vulnerability with 2.23.1 and build failure.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,11 @@ lazy val scala213 = "2.13.14"
 lazy val deltaVersion = "3.2.1"
 lazy val sparkVersion = "3.5.3"
 
+// Library versions
+lazy val jacksonVersion = "2.17.0"
+lazy val openApiToolsJacksonBindNullableVersion = "0.2.6"
+lazy val log4jVersion = "2.24.3"
+
 lazy val commonSettings = Seq(
   organization := orgName,
   // Compilation configs
@@ -44,8 +49,8 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "2.0.13",
     "org.slf4j" % "slf4j-log4j12" % "2.0.13" % Test,
-    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.23.1",
-    "org.apache.logging.log4j" % "log4j-api" % "2.23.1"
+    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % log4jVersion,
+    "org.apache.logging.log4j" % "log4j-api" % log4jVersion
   ),
   excludeDependencies ++= Seq(
     ExclusionRule("org.slf4j", "slf4j-reload4j")
@@ -661,7 +666,3 @@ def generateClasspathFile(targetDir: File, classpath: Classpath): Unit = {
 
 val generate = taskKey[Unit]("generate code from APIs")
 
-// Library versions
-val jacksonVersion = "2.17.0"
-val openApiToolsJacksonBindNullableVersion = "0.2.6"
-val log4jVersion = "2.23.1"


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

This is an upgrade to the log4j version, from 2.23.1 to 2.24.3. The current version has a vulnerability which results in `sbt` not downloading the artifact, causing new builds to fail, unless those artifacts had previously been cached locally.

See Issue https://github.com/unitycatalog/unitycatalog/issues/879