### PR TITLE
Fix time-travel on Delta tables using SQL

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -72,6 +72,10 @@ class UCSingleCatalog extends TableCatalog with SupportsNamespaces with Logging 
 
   override def loadTable(ident: Identifier): Table = delegate.loadTable(ident)
 
+  override def loadTable(ident: Identifier, version:  String): Table = delegate.loadTable(ident, version)
+
+  override def loadTable(ident: Identifier, timestamp:  Long): Table = delegate.loadTable(ident, timestamp)
+
   override def tableExists(ident: Identifier): Boolean = {
     delegate.tableExists(ident)
   }


### PR DESCRIPTION
**Description of changes**
[UCSingleCatalog](https://github.com/unitycatalog/unitycatalog/blob/b141f19665c0c88ed6b72a04149881690ac29dcd/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala) is missing overloads for `loadTable` with time-travel arguments (version/timestamp). This effectively prevents time-travelling on Spark + Delta tables using SQL - Scala/python are working without this because delta-spark resolves the table itself in that case without delegating to Spark.

Note: this change doesn't add similar overloads to [UCProxy](https://github.com/unitycatalog/unitycatalog/blob/b141f19665c0c88ed6b72a04149881690ac29dcd/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala#L205C15-L205C22), so time-travel likely still won't work when a DeltaCatalog implementation isn't available. I'm not actually sure how to properly implement `loadTable` with time-travel there, so leaving it out of this PR.

**Testing**
- Added tests for time-travel on a Delta table using SQL/Scala APIs in `TableReadWriteTest`