### PR TITLE
Update Dockerfile with fix

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,17 +8,15 @@ COPY package.json yarn.lock ./
 
 # TODO: configure this directly from the ui app
 # Work around to set the proxy host; required for running locally with docker-compose
-RUN <<EOF
-set -ex
-apt-get update
-apt-get install -y jq
-jq --arg proxy "http://$PROXY_HOST:8080" '.proxy = $proxy' package.json > temp.json
-mv temp.json package.json
+RUN set -ex && \
+apt-get update &&\
+apt-get install -y jq &&\
+jq --arg proxy "http://$PROXY_HOST:8080" '.proxy = $proxy' package.json > temp.json &&\
+mv temp.json package.json && \
 # '--network-timeout 1000000' is workaround for yarn install to work in github actions
 # https://github.com/yarnpkg/yarn/issues/9004
-yarn install --network-timeout 1000000
+yarn install --network-timeout 1000000 &&\
 apt-get clean
-EOF
 
 COPY --exclude=package.json --exclude=yarn.lock . ./
 


### PR DESCRIPTION
## Description of Changes
This PR fixes a build error in the UI service Dockerfile (`ui/Dockerfile`) on Windows when running `docker compose up --build`. The original heredoc (`RUN <<EOF ... EOF`) causes a shell parsing error (`/bin/sh: 1: set: Illegal option -`) due to Windows CRLF (`\r\n`) line endings in the `node:18` image’s `dash` shell. The server Dockerfile’s heredoc (in `amazoncorretto:17-alpine`) works because it avoids `set -ex` and uses Alpine’s `ash` shell, which is less sensitive to line-ending issues.

### Changes
- Replaced the heredoc in `ui/Dockerfile` with a chained `RUN` command using `&&` and `\` for cross-platform compatibility.
- No functional changes; the fix maintains the original behavior (sets proxy in `package.json`, installs Yarn dependencies, cleans up).


### Linux Test Results
Tested the fix in a Linux environment (Ubuntu 24.04.2 LTS, via [GitHub Codespaces/WSL2 Ubuntu, Docker version 28.3.1-1]):
- Applied the `RUN set -ex && ...` fix to `ui/Dockerfile`.
- Ran `docker compose up --build`.
- UI service built successfully without errors.
- Relevant build log excerpt:

```text
#10 [3/5] COPY package.json yarn.lock ./
#10 CACHED

#11 [4/5] RUN set -ex && apt-get update &&apt-get install -y jq &&jq --arg proxy "http://server:8080" '.proxy = $proxy' package.json > temp.json && mv temp.json package.json && yarn install --network-timeout 1000000 &&apt-get clean
#11 CACHED
```

### Windows Test Results
Tested the fix in a Windows environment (Windows 11, Docker version 28.4.0, build d8eb465]):
- Applied the `RUN set -ex && ...` fix to `ui/Dockerfile`.
- Ran `docker compose up --build`.
- UI service built successfully without errors.
- Relevant build log excerpt:

```text
#10 [3/5] COPY package.json yarn.lock ./
#10 CACHED

#11 [4/5] RUN set -ex && apt-get update &&apt-get install -y jq &&jq --arg proxy "http://server:8080" '.proxy = $proxy' package.json > temp.json && mv temp.json package.json && yarn install --network-timeout 1000000 &&apt-get clean
#11 CACHED
```

### Impact on Users
- Windows Users: Resolves the build failure, allowing docker compose up to work for local UI development.
- Linux/macOS Users: No change in behavior; the fix is compatible with dash/bash in node:18 and maintains existing functionality.
- No new dependencies or runtime changes; purely a build-time syntax fix.

### Related Issue
Closes #1082 

### Test log Attachments
[linux_build.log](https://github.com/user-attachments/files/22453045/linux_build.log)
[windows_buid.log](https://github.com/user-attachments/files/22453046/windows_buid.log)