### PR TITLE
Fix Anthropic and OpenAI utils tests

### DIFF
--- a/ai/integrations/anthropic/tests/test_anthropic_utils.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_utils.py
@@ -282,9 +282,19 @@ def test_generate_tool_call_messages_with_invalid_tool_use_block(mock_client, du
 def test_generate_tool_call_messages_with_tracing(
     dummy_history, format, function_output, data_type, full_data_type, return_params
 ):
-    with mock.patch(
-        "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
-        return_value=mock.Mock(),
+    with (
+        mock.patch(
+            "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+            return_value=mock.Mock(),
+        ),
+        mock.patch(
+            "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
+            return_value=True,
+        ),
+        mock.patch(
+            "unitycatalog.ai.core.databricks.DatabricksFunctionClient.initialize_spark_session",
+            return_value=None,
+        ),
     ):
         function_mock = Mock(
             spec=FunctionInfo,

--- a/ai/integrations/openai/tests/test_openai_utils.py
+++ b/ai/integrations/openai/tests/test_openai_utils.py
@@ -21,9 +21,19 @@ from unitycatalog.ai.test_utils.function_utils import (
 
 @pytest.fixture
 def client() -> DatabricksFunctionClient:
-    with mock.patch(
-        "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
-        return_value=mock.Mock(),
+    with (
+        mock.patch(
+            "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+            return_value=mock.Mock(),
+        ),
+        mock.patch(
+            "unitycatalog.ai.core.databricks._validate_databricks_connect_available",
+            return_value=True,
+        ),
+        mock.patch(
+            "unitycatalog.ai.core.databricks.DatabricksFunctionClient.initialize_spark_session",
+            return_value=None,
+        ),
     ):
         return DatabricksFunctionClient()
 


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

After merging both the dbconnect pin restriction AND the serverless retry logic, it turns out that we need another patch for the spark session initialization in the utils patch fixtures.