### PR TITLE
[DOCS] add client definition to toolkit creation

### DIFF
--- a/ai/integrations/llama_index/README.md
+++ b/ai/integrations/llama_index/README.md
@@ -136,7 +136,7 @@ an LLM), which are exposed with a UC interface through the use of the `unitycata
 from unitycatalog.ai.llama_index.toolkit import UCFunctionToolkit
 
 # Pass the UC function name that we created to the constructor
-toolkit = UCFunctionToolkit(function_names=[func_name])
+toolkit = UCFunctionToolkit(function_names=[func_name], client=client)
 
 # Get the LlamaIndex-compatible tools definitions
 tools = toolkit.tools


### PR DESCRIPTION
Toolkit creation requires client to be explicitly defined, using `client=client`. See #915 for similar case with LangChain