### PR TITLE
Implement callable recreation for logged python functions

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -20,8 +20,10 @@ from unitycatalog.ai.core.envs.databricks_env_vars import (
 from unitycatalog.ai.core.paged_list import PagedList
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
+    extract_collection_types,
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
+    parse_full_sql_data_type_for_return_type,
 )
 from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
@@ -742,6 +744,26 @@ class DatabricksFunctionClient(BaseFunctionClient):
         accept_keys = ["profile"]
         return cls(**{k: v for k, v in config.items() if k in accept_keys})
 
+    def get_python_callable(self, function_name: str) -> str:
+        """
+        Returns the Python callable definition as a string for an EXTERNAL Python function that
+        is stored within Unity Catalog. This function can only parse and extract the full callable
+        definition for Python functions and cannot be used on SQL or TABLE functions.
+
+        Args:
+            function_name: The name of the function to retrieve the Python callable definition for.
+
+        Returns:
+            str: The Python callable definition as a string.
+        """
+
+        function_info = self.get_function(function_name)
+        if function_info.routine_body.value != "EXTERNAL":
+            raise ValueError(
+                f"Function {function_name} is not an EXTERNAL Python function and cannot be retrieved."
+            )
+        return dynamically_construct_python_function(function_info)
+
 
 def is_scalar(function: "FunctionInfo") -> bool:
     from databricks.sdk.service.catalog import ColumnTypeName
@@ -825,3 +847,34 @@ def get_execute_function_sql_command(
         sql_query += ",".join(args)
     sql_query += ")"
     return SparkSqlCommand(sql_query=sql_query, args=params_dict)
+
+
+def dynamically_construct_python_function(function_info: "FunctionInfo") -> str:
+    """
+    Construct a Python function from the given FunctionInfo object.
+
+    Note: This function will not recreate the original docstring of the function.
+
+    Args:
+        function_info: The FunctionInfo object containing the function metadata.
+
+    Returns:
+        The re-constructed function definition as a string.
+    """
+    param_names = []
+    if function_info.input_params and function_info.input_params.parameters:
+        for param in function_info.input_params.parameters:
+            param_names.append(extract_collection_types(param))
+    return_type = parse_full_sql_data_type_for_return_type(function_info.full_data_type)
+    function_head = f"{function_info.name}({', '.join(param_names)}) -> {return_type}"
+    func_def = f"def {function_head}:\n"
+
+    if function_info.routine_body.value == "EXTERNAL":
+        for line in function_info.routine_definition.split("\n"):
+            func_def += f"{line}\n"
+    else:
+        raise NotImplementedError(
+            f"routine_body {function_info.routine_body} is not supported. Only 'EXTERNAL' Python body extraction is supported."
+        )
+
+    return func_def

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -24,6 +24,7 @@ from unitycatalog.ai.core.utils.callable_utils import (
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
     parse_full_sql_data_type_for_return_type,
+    reconstruct_docstring,
 )
 from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
@@ -868,6 +869,10 @@ def dynamically_construct_python_function(function_info: "FunctionInfo") -> str:
     return_type = parse_full_sql_data_type_for_return_type(function_info.full_data_type)
     function_head = f"{function_info.name}({', '.join(param_names)}) -> {return_type}"
     func_def = f"def {function_head}:\n"
+
+    docstring = reconstruct_docstring(function_info)
+    if docstring:
+        func_def += docstring
 
     if function_info.routine_body.value == "EXTERNAL":
         for line in function_info.routine_definition.split("\n"):

--- a/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
@@ -24,6 +24,7 @@ PYTHON_TO_SQL_TYPE_MAPPING = {
 SQL_TYPE_TO_PYTHON_TYPE_MAPPING = {
     # numpy array is not accepted, it's not json serializable
     "ARRAY": (list, tuple),
+    "BIGINT": int,
     "BINARY": (bytes, str),
     "BOOLEAN": bool,
     # tinyint type

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -690,3 +690,5 @@ def test_get_python_callable_integration_complex(client: DatabricksFunctionClien
         assert expected_header in callable_def
         assert "def _helper(x: float) -> int:" in callable_def
         assert "return {" in callable_def and '"result": [' in callable_def
+        assert "Args:" in callable_def
+        assert "Returns:" in callable_def

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -639,3 +639,54 @@ def test_execute_python_function_no_params_databricks(client: DatabricksFunction
             ValueError, match="Function does not have input parameters, but parameters"
         ):
             client.execute_function(func_obj.full_function_name, parameters={"unexpected": "value"})
+
+
+@retry_flaky_test()
+@requires_databricks
+def test_get_python_callable_integration_complex(client: DatabricksFunctionClient):
+    def complex_python_func(
+        a: int,
+        b: float,
+        c: str,
+        d: bool,
+        e: list[str],
+        f: dict[str, int],
+        g: Variant,
+        h: dict[str, list[int]],
+        i: dict[str, list[dict[str, list[int]]]],
+    ) -> dict[str, list[str]]:
+        """
+        A complex function that processes various types.
+
+        Args:
+            a: an int
+            b: a float
+            c: a string
+            d: a bool
+            e: a list of strings
+            f: a dict mapping strings to ints
+            g: a variant value
+            h: a dict mapping strings to lists of ints
+            i: a dict mapping strings to lists of dicts mapping strings to lists of ints
+
+        Returns:
+            dict[str, list[str]]: A dictionary with a single key "result" and a list of string representations.
+        """
+
+        def _helper(x: float) -> int:
+            return int(x) + a
+
+        return {"result": [str(a), str(b), c, str(d), ",".join(e), str(f), str(g), str(h), str(i)]}
+
+    with create_python_function_and_cleanup(client, func=complex_python_func, schema=SCHEMA):
+        function_name = f"{CATALOG}.{SCHEMA}.complex_python_func"
+        callable_def = client.get_python_callable(function_name)
+
+        expected_header = (
+            "def complex_python_func(a: int, b: float, c: str, d: bool, e: list[str], "
+            "f: dict[str, int], g: variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
+        )
+
+        assert expected_header in callable_def
+        assert "def _helper(x: float) -> int:" in callable_def
+        assert "return {" in callable_def and '"result": [' in callable_def

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -684,7 +684,7 @@ def test_get_python_callable_integration_complex(client: DatabricksFunctionClien
 
         expected_header = (
             "def complex_python_func(a: int, b: float, c: str, d: bool, e: list[str], "
-            "f: dict[str, int], g: variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
+            "f: dict[str, int], g: Variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
         )
 
         assert expected_header in callable_def

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -478,6 +478,64 @@ You can retrieve the function definition from UC by using the `get_function` cli
 function_info = client.get_function("your_catalog.your_schema.your_function_name")
 ```
 
+## Retrieving a UC function callable
+
+The `Databricks` client has a separate API that can be used for retrieving the base callable definition (as a string) of a registered Unity Catalog Python function.
+In order to use this API, the function that you are fetching **must be** and `EXTERNAL` (python function) type function. When called, the function's metadata will
+be retrieved and the structure of the original callable will be rebuilt and returned as a string.
+
+Note: The UnityCatalogClient (non-Databricks) provides a utility function in the client module for recreating a callable, `dynamically_construct_python_function` which accepts as input the return of a `get_function` call. The `get_python_callable` API only exists in the `DatabricksFunctionClient` due to differences in how function execution works.
+
+For example:
+
+```python
+# Define a python callable
+
+def sample_python_func(a: int, b: int) -> int:
+    """
+    Returns the sum of a and b.
+
+    Args:
+        a: an int
+        b: another int
+
+    Returns:
+        The sum of a and b
+    """
+    return a + b
+
+# Create the function within Unity Catalog
+client.create_python_function(catalog=CATALOG, schema=SCHEMA, func=sample_python_func, replace=True)
+
+# Fetch the callable definition
+my_func_def = client.get_python_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_function")
+```
+
+The returned value from the `get_python_callable` API will be the same as the original input with a few caveats:
+
+- `tuple` types will be cast to `list` due to the inability to express a Python `tuple` within Unity Catalog
+- The docstring of the original function will be stripped out. Unity Catalog persists the docstring information in the logged function and it is available in the return of the `get_function` API call if needed.
+
+The result of calling the `get_python_callable` API on the `sample_python_func` registered function will be (when printed):
+
+```text
+def sample_python_func(a: int, b: int) -> bigint:
+
+    return a + b
+```
+
+Note: If you want to convert the extracted string back into an actual Python callable, you will need to use the `exec` function. A simple example:
+
+```python
+# Caution - evaluate the contents of any function definition before executing in this manner! 
+local_namespace = {}
+exec(my_func_def, globals(), local_namespace)
+callable_fn = local_namespace["sample_ppython_func"]  # You must refer to the original name of the function
+callable_fn(a=1, b=3)  # returns `4`
+```
+
+This API is useful for extracting already-registered functions that will be used as additional in-line calls within another function through the use of the `create_wrapped_python_function` API, saving the effort required to either hand-craft a function definition or having to track down where the original implementation of a logged function was defined.
+
 ## Listing Functions
 
 You can list all functions that are defined within a given catalog and schema by using the `list_functions` client API:


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Implements the ability to recreate the original (minus the docstring) callable definition from a registered UC python function on Databricks. (This feature isn't needed in standard UC due to the existence of a helper function in the client module that already does this for local callable execution). 