### PR TITLE
Fix serverless session resumption

### DIFF
--- a/.github/workflows/ucai-core-tests.yml
+++ b/.github/workflows/ucai-core-tests.yml
@@ -67,7 +67,7 @@ jobs:
           fi
       - name: Install dependencies
         run: |
-          pip install mlflow
+          pip install mlflow databricks-connect==15.1.0
       - name: Install Unity Catalog Python Libraries
         run: |
           dev/install_client.sh

--- a/.github/workflows/ucai-core-tests.yml
+++ b/.github/workflows/ucai-core-tests.yml
@@ -67,7 +67,7 @@ jobs:
           fi
       - name: Install dependencies
         run: |
-          pip install mlflow databricks-connect==15.1.0
+          pip install mlflow
       - name: Install Unity Catalog Python Libraries
         run: |
           dev/install_client.sh
@@ -76,7 +76,12 @@ jobs:
           dev/start_unitycatalog.sh
       - name: Run Tests
         run: |
-          pytest core/tests
+          pytest core/tests --ignore=core/tests/core/databricks/test_databricks_unit_tests.py
+      - name: Run Databricks Unit Tests
+        if: matrix.python-version == '3.10'
+        run: |
+          pip install databricks-connect==15.1.0
+          pytest core/tests/core/databricks/test_databricks_unit_tests.py
       - name: Stop Unity Catalog Server
         if: always()
         run: |

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -3,7 +3,6 @@ import functools
 import json
 import logging
 import re
-import threading
 import time
 from dataclasses import dataclass
 from decimal import Decimal
@@ -57,8 +56,9 @@ DATABRICKS_CONNECT_VERSION_NOT_SUPPORTED_ERROR_MESSAGE = (
     "to use serverless compute in Databricks. Please note this requires python>=3.10."
 )
 SESSION_RETRY_BASE_DELAY = 1
-SESSION_RETRY_MAX_DELAY = 32
-SESSION_EXCEPTION_MESSAGE = "session_id is no longer usable"
+SESSION_RETRY_MAX_DELAY = 4
+SESSION_EXPIRED_MESSAGE = "session_id is no longer usable"
+SESSION_CHANGED_MESSAGE = "The existing Spark server driver has restarted."
 WAREHOUSE_DEFINED_NOT_SUPPORTED_MESSAGE = (
     "The argument `warehouse_id` was specified, which is no longer supported with "
     "the `DatabricksFunctionClient`. Please omit this argument as it is no longer used. "
@@ -69,9 +69,6 @@ WAREHOUSE_DEFINED_NOT_SUPPORTED_MESSAGE = (
 
 
 _logger = logging.getLogger(__name__)
-
-_classic_workspace_warning_emitted = False
-_classic_workspace_thread_lock = threading.Lock()
 
 
 def get_default_databricks_workspace_client(profile=None) -> "WorkspaceClient":
@@ -94,34 +91,6 @@ def _validate_databricks_connect_available() -> bool:
             raise Exception(DATABRICKS_CONNECT_VERSION_NOT_SUPPORTED_ERROR_MESSAGE)
     except ImportError as e:
         raise Exception(DATABRICKS_CONNECT_IMPORT_ERROR_MESSAGE) from e
-
-
-def _try_get_spark_session_in_dbr() -> Any:
-    global _classic_workspace_warning_emitted
-    try:
-        # if in Databricks, fetch the current active session
-        from databricks.sdk.runtime import spark
-        from pyspark.sql.connect.session import SparkSession
-
-        with _classic_workspace_thread_lock:
-            if (
-                spark is not None
-                and not isinstance(spark, SparkSession)
-                and not _classic_workspace_warning_emitted
-            ):
-                _logger.warning(
-                    f"Current SparkSession {spark} in the active environment is not a "
-                    "pyspark.sql.connect.session.SparkSession instance. Classic runtime does not support "
-                    "all functionalities of the unitycatalog-ai framework. To use the full "
-                    "capabilities of unitycatalog-ai, execute your code using a client that is attached to "
-                    "a Serverless runtime cluster. To learn more about serverless, see the guide at: "
-                    "https://docs.databricks.com/en/compute/serverless/index.html#connect-to-serverless-compute "
-                    "for more details."
-                )
-                _classic_workspace_warning_emitted = True
-        return spark
-    except Exception:
-        return
 
 
 def _is_in_databricks_notebook_environment() -> bool:
@@ -181,34 +150,45 @@ def retry_on_session_expiration(func):
         for attempt in range(1, max_attempts + 1):
             try:
                 result = func(self, *args, **kwargs)
-                # for non-session related error in the result, we should directly return the result
-                if (
-                    isinstance(result, FunctionExecutionResult)
-                    and result.error
-                    and SESSION_EXCEPTION_MESSAGE in result.error
-                ):
-                    raise Exception(result.error)
+                if isinstance(result, FunctionExecutionResult) and result.error:
+                    if any(
+                        msg in result.error
+                        for msg in (SESSION_EXPIRED_MESSAGE, SESSION_CHANGED_MESSAGE)
+                    ):
+                        raise Exception(result.error)
+                    return result
                 return result
             except Exception as e:
                 error_message = str(e)
-                if SESSION_EXCEPTION_MESSAGE in error_message:
+                if any(
+                    msg in error_message
+                    for msg in (SESSION_EXPIRED_MESSAGE, SESSION_CHANGED_MESSAGE)
+                ):
                     if not self._is_default_client:
-                        refresh_message = f"Failed to execute {func.__name__} due to session expiration. Unable to automatically refresh session when using a custom client."
+                        refresh_message = (
+                            f"Failed to execute {func.__name__} due to session expiration. "
+                            "Unable to automatically refresh session when using a custom client."
+                            "Recreate the DatabricksFunctionClient with a new client to recreate "
+                            "the custom client session."
+                        )
                         raise RuntimeError(refresh_message) from e
 
                     if attempt < max_attempts:
                         delay = min(
-                            SESSION_RETRY_BASE_DELAY * (2 ** (attempt - 1)),
-                            SESSION_RETRY_MAX_DELAY,
+                            SESSION_RETRY_BASE_DELAY * (2 ** (attempt - 1)), SESSION_RETRY_MAX_DELAY
                         )
                         _logger.warning(
-                            f"Session expired. Attempt {attempt} of {max_attempts}. Refreshing session and retrying after {delay} seconds..."
+                            f"Session expired. Retrying with attempt {attempt} of {max_attempts}. "
+                            f"Refreshing session and retrying after {delay} seconds..."
                         )
                         self.refresh_client_and_session()
                         time.sleep(delay)
                         continue
                     else:
-                        refresh_failure_message = f"Failed to execute {func.__name__} after {max_attempts} attempts due to session expiration. Generate a new session_id by detaching and reattaching your compute."
+                        refresh_failure_message = (
+                            f"Failed to execute {func.__name__} after {max_attempts} attempts due to session expiration. "
+                            "Generate a new session_id by detaching and reattaching your compute."
+                        )
                         raise RuntimeError(refresh_failure_message) from e
                 else:
                     raise
@@ -239,7 +219,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
         _warn_if_workspace_provided(**kwargs)
         self.client = client or get_default_databricks_workspace_client(profile=profile)
         self.profile = profile
-        self.spark = _try_get_spark_session_in_dbr()
+        self.spark = None
+        self.set_spark_session()
         self._is_default_client = client is None
         super().__init__()
 
@@ -250,16 +231,15 @@ class DatabricksFunctionClient(BaseFunctionClient):
             return not self.spark.is_stopped
         return self.spark.getActiveSession() is not None
 
-    def set_default_spark_session(self):
-        if not self._is_spark_session_active():
-            _validate_databricks_connect_available()
-            from databricks.connect.session import DatabricksSession as SparkSession
+    def set_spark_session(self):
+        _validate_databricks_connect_available()
+        from databricks.connect.session import DatabricksSession as SparkSession
 
-            if self.profile:
-                builder = SparkSession.builder.profile(self.profile)
-            else:
-                builder = SparkSession.builder
-            self.spark = builder.serverless(True).getOrCreate()
+        if self.profile:
+            builder = SparkSession.builder.profile(self.profile)
+        else:
+            builder = SparkSession.builder
+        self.spark = builder.serverless(True).getOrCreate()
 
     def stop_spark_session(self):
         if self._is_spark_session_active():
@@ -273,10 +253,9 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
         _logger.info("Refreshing Databricks client and Spark session due to session expiration.")
         self.client = get_default_databricks_workspace_client(profile=self.profile)
-        if not _is_in_databricks_notebook_environment:
+        if not _is_in_databricks_notebook_environment():
             self.stop_spark_session()
-        self.set_default_spark_session()
-        self.spark = _try_get_spark_session_in_dbr()
+        self.set_spark_session()
 
     @retry_on_session_expiration
     @override
@@ -300,7 +279,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
             FunctionInfo: The created function info.
         """
         if sql_function_body:
-            self.set_default_spark_session()
+            self.set_spark_session()
             # TODO: add timeout
             self.spark.sql(sql_function_body)
             created_function_info = self.get_function(extract_function_name(sql_function_body))
@@ -684,7 +663,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         self, function_info: "FunctionInfo", parameters: Dict[str, Any]
     ) -> FunctionExecutionResult:
         _logger.info("Using databricks connect to execute functions with serverless compute.")
-        self.set_default_spark_session()
+        self.set_spark_session()
 
         parameters = process_function_parameter_defaults(function_info, parameters)
 

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -157,13 +157,15 @@ def retry_on_session_expiration(func):
         for attempt in range(1, max_attempts + 1):
             try:
                 result = func(self, *args, **kwargs)
-                if isinstance(result, FunctionExecutionResult) and result.error:
-                    if any(
+                if (
+                    isinstance(result, FunctionExecutionResult)
+                    and result.error
+                    and any(
                         msg in result.error
                         for msg in (SESSION_EXPIRED_MESSAGE, SESSION_CHANGED_MESSAGE)
-                    ):
-                        raise SessionExpirationException(result.error)
-                    return result
+                    )
+                ):
+                    raise SessionExpirationException(result.error)
                 return result
             except SessionExpirationException as e:
                 if not self._is_default_client:

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -208,7 +208,7 @@ def retry_on_session_expiration(func):
                         time.sleep(delay)
                         continue
                     else:
-                        refresh_failure_message = f"Failed to execute {func.__name__} after {max_attempts} attempts due to session expiration."
+                        refresh_failure_message = f"Failed to execute {func.__name__} after {max_attempts} attempts due to session expiration. Generate a new session_id by detaching and reattaching your compute."
                         raise RuntimeError(refresh_failure_message) from e
                 else:
                     raise
@@ -275,7 +275,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         self.client = get_default_databricks_workspace_client(profile=self.profile)
         if not _is_in_databricks_notebook_environment:
             self.stop_spark_session()
-            self.set_default_spark_session()
+        self.set_default_spark_session()
         self.spark = _try_get_spark_session_in_dbr()
 
     @retry_on_session_expiration

--- a/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
@@ -25,9 +25,19 @@ def client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:
         return DatabricksFunctionClient(profile=PROFILE)
     else:
-        with mock.patch(
-            "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
-            return_value=mock.Mock(),
+        with (
+            mock.patch(
+                "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+                return_value=mock.Mock(),
+            ),
+            mock.patch(
+                "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
+                lambda: True,
+            ),
+            mock.patch(
+                "unitycatalog.ai.core.databricks.DatabricksFunctionClient.set_spark_session",
+                lambda self: None,
+            ),
         ):
             return DatabricksFunctionClient()
 
@@ -41,9 +51,19 @@ def get_client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:
         return DatabricksFunctionClient(profile=PROFILE)
     else:
-        with mock.patch(
-            "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
-            return_value=mock.Mock(),
+        with (
+            mock.patch(
+                "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+                return_value=mock.Mock(),
+            ),
+            mock.patch(
+                "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
+                lambda: True,
+            ),
+            mock.patch(
+                "unitycatalog.ai.core.databricks.DatabricksFunctionClient.set_spark_session",
+                lambda self: None,
+            ),
         ):
             return DatabricksFunctionClient()
 

--- a/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
@@ -31,10 +31,6 @@ def client() -> DatabricksFunctionClient:
                 return_value=mock.Mock(),
             ),
             mock.patch(
-                "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
-                lambda: True,
-            ),
-            mock.patch(
                 "unitycatalog.ai.core.databricks.DatabricksFunctionClient.set_spark_session",
                 lambda self: None,
             ),
@@ -55,10 +51,6 @@ def get_client() -> DatabricksFunctionClient:
             mock.patch(
                 "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
                 return_value=mock.Mock(),
-            ),
-            mock.patch(
-                "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
-                lambda: True,
             ),
             mock.patch(
                 "unitycatalog.ai.core.databricks.DatabricksFunctionClient.set_spark_session",

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -20,7 +20,6 @@ from databricks.sdk.service.catalog import (
     FunctionParameterInfos,
 )
 
-import unitycatalog.ai.core.databricks as dbr
 from unitycatalog.ai.core.databricks import (
     DatabricksFunctionClient,
     extract_function_name,
@@ -34,15 +33,6 @@ from unitycatalog.ai.test_utils.function_utils import (
 )
 
 SCHEMA = os.environ.get("SCHEMA", "ucai_core_test")
-
-
-@pytest.fixture(autouse=True)
-def bypass_sdk_auth_and_spark(monkeypatch):
-    monkeypatch.setattr(
-        dbr,
-        "get_default_databricks_workspace_client",
-        lambda profile=None: MagicMock(name="DummyWorkspaceClient"),
-    )
 
 
 def test_get_function_errors(client: DatabricksFunctionClient):

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -572,7 +572,7 @@ def test_execute_function_success(mock_workspace_client, mock_spark_session, moc
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
 
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
 
     client.get_function = MagicMock(return_value=mock_function_info)
@@ -606,7 +606,7 @@ def test_execute_function_with_retry(mock_workspace_client, mock_spark_session, 
         mock_spark_session.sql.side_effect = side_effect
 
         client = DatabricksFunctionClient(client=mock_workspace_client)
-        client.set_default_spark_session = MagicMock()
+        client.set_spark_session = MagicMock()
         client.spark = mock_spark_session
         client._is_default_client = True
 
@@ -640,7 +640,7 @@ $$
 
         client = DatabricksFunctionClient(client=mock_workspace_client)
         client._is_default_client = True
-        client.set_default_spark_session = MagicMock()
+        client.set_spark_session = MagicMock()
         client.spark = mock_spark_session
 
         mock_function_info = MagicMock()
@@ -672,7 +672,7 @@ AS $$ return 1 $$"""
 
         client = DatabricksFunctionClient(client=mock_workspace_client)
         client._is_default_client = True
-        client.set_default_spark_session = MagicMock()
+        client.set_spark_session = MagicMock()
         client.spark = mock_spark_session
         client.refresh_client_and_session = MagicMock()
 
@@ -689,7 +689,7 @@ def test_no_retry_with_custom_client(mock_workspace_client, mock_spark_session, 
     mock_spark_session.sql.side_effect = Exception("session_id is no longer usable")
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client._is_default_client = False
 
@@ -765,7 +765,7 @@ def test_execute_function_with_mock_string_input(
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
 
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=mock_function_info)
 
@@ -817,7 +817,7 @@ greet("World")"""
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
 
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
 
     client.get_function = MagicMock(return_value=mock_function_info)
@@ -865,7 +865,7 @@ def test_execute_function_with_variant_input(
     expected_args = {"a": 10}
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=mock_function_info)
 
@@ -911,7 +911,7 @@ def test_execute_function_warnings_missing_descriptions(mock_workspace_client, m
     )
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=func_info)
 
@@ -1093,7 +1093,7 @@ def test_create_wrapped_function_databricks(mock_workspace_client, mock_spark_se
             DatabricksFunctionClient, "create_function", return_value="dummy_func_info"
         ) as mock_create_func:
             client = DatabricksFunctionClient(client=mock_workspace_client)
-            client.set_default_spark_session = MagicMock()
+            client.set_spark_session = MagicMock()
             client.spark = mock_spark_session
 
             result = client.create_wrapped_function(
@@ -1128,7 +1128,7 @@ def test_create_wrapped_function_with_dependencies(mock_workspace_client, mock_s
             DatabricksFunctionClient, "create_function", return_value="dummy_func_info"
         ) as mock_create_func:
             client = DatabricksFunctionClient(client=mock_workspace_client)
-            client.set_default_spark_session = MagicMock()
+            client.set_spark_session = MagicMock()
             client.spark = mock_spark_session
 
             result = client.create_wrapped_function(
@@ -1213,7 +1213,7 @@ def test_execute_function_with_default_params_databricks(mock_workspace_client, 
     )
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=dummy_func_info)
 
@@ -1285,7 +1285,7 @@ def test_execute_function_with_all_defaults_databricks(mock_workspace_client, mo
     )
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=dummy_func_info)
 
@@ -1327,7 +1327,7 @@ def test_execute_function_no_params_databricks(mock_workspace_client, mock_spark
     )
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=dummy_func_info)
 
@@ -1377,7 +1377,7 @@ def test_execute_function_with_none_default_databricks(mock_workspace_client, mo
     )
 
     client = DatabricksFunctionClient(client=mock_workspace_client)
-    client.set_default_spark_session = MagicMock()
+    client.set_spark_session = MagicMock()
     client.spark = mock_spark_session
     client.get_function = MagicMock(return_value=dummy_func_info)
 

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -20,6 +20,7 @@ from databricks.sdk.service.catalog import (
     FunctionParameterInfos,
 )
 
+import unitycatalog.ai.core.databricks as dbr
 from unitycatalog.ai.core.databricks import (
     DatabricksFunctionClient,
     extract_function_name,
@@ -33,6 +34,15 @@ from unitycatalog.ai.test_utils.function_utils import (
 )
 
 SCHEMA = os.environ.get("SCHEMA", "ucai_core_test")
+
+
+@pytest.fixture(autouse=True)
+def bypass_sdk_auth_and_spark(monkeypatch):
+    monkeypatch.setattr(
+        dbr,
+        "get_default_databricks_workspace_client",
+        lambda profile=None: MagicMock(name="DummyWorkspaceClient"),
+    )
 
 
 def test_get_function_errors(client: DatabricksFunctionClient):


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR forces the SparkSession (triggered by the call to `set_default_spark_session` and the call to the builder to reconnect to the serverless instance in the case of session or cluster invalidation) to rebuild the spark session in accordance with recommendations of the serverless team. Also, in the event that the retry logic is exhausted, provide guidance for notebook users on how they can quickly get back up and running by detaching and reattaching their notebook to an active serverless cluster instance. 