### PR TITLE
Add default client inference with Toolkit creation

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/client_utils.py
@@ -1,6 +1,30 @@
+import logging
 from typing import Optional
 
-from unitycatalog.ai.core.base import BaseFunctionClient, get_uc_function_client
+from unitycatalog.ai.core.base import (
+    BaseFunctionClient,
+    get_uc_function_client,
+    set_uc_function_client,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def _is_databricks_client_available():
+    """
+    Checks if the connection requirements to attach to a Databricks serverless cluster
+    are available in the environment for automatic client selection purposes in
+    toolkit instantiation.
+    Returns:
+        bool: True if the requirements are available, False otherwise.
+    """
+    try:
+        from databricks.connect.session import DatabricksSession
+
+        if hasattr(DatabricksSession.builder, "serverless"):
+            return True
+    except Exception:
+        return False
 
 
 def validate_or_set_default_client(client: Optional[BaseFunctionClient] = None):
@@ -9,6 +33,8 @@ def validate_or_set_default_client(client: Optional[BaseFunctionClient] = None):
     If a client is provided, it returns the client. If not, it attempts to retrieve
     the default client using `get_uc_function_client()`. Raises a `ValueError` if no
     client is available.
+    If a client can be created automatically to connect to Databricks, a default client
+    is set to connect to Databricks.
     Args:
         client (Optional[BaseFunctionClient]): The client to validate or set.
             Defaults to None.
@@ -17,7 +43,24 @@ def validate_or_set_default_client(client: Optional[BaseFunctionClient] = None):
     Raises:
         ValueError: If no client is provided and no default client is available.
     """
+
     client = client or get_uc_function_client()
+    if client is None and _is_databricks_client_available():
+        try:
+            from unitycatalog.ai.core.databricks import DatabricksFunctionClient
+
+            client = DatabricksFunctionClient()
+            set_uc_function_client(client)
+
+            _logger.info(
+                "Client has been set to DatabricksFunctionClient with default configuration."
+            )
+        except Exception as e:
+            raise ValueError(
+                "Attempted to set DatabricksFunctionClient as the default client, but encountered an error."
+                "Provide a client directly to your toolkit invocation to ensure connection to Unity Catalog."
+            ) from e
+
     if client is None:
         raise ValueError(
             "No client provided, either set the client when creating a "

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit.py
@@ -11,7 +11,7 @@ from databricks.sdk.service.catalog import (
 )
 
 from unitycatalog.ai.anthropic.toolkit import UCFunctionToolkit
-from unitycatalog.ai.core.base import set_uc_function_client
+from unitycatalog.ai.core.base import get_uc_function_client, set_uc_function_client
 from unitycatalog.ai.core.databricks import ExecutionMode
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
 from unitycatalog.ai.test_utils.client_utils import (
@@ -268,11 +268,10 @@ def test_tool_calling_with_multiple_tools_anthropic(execution_mode):
 def test_anthropic_toolkit_initialization():
     client = get_client()
 
-    with pytest.raises(
-        ValueError,
-        match=r"No client provided, either set the client when creating a toolkit or set the default client",
-    ):
-        toolkit = UCFunctionToolkit(function_names=[])
+    assert not get_uc_function_client()
+    toolkit = UCFunctionToolkit(function_names=[])
+    assert get_uc_function_client() is not None
+    set_uc_function_client(None)
 
     set_uc_function_client(client)
     toolkit = UCFunctionToolkit(function_names=[])

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
@@ -332,9 +332,15 @@ async def test_tool_calling_with_multiple_tools_anthropic(uc_client, execution_m
 
 @pytest.mark.asyncio
 async def test_anthropic_toolkit_initialization(uc_client):
-    with pytest.raises(
-        ValidationError,
-        match=r"No client provided, either set the client when creating a toolkit or set the default client",
+    with (
+        mock.patch(
+            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            return_value=False,
+        ),
+        pytest.raises(
+            ValidationError,
+            match=r"No client provided, either set the client when creating a toolkit or set the default client",
+        ),
     ):
         toolkit = UCFunctionToolkit(function_names=[])
 

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
@@ -104,6 +104,18 @@ async def uc_client():
     await uc_api_client.close()
 
 
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=r"No client provided, either set the client when creating a toolkit or set the default client",
+    ):
+        UCFunctionToolkit(function_names=["test.test.test"])
+
+
 @pytest.mark.parametrize("execution_mode", ["local", "sandbox"])
 @pytest.mark.asyncio
 async def test_tool_calling_with_anthropic(uc_client, execution_mode):

--- a/ai/integrations/anthropic/tests/test_anthropic_utils.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_utils.py
@@ -209,8 +209,13 @@ def test_generate_tool_call_messages_validate_default_client(
     mock_message_single_tool, dummy_history
 ):
     client = None
-
-    with pytest.raises(ValueError, match="No client provided"):
+    with (
+        mock.patch(
+            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            return_value=False,
+        ),
+        pytest.raises(ValueError, match="No client provided"),
+    ):
         generate_tool_call_messages(
             response=mock_message_single_tool, conversation_history=dummy_history, client=client
         )
@@ -282,6 +287,14 @@ def test_generate_tool_call_messages_with_invalid_tool_use_block(mock_client, du
 def test_generate_tool_call_messages_with_tracing(
     dummy_history, format, function_output, data_type, full_data_type, return_params
 ):
+    if not TEST_IN_DATABRICKS:
+        patch_registry = mock.patch(
+            "mlflow.tracking._model_registry.utils._get_registry_uri_from_spark_session",
+            return_value="databricks-uc",
+        )
+    else:
+        patch_registry = mock.nullcontext()
+
     with (
         mock.patch(
             "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
@@ -295,6 +308,11 @@ def test_generate_tool_call_messages_with_tracing(
             "unitycatalog.ai.core.databricks.DatabricksFunctionClient.initialize_spark_session",
             return_value=None,
         ),
+        mock.patch(
+            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            return_value=False,
+        ),
+        patch_registry,
     ):
         function_mock = Mock(
             spec=FunctionInfo,

--- a/ai/integrations/autogen/tests/test_autogen_toolkit.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit.py
@@ -167,14 +167,6 @@ async def test_multiple_toolkits(dbx_client, execution_mode):
         assert result1 == result2
 
 
-def test_toolkit_creation_errors_no_client():
-    """
-    Example: if you didn't set a default client or pass one in, raises an error.
-    """
-    with pytest.raises(ValidationError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
-
-
 def test_toolkit_creation_errors_bad_client():
     """
     If you pass `client="client"` instead of a real BaseFunctionClient, you get a ValidationError.

--- a/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
@@ -181,12 +181,16 @@ async def test_multiple_toolkits(uc_client, execution_mode):
         assert result1 == result2
 
 
-def test_toolkit_creation_errors_no_client():
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
     with pytest.raises(
         ValidationError,
         match=r"No client provided, either set the client when creating a toolkit or set the default client",
     ):
-        UCFunctionToolkit(function_names=[])
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 def test_toolkit_creation_errors_invalid_client(uc_client):

--- a/ai/integrations/crewai/tests/test_crewai_toolkit.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit.py
@@ -103,9 +103,6 @@ def test_multiple_toolkits(execution_mode):
 
 
 def test_toolkit_creation_errors():
-    with pytest.raises(ValidationError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
-
     with pytest.raises(ValidationError, match=r"Input should be an instance of BaseFunctionClient"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
@@ -113,13 +113,16 @@ async def test_multiple_toolkits(uc_client, execution_mode):
         assert result1 == result2
 
 
-def test_toolkit_creation_errors_no_client():
-    """Test that UCFunctionToolkit raises ValidationError when no client is provided."""
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
     with pytest.raises(
         ValidationError,
         match=r"No client provided, either set the client when creating a toolkit or set the default client",
     ):
-        UCFunctionToolkit(function_names=[])
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 def test_toolkit_creation_errors_invalid_client(uc_client):

--- a/ai/integrations/gemini/tests/test_gemini_toolkit.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit.py
@@ -139,9 +139,6 @@ def test_multiple_toolkits(execution_mode):
 
 
 def test_toolkit_creation_errors():
-    with pytest.raises(ValidationError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
-
     with pytest.raises(ValidationError, match=r"Input should be an instance of BaseFunctionClient"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -169,12 +169,16 @@ async def test_multiple_toolkits(uc_client, execution_mode):
         assert result1 == result2
 
 
-def test_toolkit_creation_errors_no_client():
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
     with pytest.raises(
         ValidationError,
         match=r"No client provided, either set the client when creating a toolkit or set the default client",
     ):
-        UCFunctionToolkit(function_names=[])
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 def test_toolkit_creation_errors_invalid_client(uc_client):

--- a/ai/integrations/langchain/tests/test_langchain_toolkit.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit.py
@@ -143,9 +143,6 @@ def test_multiple_toolkits(execution_mode):
 
 
 def test_toolkit_creation_errors():
-    with pytest.raises(ValueError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
-
     with pytest.raises(ValueError, match=r"instance of BaseFunctionClient expected"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
@@ -160,10 +160,19 @@ async def test_multiple_toolkits(uc_client, execution_mode):
         )
 
 
-def test_toolkit_creation_errors(uc_client):
-    with pytest.raises(ValueError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
 
+    with pytest.raises(
+        ValueError,
+        match=r"No client provided, either set the client when creating a toolkit or set the default client",
+    ):
+        UCFunctionToolkit(function_names=["test.test.test"])
+
+
+def test_toolkit_creation_errors(uc_client):
     with pytest.raises(ValueError, match=r"instance of BaseFunctionClient expected"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/litellm/tests/test_litellm_toolkit.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit.py
@@ -149,9 +149,6 @@ def test_multiple_toolkits():
 
 
 def test_toolkit_creation_errors():
-    with pytest.raises(ValidationError, match="No client provided"):
-        UCFunctionToolkit(function_names=[])
-
     with pytest.raises(ValidationError, match="Input should be an instance of BaseFunctionClient"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
@@ -91,13 +91,16 @@ async def test_multiple_toolkits(uc_client, execution_mode):
         assert all(isinstance(toolkit.tools[0], dict) for toolkit in toolkits)
 
 
-def test_toolkit_creation_errors_no_client():
-    """Test that UCFunctionToolkit raises ValidationError when no client is provided."""
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
     with pytest.raises(
         ValidationError,
         match=r"No client provided, either set the client when creating a toolkit or set the default client",
     ):
-        UCFunctionToolkit(function_names=[])
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 def test_toolkit_creation_errors_invalid_client(uc_client):

--- a/ai/integrations/litellm/tests/test_litellm_utils.py
+++ b/ai/integrations/litellm/tests/test_litellm_utils.py
@@ -332,8 +332,12 @@ def test_generate_tool_call_messages_no_tool_use(
 
 
 def test_generate_tool_call_messages_validate_default_client(
-    mock_message_single_tool, dummy_history
+    mock_message_single_tool, dummy_history, monkeypatch
 ):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+        lambda: False,
+    )
     client = None
 
     with pytest.raises(ValueError, match="No client provided"):

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit.py
@@ -202,9 +202,6 @@ def test_multiple_toolkits(execution_mode):
 
 
 def test_toolkit_creation_errors():
-    with pytest.raises(ValidationError, match=r"No client provided"):
-        UCFunctionToolkit(function_names=[])
-
     with pytest.raises(ValidationError, match=r"Input should be an instance of BaseFunctionClient"):
         UCFunctionToolkit(function_names=[], client="client")
 

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 from databricks.sdk.service.catalog import ColumnTypeName
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from unitycatalog.ai.core.base import (
     BaseFunctionClient,
@@ -119,6 +119,18 @@ def generate_mock_function_info(has_properties: bool = False) -> FunctionInfo:
 
 def generate_mock_execution_result(return_value: str = "result") -> FunctionExecutionResult:
     return FunctionExecutionResult(format="SCALAR", value=return_value)
+
+
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=r"No client provided, either set the client when creating a toolkit or set the default client",
+    ):
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 @pytest.mark.asyncio

--- a/ai/integrations/openai/tests/test_openai_toolkit.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit.py
@@ -13,7 +13,6 @@ from databricks.sdk.service.catalog import (
 from openai.types.chat.chat_completion_message_tool_call import Function
 
 from tests.helper_functions import mock_chat_completion_response, mock_choice
-from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.databricks import ExecutionMode
 from unitycatalog.ai.core.utils.function_processing_utils import get_tool_name
 from unitycatalog.ai.core.utils.validation_utils import has_retriever_signature
@@ -395,23 +394,6 @@ $$
         arguments = json.loads(tool_call.function.arguments)
         result = client.execute_function(upper_func, arguments)
         assert result.value == "ABC"
-
-
-def test_openai_toolkit_initialization():
-    client = get_client()
-    with pytest.raises(
-        ValueError,
-        match=r"No client provided, either set the client when creating a toolkit or set the default client",
-    ):
-        toolkit = UCFunctionToolkit(function_names=[])
-
-    set_uc_function_client(client)
-    toolkit = UCFunctionToolkit(function_names=[])
-    assert len(toolkit.tools) == 0
-    set_uc_function_client(None)
-
-    toolkit = UCFunctionToolkit(function_names=[], client=client)
-    assert len(toolkit.tools) == 0
 
 
 def generate_function_info(parameters: List[Dict], catalog="catalog", schema="schema"):

--- a/ai/integrations/openai/tests/test_openai_toolkit_oss.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit_oss.py
@@ -7,9 +7,9 @@ import openai
 import pytest
 import pytest_asyncio
 from openai.types.chat.chat_completion_message_tool_call import Function
+from pydantic import ValidationError
 
 from tests.helper_functions import mock_chat_completion_response, mock_choice
-from unitycatalog.ai.core.base import set_uc_function_client
 from unitycatalog.ai.core.client import (
     ExecutionMode,
     UnitycatalogFunctionClient,
@@ -279,21 +279,16 @@ async def test_tool_choice_param(uc_client):
         assert result.value == "ABC"
 
 
-@pytest.mark.asyncio
-async def test_openai_toolkit_initialization(uc_client):
+def test_toolkit_creation_errors_no_client(monkeypatch):
+    monkeypatch.setattr(
+        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+    )
+
     with pytest.raises(
-        ValueError,
+        ValidationError,
         match=r"No client provided, either set the client when creating a toolkit or set the default client",
     ):
-        toolkit = UCFunctionToolkit(function_names=[])
-
-    set_uc_function_client(uc_client)
-    toolkit = UCFunctionToolkit(function_names=[])
-    assert len(toolkit.tools) == 0
-    set_uc_function_client(None)
-
-    toolkit = UCFunctionToolkit(function_names=[], client=uc_client)
-    assert len(toolkit.tools) == 0
+        UCFunctionToolkit(function_names=["test.test.test"])
 
 
 def generate_function_info(parameters: List[Dict], catalog="catalog", schema="schema"):


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds the ability to assume a default serverless client for UCFunctionToolkit instances if the required connectivity packages are installed in the system.