### PR TITLE
Propagate Workspace Client Config to DB Connect

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -276,6 +276,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
             self.spark.stop()
 
     def initialize_spark_session(self):
+        print("INITIALIZING SPARK SESSION")
         """
         Initialize the spark session with serverless compute.
         This method is called when the spark session is not active.
@@ -283,10 +284,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
         _validate_databricks_connect_available()
 
         from databricks.connect.session import DatabricksSession as SparkSession
-
+        print(self.client)
         if self.profile:
             builder = SparkSession.builder.profile(self.profile)
         elif self.client is not None:
+            print("SETTING CLIENT")
             config = self.client.config
             config.as_dict().pop("cluster_id", None)
             config.serverless_compute_id = "auto" # Setting Serverless to true by adding "auto"

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -286,7 +286,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
         from databricks.connect.session import DatabricksSession as SparkSession
         print(self.client)
         if self.profile:
-            builder = SparkSession.builder.profile(self.profile)
+            builder = SparkSession.builder.profile(self.profile).serverless(True)
         elif self.client is not None:
             print("SETTING CLIENT")
             config = self.client.config
@@ -294,8 +294,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
             config.serverless_compute_id = "auto" # Setting Serverless to true by adding "auto"
             builder = SparkSession.builder.sdkConfig(config)
         else:
-            builder = SparkSession.builder
-        self.spark = builder.serverless(True).getOrCreate()
+            builder = SparkSession.builder.serverless(True)
+        self.spark = builder.getOrCreate()
 
     def refresh_client_and_session(self):
         """

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -286,6 +286,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
 
         if self.profile:
             builder = SparkSession.builder.profile(self.profile)
+        elif self.client is not None:
+            config = self.client.config
+            config.as_dict().pop("cluster_id", None)
+            config.serverless_compute_id = "auto" # Setting Serverless to true by adding "auto"
+            builder = SparkSession.builder.sdkConfig(config)
         else:
             builder = SparkSession.builder
         self.spark = builder.serverless(True).getOrCreate()

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -276,7 +276,6 @@ class DatabricksFunctionClient(BaseFunctionClient):
             self.spark.stop()
 
     def initialize_spark_session(self):
-        print("INITIALIZING SPARK SESSION")
         """
         Initialize the spark session with serverless compute.
         This method is called when the spark session is not active.
@@ -284,14 +283,13 @@ class DatabricksFunctionClient(BaseFunctionClient):
         _validate_databricks_connect_available()
 
         from databricks.connect.session import DatabricksSession as SparkSession
-        print(self.client)
+
         if self.profile:
             builder = SparkSession.builder.profile(self.profile).serverless(True)
         elif self.client is not None:
-            print("SETTING CLIENT")
             config = self.client.config
             config.as_dict().pop("cluster_id", None)
-            config.serverless_compute_id = "auto" # Setting Serverless to true by adding "auto"
+            config.serverless_compute_id = "auto"  # Setting Serverless to true by adding "auto"
             builder = SparkSession.builder.sdkConfig(config)
         else:
             builder = SparkSession.builder.serverless(True)

--- a/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
@@ -42,12 +42,18 @@ def client() -> DatabricksFunctionClient:
 def serverless_client() -> DatabricksFunctionClient:
     return DatabricksFunctionClient(profile=PROFILE)
 
+
 @pytest.fixture
 def serverless_client_with_config() -> DatabricksFunctionClient:
     from databricks.sdk import WorkspaceClient
-    
-    w = WorkspaceClient(host = os.environ.get("DATABRICKS_HOST"), client_id =os.environ.get("DATABRICKS_CLIENT_ID"), client_secret = os.environ.get("DATABRICKS_CLIENT_SECRET"))
+
+    w = WorkspaceClient(
+        host=os.environ.get("DATABRICKS_HOST"),
+        client_id=os.environ.get("DATABRICKS_CLIENT_ID"),
+        client_secret=os.environ.get("DATABRICKS_CLIENT_SECRET"),
+    )
     return DatabricksFunctionClient(client=w)
+
 
 def get_client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:

--- a/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/test_utils/client_utils.py
@@ -42,6 +42,12 @@ def client() -> DatabricksFunctionClient:
 def serverless_client() -> DatabricksFunctionClient:
     return DatabricksFunctionClient(profile=PROFILE)
 
+@pytest.fixture
+def serverless_client_with_config() -> DatabricksFunctionClient:
+    from databricks.sdk import WorkspaceClient
+    
+    w = WorkspaceClient(host = os.environ.get("DATABRICKS_HOST"), client_id =os.environ.get("DATABRICKS_CLIENT_ID"), client_secret = os.environ.get("DATABRICKS_CLIENT_SECRET"))
+    return DatabricksFunctionClient(client=w)
 
 def get_client() -> DatabricksFunctionClient:
     if TEST_IN_DATABRICKS:

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -762,7 +762,7 @@ def test_execute_function_with_custom_client(
             assert result.value == function_sample.output
 
         # Client with fake config should fail as expected
-        function_info = serverless_client.get_function()
+        function_info = serverless_client.get_function(func_name)
         from databricks.sdk import WorkspaceClient
 
         w = WorkspaceClient(

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -744,12 +744,12 @@ def test_execute_function_in_local_sandbox(client: DatabricksFunctionClient):
 @requires_databricks
 def test_execute_function_with_custom_client(
     serverless_client: DatabricksFunctionClient,
-    serverless_client_with_config: DatabricksFunctionClient
+    serverless_client_with_config: DatabricksFunctionClient,
 ):
     with generate_func_name_and_cleanup(serverless_client, schema=SCHEMA) as func_name:
         function_sample = function_with_string_input(func_name)
         serverless_client.create_function(sql_function_body=function_sample.sql_body)
-        
+
         # Client which created the function should execute successfully
         for input_example in function_sample.inputs:
             result = serverless_client.execute_function(func_name, input_example)
@@ -763,11 +763,13 @@ def test_execute_function_with_custom_client(
         # Client with fake config should fail as expected
         function_info = serverless_client.get_function()
         from databricks.sdk import WorkspaceClient
-    
-        w = WorkspaceClient(host = os.environ.get("DATABRICKS_HOST"), client_id ="fake_id", client_secret = "fake_secret")
-        unauthorized_client =  DatabricksFunctionClient(client=w)
+
+        w = WorkspaceClient(
+            host=os.environ.get("DATABRICKS_HOST"), client_id="fake_id", client_secret="fake_secret"
+        )
+        unauthorized_client = DatabricksFunctionClient(client=w)
 
         for input_example in function_sample.inputs:
             # Calling `execute_uc_function` call directly to skip the get_function call and check if config is passed into DB Connect correctly
             result = unauthorized_client._execute_uc_function(function_info, input_example)
-            assert result.value == function_sample.output
+            assert result.error is not None  # Should error out

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -43,6 +43,7 @@ from unitycatalog.ai.test_utils.client_utils import (
     requires_databricks,
     retry_flaky_test,
     serverless_client,  # noqa: F401
+    serverless_client_with_config,  # noqa: F401
 )
 from unitycatalog.ai.test_utils.function_utils import (
     CATALOG,

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -774,3 +774,4 @@ def test_execute_function_with_custom_client(
             # Calling `execute_uc_function` call directly to skip the get_function call and check if config is passed into DB Connect correctly
             result = unauthorized_client._execute_uc_function(function_info, input_example)
             assert result.error is not None  # Should error out
+            assert "RETRIES_EXCEEDED" in result.error


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
In this PR, if a client is defined, the config is propagated to the Databricks Session. This is done by setting the `sdkConfig` parameter. However this parameter cannot be set when serverless is set to True. So we first alter the config and set serverless to auto, which has the same effect as setting `serverless` to True on Databricks Session. 

<!-- Please state what you've changed and how it might affect the users. -->
