### PR TITLE
docs: fix table path in Quickstart example (#693)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -204,7 +204,7 @@ Let's try creating a new table.
 
 ```sh
 bin/uc table create --full_name unity.default.mytable \
---columns "col1 int, col2 double" --storage_location /tmp/uc/my_table
+--columns "col1 int, col2 double" --storage_location /tmp/uc/mytable
 ```
 
 ```console
@@ -272,7 +272,7 @@ bin/uc table delete --full_name unity.default.mytable
 ```
 
 > Note, while you have deleted the table from Unity Catalog, the underlying file system may still have the files (i.e.,
-check the /tmp/uc/my_table/folder).  
+check the /tmp/uc/mytable/folder).  
 
 ## Interact with the Unity Catalog UI
 


### PR DESCRIPTION
This pull request fixes issue #693 by correcting the storage location path and documentation in the Quickstart guide. The create table example now uses `/tmp/uc/mytable` and the cleanup note references `mytable` instead of `my_table`. This aligns the docs with the actual table name used earlier in the quickstart.