### PR TITLE
Better error messages in UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -403,7 +403,7 @@ private class UCProxy(
   }
 
   override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
-    throw new UnsupportedOperationException("Multi-layer namespace is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Multi-layer namespace is not supported in Unity Catalog")
   }
 
   override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -130,11 +130,16 @@ class UCSingleCatalog extends TableCatalog with SupportsNamespaces with Logging 
   override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): Table = {
     throw new AssertionError("deprecated `createTable` should not be called")
   }
-  override def alterTable(ident: Identifier, changes: TableChange*): Table = ???
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    throw new UnsupportedOperationException("Altering a table is not supported yet in Unity Catalog")
+  }
 
   override def dropTable(ident: Identifier): Boolean = delegate.dropTable(ident)
 
-  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = ???
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("Renaming a table is not supported yet in Unity Catalog")
+  }
 
   override def listNamespaces(): Array[Array[String]] = {
     delegate.asInstanceOf[DelegatingCatalogExtension].listNamespaces()
@@ -370,7 +375,9 @@ private class UCProxy(
     }
   }
 
-  override def alterTable(ident: Identifier, changes: TableChange*): Table = ???
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    throw new UnsupportedOperationException("Altering a table is not supported yet in Unity Catalog")
+  }
 
   override def dropTable(ident: Identifier): Boolean = {
     checkUnsupportedNestedNamespace(ident.namespace())
@@ -379,7 +386,9 @@ private class UCProxy(
     if (ret == 200) true else false
   }
 
-  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = ???
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("Renaming a table is not supported yet in Unity Catalog")
+  }
 
   private def checkUnsupportedNestedNamespace(namespace: Array[String]): Unit = {
     if (namespace.length > 1) {
@@ -394,7 +403,7 @@ private class UCProxy(
   }
 
   override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
-    throw new UnsupportedOperationException("Multi-layer namespace is not supported in Unity Catalog")
+    throw new UnsupportedOperationException("Multi-layer namespace is not supported yet in Unity Catalog")
   }
 
   override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
@@ -428,7 +437,9 @@ private class UCProxy(
     schemasApi.createSchema(createSchema)
   }
 
-  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = ???
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
+    throw new UnsupportedOperationException("Renaming a namespace is not supported yet in Unity Catalog")
+  }
 
   override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {
     checkUnsupportedNestedNamespace(namespace)

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -34,7 +34,7 @@ class UCSingleCatalog extends TableCatalog with SupportsNamespaces with Logging 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     val urlStr = options.get("uri")
     if (urlStr == null) {
-      throw new IllegalArgumentException("uri must be specified for Unity Catalog")
+      throw new IllegalArgumentException(s"uri must be specified for Unity Catalog '$name'")
     }
     val url = new URI(urlStr)
     apiClient = new ApiClient()

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -132,13 +132,13 @@ class UCSingleCatalog extends TableCatalog with SupportsNamespaces with Logging 
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException("Altering a table is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Altering a table is not supported yet")
   }
 
   override def dropTable(ident: Identifier): Boolean = delegate.dropTable(ident)
 
   override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
-    throw new UnsupportedOperationException("Renaming a table is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Renaming a table is not supported yet")
   }
 
   override def listNamespaces(): Array[Array[String]] = {
@@ -376,7 +376,7 @@ private class UCProxy(
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException("Altering a table is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Altering a table is not supported yet")
   }
 
   override def dropTable(ident: Identifier): Boolean = {
@@ -387,7 +387,7 @@ private class UCProxy(
   }
 
   override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
-    throw new UnsupportedOperationException("Renaming a table is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Renaming a table is not supported yet")
   }
 
   private def checkUnsupportedNestedNamespace(namespace: Array[String]): Unit = {
@@ -438,7 +438,7 @@ private class UCProxy(
   }
 
   override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
-    throw new UnsupportedOperationException("Renaming a namespace is not supported yet in Unity Catalog")
+    throw new UnsupportedOperationException("Renaming a namespace is not supported yet")
   }
 
   override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {


### PR DESCRIPTION
**Description of changes**
- Add user-facing unsupported operation exceptions for unimplemented operations in UCSingleCatalog instead of the scala default and not user-friendly 'not implemented yet' error.
- Include the catalog name in the error message when a UCSingleCatalog catalog is configured without providing a URI.