### PR TITLE
Only create spark session in serverless mode

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -137,7 +137,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
         self.profile = profile
         self.execution_mode = ExecutionModeDatabricks.validate(execution_mode)
         self.spark = None
-        self.set_spark_session()
+        if self.execution_mode == ExecutionModeDatabricks.SERVERLESS:
+            self.set_spark_session()
         self._is_default_client = client is None
         super().__init__()
 

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -1637,5 +1637,9 @@ def test_invalid_execution_mode(execution_mode):
 
 
 def test_no_spark_session_created_for_local_execution_mode():
-    client = DatabricksFunctionClient(execution_mode="local")
-    assert client.spark is None
+    with patch(
+        "unitycatalog.ai.core.databricks.get_default_databricks_workspace_client",
+        return_value=MagicMock(),
+    ):
+        client = DatabricksFunctionClient(execution_mode="local")
+        assert client.spark is None

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -1634,3 +1634,8 @@ def test_invalid_execution_mode(execution_mode):
         ),
     ):
         DatabricksFunctionClient(execution_mode=execution_mode)
+
+
+def test_no_spark_session_created_for_local_execution_mode():
+    client = DatabricksFunctionClient(execution_mode="local")
+    assert client.spark is None


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
If users use 'local' mode for execution, we don't need to start a spark session. The spark session will be started if users need to create a function.


<!-- Please state what you've changed and how it might affect the users. -->
