### PR TITLE
[DOCS] add client definition to toolkit creation

### DIFF
--- a/docs/ai/integrations/langchain.md
+++ b/docs/ai/integrations/langchain.md
@@ -101,7 +101,7 @@ Here we create an instance of our UC function as a toolkit, then verify that the
 from unitycatalog.ai.langchain.toolkit import UCFunctionToolkit
 
 # Create a UCFunctionToolkit that includes the UC function
-toolkit = UCFunctionToolkit(function_names=[func_name])
+toolkit = UCFunctionToolkit(function_names=[func_name], client=client)
 
 # Fetch the tools stored in the toolkit
 tools = toolkit.tools


### PR DESCRIPTION
When testing the LangChain integration code I ran into the following error when creating the Toolkit instance following the syntax in the docs:

`UC function client is not set.`

Adding the `client=client` to define the UC function client solves the issue. Feedback welcome.