### PR TITLE
Add notification for users that reconnection to a serverless endpoint was successful in Unity Catalog AI client

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -194,6 +194,7 @@ def retry_on_session_expiration(func):
                     )
                 ):
                     raise SessionExpirationException(result.error)
+                _logger.info("Successfully re-acquired connection to a serverless instance.")
                 return result
             except SessionExpirationException as e:
                 if not self._is_default_client:

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -511,7 +511,8 @@ class MockClient:
         self.refresh_count += 1
 
 
-def test_retry_on_session_expiration_decorator():
+def test_retry_on_session_expiration_decorator(caplog):
+    caplog.set_level(logging.INFO)
     client = MockClient()
 
     result = client.mock_function()
@@ -519,6 +520,7 @@ def test_retry_on_session_expiration_decorator():
     assert result == "Success"
     assert client.call_count == 2
     assert client.refresh_count == 2
+    assert "Successfully re-acquired connection to a serverless instance." in caplog.text
 
 
 @patch("time.sleep", return_value=None)


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds an info statement to make the retry and subsequent success for a terminated serverless endpoint more clear and less ambiguous of the behavior of the refresh logic. 