### PR TITLE
Github action to automatically create backport PR from merged PR's changes using labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,17 +26,17 @@ jobs:
         with:
           # Use custom token for backport operations
           github_token: ${{ secrets.BACKPORT_ACTION_TOKEN }}
-          
+
           # Match labels like "backport branch-0.3"
           # The branch name is extracted from the capture group
           label_pattern: '^backport ([^ ]+)$'
-          
+
           # Copy the reviewers from the original PR
           copy_requested_reviewers: true
-          
+
           # Customize the title of the backport PR
           pull_title: '[Backport ${target_branch}] ${pull_title}'
-          
+
           # Customize the description
           pull_description: |
             Backport of #${pull_number} to `${target_branch}`.
@@ -44,7 +44,7 @@ jobs:
             ---
 
             ${pull_description}
-          
+
           add_author_as_assignee: true
           experimental: >
             {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

As the title says. Specifically,
- If you add a label "backport branch-0.3" to a PR, once the PR is merged, this github action will automatically create new PR with the merged + squashed changes on branch-0.3
- if there is a merge conflict, then it will create a draft pull request with the first conflict encountered committed.

It uses this market place action - https://github.com/marketplace/actions/backport-merged-pull-requests-to-selected-branches#backport-action

Here is an example usage in a project that i coped - https://github.com/camunda/camunda/blob/main/.github/workflows/backport.yml

