### PR TITLE
feat: Support custom S3 endpoint configuration

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -68,6 +68,8 @@ the following parameters need to be set:
 - `s3.accessKey.i`: The AWS access key, an identifier of temp credentials.
 - `s3.secretKey.i`: The AWS secret key used to sign API requests to AWS.
 - `s3.sessionToken.i`: THE AWS session token, used to verify that the request is coming from a trusted source.
+- `s3.region.i`: The AWS region where the bucket is located.
+- `s3.endpointUrl.i`: (Optional) The S3 endpoint URL. Useful for S3-compatible storage e.g. <http://minio:9000>.
 
 You can configure multiple buckets by incrementing the index *i* in the above parameters. The starting index should
 be 0.

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
@@ -20,7 +20,9 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 public class FileOperations {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileOperations.class);

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
@@ -19,6 +19,7 @@ public class AwsCredentialVendor {
 
   private CredentialsGenerator createCredentialsGenerator(S3StorageConfig config) {
     // Dynamically load and initialize the generator if it's intentionally configured.
+    String endpointUrl = config.getEndpointUrl();
     if (config.getCredentialGenerator() != null) {
       try {
         return (CredentialsGenerator)
@@ -31,15 +32,19 @@ public class AwsCredentialVendor {
     if (config.getSessionToken() != null && !config.getSessionToken().isEmpty()) {
       // if a session token was supplied, then we will just return static session credentials
       return new CredentialsGenerator.StaticCredentialsGenerator(
-          config.getAccessKey(), config.getSecretKey(), config.getSessionToken());
+          config.getAccessKey(), config.getSecretKey(), config.getSessionToken(), endpointUrl);
     }
 
     if (config.getAccessKey() != null && !config.getAccessKey().isEmpty()) {
       return new CredentialsGenerator.StsCredentialsGenerator(
-          config.getRegion(), config.getAccessKey(), config.getSecretKey(), config.getAwsRoleArn());
+          config.getRegion(),
+          config.getAccessKey(),
+          config.getSecretKey(),
+          config.getAwsRoleArn(),
+          endpointUrl);
     } else {
       return new CredentialsGenerator.StsCredentialsGenerator(
-          config.getRegion(), config.getAwsRoleArn());
+          config.getRegion(), config.getAwsRoleArn(), endpointUrl);
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
@@ -15,4 +15,5 @@ public class S3StorageConfig {
   private final String secretKey;
   private final String sessionToken;
   private final String credentialGenerator;
+  private final String endpointUrl;
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -76,7 +76,10 @@ public class TableConfigService {
         S3FileIOProperties.ACCESS_KEY_ID, awsCredential.accessKeyId(),
         S3FileIOProperties.SECRET_ACCESS_KEY, awsCredential.secretAccessKey(),
         S3FileIOProperties.SESSION_TOKEN, awsCredential.sessionToken(),
-        AwsClientProperties.CLIENT_REGION, s3StorageConfig.getRegion());
+        AwsClientProperties.CLIENT_REGION, s3StorageConfig.getRegion(),
+        S3FileIOProperties.ENDPOINT, s3StorageConfig.getEndpointUrl()
+    );
+
   }
 }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/AwsUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/AwsUtils.java
@@ -1,0 +1,55 @@
+package io.unitycatalog.server.utils;
+
+import io.unitycatalog.server.exception.BaseException;
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.utils.Validate;
+
+public class AwsUtils {
+
+  public static AwsCredentialsProvider getAwsCredentialsProvider(
+      String accessKeyId, String secretAccessKey, String sessionToken) {
+    try {
+      return StaticCredentialsProvider.create(
+          AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
+    } catch (BaseException e) {
+      return DefaultCredentialsProvider.create();
+    }
+  }
+
+  public static AwsCredentialsProvider getAwsCredentialsProvider(Credentials awsCredentials) {
+    return getAwsCredentialsProvider(
+        awsCredentials.accessKeyId(),
+        awsCredentials.secretAccessKey(),
+        awsCredentials.sessionToken());
+  }
+
+  public static S3Client getS3Client(
+      AwsCredentialsProvider awsCredentialsProvider, String region, String endpointUrl) {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(awsCredentialsProvider)
+        .endpointOverride(
+            endpointUrl != null && !endpointUrl.isEmpty() ? URI.create(endpointUrl) : null)
+        .forcePathStyle(false)
+        .build();
+  }
+
+  public static boolean doesObjectExist(S3Client s3Client, String bucketName, String key) {
+    try {
+      Validate.notEmpty(bucketName, "The bucket name must not be null or an empty string.", "");
+      s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+      return true;
+    } catch (NoSuchKeyException e) {
+      return false;
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -38,7 +38,8 @@ public class ServerProperties {
     AWS_S3_ACCESS_KEY("aws.s3.accessKey"),
     AWS_S3_SECRET_KEY("aws.s3.secretKey"),
     AWS_S3_SESSION_TOKEN("aws.s3.sessionToken"),
-    AWS_REGION("aws.region");
+    AWS_REGION("aws.region"),
+    AWS_S3_ENDPOINT_URL("aws.s3.endpointUrl");
     // The is not an exhaustive list. Some property keys like s3.bucketPath.0 with a numbering
     // suffix is not included. They are only accessed internally from functions like
     // getS3Configurations.
@@ -99,6 +100,7 @@ public class ServerProperties {
       String secretKey = getProperty("s3.secretKey." + i);
       String sessionToken = getProperty("s3.sessionToken." + i);
       String credentialsGenerator = getProperty("s3.credentialsGenerator." + i);
+      String endpointUrl = getProperty("s3.endpointUrl." + i);
       if ((bucketPath == null || region == null || awsRoleArn == null)
           && (accessKey == null || secretKey == null || sessionToken == null)) {
         break;
@@ -112,6 +114,7 @@ public class ServerProperties {
               .secretKey(secretKey)
               .sessionToken(sessionToken)
               .credentialGenerator(credentialsGenerator)
+              .endpointUrl(endpointUrl)
               .build();
       s3BucketConfigMap.put(bucketPath, s3StorageConfig);
       i++;

--- a/server/src/test/java/io/unitycatalog/server/utils/AwsUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/AwsUtilsTest.java
@@ -1,0 +1,223 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+public class AwsUtilsTest {
+
+  private S3Client mockS3Client;
+
+  @BeforeEach
+  public void setUp() {
+    mockS3Client = mock(S3Client.class);
+  }
+
+  // Tests for getAwsCredentialsProvider(String, String, String)
+  @Test
+  public void testGetAwsCredentialsProviderWithValidCredentials() {
+    String accessKeyId = "test-access-key";
+    String secretAccessKey = "test-secret-key";
+    String sessionToken = "test-session-token";
+
+    AwsCredentialsProvider provider =
+        AwsUtils.getAwsCredentialsProvider(accessKeyId, secretAccessKey, sessionToken);
+
+    assertThat(provider).isNotNull();
+    assertThat(provider.resolveCredentials()).isNotNull();
+    assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo(accessKeyId);
+    assertThat(provider.resolveCredentials().secretAccessKey()).isEqualTo(secretAccessKey);
+  }
+
+  @Test
+  public void testGetAwsCredentialsProviderWithEmptySessionToken() {
+    String accessKeyId = "test-access-key";
+    String secretAccessKey = "test-secret-key";
+    String sessionToken = "";
+
+    AwsCredentialsProvider provider =
+        AwsUtils.getAwsCredentialsProvider(accessKeyId, secretAccessKey, sessionToken);
+
+    assertThat(provider).isNotNull();
+    assertThat(provider.resolveCredentials()).isNotNull();
+    assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo(accessKeyId);
+  }
+
+  @Test
+  public void testGetAwsCredentialsProviderWithMultipleCredentials() {
+    // Test that multiple providers can be created independently
+    AwsCredentialsProvider provider1 =
+        AwsUtils.getAwsCredentialsProvider("key1", "secret1", "token1");
+    AwsCredentialsProvider provider2 =
+        AwsUtils.getAwsCredentialsProvider("key2", "secret2", "token2");
+
+    assertThat(provider1).isNotNull();
+    assertThat(provider2).isNotNull();
+    assertThat(provider1.resolveCredentials().accessKeyId()).isEqualTo("key1");
+    assertThat(provider2.resolveCredentials().accessKeyId()).isEqualTo("key2");
+  }
+
+  // Tests for getAwsCredentialsProvider(Credentials)
+  @Test
+  public void testGetAwsCredentialsProviderWithCredentialsObject() {
+    software.amazon.awssdk.services.sts.model.Credentials awsCredentials =
+        software.amazon.awssdk.services.sts.model.Credentials.builder()
+            .accessKeyId("test-access-key")
+            .secretAccessKey("test-secret-key")
+            .sessionToken("test-session-token")
+            .build();
+
+    AwsCredentialsProvider provider = AwsUtils.getAwsCredentialsProvider(awsCredentials);
+
+    assertThat(provider).isNotNull();
+    assertThat(provider.resolveCredentials()).isNotNull();
+    assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo("test-access-key");
+    assertThat(provider.resolveCredentials().secretAccessKey()).isEqualTo("test-secret-key");
+  }
+
+  // Tests for getS3Client
+  @Test
+  public void testGetS3ClientWithValidParameters() {
+    AwsCredentialsProvider credentialsProvider =
+        AwsUtils.getAwsCredentialsProvider("key", "secret", "token");
+    String region = "us-east-1";
+    String endpointUrl = null;
+
+    S3Client client = AwsUtils.getS3Client(credentialsProvider, region, endpointUrl);
+
+    assertThat(client).isNotNull();
+    client.close();
+  }
+
+  @Test
+  public void testGetS3ClientWithCustomEndpointUrl() {
+    AwsCredentialsProvider credentialsProvider =
+        AwsUtils.getAwsCredentialsProvider("key", "secret", "token");
+    String region = "us-west-2";
+    String endpointUrl = "http://localhost:9000";
+
+    S3Client client = AwsUtils.getS3Client(credentialsProvider, region, endpointUrl);
+    assertThat(client).isNotNull();
+    client.close();
+  }
+
+  @Test
+  public void testGetS3ClientWithEmptyEndpointUrl() {
+    AwsCredentialsProvider credentialsProvider =
+        AwsUtils.getAwsCredentialsProvider("key", "secret", "token");
+    String region = "eu-west-1";
+    String endpointUrl = "";
+
+    S3Client client = AwsUtils.getS3Client(credentialsProvider, region, endpointUrl);
+
+    assertThat(client).isNotNull();
+    client.close();
+  }
+
+  @Test
+  public void testGetS3ClientWithDifferentRegions() {
+    AwsCredentialsProvider credentialsProvider =
+        AwsUtils.getAwsCredentialsProvider("key", "secret", "token");
+
+    String[] regions = {"us-east-1", "us-west-2", "eu-west-1", "ap-northeast-1"};
+    for (String region : regions) {
+      S3Client client = AwsUtils.getS3Client(credentialsProvider, region, null);
+      assertThat(client).isNotNull();
+      client.close();
+    }
+  }
+
+  // Tests for doesObjectExist
+  @Test
+  public void testDoesObjectExistWhenObjectExists() {
+    when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(null);
+
+    boolean exists = AwsUtils.doesObjectExist(mockS3Client, "test-bucket", "test-key");
+
+    assertThat(exists).isTrue();
+    verify(mockS3Client).headObject(any(HeadObjectRequest.class));
+  }
+
+  @Test
+  public void testDoesObjectExistWhenObjectDoesNotExist() {
+    when(mockS3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(NoSuchKeyException.builder().build());
+
+    boolean exists = AwsUtils.doesObjectExist(mockS3Client, "test-bucket", "test-key");
+
+    assertThat(exists).isFalse();
+    verify(mockS3Client).headObject(any(HeadObjectRequest.class));
+  }
+
+  @Test
+  public void testDoesObjectExistWithEmptyBucketName() {
+    assertThatThrownBy(() -> AwsUtils.doesObjectExist(mockS3Client, "", "test-key"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("The bucket name must not be null or an empty string");
+  }
+
+  @Test
+  public void testDoesObjectExistWithNullBucketName() {
+    assertThatThrownBy(() -> AwsUtils.doesObjectExist(mockS3Client, null, "test-key"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("The bucket name must not be null or an empty string");
+  }
+
+  @Test
+  public void testDoesObjectExistWithValidBucketAndKey() {
+    when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(null);
+
+    boolean exists = AwsUtils.doesObjectExist(mockS3Client, "my-bucket", "path/to/object");
+
+    assertThat(exists).isTrue();
+
+    ArgumentCaptor<HeadObjectRequest> captor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+    verify(mockS3Client).headObject(captor.capture());
+
+    HeadObjectRequest request = captor.getValue();
+    assertThat(request.bucket()).isEqualTo("my-bucket");
+    assertThat(request.key()).isEqualTo("path/to/object");
+  }
+
+  @Test
+  public void testDoesObjectExistWithKeyContainingSpecialCharacters() {
+    when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(null);
+
+    String keyWithSpecialChars = "path/to/object-with_special.chars(123).txt";
+    boolean exists = AwsUtils.doesObjectExist(mockS3Client, "test-bucket", keyWithSpecialChars);
+
+    assertThat(exists).isTrue();
+
+    ArgumentCaptor<HeadObjectRequest> captor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+    verify(mockS3Client).headObject(captor.capture());
+
+    assertThat(captor.getValue().key()).isEqualTo(keyWithSpecialChars);
+  }
+
+  @Test
+  public void testDoesObjectExistMultipleCallsWithDifferentKeys() {
+    when(mockS3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(null)
+        .thenThrow(NoSuchKeyException.builder().build())
+        .thenReturn(null);
+
+    boolean exists1 = AwsUtils.doesObjectExist(mockS3Client, "bucket", "key1");
+    boolean exists2 = AwsUtils.doesObjectExist(mockS3Client, "bucket", "key2");
+    boolean exists3 = AwsUtils.doesObjectExist(mockS3Client, "bucket", "key3");
+
+    assertThat(exists1).isTrue();
+    assertThat(exists2).isFalse();
+    assertThat(exists3).isTrue();
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR introduces support for a custom S3 endpoint URL

This allows users to connect to any S3-compatible object storage solution (such as MinIO, Ceph, LocalStack, etc.) instead of being limited to the default AWS S3 endpoints.

<!-- Signed-off-by: stanleylaw <19900516+dingo4dev@users.noreply.github.com> -->