### PR TITLE
Created AWSVendedTokenProvider from Issue #1096

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/AwsVendedTokenProvider.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/AwsVendedTokenProvider.java
@@ -1,0 +1,82 @@
+package io.unitycatalog.spark;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+
+/**
+ * AWS credentials provider for vended temporary tokens from Unity Catalog.
+ * This provider implements AWSCredentialsProvider to supply temporary AWS credentials
+ * (access key, secret key, and session token) that are vended by Unity Catalog
+ * for table-level access control.
+ */
+public class AwsVendedTokenProvider extends Configured implements AWSCredentialsProvider {
+    protected static final String ACCESS_KEY_ID = "fs.s3a.access.key.credential";
+    protected static final String SECRET_ACCESS_KEY = "fs.s3a.secret.key.credential";
+    protected static final String SESSION_TOKEN = "fs.s3a.session.token.credential";
+
+    private Configuration conf;
+    private AWSSessionCredentials credentials;
+
+    public AwsVendedTokenProvider() {
+        super();
+    }
+
+    public AwsVendedTokenProvider(Configuration conf) {
+        super(conf);
+        this.conf = conf;
+        refresh();
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        super.setConf(conf);
+        this.conf = conf;
+        refresh();
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        if (credentials == null) {
+            refresh();
+        }
+        return credentials;
+    }
+
+    @Override
+    public void refresh() {
+        if (conf == null) {
+            throw new IllegalStateException("Configuration not set for AwsVendedTokenProvider");
+        }
+
+        String accessKeyId = conf.get(ACCESS_KEY_ID);
+        String secretAccessKey = conf.get(SECRET_ACCESS_KEY);
+        String sessionToken = conf.get(SESSION_TOKEN);
+
+        if (accessKeyId == null || secretAccessKey == null || sessionToken == null) {
+            throw new IllegalArgumentException(
+                "AWS credentials not found in configuration. Required keys: " +
+                ACCESS_KEY_ID + ", " + SECRET_ACCESS_KEY + ", " + SESSION_TOKEN
+            );
+        }
+
+        credentials = new AWSSessionCredentials() {
+            @Override
+            public String getSessionToken() {
+                return sessionToken;
+            }
+
+            @Override
+            public String getAWSAccessKeyId() {
+                return accessKeyId;
+            }
+
+            @Override
+            public String getAWSSecretKey() {
+                return secretAccessKey;
+            }
+        };
+    }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -176,10 +176,15 @@ object UCSingleCatalog {
   def generateCredentialProps(
       scheme: String,
       temporaryCredentials: TemporaryCredentials): Map[String, String] = {
-    if (scheme == "s3") {
+    if (scheme == "s3" || scheme == "s3a") {
       val awsCredentials = temporaryCredentials.getAwsTempCredentials
       Map(
         // TODO: how to support s3:// properly?
+         "fs.s3a.aws.credentials.provider" -> classOf[AwsVendedTokenProvider].getName,
+        // Store credentials in configuration for the provider to access
+        AwsVendedTokenProvider.ACCESS_KEY_ID -> awsCredentials.getAccessKeyId,
+        AwsVendedTokenProvider.SECRET_ACCESS_KEY -> awsCredentials.getSecretAccessKey,
+        AwsVendedTokenProvider.SESSION_TOKEN -> awsCredentials.getSessionToken,
         "fs.s3a.access.key" -> awsCredentials.getAccessKeyId,
         "fs.s3a.secret.key" -> awsCredentials.getSecretAccessKey,
         "fs.s3a.session.token" -> awsCredentials.getSessionToken,


### PR DESCRIPTION
Created AWSVendedTokenProvider from Issue #1096

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
This PR introduces AwsVendedTokenProvider, a dedicated AWS credentials provider for managing temporary S3 credentials vended by Unity Catalog. This aligns the S3 credential handling with the existing patterns used for GCS (GcsVendedTokenProvider) and Azure (AbfsVendedTokenProvider).

Issue - https://github.com/unitycatalog/unitycatalog/issues/1096

<!-- Please state what you've changed and how it might affect the users. -->
