### PR TITLE
Add functionality for retrieving callable definitions and converting them to callables

### DIFF
--- a/ai/core/README.md
+++ b/ai/core/README.md
@@ -339,8 +339,17 @@ within the `FunctionInfo` object. In Databricks, full typing is supported for co
 The result of calling the `get_function_source` API on the `sample_python_func` registered function will be (when printed):
 
 ```text
-def sample_python_func(a: int, b: int) -> bigint:
+def sample_python_func(a: int, b: int) -> int:
+    """
+    Returns the sum of a and b.
 
+    Args:
+        a: an int
+        b: another int
+
+    Returns:
+        int
+    """
     return a + b
 ```
 
@@ -376,7 +385,16 @@ from unitycatalog.ai.core.utils.execution_utils import load_function_from_string
 
 func_str = """
 def multiply_numbers(a: int, b: int) -> int:
-    \"\"\"Multiplies two numbers.\"\"\"
+    \"\"\"
+    Multiplies two numbers.
+
+    Args:
+        a: first number.
+        b: second number.
+
+    Returns:
+        int
+    \"\"\"
     return a * b
 """
 
@@ -403,9 +421,13 @@ func_str2 = """
 def multiply_numbers_with_constant(a: int, b: int) -> int:
     \"\"\"
     Multiplies two numbers with a constant.
-        Args:
-            a (int): first number.
-            b (int): second number.
+
+    Args:
+        a: first number.
+        b: second number.
+    
+    Returns:
+        int
     \"\"\"
     return a * b * c
 """

--- a/ai/core/src/unitycatalog/ai/core/base.py
+++ b/ai/core/src/unitycatalog/ai/core/base.py
@@ -223,7 +223,7 @@ class BaseFunctionClient(ABC):
         """
 
     @abstractmethod
-    def get_python_callable(self, function_name: str) -> str:
+    def get_function_source(self, function_name: str) -> str:
         """
         Get the Python callable definition reconstructed from Unity Catalog
           for a function by its name. The return of this method is a string

--- a/ai/core/src/unitycatalog/ai/core/base.py
+++ b/ai/core/src/unitycatalog/ai/core/base.py
@@ -222,6 +222,20 @@ class BaseFunctionClient(ABC):
         Sensitive information should be excluded.
         """
 
+    @abstractmethod
+    def get_python_callable(self, function_name: str) -> str:
+        """
+        Get the Python callable definition reconstructed from Unity Catalog
+          for a function by its name. The return of this method is a string
+          that contains the callable's definition.
+
+        Args:
+            function_name: The name of the function to retrieve from Unity Catalog.
+
+        Returns:
+            str: The Python callable definition as a string.
+        """
+
 
 # TODO: update BaseFunctionClient to Union[BaseFunctionClient, AsyncBaseFunctionClient] after async client is supported
 def get_uc_function_client() -> Optional[BaseFunctionClient]:

--- a/ai/core/src/unitycatalog/ai/core/client.py
+++ b/ai/core/src/unitycatalog/ai/core/client.py
@@ -12,6 +12,9 @@ from typing_extensions import override
 
 from unitycatalog.ai.core.base import BaseFunctionClient, FunctionExecutionResult
 from unitycatalog.ai.core.paged_list import PagedList
+from unitycatalog.ai.core.utils.callable_utils import (
+    dynamically_construct_python_function,
+)
 from unitycatalog.ai.core.utils.callable_utils_oss import (
     generate_function_info,
     generate_wrapped_function_info,
@@ -845,7 +848,7 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
             except Exception as e:
                 return FunctionExecutionResult(error=str(e))
         else:
-            python_function = dynamically_construct_python_function(function_info)
+            python_function = _get_callable_definition(function_info)
             exec(python_function, self.func_cache)
             try:
                 func = self.func_cache[function_info.name]
@@ -907,30 +910,32 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
         elements = ["uc"]
         return {k: getattr(self, k) for k in elements if getattr(self, k) is not None}
 
+    @override
+    def get_python_callable(self, function_name: str, base_indent_level: int = 4) -> str:
+        """
+        Returns the Python callable definition as a string for an EXTERNAL Python function that
+        is stored within Unity Catalog. This function can only parse and extract the full callable
+        definition for Python functions and cannot be used on SQL or TABLE functions.
 
-def dynamically_construct_python_function(function_info: FunctionInfo) -> str:
-    """
-    Construct a Python function from the given FunctionInfo.
+        NOTE: If the returned string representation of the function is not indented correctly,
+        override the `base_indent_level` parameter to adjust the indentation level of the function.
+        The default is `4` spaces, but Python allows for `2` spaces as a standard indentation as well.
 
-    Args:
-        function_info: The FunctionInfo object containing the function metadata.
+        Args:
+            function_name: The name of the function to retrieve the Python callable definition for.
+            base_indent_level: The base indentation level for the function definition. Defaults to 4.
 
-    Returns:
-        The re-constructed function definition.
-    """
-
-    param_names = []
-    if function_info.input_params and function_info.input_params.parameters:
-        param_names = [param.name for param in function_info.input_params.parameters]
-    function_head = f"{function_info.name}({', '.join(param_names)})"
-    func_def = f"def {function_head}:\n"
-    if function_info.routine_body == "EXTERNAL":
-        for line in function_info.routine_definition.split("\n"):
-            func_def += f"    {line}\n"
-    else:
-        raise NotImplementedError(f"routine_body {function_info.routine_body} not supported")
-
-    return func_def
+        Returns:
+            str: The Python callable definition as a string.
+        """
+        function_info = self.get_function(function_name)
+        if function_info.routine_body != "EXTERNAL":
+            raise ValueError(
+                f"Function {function_name} is not an EXTERNAL Python function and cannot be retrieved."
+            )
+        return dynamically_construct_python_function(
+            function_info=function_info, base_indent_level=base_indent_level
+        )
 
 
 def validate_input_parameter(
@@ -1002,3 +1007,31 @@ def validate_param(param: Any, column_type: str, param_type_text: str) -> None:
             f"Invalid interval type text: {param_type_text}, expecting 'interval day to second', "
             "python timedelta can only be used for day-time interval."
         )
+
+
+def _get_callable_definition(function_info: FunctionInfo) -> str:
+    """
+    Construct a Python function from the given FunctionInfo without docstring, comments, or types.
+    This funciton is purely used for local function execution encapsulated within a call to
+    `execute_function` and is not intended to be used for retrieving a callable definition.
+    Use `get_python_callable` instead.
+
+    Args:
+        function_info: The FunctionInfo object containing the function metadata.
+
+    Returns:
+        The minimal re-constructed function definition.
+    """
+
+    param_names = []
+    if function_info.input_params and function_info.input_params.parameters:
+        param_names = [param.name for param in function_info.input_params.parameters]
+    function_head = f"{function_info.name}({', '.join(param_names)})"
+    func_def = f"def {function_head}:\n"
+    if function_info.routine_body == "EXTERNAL":
+        for line in function_info.routine_definition.split("\n"):
+            func_def += f"    {line}\n"
+    else:
+        raise NotImplementedError(f"routine_body {function_info.routine_body} not supported")
+
+    return func_def

--- a/ai/core/src/unitycatalog/ai/core/client.py
+++ b/ai/core/src/unitycatalog/ai/core/client.py
@@ -911,19 +911,17 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
         return {k: getattr(self, k) for k in elements if getattr(self, k) is not None}
 
     @override
-    def get_python_callable(self, function_name: str, base_indent_level: int = 4) -> str:
+    def get_function_source(self, function_name: str) -> str:
         """
         Returns the Python callable definition as a string for an EXTERNAL Python function that
         is stored within Unity Catalog. This function can only parse and extract the full callable
         definition for Python functions and cannot be used on SQL or TABLE functions.
 
-        NOTE: If the returned string representation of the function is not indented correctly,
-        override the `base_indent_level` parameter to adjust the indentation level of the function.
-        The default is `4` spaces, but Python allows for `2` spaces as a standard indentation as well.
+        NOTE: To unify the behavior of creating a valid Python callable, existing indentation in the
+        stored function body will be unified to a consistent indentation level of `4` spaces.
 
         Args:
             function_name: The name of the function to retrieve the Python callable definition for.
-            base_indent_level: The base indentation level for the function definition. Defaults to 4.
 
         Returns:
             str: The Python callable definition as a string.
@@ -933,9 +931,7 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
             raise ValueError(
                 f"Function {function_name} is not an EXTERNAL Python function and cannot be retrieved."
             )
-        return dynamically_construct_python_function(
-            function_info=function_info, base_indent_level=base_indent_level
-        )
+        return dynamically_construct_python_function(function_info=function_info)
 
 
 def validate_input_parameter(

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -20,8 +20,10 @@ from unitycatalog.ai.core.envs.databricks_env_vars import (
 from unitycatalog.ai.core.paged_list import PagedList
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
+    extract_collection_types,
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
+    parse_full_sql_data_type_for_return_type,
 )
 from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
@@ -742,6 +744,26 @@ class DatabricksFunctionClient(BaseFunctionClient):
         accept_keys = ["profile"]
         return cls(**{k: v for k, v in config.items() if k in accept_keys})
 
+    def get_python_callable(self, function_name: str) -> str:
+        """
+        Returns the Python callable definition as a string for an EXTERNAL Python function that
+        is stored within Unity Catalog. This function can only parse and extract the full callable
+        definition for Python functions and cannot be used on SQL or TABLE functions.
+
+        Args:
+            function_name: The name of the function to retrieve the Python callable definition for.
+
+        Returns:
+            str: The Python callable definition as a string.
+        """
+
+        function_info = self.get_function(function_name)
+        if function_info.routine_body.value != "EXTERNAL":
+            raise ValueError(
+                f"Function {function_name} is not an EXTERNAL Python function and cannot be retrieved."
+            )
+        return dynamically_construct_python_function(function_info)
+
 
 def is_scalar(function: "FunctionInfo") -> bool:
     from databricks.sdk.service.catalog import ColumnTypeName
@@ -825,3 +847,34 @@ def get_execute_function_sql_command(
         sql_query += ",".join(args)
     sql_query += ")"
     return SparkSqlCommand(sql_query=sql_query, args=params_dict)
+
+
+def dynamically_construct_python_function(function_info: "FunctionInfo") -> str:
+    """
+    Construct a Python function from the given FunctionInfo object.
+
+    Note: This function will not recreate the original docstring of the function.
+
+    Args:
+        function_info: The FunctionInfo object containing the function metadata.
+
+    Returns:
+        The re-constructed function definition as a string.
+    """
+    param_names = []
+    if function_info.input_params and function_info.input_params.parameters:
+        for param in function_info.input_params.parameters:
+            param_names.append(extract_collection_types(param))
+    return_type = parse_full_sql_data_type_for_return_type(function_info.full_data_type)
+    function_head = f"{function_info.name}({', '.join(param_names)}) -> {return_type}"
+    func_def = f"def {function_head}:\n"
+
+    if function_info.routine_body.value == "EXTERNAL":
+        for line in function_info.routine_definition.split("\n"):
+            func_def += f"{line}\n"
+    else:
+        raise NotImplementedError(
+            f"routine_body {function_info.routine_body} is not supported. Only 'EXTERNAL' Python body extraction is supported."
+        )
+
+    return func_def

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -20,11 +20,9 @@ from unitycatalog.ai.core.envs.databricks_env_vars import (
 from unitycatalog.ai.core.paged_list import PagedList
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
-    extract_collection_types,
+    dynamically_construct_python_function,
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
-    parse_full_sql_data_type_for_return_type,
-    reconstruct_docstring,
 )
 from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
@@ -745,6 +743,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         accept_keys = ["profile"]
         return cls(**{k: v for k, v in config.items() if k in accept_keys})
 
+    @override
     def get_python_callable(self, function_name: str) -> str:
         """
         Returns the Python callable definition as a string for an EXTERNAL Python function that
@@ -848,38 +847,3 @@ def get_execute_function_sql_command(
         sql_query += ",".join(args)
     sql_query += ")"
     return SparkSqlCommand(sql_query=sql_query, args=params_dict)
-
-
-def dynamically_construct_python_function(function_info: "FunctionInfo") -> str:
-    """
-    Construct a Python function from the given FunctionInfo object.
-
-    Note: This function will not recreate the original docstring of the function.
-
-    Args:
-        function_info: The FunctionInfo object containing the function metadata.
-
-    Returns:
-        The re-constructed function definition as a string.
-    """
-    param_names = []
-    if function_info.input_params and function_info.input_params.parameters:
-        for param in function_info.input_params.parameters:
-            param_names.append(extract_collection_types(param))
-    return_type = parse_full_sql_data_type_for_return_type(function_info.full_data_type)
-    function_head = f"{function_info.name}({', '.join(param_names)}) -> {return_type}"
-    func_def = f"def {function_head}:\n"
-
-    docstring = reconstruct_docstring(function_info)
-    if docstring:
-        func_def += docstring
-
-    if function_info.routine_body.value == "EXTERNAL":
-        for line in function_info.routine_definition.split("\n"):
-            func_def += f"{line}\n"
-    else:
-        raise NotImplementedError(
-            f"routine_body {function_info.routine_body} is not supported. Only 'EXTERNAL' Python body extraction is supported."
-        )
-
-    return func_def

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -24,6 +24,7 @@ from unitycatalog.ai.core.utils.callable_utils import (
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
     parse_full_sql_data_type_for_return_type,
+    reconstruct_docstring,
 )
 from unitycatalog.ai.core.utils.function_processing_utils import process_function_parameter_defaults
 from unitycatalog.ai.core.utils.type_utils import (
@@ -868,6 +869,10 @@ def dynamically_construct_python_function(function_info: "FunctionInfo") -> str:
     return_type = parse_full_sql_data_type_for_return_type(function_info.full_data_type)
     function_head = f"{function_info.name}({', '.join(param_names)}) -> {return_type}"
     func_def = f"def {function_head}:\n"
+
+    docstring = reconstruct_docstring(function_info)
+    if docstring:
+        func_def += docstring
 
     if function_info.routine_body.value == "EXTERNAL":
         for line in function_info.routine_definition.split("\n"):

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -744,7 +744,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         return cls(**{k: v for k, v in config.items() if k in accept_keys})
 
     @override
-    def get_python_callable(self, function_name: str) -> str:
+    def get_function_source(self, function_name: str) -> str:
         """
         Returns the Python callable definition as a string for an EXTERNAL Python function that
         is stored within Unity Catalog. This function can only parse and extract the full callable

--- a/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
@@ -879,14 +879,17 @@ def _reconstruct_docstring(function_info: "FunctionInfo", max_width: int = 100) 
     doc_lines.append("")
     doc_lines.append("Returns:")
     wrapped_return = fill(
-        return_type_str, width=max_width, initial_indent="    ", subsequent_indent="    "
+        return_type_str,
+        width=max_width,
+        initial_indent=PRIMARY_INDENT,
+        subsequent_indent=WRAPPED_INDENT,
     )
     doc_lines.append(wrapped_return)
 
     if not doc_lines:
         return ""
 
-    indented_doc = "\n".join("    " + line for line in doc_lines)
+    indented_doc = "\n".join(PRIMARY_INDENT + line for line in doc_lines)
     return f'    """\n{indented_doc}\n    """\n'
 
 

--- a/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
@@ -24,6 +24,8 @@ from unitycatalog.ai.core.utils.type_utils import (
 )
 
 FORBIDDEN_PARAMS = ["self", "cls"]
+PRIMARY_INDENT = " " * 4
+WRAPPED_INDENT = " " * 6
 
 
 class FunctionBodyExtractor(ast.NodeVisitor):
@@ -865,7 +867,10 @@ def _reconstruct_docstring(function_info: "FunctionInfo", max_width: int = 100) 
             arg_comment = f": {param_comment}" if param_comment else ""
             arg_line = param.name + arg_comment
             wrapped_arg = fill(
-                arg_line, width=max_width, initial_indent=" " * 4, subsequent_indent=" " * 6
+                arg_line,
+                width=max_width,
+                initial_indent=PRIMARY_INDENT,
+                subsequent_indent=WRAPPED_INDENT,
             )
             doc_lines.append(wrapped_arg)
 
@@ -934,7 +939,7 @@ def _parse_routine_definition(routine_definition: str) -> str:
             normalized_lines.append(" " * indent_level + line.strip())
         else:
             normalized_lines.append("")
-    return indent("\n".join(normalized_lines), " " * 4)
+    return indent("\n".join(normalized_lines), PRIMARY_INDENT)
 
 
 def dynamically_construct_python_function(

--- a/ai/core/src/unitycatalog/ai/core/utils/execution_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/execution_utils.py
@@ -1,0 +1,49 @@
+import ast
+
+
+def load_function_from_string(
+    func_def_str: str, register_global: bool = True, namespace: dict = None
+) -> callable:
+    """
+    Convert a function definition string into a callable using the ast module.
+
+    This function parses the string into an AST, finds the first function definition,
+    compiles the AST into a code object, executes it in a temporary namespace,
+    and optionally registers the function in the global namespace.
+
+    Args:
+        func_def_str: A string containing a valid Python function definition.
+        register_global: If True, registers the function in the global namespace.
+            If False, the function is not registered globally.
+        namespace: Optional dictionary to execute the function in a specific namespace.
+
+    Returns:
+        callable: The function object created from the string.
+    """
+
+    namespace = namespace if namespace is not None else globals()
+
+    function_error = "Function definition not found in the provided string."
+
+    try:
+        module_ast = ast.parse(func_def_str)
+    except SyntaxError as e:
+        raise ValueError(function_error) from e
+
+    func_def_node = None
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef):
+            func_def_node = node
+            break
+    if func_def_node is None:
+        raise ValueError(function_error)
+
+    func_name = func_def_node.name
+    code_obj = compile(module_ast, filename="<ast>", mode="exec")
+    temp_namespace = {}
+    exec(code_obj, namespace, temp_namespace)
+    func_obj = temp_namespace[func_name]
+
+    if register_global:
+        namespace[func_name] = func_obj
+    return func_obj

--- a/ai/core/src/unitycatalog/ai/core/utils/execution_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/execution_utils.py
@@ -2,7 +2,7 @@ import ast
 
 
 def load_function_from_string(
-    func_def_str: str, register_global: bool = True, namespace: dict = None
+    func_def_str: str, register_function: bool = True, namespace: dict = None
 ) -> callable:
     """
     Convert a function definition string into a callable using the ast module.
@@ -11,10 +11,97 @@ def load_function_from_string(
     compiles the AST into a code object, executes it in a temporary namespace,
     and optionally registers the function in the global namespace.
 
+    Example usage:
+
+    With default global registration (does not work in interactive environments):
+    ```python
+    func_str = '''
+    def multiply_numbers(a: int, b: int) -> int:
+        \"\"\"
+        Multiplies two numbers.
+            Args:
+                a (int): first number.
+                b (int): second number.
+        \"\"\"
+        return a * b
+    '''
+    function_def = load_function_from_string(func_str, register_function=True)
+    multiply_numbers(a=2, b=4)  # returns 8
+    ```
+
+    With default global registration in an interactive environment (i.e. Jupyter):
+    ```python
+    func_str = '''
+    def multiply_numbers(a: int, b: int) -> int:
+        \"\"\"
+        Multiplies two numbers.
+            Args:
+                a (int): first number.
+                b (int): second number.
+        \"\"\"
+        return a * b
+    '''
+
+    function_def = load_function_from_string(func_str, register_function=True)
+
+    globals()["multiply_numbers"] = (
+        function_def  # directly applying to globals outside of the callable is required for Jupyter
+    )
+
+    multiply_numbers(a=2, b=4)  # returns 8
+    ```
+
+    With custom namespace:
+    ```python
+    from types import SimpleNamespace
+
+    func_str = '''
+    def multiply_numbers_with_constant(a: int, b: int) -> int:
+        \"\"\"
+        Multiplies two numbers with a constant.
+            Args:
+                a (int): first number.
+                b (int): second number.
+        \"\"\"
+        return a * b * c
+    '''
+
+    scoped_namespace = {
+        "__builtins__": __builtins__,
+        "c": 42,
+    }
+    c = 100  # this will not be used in the function
+    load_function_from_string(func_str, register_function=True, namespace=scoped_namespace)
+
+    scoped_ns = SimpleNamespace(**scoped_namespace)
+
+    scoped_ns.multiply_numbers_with_constant(a=2, b=3)  # returns 252
+    ```
+
+    With no registration and direct usage of the aliased function object:
+    ```python
+    func_str = '''
+    def multiply_numbers(a: int, b: int) -> int:
+        \"\"\"
+        Multiplies two numbers.
+            Args:
+                a (int): first number.
+                b (int): second number.
+        \"\"\"
+        return a * b
+    '''
+
+    function_def = load_function_from_string(func_str, register_function=False)
+
+    function_def(a=3, b=4)  # returns 12
+    ```
+
     Args:
         func_def_str: A string containing a valid Python function definition.
-        register_global: If True, registers the function in the global namespace.
-            If False, the function is not registered globally.
+        register_function: If True, registers the function in either the specified
+            `namespace` entry or, if `namespace` is not specified, the global namespace.
+            If False, the function is not registered and is only accessible via the
+            returned callable function object.
         namespace: Optional dictionary to execute the function in a specific namespace.
 
     Returns:
@@ -44,6 +131,6 @@ def load_function_from_string(
     exec(code_obj, namespace, temp_namespace)
     func_obj = temp_namespace[func_name]
 
-    if register_global:
+    if register_function:
         namespace[func_name] = func_obj
     return func_obj

--- a/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
@@ -24,6 +24,7 @@ PYTHON_TO_SQL_TYPE_MAPPING = {
 SQL_TYPE_TO_PYTHON_TYPE_MAPPING = {
     # numpy array is not accepted, it's not json serializable
     "ARRAY": (list, tuple),
+    "BIGINT": int,
     "BINARY": (bytes, str),
     "BOOLEAN": bool,
     # tinyint type

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -680,7 +680,7 @@ def test_get_python_callable_integration_complex(client: DatabricksFunctionClien
 
     with create_python_function_and_cleanup(client, func=complex_python_func, schema=SCHEMA):
         function_name = f"{CATALOG}.{SCHEMA}.complex_python_func"
-        callable_def = client.get_python_callable(function_name)
+        callable_def = client.get_function_source(function_name)
 
         expected_header = (
             "def complex_python_func(a: int, b: float, c: str, d: bool, e: list[str], "

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -690,3 +690,5 @@ def test_get_python_callable_integration_complex(client: DatabricksFunctionClien
         assert expected_header in callable_def
         assert "def _helper(x: float) -> int:" in callable_def
         assert "return {" in callable_def and '"result": [' in callable_def
+        assert "Args:" in callable_def
+        assert "Returns:" in callable_def

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -639,3 +639,54 @@ def test_execute_python_function_no_params_databricks(client: DatabricksFunction
             ValueError, match="Function does not have input parameters, but parameters"
         ):
             client.execute_function(func_obj.full_function_name, parameters={"unexpected": "value"})
+
+
+@retry_flaky_test()
+@requires_databricks
+def test_get_python_callable_integration_complex(client: DatabricksFunctionClient):
+    def complex_python_func(
+        a: int,
+        b: float,
+        c: str,
+        d: bool,
+        e: list[str],
+        f: dict[str, int],
+        g: Variant,
+        h: dict[str, list[int]],
+        i: dict[str, list[dict[str, list[int]]]],
+    ) -> dict[str, list[str]]:
+        """
+        A complex function that processes various types.
+
+        Args:
+            a: an int
+            b: a float
+            c: a string
+            d: a bool
+            e: a list of strings
+            f: a dict mapping strings to ints
+            g: a variant value
+            h: a dict mapping strings to lists of ints
+            i: a dict mapping strings to lists of dicts mapping strings to lists of ints
+
+        Returns:
+            dict[str, list[str]]: A dictionary with a single key "result" and a list of string representations.
+        """
+
+        def _helper(x: float) -> int:
+            return int(x) + a
+
+        return {"result": [str(a), str(b), c, str(d), ",".join(e), str(f), str(g), str(h), str(i)]}
+
+    with create_python_function_and_cleanup(client, func=complex_python_func, schema=SCHEMA):
+        function_name = f"{CATALOG}.{SCHEMA}.complex_python_func"
+        callable_def = client.get_python_callable(function_name)
+
+        expected_header = (
+            "def complex_python_func(a: int, b: float, c: str, d: bool, e: list[str], "
+            "f: dict[str, int], g: variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
+        )
+
+        assert expected_header in callable_def
+        assert "def _helper(x: float) -> int:" in callable_def
+        assert "return {" in callable_def and '"result": [' in callable_def

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -684,7 +684,7 @@ def test_get_python_callable_integration_complex(client: DatabricksFunctionClien
 
         expected_header = (
             "def complex_python_func(a: int, b: float, c: str, d: bool, e: list[str], "
-            "f: dict[str, int], g: variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
+            "f: dict[str, int], g: Variant, h: dict[str, list[int]], i: dict[str, list[dict[str, list[int]]]]) -> dict[str, list[str]]:"
         )
 
         assert expected_header in callable_def

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -1433,7 +1433,7 @@ def test_get_python_callable_valid(mock_workspace_client):
     client = DatabricksFunctionClient(client=mock_workspace_client)
     client.get_function = MagicMock(return_value=fake_function_info)
 
-    result = client.get_python_callable("my_func")
+    result = client.get_function_source("my_func")
     assert "def my_func(x: int) -> str:" in result
     assert '"""' in result
     assert "A function that doubles the input" in result
@@ -1458,7 +1458,7 @@ def test_get_python_callable_non_external(mock_workspace_client):
     client.get_function = MagicMock(return_value=fake_function_info)
 
     with pytest.raises(ValueError, match="is not an EXTERNAL Python function"):
-        client.get_python_callable("non_external_func")
+        client.get_function_source("non_external_func")
 
 
 def test_get_python_callable_multiline(mock_workspace_client):
@@ -1474,7 +1474,7 @@ def test_get_python_callable_multiline(mock_workspace_client):
 
     client.get_function = MagicMock(return_value=fake_function_info)
 
-    result = client.get_python_callable("multi_line_func")
+    result = client.get_function_source("multi_line_func")
     assert "def multi_line_func() -> str:" in result
     assert "line1" in result
     assert "line2" in result

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -1392,9 +1392,9 @@ def test_execute_function_with_none_default_databricks(mock_workspace_client, mo
 
 
 class DummyParameter:
-    def __init__(self, name, type_json, comment):
+    def __init__(self, name: str, type_text: str, comment: str):
         self.name = name
-        self.type_json = type_json
+        self.type_text = type_text
         self.comment = comment
 
 
@@ -1486,104 +1486,48 @@ def complex_function_info():
     # Build parameters for a complex function.
     a = DummyParameter(
         "a",
-        '{"name": "a", "type": "long", "nullable": true, "metadata": {"comment": "an int"}}',
+        "LONG",
         "an int",
     )
     b = DummyParameter(
         "b",
-        '{"name": "b", "type": "double", "nullable": true, "metadata": {"comment": "a float"}}',
+        "DOUBLE",
         "a float",
     )
     c = DummyParameter(
         "c",
-        '{"name": "c", "type": "string", "nullable": true, "metadata": {"comment": "a string"}}',
+        "STRING",
         "a string",
     )
     d = DummyParameter(
         "d",
-        '{"name": "d", "type": "boolean", "nullable": true, "metadata": {"comment": "some bool"}}',
+        "BOOLEAN",
         "some bool",
     )
     e = DummyParameter(
         "e",
-        json.dumps(
-            {
-                "name": "e",
-                "type": {"type": "array", "elementType": "string", "containsNull": True},
-                "nullable": True,
-                "metadata": {"comment": "a list of str"},
-            }
-        ),
+        "ARRAY<STRING>",
         "a list of str",
     )
     f = DummyParameter(
         "f",
-        json.dumps(
-            {
-                "name": "f",
-                "type": {
-                    "type": "map",
-                    "keyType": "string",
-                    "valueType": "long",
-                    "valueContainsNull": True,
-                },
-                "nullable": True,
-                "metadata": {"comment": "a dict of str to int"},
-            }
-        ),
+        "MAP<STRING, LONG>",
         "a dict of str to int",
     )
     g = DummyParameter(
         "g",
-        '{"name": "g", "type": "variant", "nullable": true, "metadata": {"comment": "a variant"}}',
+        "VARIANT",
         "a variant",
     )
     h = DummyParameter(
         "h",
-        json.dumps(
-            {
-                "name": "h",
-                "type": {
-                    "type": "map",
-                    "keyType": "string",
-                    "valueType": {"type": "array", "elementType": "long", "containsNull": True},
-                    "valueContainsNull": True,
-                },
-                "nullable": True,
-                "metadata": {"comment": "a complex type"},
-            }
-        ),
+        "MAP<STRING, ARRAY<LONG>>",
         "a complex type",
     )
     i = DummyParameter(
         "i",
-        json.dumps(
-            {
-                "name": "i",
-                "type": {
-                    "type": "map",
-                    "keyType": "string",
-                    "valueType": {
-                        "type": "array",
-                        "elementType": {
-                            "type": "map",
-                            "keyType": "string",
-                            "valueType": {
-                                "type": "array",
-                                "elementType": "long",
-                                "containsNull": True,
-                            },
-                            "valueContainsNull": True,
-                        },
-                        "containsNull": True,
-                    },
-                    "valueContainsNull": True,
-                },
-                "nullable": True,
-                "metadata": {},
-            }
-        ),
-        "",
+        "MAP<STRING, ARRAY<MAP<STRING, ARRAY<LONG>>>>",
+        "a very complex type",
     )
 
     dummy_params = DummyInputParams([a, b, c, d, e, f, g, h, i])
@@ -1620,7 +1564,7 @@ def test_reconstruct_callable_complex_function(complex_function_info):
     assert "f: a dict of str to int" in reconstructed
     assert "g: a variant" in reconstructed
     assert "h: a complex type" in reconstructed
-    assert "i:" in reconstructed
+    assert "i: a very complex type" in reconstructed
 
     assert "def _internal(g: float) -> int:" in reconstructed
     assert "return str(a+b+_internal(4.5))" in reconstructed

--- a/ai/core/tests/core/test_callable_utils.py
+++ b/ai/core/tests/core/test_callable_utils.py
@@ -1,5 +1,6 @@
 import json
 import re
+import textwrap
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -7,9 +8,11 @@ import pytest
 
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
-    extract_collection_types,
+    _extract_collection_types,
+    _parse_full_sql_data_type_for_return_type,
+    _parse_routine_definition,
+    dynamically_construct_python_function,
     generate_sql_function_body,
-    parse_full_sql_data_type_for_return_type,
 )
 from unitycatalog.ai.core.utils.type_utils import SQL_TYPE_TO_PYTHON_TYPE_MAPPING
 
@@ -1767,7 +1770,7 @@ class FakeParam:
     ],
 )
 def test_parse_full_sql_data_type_for_return_types(input_type: str, expected: str):
-    result = parse_full_sql_data_type_for_return_type(input_type)
+    result = _parse_full_sql_data_type_for_return_type(input_type)
     assert result == expected
 
 
@@ -1859,5 +1862,119 @@ def test_parse_full_sql_data_type_for_return_types(input_type: str, expected: st
 )
 def test_extract_collection_types(param_name: str, type_json: str, expected: str):
     fake_param = FakeParam(param_name, type_json)
-    result = extract_collection_types(fake_param)
+    result = _extract_collection_types(fake_param)
     assert result == expected
+
+
+class DummyParameter:
+    def __init__(self, name: str, type_json: str, comment: str):
+        self.name = name
+        self.type_json = type_json
+        self.comment = comment
+
+
+class DummyInputParams:
+    def __init__(self, parameters):
+        self.parameters = parameters
+
+
+class DummyRoutineBody:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class DummyFunctionInfo:
+    pass
+
+
+def build_expected_definition(func_name: str, routine_definition: str, comment: str) -> str:
+    """
+    Given the function name, the raw routine definition, and an overall comment,
+    build the complete expected function definition string.
+
+    The expected definition has:
+      - A header: "def <func_name>() -> str:" (since full_data_type "STRING" maps to "str")
+      - A reconstructed docstring that uses the provided comment and a "Returns:" section
+        that shows "str" (the parsed return type).
+      - A function body that is normalized by our _parse_routine_definition helper.
+
+    Returns:
+        The expected full function definition as a string.
+    """
+    header = f"def {func_name}() -> str:"
+    # Build the docstring.
+    wrapped_comment = textwrap.fill(comment.strip(), width=100)
+    # Here we assume that if no explicit returns text is stored, we use the parsed type "str".
+    wrapped_return = textwrap.fill(
+        "str", width=100, initial_indent="    ", subsequent_indent="    "
+    )
+    doc_lines = [
+        wrapped_comment,
+        "",
+        "Returns:",
+        wrapped_return,
+    ]
+    indented_doc = "\n".join("    " + line for line in doc_lines)
+    docstring = f'    """\n{indented_doc}\n    """\n'
+    # Use our helper _parse_routine_definition to normalize the routine definition.
+    expected_body = _parse_routine_definition(routine_definition)
+    expected_def = f"{header}\n{docstring}{expected_body}\n"
+    return expected_def
+
+
+test_cases = [
+    # 1. Already properly indented with 4 spaces.
+    ("    return a + b", "    return a + b"),
+    # 2. Indented with 2 spaces.
+    ("  return a + b", "    return a + b"),
+    # 3. Nested definition: outer indent 2, nested line indent 6, outer again indent 2.
+    (
+        "  def _helper(x):\n      return x * 2\n  return _helper(a)",
+        "    def _helper(x):\n        return x * 2\n    return _helper(a)",
+    ),
+    # 4. Inconsistent indentation: first line indent 2, second line flush left, third line indent 4.
+    (
+        "  line one\nline two\n    line three",
+        # Because one nonempty line is flush left, baseline becomes 0, so every nonempty line gets fixed 4-space indent.
+        "        line one\n    line two\n            line three",
+    ),
+    # 5. Contains a blank line; nonempty lines have indents 2 and 4, so baseline = 2.
+    ("  line one\n\n    line three\n", "    line one\n\n        line three"),
+    # 6. Nested definitions: outer indent 2, inner indent 4, inner's body indent 6, then outer again indent 2.
+    (
+        "  def outer():\n    def inner():\n      return 1\n    return inner()",
+        "    def outer():\n        def inner():\n            return 1\n        return inner()",
+    ),
+    # 7. Already flush left.
+    ("def foo():\n    return 'bar'", "    def foo():\n        return 'bar'"),
+    # 8. Trailing whitespace.
+    ("    return a + b    \n   ", "    return a + b"),
+    # 9. Uses a tab.
+    ("\treturn a + b", "    return a + b"),
+    # 10. All flush left.
+    ("return a + b", "    return a + b"),
+]
+
+
+@pytest.mark.parametrize("input_body, expected_normalized", test_cases)
+def test_parse_routine_definition_indentation(input_body, expected_normalized):
+    # Expand tabs to spaces
+    input_body = "\n".join(line.expandtabs(4) for line in input_body.splitlines())
+    result = _parse_routine_definition(input_body)
+    assert result == expected_normalized, f"Expected:\n{expected_normalized}\nGot:\n{result}"
+
+
+@pytest.mark.parametrize("input_body, expected_normalized", test_cases)
+def test_dynamically_construct_python_function_indentation(input_body, expected_normalized):
+    # Create a dummy FunctionInfo object.
+    dummy = DummyFunctionInfo()
+    dummy.name = "test_func"
+    dummy.input_params = DummyInputParams([])  # No parameters.
+    dummy.full_data_type = "STRING"  # Maps to "str"
+    dummy.comment = "Test function"
+    dummy.routine_body = DummyRoutineBody("EXTERNAL")
+    dummy.routine_definition = input_body
+
+    reconstructed = dynamically_construct_python_function(dummy)
+    expected_def = build_expected_definition("test_func", input_body, "Test function")
+    assert reconstructed == expected_def, f"Expected:\n{expected_def}\nGot:\n{reconstructed}"

--- a/ai/core/tests/core/test_client.py
+++ b/ai/core/tests/core/test_client.py
@@ -75,6 +75,10 @@ class MockClient(BaseFunctionClient):
     def to_dict(self):
         return {}
 
+    @override
+    def get_python_callable(self):
+        return ""
+
 
 @pytest.fixture
 def client():

--- a/ai/core/tests/core/test_client.py
+++ b/ai/core/tests/core/test_client.py
@@ -76,7 +76,7 @@ class MockClient(BaseFunctionClient):
         return {}
 
     @override
-    def get_python_callable(self):
+    def get_function_source(self):
         return ""
 
 

--- a/ai/core/tests/core/test_execution_utils.py
+++ b/ai/core/tests/core/test_execution_utils.py
@@ -1,0 +1,52 @@
+import pytest
+
+from unitycatalog.ai.core.utils.execution_utils import load_function_from_string
+
+
+def test_load_function_default_registration():
+    func_str = """
+def add_numbers(a: int, b: int) -> int:
+    \"\"\"Adds two numbers.\"\"\"
+    return a + b
+"""
+    test_namespace = {}
+    func = load_function_from_string(func_str, register_global=True, namespace=test_namespace)
+    assert callable(func)
+    assert func.__name__ == "add_numbers"
+    assert "add_numbers" in test_namespace
+    assert test_namespace["add_numbers"] is func
+    assert func(2, 3) == 5
+
+
+def test_load_function_no_registration():
+    func_str = """
+def multiply_numbers(a: int, b: int) -> int:
+    \"\"\"Multiplies two numbers.\"\"\"
+    return a * b
+"""
+    globals().pop("multiply_numbers", None)
+
+    func = load_function_from_string(func_str, register_global=False)
+    assert callable(func)
+    assert func.__name__ == "multiply_numbers"
+    assert globals().get("multiply_numbers") is None
+    assert func(3, 4) == 12
+
+
+def test_load_function_invalid_string():
+    invalid_str = "This is not a function definition"
+    with pytest.raises(ValueError, match="Function definition not found in the provided string."):
+        load_function_from_string(invalid_str)
+
+
+def test_load_function_ast_name_extraction():
+    func_str = """
+def greet(name: str) -> str:
+    \"\"\"Greet someone.\"\"\"
+    return f"Hello, {name}!"
+"""
+    globals().pop("greet", None)
+    func = load_function_from_string(func_str, register_global=False)
+    assert func.__name__ == "greet"
+    assert func("Alice") == "Hello, Alice!"
+    assert globals().get("greet") is None

--- a/ai/core/tests/core/test_execution_utils.py
+++ b/ai/core/tests/core/test_execution_utils.py
@@ -10,7 +10,7 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 """
     test_namespace = {}
-    func = load_function_from_string(func_str, register_global=True, namespace=test_namespace)
+    func = load_function_from_string(func_str, register_function=True, namespace=test_namespace)
     assert callable(func)
     assert func.__name__ == "add_numbers"
     assert "add_numbers" in test_namespace
@@ -26,7 +26,7 @@ def multiply_numbers(a: int, b: int) -> int:
 """
     globals().pop("multiply_numbers", None)
 
-    func = load_function_from_string(func_str, register_global=False)
+    func = load_function_from_string(func_str, register_function=False)
     assert callable(func)
     assert func.__name__ == "multiply_numbers"
     assert globals().get("multiply_numbers") is None
@@ -46,7 +46,7 @@ def greet(name: str) -> str:
     return f"Hello, {name}!"
 """
     globals().pop("greet", None)
-    func = load_function_from_string(func_str, register_global=False)
+    func = load_function_from_string(func_str, register_function=False)
     assert func.__name__ == "greet"
     assert func("Alice") == "Hello, Alice!"
     assert globals().get("greet") is None

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -519,8 +519,17 @@ within the `FunctionInfo` object. In Databricks, full typing is supported for co
 The result of calling the `get_function_source` API on the `sample_python_func` registered function will be (when printed):
 
 ```text
-def sample_python_func(a: int, b: int) -> bigint:
+def sample_python_func(a: int, b: int) -> int:
+    """
+    Returns the sum of a and b.
 
+    Args:
+        a: an int
+        b: another int
+
+    Returns:
+        int
+    """
     return a + b
 ```
 
@@ -568,7 +577,16 @@ from unitycatalog.ai.core.utils.execution_utils import load_function_from_string
 
 func_str = """
 def multiply_numbers(a: int, b: int) -> int:
-    \"\"\"Multiplies two numbers.\"\"\"
+    \"\"\"
+    Multiplies two numbers.
+
+    Args:
+        a: first number.
+        b: second number.
+
+    Returns:
+        int
+    \"\"\"
     return a * b
 """
 
@@ -595,9 +613,13 @@ func_str2 = """
 def multiply_numbers_with_constant(a: int, b: int) -> int:
     \"\"\"
     Multiplies two numbers with a constant.
-        Args:
-            a (int): first number.
-            b (int): second number.
+
+    Args:
+        a: first number.
+        b: second number.
+        
+    Returns:
+        int
     \"\"\"
     return a * b * c
 """

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -478,6 +478,64 @@ You can retrieve the function definition from UC by using the `get_function` cli
 function_info = client.get_function("your_catalog.your_schema.your_function_name")
 ```
 
+## Retrieving a UC function callable
+
+The `Databricks` client has a separate API that can be used for retrieving the base callable definition (as a string) of a registered Unity Catalog Python function.
+In order to use this API, the function that you are fetching **must be** and `EXTERNAL` (python function) type function. When called, the function's metadata will
+be retrieved and the structure of the original callable will be rebuilt and returned as a string.
+
+Note: The UnityCatalogClient (non-Databricks) provides a utility function in the client module for recreating a callable, `dynamically_construct_python_function` which accepts as input the return of a `get_function` call. The `get_python_callable` API only exists in the `DatabricksFunctionClient` due to differences in how function execution works.
+
+For example:
+
+```python
+# Define a python callable
+
+def sample_python_func(a: int, b: int) -> int:
+    """
+    Returns the sum of a and b.
+
+    Args:
+        a: an int
+        b: another int
+
+    Returns:
+        The sum of a and b
+    """
+    return a + b
+
+# Create the function within Unity Catalog
+client.create_python_function(catalog=CATALOG, schema=SCHEMA, func=sample_python_func, replace=True)
+
+# Fetch the callable definition
+my_func_def = client.get_python_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_function")
+```
+
+The returned value from the `get_python_callable` API will be the same as the original input with a few caveats:
+
+- `tuple` types will be cast to `list` due to the inability to express a Python `tuple` within Unity Catalog
+- The docstring of the original function will be stripped out. Unity Catalog persists the docstring information in the logged function and it is available in the return of the `get_function` API call if needed.
+
+The result of calling the `get_python_callable` API on the `sample_python_func` registered function will be (when printed):
+
+```text
+def sample_python_func(a: int, b: int) -> bigint:
+
+    return a + b
+```
+
+Note: If you want to convert the extracted string back into an actual Python callable, you will need to use the `exec` function. A simple example:
+
+```python
+# Caution - evaluate the contents of any function definition before executing in this manner! 
+local_namespace = {}
+exec(my_func_def, globals(), local_namespace)
+callable_fn = local_namespace["sample_ppython_func"]  # You must refer to the original name of the function
+callable_fn(a=1, b=3)  # returns `4`
+```
+
+This API is useful for extracting already-registered functions that will be used as additional in-line calls within another function through the use of the `create_wrapped_python_function` API, saving the effort required to either hand-craft a function definition or having to track down where the original implementation of a logged function was defined.
+
 ## Listing Functions
 
 You can list all functions that are defined within a given catalog and schema by using the `list_functions` client API:

--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -480,7 +480,7 @@ function_info = client.get_function("your_catalog.your_schema.your_function_name
 
 ## Retrieving a UC function callable
 
-The `get_python_callable` API is used to retrieve a recreated python callable definition (as a string) from a registered Unity Catalog Python function.
+The `get_function_source` API is used to retrieve a recreated python callable definition (as a string) from a registered Unity Catalog Python function.
 In order to use this API, the function that you are fetching **must be** an `EXTERNAL` (python function) type function. When called, the function's metadata will
 be retrieved and the structure of the original callable will be rebuilt and returned as a string.
 
@@ -506,17 +506,17 @@ def sample_python_func(a: int, b: int) -> int:
 client.create_python_function(catalog=CATALOG, schema=SCHEMA, func=sample_python_func, replace=True)
 
 # Fetch the callable definition
-my_func_def = client.get_python_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_function")
+my_func_def = client.get_function_source(function_name=f"{CATALOG}.{SCHEMA}.sample_python_function")
 ```
 
-The returned value from the `get_python_callable` API will be the same as the original input with a few caveats:
+The returned value from the `get_function_source` API will be the same as the original input with a few caveats:
 
 - `tuple` types will be cast to `list` due to the inability to express a Python `tuple` within Unity Catalog
 - The docstring of the original function will be stripped out. Unity Catalog persists the docstring information in the logged function and it is available in the return of the `get_function` API call if needed.
 - Collection types for open source Unity Catalog will only capture the outer type (i.e., `list` or `dict`) as inner collection type metadata is not preserved
 within the `FunctionInfo` object. In Databricks, full typing is supported for collecitons.
 
-The result of calling the `get_python_callable` API on the `sample_python_func` registered function will be (when printed):
+The result of calling the `get_function_source` API on the `sample_python_func` registered function will be (when printed):
 
 ```text
 def sample_python_func(a: int, b: int) -> bigint:
@@ -560,7 +560,7 @@ print(result.value)  # Outputs: HELLO WORLD
 ## Execute a UC Python function locally
 
 A utility `load_function_from_string` is available in `unitycatalog.ai.core.utils.execution_utils.py`. This utility allows you to couple the functionality
-in the `get_python_callable` API to create a locally-available python callable that can be direclty accessed, precisely as if it were originally defined
+in the `get_function_source` API to create a locally-available python callable that can be direclty accessed, precisely as if it were originally defined
 within your current REPL.
 
 ```python
@@ -572,7 +572,49 @@ def multiply_numbers(a: int, b: int) -> int:
     return a * b
 """
 
-my_new_multiplier = load_function_from_string(a=1, b=2)  # returns `2`
+# If specifying `register_global=False`, the original function name cannot be called and must be used
+# with the returned callable reference.
+my_new_multiplier = load_function_from_string(func_str, register_global=False)
+my_new_multiplier(a=1, b=2)  # returns `2`
+
+# Alternatively, if allowing for global reference `register_global=True` (default)
+# The original callable name can be used. This will not work in interactive environments like Jupyter.
+load_function_from_string(func_str)
+multiply_numbers(a=2, b=2)  # returns `4`
+
+# For interactive environments, setting the return object directly within globals() is required in order
+# to utilize the original function name
+alias = load_function_from_string(func_str)
+globals()["multiply_numbers"] = alias
+multiply_numbers(a=3, b=3)  # returns `9`
+
+# Additionally, a scoped namespace can be provided to restrict scope and access to scoped arguments
+from types import SimpleNamespace
+
+func_str2 = """
+def multiply_numbers_with_constant(a: int, b: int) -> int:
+    \"\"\"
+    Multiplies two numbers with a constant.
+        Args:
+            a (int): first number.
+            b (int): second number.
+    \"\"\"
+    return a * b * c
+"""
+
+c = 100  # Not part of the scoped namespace; local constant
+
+scoped_namespace = {
+    "__builtins__": __builtins__,
+    "c": 42,
+}
+    
+load_function_from_string(func_str, register_function=True, namespace=scoped_namespace)
+
+scoped_ns = SimpleNamespace(**scoped_namespace)
+
+scoped_ns.multiply_numbers_with_constant(a=2, b=3)  # returns 252, utilizing the `c` constant of the namespace
+
 ```
 
 ## Function Parameter Defaults


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Extension of #911 , bringing a unified functionality across both clients. Adds a utility for converting the string representation to an actual callable for local execution. 