### PR TITLE
Set default client in get_uc_function_client

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/base.py
+++ b/ai/core/src/unitycatalog/ai/core/base.py
@@ -254,8 +254,6 @@ def get_uc_function_client() -> Optional[BaseFunctionClient]:
     global _uc_function_client
 
     with _client_lock:
-        if _uc_function_client is None:
-            _logger.warning("UC function client is not set.")
         return _uc_function_client
 
 

--- a/ai/core/src/unitycatalog/ai/core/base.py
+++ b/ai/core/src/unitycatalog/ai/core/base.py
@@ -253,7 +253,7 @@ class BaseFunctionClient(ABC):
 def get_uc_function_client() -> Optional[BaseFunctionClient]:
     global _uc_function_client
 
-    if client is None and _is_databricks_client_available():
+    if _uc_function_client is None and _is_databricks_client_available():
         try:
             from unitycatalog.ai.core.databricks import DatabricksFunctionClient
 

--- a/ai/core/src/unitycatalog/ai/core/base.py
+++ b/ai/core/src/unitycatalog/ai/core/base.py
@@ -267,7 +267,9 @@ def get_uc_function_client() -> Optional[BaseFunctionClient]:
             )
         else:
             set_uc_function_client(client)
-            _logger.info("Setting global UC Function client to DatabricksFunctionClient with default configuration.")
+            _logger.info(
+                "Setting global UC Function client to DatabricksFunctionClient with default configuration."
+            )
 
     with _client_lock:
         return _uc_function_client

--- a/ai/core/src/unitycatalog/ai/core/utils/client_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/client_utils.py
@@ -1,31 +1,9 @@
-import logging
 from typing import Optional
 
 from unitycatalog.ai.core.base import (
     BaseFunctionClient,
     get_uc_function_client,
-    set_uc_function_client,
 )
-
-_logger = logging.getLogger(__name__)
-
-
-def _is_databricks_client_available():
-    """
-    Checks if the connection requirements to attach to a Databricks serverless cluster
-    are available in the environment for automatic client selection purposes in
-    toolkit instantiation.
-
-    Returns:
-        bool: True if the requirements are available, False otherwise.
-    """
-    try:
-        from databricks.connect.session import DatabricksSession
-
-        if hasattr(DatabricksSession.builder, "serverless"):
-            return True
-    except Exception:
-        return False
 
 
 def validate_or_set_default_client(client: Optional[BaseFunctionClient] = None):
@@ -49,21 +27,6 @@ def validate_or_set_default_client(client: Optional[BaseFunctionClient] = None):
     """
 
     client = client or get_uc_function_client()
-    if client is None and _is_databricks_client_available():
-        try:
-            from unitycatalog.ai.core.databricks import DatabricksFunctionClient
-
-            client = DatabricksFunctionClient()
-
-        except Exception as e:
-            raise ValueError(
-                "Attempted to set DatabricksFunctionClient as the default client, but encountered an error. "
-                "Provide a client directly to your toolkit invocation to ensure connection to Unity Catalog."
-            ) from e
-
-        set_uc_function_client(client)
-        _logger.info("Client has been set to DatabricksFunctionClient with default configuration.")
-
     if client is None:
         raise ValueError(
             "No client provided, either set the client when creating a "

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
@@ -106,7 +106,7 @@ async def uc_client():
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(
@@ -346,7 +346,7 @@ async def test_tool_calling_with_multiple_tools_anthropic(uc_client, execution_m
 async def test_anthropic_toolkit_initialization(uc_client):
     with (
         mock.patch(
-            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            "unitycatalog.ai.core.base._is_databricks_client_available",
             return_value=False,
         ),
         pytest.raises(

--- a/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_toolkit_oss.py
@@ -105,9 +105,7 @@ async def uc_client():
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/anthropic/tests/test_anthropic_utils.py
+++ b/ai/integrations/anthropic/tests/test_anthropic_utils.py
@@ -212,7 +212,7 @@ def test_generate_tool_call_messages_validate_default_client(
     client = None
     with (
         mock.patch(
-            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            "unitycatalog.ai.core.base._is_databricks_client_available",
             return_value=False,
         ),
         pytest.raises(ValueError, match="No client provided"),
@@ -310,7 +310,7 @@ def test_generate_tool_call_messages_with_tracing(
             return_value=None,
         ),
         mock.patch(
-            "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+            "unitycatalog.ai.core.base._is_databricks_client_available",
             return_value=False,
         ),
         patch_registry,

--- a/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
@@ -183,7 +183,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
+++ b/ai/integrations/autogen/tests/test_autogen_toolkit_oss.py
@@ -182,9 +182,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
@@ -114,9 +114,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
+++ b/ai/integrations/crewai/tests/test_crewai_toolkit_oss.py
@@ -115,7 +115,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -171,7 +171,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
+++ b/ai/integrations/gemini/tests/test_gemini_toolkit_oss.py
@@ -170,9 +170,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
@@ -161,9 +161,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValueError,

--- a/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
+++ b/ai/integrations/langchain/tests/test_langchain_toolkit_oss.py
@@ -162,7 +162,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
@@ -92,9 +92,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
+++ b/ai/integrations/litellm/tests/test_litellm_toolkit_oss.py
@@ -93,7 +93,7 @@ async def test_multiple_toolkits(uc_client, execution_mode):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/litellm/tests/test_litellm_utils.py
+++ b/ai/integrations/litellm/tests/test_litellm_utils.py
@@ -335,7 +335,7 @@ def test_generate_tool_call_messages_validate_default_client(
     mock_message_single_tool, dummy_history, monkeypatch
 ):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available",
+        "unitycatalog.ai.core.base._is_databricks_client_available",
         lambda: False,
     )
     client = None

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
@@ -123,7 +123,7 @@ def generate_mock_execution_result(return_value: str = "result") -> FunctionExec
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
+++ b/ai/integrations/llama_index/tests/test_llama_index_toolkit_oss.py
@@ -122,9 +122,7 @@ def generate_mock_execution_result(return_value: str = "result") -> FunctionExec
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,

--- a/ai/integrations/openai/tests/test_openai_toolkit_oss.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit_oss.py
@@ -281,7 +281,7 @@ async def test_tool_choice_param(uc_client):
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
     monkeypatch.setattr(
-        "unitycatalog.ai.core.utils.client_utils._is_databricks_client_available", lambda: False
+        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
     )
 
     with pytest.raises(

--- a/ai/integrations/openai/tests/test_openai_toolkit_oss.py
+++ b/ai/integrations/openai/tests/test_openai_toolkit_oss.py
@@ -280,9 +280,7 @@ async def test_tool_choice_param(uc_client):
 
 
 def test_toolkit_creation_errors_no_client(monkeypatch):
-    monkeypatch.setattr(
-        "unitycatalog.ai.core.base._is_databricks_client_available", lambda: False
-    )
+    monkeypatch.setattr("unitycatalog.ai.core.base._is_databricks_client_available", lambda: False)
 
     with pytest.raises(
         ValidationError,


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
We don't need a warning for get_uc_function_client when it's none. It's also confusing when it's used in validate_or_set_default_client.
This PR also moves the logic to set default client in get_uc_function_client, so users don't need to create a UCFunctionToolkit in order to trigger default client setup.

<!-- Please state what you've changed and how it might affect the users. -->
