### PR TITLE
unity-catalog-spark: optionally set URL path for UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -39,11 +39,20 @@ class UCSingleCatalog
     if (urlStr == null) {
       throw new IllegalArgumentException(s"uri must be specified for Unity Catalog '$name'")
     }
+
     val url = new URI(urlStr)
-    apiClient = new ApiClient()
-      .setHost(url.getHost)
-      .setPort(url.getPort)
-      .setScheme(url.getScheme)
+    apiClient = {
+      val c = new ApiClient()
+        .setHost(url.getHost)
+        .setPort(url.getPort)
+        .setScheme(url.getScheme)
+      val p = url.getPath
+      if (p != null && p.nonEmpty && p != "/") {
+        c.setBasePath(p)
+      }
+      c
+    }
+
     val token = options.get("token")
     if (token != null && token.nonEmpty) {
       apiClient = apiClient.setRequestInterceptor { request =>


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

Closes #1068

### Testing
```
build/sbt publishLocal -ivy ~/.ivy2.5.2 
```

```
spark = (
    SparkSession.builder
    .master("local[*]")
    .appName("DeltaUnityCatalogDemo")
    .config(
        "spark.jars.packages",
        "io.delta:delta-spark_2.13:4.0.0,io.unitycatalog:unitycatalog-spark_2.13:0.3.0-SNAPSHOT"
    )
    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
    .config(f"spark.sql.catalog.{catalog_name}", "io.unitycatalog.spark.UCSingleCatalog")
    .config(f"spark.sql.catalog.{catalog_name}.uri", uri)
    .config(f"spark.sql.catalog.{catalog_name}.token", token)
    .config("spark.sql.defaultCatalog", catalog_name)
    .getOrCreate()
)
spark
```
