### PR TITLE
Bump versions: Spark 4.0.0, Delta 4.0.0, Scala 2.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,10 @@ val artifactNamePrefix = "unitycatalog"
 lazy val javacRelease11 = Seq("--release", "11")
 lazy val javacRelease17 = Seq("--release", "17")
 
-lazy val scala212 = "2.12.15"
-lazy val scala213 = "2.13.14"
+lazy val scala213 = "2.13.16"
 
-lazy val deltaVersion = "3.2.1"
-lazy val sparkVersion = "3.5.3"
+lazy val deltaVersion = "4.0.0"
+lazy val sparkVersion = "4.0.0"
 
 // Library versions
 lazy val jacksonVersion = "2.17.0"
@@ -552,8 +551,8 @@ lazy val spark = (project in file("connectors/spark"))
   .dependsOn(client)
   .settings(
     name := s"$artifactNamePrefix-spark",
-    scalaVersion := scala212,
-    crossScalaVersions := Seq(scala212, scala213),
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213),
     commonSettings,
     scalaReleaseSettings,
     javaOptions ++= Seq(
@@ -568,8 +567,8 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
-      "org.antlr" % "antlr4-runtime" % "4.9.3",
-      "org.antlr" % "antlr4" % "4.9.3",
+      "org.antlr" % "antlr4-runtime" % "4.13.1",
+      "org.antlr" % "antlr4" % "4.13.1",
       "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2" % Provided,
       "org.apache.hadoop" % "hadoop-azure" % "3.4.0" % Provided,
     ),
@@ -590,8 +589,8 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
-      "org.antlr" % "antlr4-runtime" % "4.9.3",
-      "org.antlr" % "antlr4" % "4.9.3",
+      "org.antlr" % "antlr4-runtime" % "4.13.1",
+      "org.antlr" % "antlr4" % "4.13.1",
     ),
     Test / unmanagedJars += (serverShaded / assembly).value,
     licenseDepExclusions := {
@@ -621,6 +620,7 @@ lazy val integrationTests = (project in file("integration-tests"))
   .settings(
     name := s"$artifactNamePrefix-integration-tests",
     commonSettings,
+    scalaVersion := scala213,
     javaOptions ++= Seq(
       "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
     ),
@@ -630,7 +630,7 @@ lazy val integrationTests = (project in file("integration-tests"))
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
       "org.assertj" % "assertj-core" % "3.26.3" % Test,
       "org.projectlombok" % "lombok" % "1.18.32" % Provided,
-      "org.apache.spark" %% "spark-sql" % "3.5.3" % Test,
+      "org.apache.spark" %% "spark-sql" % "4.0.0" % Test,
       "io.delta" %% "delta-spark" % "3.2.1" % Test,
       "org.apache.hadoop" % "hadoop-aws" % "3.3.6" % Test,
       "org.apache.hadoop" % "hadoop-azure" % "3.3.6" % Test,
@@ -643,8 +643,8 @@ lazy val integrationTests = (project in file("integration-tests"))
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
-      "org.antlr" % "antlr4-runtime" % "4.9.3",
-      "org.antlr" % "antlr4" % "4.9.3",
+      "org.antlr" % "antlr4-runtime" % "4.13.1",
+      "org.antlr" % "antlr4" % "4.13.1",
       "org.apache.hadoop" % "hadoop-client-api" % "3.3.6",
     ),
     Test / javaOptions += s"-Duser.dir=${((ThisBuild / baseDirectory).value / "integration-tests").getAbsolutePath}",

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/TableReadWriteTest.java
@@ -386,7 +386,7 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   @Test
-  public void testCreateExternalTableWithoutLocation() {
+  public void testCreateExternalTableWithoutLocation() throws IOException {
     SparkSession session = createSparkSessionWithCatalogs(CATALOG_NAME);
 
     String fullTableName1 = CATALOG_NAME + "." + SCHEMA_NAME + "." + PARQUET_TABLE;
@@ -564,6 +564,8 @@ public class TableReadWriteTest extends BaseSparkIntegrationTest {
     try {
       JavaUtils.deleteRecursively(dataDir);
     } catch (IOException e) {
+      throw new RuntimeException(e);
+    } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
   }

--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -47,7 +47,7 @@ Run the command from the Spark folder to start a Spark SQL shell .
 ```sh
 ./bin/spark-sql \
   --packages \
-    io.delta:delta-spark_2.12:3.2.0,io.unitycatalog:unitycatalog-spark:0.2.0-SNAPSHOT \
+    io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark:0.3.0-SNAPSHOT \
   --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
   --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
   --conf spark.sql.catalog.puppygraph=io.unitycatalog.spark.UCSingleCatalog \

--- a/docs/integrations/unity-catalog-spark.md
+++ b/docs/integrations/unity-catalog-spark.md
@@ -95,7 +95,7 @@ You can run the code below to work with data stored in the `unity` catalog that 
     ```sh
     bin/spark-sql --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+        --packages "io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
         --conf "spark.sql.catalog.<catalog_name>=io.unitycatalog.spark.UCSingleCatalog" \
@@ -109,7 +109,7 @@ You can run the code below to work with data stored in the `unity` catalog that 
     ```sh
     bin/pyspark --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+        --packages "io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
         --conf "spark.sql.catalog.<catalog_name>=io.unitycatalog.spark.UCSingleCatalog" \
@@ -148,7 +148,7 @@ command.
     ```sh
     bin/spark-sql --name "s3-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+        --packages "org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
         --conf "spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem" \
@@ -163,7 +163,7 @@ command.
     ```sh
     bin/spark-sql --name "azure-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-azure:3.3.6,io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+        --packages "org.apache.hadoop:hadoop-azure:3.3.6,io.delta:delta-spark_2.14:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
         --conf "spark.sql.catalog.<catalog_name>=io.unitycatalog.spark.UCSingleCatalog" \
@@ -178,7 +178,7 @@ command.
     bin/spark-sql --name "gcs-uc-test" \
         --master "local[*]" \
         --jars "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/3.0.2/gcs-connector-3.0.2-shaded.jar" \
-        --packages "io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+        --packages "io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
         --conf "spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" \

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -272,7 +272,7 @@ step.
 ```sh
 bin/spark-sql --name "local-uc-test" \
     --master "local[*]" \
-    --packages "io.delta:delta-spark_2.12:3.2.1,io.unitycatalog:unitycatalog-spark_2.12:0.2.0" \
+    --packages "io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0" \
     --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
     --conf "spark.sql.catalog.spark_catalog=io.unitycatalog.spark.UCSingleCatalog" \
     --conf "spark.sql.catalog.unity=io.unitycatalog.spark.UCSingleCatalog" \


### PR DESCRIPTION
**Description of changes**

**Requires Spark 4.0 / Delta 4.0 to be released**

Bump spark, delta and scala version in preparation for UC 0.3.0 release against Spark/Delta 4.0

This also bumps scala version 2.13.14 to 2.13.16 and drops support for scala 2.12 isn't supported with Spark 4.0 anymore.
