### PR TITLE
docs: fix spelling errors in table format documentation

### DIFF
--- a/docs/usage/tables/formats.md
+++ b/docs/usage/tables/formats.md
@@ -151,11 +151,11 @@ distinct advantages. But the challenges when working with these formats include:
 
 - No ACID transactions for these data lakes meaning it's easier to accidentally corrupt your data
 - It is not easy to delete rows from these tables
-- These table storage foramts do not offer DML transactions
+- These table storage formats do not offer DML transactions
 - They lack advanced features from schema evolution and enforcement to deletion vectors to change data feed
 - Slow file listing overhead when working with cloud object stores such as AWS S3, Azure ADLSgen2, and
     Google Cloud Storage
-- Potentialy expensive footer reads to gather statistics for file skipping
+- Potentially expensive footer reads to gather statistics for file skipping
 
 Open table formats like Apache Iceberg and Delta Lake are specifically designed to overcome these challenges. Storing
 your data in a lakehouse format is almost always more advantageous than storing it in traditional table storage


### PR DESCRIPTION
**Description of changes**
Corrected the following typos in the docs (see attached screenshot for context):
- "foramts" → "formats"
- "Potentialy" → "Potentially"

Resolves: #1089
Link: [githubpages](https://junaidkhan444.github.io/unitycatalog/usage/tables/formats/)

<img width="1361" height="649" alt="image" src="https://github.com/user-attachments/assets/201487ef-3d32-48e1-852c-fc4738f74e60" />

