### PR TITLE
Add parameter default handling correction for UnityCatalog AI clients

### DIFF
--- a/ai/core/README.md
+++ b/ai/core/README.md
@@ -200,6 +200,12 @@ result = uc_client.execute_function(full_func_name, parameters)
 print(result.value)  # Outputs: 16.0
 ```
 
+#### Function Parameter Defaults
+
+Defining and executing functions with parameter defaults behave similarly to standard Python function argument defaults. If a parameter is not provided that is marked as having a default value when called via the `execute_function` API, the existing default parameter value will be mapped to the function invocation call.
+
+If using defaults in your function signatures, ensure that the descriptions are accurate and declare what the default value is to ensure that Agentic use of your function is accurate.
+
 #### Deleting a Function
 
 To delete a function that you have write authority to, you can use the following API:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -23,6 +23,7 @@ from unitycatalog.ai.core.utils.callable_utils import (
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
 )
+from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
     column_type_to_python_type,
     convert_timedelta_to_interval_str,
@@ -639,6 +640,9 @@ class DatabricksFunctionClient(BaseFunctionClient):
     ) -> FunctionExecutionResult:
         _logger.info("Using databricks connect to execute functions with serverless compute.")
         self.set_default_spark_session()
+
+        parameters = process_function_parameter_defaults(function_info, parameters)
+
         sql_command = get_execute_function_sql_command(function_info, parameters)
         try:
             result = self.spark.sql(sqlQuery=sql_command.sql_query, args=sql_command.args or None)

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -467,6 +467,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     "Specify a SQL body statement for defaults and use the create_function API "
                     "to define functions with default values."
                 ) from e
+            raise e
 
     @retry_on_session_expiration
     @override

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -410,7 +410,10 @@ def process_function_parameter_defaults(
     if function_info.input_params and function_info.input_params.parameters:
         for param in function_info.input_params.parameters:
             if param.parameter_default is not None:
-                defaults[param.name] = ast.literal_eval(param.parameter_default)
+                if param.parameter_default.strip().upper() == "NULL":
+                    defaults[param.name] = None
+                else:
+                    defaults[param.name] = ast.literal_eval(param.parameter_default)
     if parameters is None:
         parameters = {}
     return defaults | parameters

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -19,7 +19,10 @@ from unitycatalog.ai.core.utils.pydantic_utils import (
     PydanticFunctionInputParams,
     PydanticType,
 )
-from unitycatalog.ai.core.utils.type_utils import UC_TYPE_JSON_MAPPING
+from unitycatalog.ai.core.utils.type_utils import (
+    UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING,
+    UC_TYPE_JSON_MAPPING,
+)
 from unitycatalog.ai.core.utils.validation_utils import FullFunctionName
 
 _logger = logging.getLogger(__name__)
@@ -411,12 +414,9 @@ def process_function_parameter_defaults(
         for param in function_info.input_params.parameters:
             if param.parameter_default is not None:
                 default_str = param.parameter_default.strip()
-                if default_str.upper() == "NULL":
-                    defaults[param.name] = None
-                elif default_str.upper() == "TRUE":
-                    defaults[param.name] = True
-                elif default_str.upper() == "FALSE":
-                    defaults[param.name] = False
+                upper_str = default_str.upper()
+                if upper_str in UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING:
+                    defaults[param.name] = UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING[upper_str]
                 else:
                     try:
                         defaults[param.name] = ast.literal_eval(default_str)

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -413,7 +413,13 @@ def process_function_parameter_defaults(
                 if param.parameter_default.strip().upper() == "NULL":
                     defaults[param.name] = None
                 else:
-                    defaults[param.name] = ast.literal_eval(param.parameter_default)
+                    # NB: ast.literal_eval cannot handle all SQL types and will error
+                    # with a malformed node on certain data types, e.g. DECIMAL(38, 18) or
+                    # for SQL Bool or NULL types.
+                    try:
+                        defaults[param.name] = ast.literal_eval(param.parameter_default)
+                    except ValueError:
+                        defaults[param.name] = param.parameter_default
     if parameters is None:
         parameters = {}
     return defaults | parameters

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -391,3 +391,26 @@ def _execute_uc_function_with_retriever_tracing(
             f"Skipping tracing {function_info.full_name} as a retriever because of the following error:\n {e}"
         )
         return _execute_uc_function(function_info, parameters, **kwargs)
+
+
+def process_function_parameter_defaults(
+    function_info: "FunctionInfo", parameters: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
+    """
+    Handle default values for input parameters.
+
+    Args:
+        function_info: The FunctionInfo object containing the function metadata.
+        parameters: The parameters to handle.
+
+    Returns:
+        The updated parameters with default values filled in.
+    """
+    defaults = {}
+    if function_info.input_params and function_info.input_params.parameters:
+        for param in function_info.input_params.parameters:
+            if param.parameter_default is not None:
+                defaults[param.name] = ast.literal_eval(param.parameter_default)
+    if parameters is None:
+        parameters = {}
+    return defaults | parameters

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -410,16 +410,18 @@ def process_function_parameter_defaults(
     if function_info.input_params and function_info.input_params.parameters:
         for param in function_info.input_params.parameters:
             if param.parameter_default is not None:
-                if param.parameter_default.strip().upper() == "NULL":
+                default_str = param.parameter_default.strip()
+                if default_str.upper() == "NULL":
                     defaults[param.name] = None
+                elif default_str.upper() == "TRUE":
+                    defaults[param.name] = True
+                elif default_str.upper() == "FALSE":
+                    defaults[param.name] = False
                 else:
-                    # NB: ast.literal_eval cannot handle all SQL types and will error
-                    # with a malformed node on certain data types, e.g. DECIMAL(38, 18) or
-                    # for SQL Bool or NULL types.
                     try:
-                        defaults[param.name] = ast.literal_eval(param.parameter_default)
+                        defaults[param.name] = ast.literal_eval(default_str)
                     except ValueError:
-                        defaults[param.name] = param.parameter_default
+                        defaults[param.name] = default_str
     if parameters is None:
         parameters = {}
     return defaults | parameters

--- a/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
@@ -62,6 +62,12 @@ UC_TYPE_JSON_MAPPING = {
     "INTERVAL DAY TO SECOND": (datetime.timedelta, str),
 }
 
+UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING = {
+    "NULL": None,
+    "TRUE": True,
+    "FALSE": False,
+}
+
 
 def column_type_to_python_type(
     column_type: str, mapping: Dict[str, Any] = SQL_TYPE_TO_PYTHON_TYPE_MAPPING

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -579,7 +579,8 @@ CONTAINS SQL
 COMMENT 'Concatenates integer and string with defaults'
 RETURN CONCAT(CAST(a AS STRING), ' ', b);
 """
-    with create_function_and_cleanup(client=client, schema=SCHEMA, sql_body=sql_body) as func_name:
+    with create_function_and_cleanup(client=client, schema=SCHEMA, sql_body=sql_body):
+        func_name = f"{CATALOG}.{SCHEMA}.concat_func"
         result = client.execute_function(func_name, parameters={})
         assert result.value == "10 default"
 
@@ -602,7 +603,8 @@ CONTAINS SQL
 COMMENT 'Concatenates all default parameters'
 RETURN CONCAT(CAST(a AS STRING), ' ', b, ' ', CAST(c AS STRING), ' ', CAST(d AS STRING));
 """
-    with create_function_and_cleanup(client=client, schema=SCHEMA, sql_body=sql_body) as func_name:
+    with create_function_and_cleanup(client=client, schema=SCHEMA, sql_body=sql_body):
+        func_name = f"{CATALOG}.{SCHEMA}.all_defaults"
         result = client.execute_function(func_name, parameters={})
         assert result.value.lower() == "1 default 3.14 true"
 

--- a/ai/core/tests/core/oss/test_oss_client.py
+++ b/ai/core/tests/core/oss/test_oss_client.py
@@ -1319,3 +1319,97 @@ async def test_function_with_variant_param_raises_in_oss(uc_client):
         uc_client.create_python_function(
             func=func_variant_param, catalog=CATALOG, schema=SCHEMA, replace=True
         )
+
+
+# --------------------------
+# Test default parameter handling
+# --------------------------
+
+
+def test_create_function_with_default_params(uc_client: UnitycatalogFunctionClient):
+    def func_with_defaults(a: int, b: str = "default") -> str:
+        """
+        A function that concatenates an integer and a string with a default string value.
+
+        Args:
+            a (int): An integer.
+            b (str, optional): A string. Defaults to "default".
+
+        Returns:
+            str: The concatenated string.
+        """
+        return f"{a} {b}"
+
+    full_name = f"{CATALOG}.{SCHEMA}.func_with_defaults"
+
+    uc_client.create_python_function(
+        func=func_with_defaults, catalog=CATALOG, schema=SCHEMA, replace=True
+    )
+
+    result = uc_client.execute_function(function_name=full_name, parameters={"a": 10})
+    assert result.value == "10 default"
+
+    result = uc_client.execute_function(function_name=full_name, parameters={"a": 20, "b": "test"})
+    assert result.value == "20 test"
+
+
+def test_create_function_with_all_defaults(uc_client: UnitycatalogFunctionClient):
+    def func_with_all_defaults(
+        a: int = 1, b: str = "default", c: float = 3.14, d: bool = True
+    ) -> str:
+        """
+        A function that concatenates various types with default values.
+
+        Args:
+            a (int, optional): An integer. Defaults to 1.
+            b (str, optional): A string. Defaults to "default".
+            c (float, optional): A float. Defaults to 3.14.
+            d (bool, optional): A boolean. Defaults to True.
+
+        Returns:
+            str: The concatenated string.
+        """
+        return f"{a} {b} {c} {d}"
+
+    full_name = f"{CATALOG}.{SCHEMA}.func_with_all_defaults"
+
+    uc_client.create_python_function(
+        func=func_with_all_defaults, catalog=CATALOG, schema=SCHEMA, replace=True
+    )
+
+    result = uc_client.execute_function(function_name=full_name, parameters={})
+    assert result.value == "1 default 3.14 True"
+
+    result = uc_client.execute_function(
+        function_name=full_name,
+        parameters={"a": 10, "b": "test", "c": 2.71, "d": False},
+    )
+    assert result.value == "10 test 2.71 False"
+
+    result = uc_client.execute_function(
+        function_name=full_name,
+    )
+    assert result.value == "1 default 3.14 True"
+
+
+def test_create_function_no_params(uc_client: UnitycatalogFunctionClient):
+    def func_no_params() -> str:
+        """
+        A function that returns a static string.
+
+        Returns:
+            str: A static string.
+        """
+        return "No parameters here!"
+
+    full_name = f"{CATALOG}.{SCHEMA}.func_no_params"
+
+    uc_client.create_python_function(
+        func=func_no_params, catalog=CATALOG, schema=SCHEMA, replace=True
+    )
+
+    result = uc_client.execute_function(function_name=full_name, parameters={})
+    assert result.value == "No parameters here!"
+
+    with pytest.raises(ValueError, match="Function does not have input parameters, but parameters"):
+        uc_client.execute_function(function_name=full_name, parameters={"unexpected": "value"})

--- a/ai/core/tests/core/oss/test_oss_client.py
+++ b/ai/core/tests/core/oss/test_oss_client.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 import pytest_asyncio
@@ -1413,3 +1413,22 @@ def test_create_function_no_params(uc_client: UnitycatalogFunctionClient):
 
     with pytest.raises(ValueError, match="Function does not have input parameters, but parameters"):
         uc_client.execute_function(function_name=full_name, parameters={"unexpected": "value"})
+
+
+def test_create_function_with_none_param_default(uc_client: UnitycatalogFunctionClient):
+    def null_func(a: Optional[str] = None) -> str:
+        """
+        A function that returns the string representation of its input.
+
+        Args:
+            a (Optional[str], optional): An optional string. Defaults to None.
+
+        Returns:
+            str: The string representation of the input.
+        """
+        return str(a)
+
+    full_name = f"{CATALOG}.{SCHEMA}.null_func"
+    uc_client.create_python_function(func=null_func, catalog=CATALOG, schema=SCHEMA, replace=True)
+    result = uc_client.execute_function(function_name=full_name, parameters={})
+    assert result.value == "None"

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -457,6 +457,12 @@ result = client.execute_function(
 print(result.value)  # Outputs: HELLO WORLD
 ```
 
+## Function Parameter Defaults
+
+Defining and executing functions with parameter defaults behave similarly to standard Python function argument defaults. If a parameter is not provided that is marked as having a default value when called via the `execute_function` API, the existing default parameter value will be mapped to the function invocation call.
+
+If using defaults in your function signatures, ensure that the descriptions are accurate and declare what the default value is to ensure that Agentic use of your function is accurate.
+
 ---
 
 ## Examples


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes an issue with default parameter value handling where the parameters were not reading in the defaults from the FunctionInfo configuration properly. 