### PR TITLE
Add UC latest official image to compose.yaml 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,9 +3,7 @@ name: unitycatalog
 services:
 
   server:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: unitycatalog/unitycatalog:latest
     ports:
       - "8080:8080"
     volumes:
@@ -23,7 +21,7 @@ services:
       - "3000:3000"
     depends_on:
       - server
-      
+
 volumes:
   # Persist docker volume across container restarts
   unitycatalog_data:


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Updates the docker compose configuration to pull the [latest official image](https://hub.docker.com/repository/docker/unitycatalog/unitycatalog/general) from DockerHub, rather than have the user build the image locally from `main`. 
