### PR TITLE
Remove ancient package dependency

### DIFF
--- a/ai/core/pyproject.toml
+++ b/ai/core/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.9"
 dependencies = [
   "typing_extensions",
   "pydantic",
-  "asyncio",
   "nest_asyncio",
   "unitycatalog-client",
   "cloudpickle",


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

We shouldn't be including the old asyncio dependency in the build as it is incompatible with Python 3.13. The functionality of this library was merged many years ago into the core asyncio built-in provided asyncio module within base Python.