### PR TITLE
[AI client] Set maximum version of databricks-connect for Databricks integration

### DIFF
--- a/ai/core/pyproject.toml
+++ b/ai/core/pyproject.toml
@@ -70,13 +70,13 @@ only-include = ["src/unitycatalog/ai/core"]
 databricks = [
   "databricks-sdk>=0.32.0",
   "pandas",
-  "databricks-connect>=15.1.0"
+  "databricks-connect>=15.1.0,<16.4"
 ]
 databricks-dev = [
   "hatch",
   "pytest",
   "databricks-sdk>=0.32.0",
-  "databricks-connect>=15.1.0",
+  "databricks-connect>=15.1.0,<16.4",
   "pandas",
   "ruff==0.9.3",
 ]
@@ -85,7 +85,7 @@ dev = [
   "pytest",
   "pytest-asyncio",
   "databricks-sdk>=0.32.0",
-  "databricks-connect",
+  "databricks-connect<16.4",
   "pandas",
   "ruff==0.9.3",
 ]


### PR DESCRIPTION
**PR Checklist**


- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
See title - sets a maximum version of `databricks-connect` for Databricks UC AI integrations, since the newest 16.4 release doesn't support serverless. In general, we can bump this maximum version when serverless support is released per https://docs.databricks.com/aws/en/dev-tools/databricks-connect/python/install#version-support-matrix. databricks-connect is forward-compatible, so using old databricks-connect on new DBR versions is expected to work fine

<!-- Please state what you've changed and how it might affect the users. -->
