### PR TITLE
Updated "create a table" describing fields

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -295,8 +295,8 @@ bin/uc table create \
 2. `columns`: The columns of the table in SQL-like format `"column_name column_data_type"`.
    Supported data types include `BOOLEAN`, `BYTE`, `SHORT`, `INT`, `LONG`, `FLOAT`, `DOUBLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `STRING`, `BINARY`, `DECIMAL`. Separate multiple columns with a comma
    (e.g., `"id INT, name STRING"`).
-3. `format`: _\[Optional\]_ The format of the data source. Supported values are `DELTA`, `PARQUET`, `ORC`, `JSON`,`CSV`, `AVRO`, and `TEXT`. If not specified the default format is `DELTA`.
-4. `storage_location`: The storage location associated with the table. It is a mandatory field for `EXTERNAL` tables.
+3. `storage_location`: The storage location associated with the table. It is a mandatory field for `EXTERNAL` tables.
+4. `format`: _\[Optional\]_ The format of the data source. Supported values are `DELTA`, `PARQUET`, `ORC`, `JSON`,`CSV`, `AVRO`, and `TEXT`. If not specified the default format is `DELTA`.
 5. `properties`: _\[Optional\]_ The properties of the table in JSON format
    (e.g., `'{"key1": "value1", "key2": "value2"}'`). Make sure to either escape the double quotes(`\"`) inside the properties string or just use single quotes(`''`) around the same.
 


### PR DESCRIPTION
If you check this link https://docs.unitycatalog.io/usage/cli/#create-a-table, in the create table syntax, "storage_location" arrow describes the format and "format" describes the "storage location". Hence, fixing this

**PR Checklist**

- [x] If you check this link https://docs.unitycatalog.io/usage/cli/#create-a-table, in the create table syntax, "storage_location" arrow describes the format and "format" describes the "storage location". Hence, fixing this.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

If you check this link https://docs.unitycatalog.io/usage/cli/#create-a-table, in the create table syntax, "storage_location" arrow describes the format and "format" describes the "storage location". 
Hence, fixing this. It only updates the documentation. So, no impact to the users.
