### PR TITLE
Uc function client invoker access

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -579,13 +579,18 @@ class DatabricksFunctionClient(BaseFunctionClient):
         Returns:
             FunctionInfo: The function info.
         """
+        from databricks.sdk.errors.platform import PermissionDenied
+
         full_func_name = FullFunctionName.validate_full_function_name(function_name)
         if "*" in full_func_name.function:
             raise ValueError(
                 "function name cannot include *, to get all functions in a catalog and schema, "
                 "please use list_functions API instead."
             )
-        return self.client.functions.get(function_name)
+        try:
+            return self.client.functions.get(function_name)
+        except PermissionDenied as e:
+            raise PermissionError(f"Permission denied: {e}") from e
 
     @override
     def list_functions(

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -199,9 +199,10 @@ def process_function_names(
                     if token is None:
                         break
             else:
-                tools_dict[name] = uc_function_to_tool_func(
-                    function_name=name, client=client, **kwargs
-                )
+                tool = uc_function_to_tool_func(function_name=name, client=client, **kwargs)
+                # Skip adding this tool if this function returns None
+                if tool:
+                    tools_dict[name] = tool
     return tools_dict
 
 

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
@@ -339,3 +339,41 @@ def test_anthropic_tool_definition_generation():
                 "required": [],
             },
         }
+
+
+@pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def test_uc_function_to_anthropic_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_anthropic_tool(
+                client=client,
+                function_name="code",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_anthropic_tool(
+                    client=client,
+                    function_name="code",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_anthropic_tool(
+                client=client,
+                function_name="code",
+                filter_accessible_functions=filter_accessible_functions,
+            )

--- a/ai/integrations/autogen/tests/test_autogen_toolkit.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit.py
@@ -228,6 +228,44 @@ async def test_uc_function_to_autogen_tool(dbx_client):
         assert result == "some_string"
 
 
+@pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def test_uc_function_to_autogen_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_autogen_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_autogen_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_autogen_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+
+
 @pytest.mark.skipif(
     skip_mlflow_test, reason="MLflow autologging is not supported for autogen_core 0.4.0 and above."
 )

--- a/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
+++ b/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
@@ -132,7 +132,8 @@ class UCFunctionToolkit(BaseModel):
         description_updated: Optional[bool] = False,
         cache_function: Callable = lambda _args, _result: True,
         result_as_answer: bool = False,
-        filter_accessible_functions: bool = False**kwargs,
+        filter_accessible_functions: bool = False,
+        **kwargs,
     ) -> Optional[CrewAIBaseTool]:
         """
         Converts a Unity Catalog function into a CrewAI tool.

--- a/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
+++ b/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
@@ -82,6 +82,10 @@ class UCFunctionToolkit(BaseModel):
         default=None,
         description="Client for managing functions",
     )
+    filter_accessible_functions: bool = Field(
+        default=False,
+        description="When set to true, UCFunctionToolkit is initialized with functions that only the client has access to",
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -112,6 +116,7 @@ class UCFunctionToolkit(BaseModel):
             function_names=self.function_names,
             tools_dict=self.tools_dict,
             client=self.client,
+            filter_accessible_functions=self.filter_accessible_functions,
             uc_function_to_tool_func=self.uc_function_to_crewai_tool,
             description_updated=self.description_updated,
             cache_function=self.cache_function,
@@ -127,8 +132,8 @@ class UCFunctionToolkit(BaseModel):
         description_updated: Optional[bool] = False,
         cache_function: Callable = lambda _args, _result: True,
         result_as_answer: bool = False,
-        **kwargs,
-    ) -> CrewAIBaseTool:
+        filter_accessible_functions: bool = False**kwargs,
+    ) -> Optional[CrewAIBaseTool]:
         """
         Converts a Unity Catalog function into a CrewAI tool.
 
@@ -148,7 +153,13 @@ class UCFunctionToolkit(BaseModel):
 
         if function_name is None:
             raise ValueError("function_name must be provided.")
-        function_info = client.get_function(function_name)
+        try:
+            function_info = client.get_function(function_name)
+        except PermissionError as e:
+            _logger.info(f"Skipping {function_name} due to permission errors.")
+            if filter_accessible_functions:
+                return None
+            raise e
 
         def func(**kwargs: Any) -> str:
             args_json = json.loads(json.dumps(kwargs, default=str))

--- a/ai/integrations/crewai/tests/test_crewai_toolkit.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit.py
@@ -179,6 +179,44 @@ def test_uc_function_to_crewai_tool(client):
 
 
 @pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def test_uc_function_to_crewai_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_crewai_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_crewai_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_crewai_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+
+
+@pytest.mark.parametrize(
     "format,function_output",
     [
         ("SCALAR", RETRIEVER_OUTPUT_SCALAR),

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -244,6 +244,44 @@ def test_uc_function_to_gemini_tool(client):
         assert result == "some_string"
 
 
+@pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def test_uc_function_to_gemini_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_gemini_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_gemini_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_gemini_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+
+
 @requires_databricks
 def test_gemini_tool_calling_with_trace_as_retriever():
     client = get_client()

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -207,6 +207,44 @@ def test_uc_function_to_langchain_tool():
 
 
 @pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def test_uc_function_to_langchain_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_langchain_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_langchain_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_langchain_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+
+
+@pytest.mark.parametrize(
     "format,function_output",
     [
         ("SCALAR", RETRIEVER_OUTPUT_SCALAR),

--- a/ai/integrations/litellm/tests/test_litellm_toolkit.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit.py
@@ -100,6 +100,7 @@ def test_uc_function_to_litellm_tool(function_info, client):
         )
         assert tool["name"] == function_name.replace(".", "__")
 
+
 @pytest.mark.parametrize(
     "filter_accessible_functions",
     [True, False],
@@ -136,7 +137,8 @@ def uc_function_to_litellm_tool_permission_denied(filter_accessible_functions):
                 function_name=f"{CATALOG}.{SCHEMA}.test",
                 filter_accessible_functions=filter_accessible_functions,
             )
-            
+
+
 @pytest.mark.parametrize("execution_mode", ["serverless", "local"])
 @requires_databricks
 def test_toolkit_e2e(execution_mode):

--- a/ai/integrations/litellm/tests/test_litellm_toolkit.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit.py
@@ -100,7 +100,43 @@ def test_uc_function_to_litellm_tool(function_info, client):
         )
         assert tool["name"] == function_name.replace(".", "__")
 
-
+@pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def uc_function_to_litellm_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_litellm_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_litellm_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_litellm_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            
 @pytest.mark.parametrize("execution_mode", ["serverless", "local"])
 @requires_databricks
 def test_toolkit_e2e(execution_mode):

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
@@ -279,6 +279,44 @@ def test_uc_function_to_llama_tool(client):
         assert result == "some_string"
 
 
+@pytest.mark.parametrize(
+    "filter_accessible_functions",
+    [True, False],
+)
+def uc_function_to_llama_tool_permission_denied(filter_accessible_functions):
+    client = get_client()
+    # Permission Error should be caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=PermissionError("Permission Denied to Underlying Assets"),
+    ):
+        if filter_accessible_functions:
+            tool = UCFunctionToolkit.uc_function_to_llama_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+            assert tool == None
+        else:
+            with pytest.raises(PermissionError):
+                tool = UCFunctionToolkit.uc_function_to_llama_tool(
+                    client=client,
+                    function_name=f"{CATALOG}.{SCHEMA}.test",
+                    filter_accessible_functions=filter_accessible_functions,
+                )
+    # Other errors should not be Caught
+    with mock.patch(
+        "unitycatalog.ai.core.databricks.DatabricksFunctionClient.get_function",
+        side_effect=ValueError("Wrong Get Function Call"),
+    ):
+        with pytest.raises(ValueError):
+            tool = UCFunctionToolkit.uc_function_to_llama_tool(
+                client=client,
+                function_name=f"{CATALOG}.{SCHEMA}.test",
+                filter_accessible_functions=filter_accessible_functions,
+            )
+
+
 def test_toolkit_with_invalid_function_input(client):
     """Test toolkit with invalid input parameters for function conversion."""
     mock_function_info = generate_function_info()


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

This pr introduces a new flag `filter_accessible_functions` to UCFunctionToolkit. When set to true and a client's get function throws a permission error, this function is skipped when adding to UCFunctionToolkit
