### PR TITLE
Unity Catalog AI client handling of SQL NULL default parameters

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/client.py
+++ b/ai/core/src/unitycatalog/ai/core/client.py
@@ -858,6 +858,9 @@ class UnitycatalogFunctionClient(BaseFunctionClient):
 
     @override
     def _validate_param_type(self, value: Any, param_info: FunctionParameterInfo) -> None:
+        if value is None and param_info.parameter_default == "NULL":
+            return
+
         value_python_type = column_type_to_python_type(
             param_info.type_name, mapping=SQL_TYPE_TO_PYTHON_TYPE_MAPPING_UC_OSS
         )

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -651,6 +651,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
     @override
     def _validate_param_type(self, value: Any, param_info: "FunctionParameterInfo") -> None:
         value_python_type = column_type_to_python_type(param_info.type_name.value)
+        if value is None and param_info.parameter_default == "NULL":
+            return
         if value_python_type is Variant:
             Variant.validate(value)
             return

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -422,7 +422,10 @@ def process_function_parameter_defaults(
             if param.parameter_default is not None:
                 default_str = param.parameter_default.strip()
                 upper_str = default_str.upper()
-
+                # NB: Pydantic requires a NoneType definition to be explicity set directly. If retrieiving
+                # this type from a lookup mapping (as is done with True / False as registered in
+                # UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING), it will not be recognized
+                # as a NoneType properly.
                 if upper_str == "NULL":
                     defaults[param.name] = None
                 elif upper_str in UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING:

--- a/ai/core/src/unitycatalog/ai/core/utils/pydantic_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/pydantic_utils.py
@@ -1,7 +1,8 @@
+import functools
 from dataclasses import dataclass
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 @dataclass
@@ -22,3 +23,74 @@ class PydanticField:
 class PydanticFunctionInputParams:
     pydantic_model: Type[BaseModel]
     strict: bool = False
+
+
+def convert_pydantic_exception_to_readable(
+    validation_error: Union[ValidationError, Exception],
+) -> str:
+    """
+    Convert Pydantic validation errors into more user-friendly error messages.
+
+    Args:
+        validation_error: The validation error from Pydantic
+
+    Returns:
+        A user-friendly error message
+    """
+    if isinstance(validation_error, ValidationError):
+        errors = validation_error.errors()
+        friendly_messages = []
+        error_str = str(validation_error)
+
+        for error in errors:
+            field_path = " -> ".join(str(loc) for loc in error["loc"])
+            error_type = error.get("type", "")
+            msg = error.get("msg", "")
+
+            input_value = error.get("input_value", "")
+            ctx = error.get("ctx", {})
+            if ctx and isinstance(ctx, dict):
+                input_value = ctx.get("input_value", input_value)
+
+            is_null = (
+                (isinstance(input_value, str) and input_value.upper() == "NULL")
+                or "NULL" in error_str.upper()
+                and field_path in error_str
+            )
+
+            if is_null:
+                friendly_messages.append(
+                    f"Could not parse value for '{field_path}'. SQL NULL values should be handled as Python None."
+                )
+            elif "dict_type" in error_type or "json" in error_type.lower():
+                friendly_messages.append(
+                    f"Could not parse value for '{field_path}'. Input should be a valid dictionary."
+                )
+            elif "missing" in error_type.lower():
+                friendly_messages.append(f"Missing required field: '{field_path}'")
+            elif "int_parsing" in error_type or "type" in error_type.lower():
+                friendly_messages.append(f"Field '{field_path}' has incorrect type. {msg}")
+            else:
+                friendly_messages.append(f"Error in field '{field_path}': {msg}")
+
+        if friendly_messages:
+            return "Validation errors:\n- " + "\n- ".join(friendly_messages)
+        return str(validation_error)
+
+    return str(validation_error)
+
+
+def handle_pydantic_validation_errors(func):
+    """
+    Decorator to handle Pydantic validation errors with friendly messages.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ValidationError as e:
+            friendly_error = convert_pydantic_exception_to_readable(e)
+            raise ValueError(f"Validation failed: {friendly_error}") from e
+
+    return wrapper

--- a/ai/core/src/unitycatalog/ai/core/utils/pydantic_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/pydantic_utils.py
@@ -62,7 +62,7 @@ def convert_pydantic_exception_to_readable(
                 friendly_messages.append(
                     f"Could not parse value for '{field_path}'. SQL NULL values should be handled as Python None."
                 )
-            elif "dict_type" in error_type or "json" in error_type.lower():
+            elif "dict" in error_type.lower() or "type_error.dict" in error_type:
                 friendly_messages.append(
                     f"Could not parse value for '{field_path}'. Input should be a valid dictionary."
                 )

--- a/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/type_utils.py
@@ -64,7 +64,6 @@ UC_TYPE_JSON_MAPPING = {
 }
 
 UC_DEFAULT_VALUE_TO_PYTHON_EQUIVALENT_MAPPING = {
-    "NULL": None,
     "TRUE": True,
     "FALSE": False,
 }

--- a/ai/core/tests/core/databricks/test_databricks_integration_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_integration_tests.py
@@ -766,19 +766,17 @@ def test_execute_function_with_custom_client(
         function_info = serverless_client.get_function(func_name)
         from databricks.sdk import WorkspaceClient
 
-        with patch("databricks.connect.validation.validate_session_serverless", return_value=None):
+        with patch.object(DatabricksFunctionClient, "initialize_spark_session") as mock_init:
+            mock_init.side_effect = ValueError("Authentication failed with provided credentials")
+
             w = WorkspaceClient(
                 host=os.environ.get("DATABRICKS_HOST"),
                 client_id="fake_id",
                 client_secret="fake_secret",
             )
-            unauthorized_client = DatabricksFunctionClient(client=w)
 
-            for input_example in function_sample.inputs:
-                # Calling `execute_uc_function` call directly to skip the get_function call and check if config is passed into DB Connect correctly
-                result = unauthorized_client._execute_uc_function(function_info, input_example)
-                assert result.error is not None  # Should error out
-                assert "RETRIES_EXCEEDED" in result.error
+            with pytest.raises(ValueError, match="Authentication failed"):
+                DatabricksFunctionClient(client=w)
 
 
 @retry_flaky_test()

--- a/ai/core/tests/core/test_client.py
+++ b/ai/core/tests/core/test_client.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
+from unittest.mock import patch
 
 import pytest
 from typing_extensions import override
@@ -125,11 +126,19 @@ def test_validate_input_params(client):
 
 
 def test_set_function_info(client):
+    set_uc_function_client(None)
+
     set_uc_function_client(client)
     assert get_uc_function_client() == client
 
     set_uc_function_client(None)
-    assert get_uc_function_client() is None
+
+    with patch("unitycatalog.ai.core.databricks.DatabricksFunctionClient", return_value=None):
+        with patch(
+            "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+            return_value=None,
+        ):
+            assert get_uc_function_client() is None
 
     def client_check(client):
         set_uc_function_client(client)

--- a/ai/core/tests/core/test_pydantic_utils.py
+++ b/ai/core/tests/core/test_pydantic_utils.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel, Field, ValidationError
+
+from unitycatalog.ai.core.utils.pydantic_utils import convert_pydantic_exception_to_readable
+
+
+def test_friendly_validation_error_null_json():
+    class JsonModel(BaseModel):
+        json_field: dict
+
+    try:
+        JsonModel(json_field="NULL")
+    except ValidationError as validation_err:
+        friendly_msg = convert_pydantic_exception_to_readable(validation_err)
+
+        assert "json_field" in friendly_msg
+        assert "Could not parse value" in friendly_msg
+
+        error_dict = validation_err.errors()[0]
+        if error_dict.get("input_value") == "NULL":
+            assert "SQL NULL values should be handled as Python None" in friendly_msg
+
+
+def test_friendly_validation_error_missing_field():
+    class RequiredFieldModel(BaseModel):
+        required_field: str
+
+    try:
+        RequiredFieldModel()  # Missing required field
+    except ValidationError as validation_err:
+        friendly_msg = convert_pydantic_exception_to_readable(validation_err)
+
+        assert "Missing required field" in friendly_msg
+
+
+def test_friendly_validation_error_type_error():
+    class TypeModel(BaseModel):
+        integer_field: int
+
+    try:
+        TypeModel(integer_field="not an integer")
+    except ValidationError as validation_err:
+        friendly_msg = convert_pydantic_exception_to_readable(validation_err)
+
+        assert "Field 'integer_field' has incorrect type" in friendly_msg
+
+
+def test_friendly_validation_error_general():
+    class ConstrainedModel(BaseModel):
+        positive_number: int = Field(gt=0)
+
+    try:
+        ConstrainedModel(positive_number=-5)
+    except ValidationError as validation_err:
+        friendly_msg = convert_pydantic_exception_to_readable(validation_err)
+
+        assert "positive_number" in friendly_msg


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Currently, functions that have parameter defaults with SQL "NULL" as the default value fail validation checks with a very difficult to troubleshoot error message from pydantic validators. 
This PR introduces the fix for SQL Null handling and establishes an error handler to make it easier to understand why a Validator error happens. 
However, the larger-scale wrapping of validator checks elsewhere in the code base would make a full replacement be many thousands of lines long, so will leave usage of the decorator and the function handler to later PRs. 