### PR TITLE
[SPARK] UCCatalog preserve old table properties in REPLACE TABLE AS SELECT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val javacRelease17 = Seq("--release", "17")
 lazy val scala213 = "2.13.16"
 
 lazy val deltaVersion = "4.0.0"
-lazy val sparkVersion = "3.5.3"
+lazy val sparkVersion = "4.0.0"
 
 // Library versions
 lazy val jacksonVersion = "2.17.0"
@@ -551,7 +551,7 @@ lazy val spark = (project in file("connectors/spark"))
   .dependsOn(client)
   .settings(
     name := s"$artifactNamePrefix-spark",
-    scalaVersion := scala212,
+    scalaVersion := scala213,
     crossScalaVersions := Seq(scala213),
     commonSettings,
     scalaReleaseSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val javacRelease17 = Seq("--release", "17")
 lazy val scala213 = "2.13.16"
 
 lazy val deltaVersion = "4.0.0"
-lazy val sparkVersion = "4.0.0"
+lazy val sparkVersion = "3.5.3"
 
 // Library versions
 lazy val jacksonVersion = "2.17.0"
@@ -551,7 +551,7 @@ lazy val spark = (project in file("connectors/spark"))
   .dependsOn(client)
   .settings(
     name := s"$artifactNamePrefix-spark",
-    scalaVersion := scala213,
+    scalaVersion := scala212,
     crossScalaVersions := Seq(scala213),
     commonSettings,
     scalaReleaseSettings,

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -14,6 +14,7 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchT
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -27,6 +28,7 @@ import scala.language.existentials
 class UCSingleCatalog
   extends TableCatalog
   with SupportsNamespaces
+  with StagingTableCatalog
   with Logging {
 
   private[this] var apiClient: ApiClient = null;
@@ -166,6 +168,86 @@ class UCSingleCatalog
 
   override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {
     delegate.asInstanceOf[DelegatingCatalogExtension].dropNamespace(namespace, cascade)
+  }
+
+  override def stageCreate(ident: Identifier, columns: Array[Column], partitions: Array[Transform], properties: java.util.Map[String, String]): StagedTable = {
+    createTable(ident, columns, partitions, properties)
+    null
+  }
+
+  override def stageReplace(ident: Identifier, columns: Array[Column], partitions: Array[Transform], properties: java.util.Map[String, String]): StagedTable = {
+    val oldProperties = loadTableProperties(ident, properties)
+    this.dropTable(ident)
+    createTable(ident, columns, partitions, oldProperties ++ properties)
+    null
+  }
+
+  override def stageCreateOrReplace(ident: Identifier, columns: Array[Column], partitions: Array[Transform], properties: java.util.Map[String, String]): StagedTable = {
+    val oldProperties = loadTableProperties(ident, properties)
+    try dropTable(ident)
+    catch {
+      case _: NoSuchTableException => // this is fine
+    }
+    createTable(ident, columns, partitions, oldProperties ++ properties)
+    null
+  }
+
+  private def loadTableProperties(ident: Identifier, properties: util.Map[String, String]): util.Map[String, String] = {
+    if (UCSingleCatalog.DELTA_CATALOG_LOADED.get() &&
+      properties.get("provider").equalsIgnoreCase("delta")) {
+      try {
+        val props = new util.HashMap[String, String](loadTable(ident).properties())
+        props.remove("delta.minReaderVersion")
+        props.remove("delta.minWriterVersion")
+        props
+      } catch {
+        case _: Exception => new util.HashMap[String, String]()
+      }
+    } else {
+      new util.HashMap[String, String]()
+    }
+  }
+
+  private def removeDeltaProperties(properties: util.Map[String, String]): util.Map[String, String] = {
+    properties.remove("delta.minReaderVersion")
+    properties.remove("delta.minWriterVersion")
+    properties
+  }
+
+  private case class BestEffortStagedTable(
+      ident: Identifier,
+      table: Table,
+      catalog: TableCatalog) extends StagedTable with SupportsWrite {
+    override def abortStagedChanges(): Unit = catalog.dropTable(ident)
+
+    override def commitStagedChanges(): Unit = {}
+
+    override def name(): String = table.name()
+
+    override def schema(): StructType = table.schema()
+
+    override def partitioning(): Array[Transform] = table.partitioning()
+
+    override def capabilities(): util.Set[TableCapability] = table.capabilities()
+
+    override def properties(): util.Map[String, String] = table.properties()
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = table match {
+      case supportsWrite: SupportsWrite => supportsWrite.newWriteBuilder(info)
+      case _ => throw new ApiException("Unsupported Table: " + name)
+    }
+  }
+  
+  override def stageCreate(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): StagedTable = {
+    throw new AssertionError("deprecated `stageCreate` should not be called")
+  }
+
+  override def stageReplace(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): StagedTable = {
+    throw new AssertionError("deprecated `stageReplace` should not be called")
+  }
+
+  override def stageCreateOrReplace(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): StagedTable = {
+    throw new AssertionError("deprecated `stageCreateOrReplace` should not be called")
   }
 }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
@@ -122,7 +122,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
 
     session.stop();
   }
-
+  
   private void validateTimeTravelDeltaTable(Dataset<Row> df) {
     List<Row> rows = df.collectAsList();
     assertThat(rows).hasSize(1);
@@ -146,7 +146,21 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     validateTimeTravelDeltaTable(session.sql("SELECT * FROM " + t1 + " TIMESTAMP AS OF '" + timestamp + "'"));
     validateTimeTravelDeltaTable(session.read().option("versionAsOf", 1).table(t1));
     validateTimeTravelDeltaTable(session.read().option("timestampAsOf", timestamp).table(t1));
+  }
 
+  @Test
+  public void testDeltaReplaceTable() throws IOException, ApiException {
+    SparkSession session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    setupExternalDeltaTable(SPARK_CATALOG, DELTA_TABLE, new ArrayList<>(0), session);
+    String fullTableName = SPARK_CATALOG + "." + SCHEMA_NAME + "." + DELTA_TABLE;
+    assertThat(session.sql("SELECT * FROM " + fullTableName).collectAsList()).isEmpty();
+    session.sql("INSERT INTO " + fullTableName + " SELECT 1, 'a'");
+
+    Dataset<Row> df = session.sql("SELECT * FROM VALUES (2, 'b') AS t(i, s);");
+    df.write().format("delta").mode("overwrite").saveAsTable(fullTableName);
+    Row row2 = session.sql("SELECT * FROM " + fullTableName).collectAsList().get(0);
+    assertThat(row2.getInt(0)).isEqualTo(2);
+    assertThat(row2.getString(1)).isEqualTo("b");
     session.stop();
   }
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
UC Catalog can implement `StagingTableCatalog` to customize `REPLACE TABLE AS SELECT` behavior. With this change, UC Catalog when handling Delta tables, will preserve the old Delta table properties in the new created table.