### PR TITLE
fix: only login to docker hub on tag push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,6 +33,7 @@ jobs:
           images: ${{ env.IMAGE }}
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-          # Use registry caching: https://tinyurl.com/4b8mfexr
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+          # Use github actions cache: https://docs.docker.com/build/cache/backends/gha/
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes the `docker-build.yml` GitHub workflow to only login to DockerHub on `push` with tags, ie. a release by a maintainer. Previously was failing because repository secrets are not available in PRs from forks. Also uses Github Actions cache for image builds, because DockerHub would require login. 
