### PR TITLE
docs: spark/publishLocal is not required to build Spark integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ See the [cli usage](docs/usage/cli.md) for more details.
 
 ## Building Unity Catalog
 
-Unity Catalog can be built using [sbt](https://www.scala-sbt.org/).
+Unity Catalog is built using [sbt](https://www.scala-sbt.org/).
 
 To build UC (incl. [Spark Integration](./connectors/spark) module), run the following command:
 
 ```sh
-build/sbt clean package publishLocal spark/publishLocal
+build/sbt clean package publishLocal
 ```
 
 Refer to [sbt docs](https://www.scala-sbt.org/1.x/docs/) for more commands.


### PR DESCRIPTION
`spark/publishLocal` is not required to build Spark integration