### PR TITLE
Refactor BaseTableCRUDTest to split the testing table preparation into a new base class

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTest.java
@@ -7,17 +7,10 @@ import static org.assertj.core.api.Assertions.fail;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
-import io.unitycatalog.client.model.CreateCatalog;
-import io.unitycatalog.client.model.CreateSchema;
-import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.DataSourceFormat;
-import io.unitycatalog.client.model.SchemaInfo;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.client.model.UpdateSchema;
-import io.unitycatalog.server.base.BaseCRUDTest;
-import io.unitycatalog.server.base.ServerConfig;
-import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.utils.TestUtils;
@@ -31,43 +24,22 @@ import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public abstract class BaseTableCRUDTest extends BaseCRUDTest {
-
-  protected SchemaOperations schemaOperations;
-  protected TableOperations tableOperations;
-  private String schemaId;
-
-  protected abstract SchemaOperations createSchemaOperations(ServerConfig serverConfig);
-
-  protected abstract TableOperations createTableOperations(ServerConfig serverConfig);
-
-  @BeforeEach
-  @Override
-  public void setUp() {
-    super.setUp();
-    schemaOperations = createSchemaOperations(serverConfig);
-    tableOperations = createTableOperations(serverConfig);
-  }
-
-  protected void createCommonResources() throws ApiException {
-    CreateCatalog createCatalog =
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
-    catalogOperations.createCatalog(createCatalog);
-
-    SchemaInfo schemaInfo =
-        schemaOperations.createSchema(
-            new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
-    schemaId = schemaInfo.getSchemaId();
-  }
+/**
+ * Abstract base class that provides some test cases for table CRUD operations in Unity Catalog.
+ *
+ * <p>This class extends {@link BaseTableCRUDTestEnv} and implements test suite that verifies the
+ * correct behavior of table operations including creation, retrieval, update, and deletion. It is
+ * derived by both CliTableCRUDTest and SdkTableCRUDTest which would exercise CLI and SDK with the
+ * test cases defined in this base class.
+ */
+public abstract class BaseTableCRUDTest extends BaseTableCRUDTestEnv {
 
   @Test
   public void testTableCRUD() throws IOException, ApiException {
     assertThatThrownBy(() -> tableOperations.getTable(TestUtils.TABLE_FULL_NAME))
         .isInstanceOf(Exception.class);
-    createCommonResources();
 
     // Create and verify a table
     TableInfo createdTable = createAndVerifyTable();
@@ -92,16 +64,6 @@ public abstract class BaseTableCRUDTest extends BaseCRUDTest {
 
     // Test schema update and deletion scenarios
     testTableAfterSchemaUpdateAndDeletion();
-  }
-
-  private TableInfo createAndVerifyTable() throws IOException, ApiException {
-    TableInfo tableInfo =
-        createTestingTable(TestUtils.TABLE_NAME, TestUtils.STORAGE_LOCATION, tableOperations);
-    assertThat(tableInfo.getName()).isEqualTo(TestUtils.TABLE_NAME);
-    assertThat(tableInfo.getCatalogName()).isEqualTo(TestUtils.CATALOG_NAME);
-    assertThat(tableInfo.getSchemaName()).isEqualTo(TestUtils.SCHEMA_NAME);
-    assertThat(tableInfo.getTableId()).isNotNull();
-    return tableInfo;
   }
 
   private void verifyTableInfo(TableInfo retrievedTable, TableInfo expectedTable) {
@@ -254,46 +216,6 @@ public abstract class BaseTableCRUDTest extends BaseCRUDTest {
                 schemaOperations.getSchema(
                     TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NEW_NAME))
         .isInstanceOf(Exception.class);
-  }
-
-  public static TableInfo createTestingTable(
-      String tableName, String storageLocation, TableOperations tableOperations)
-      throws IOException, ApiException {
-    ColumnInfo columnInfo1 =
-        new ColumnInfo()
-            .name("as_int")
-            .typeText("INTEGER")
-            .typeJson("{\"type\": \"integer\"}")
-            .typeName(ColumnTypeName.INT)
-            .typePrecision(10)
-            .typeScale(0)
-            .position(0)
-            .comment("Integer column")
-            .nullable(true);
-
-    ColumnInfo columnInfo2 =
-        new ColumnInfo()
-            .name("as_string")
-            .typeText("VARCHAR(255)")
-            .typeJson("{\"type\": \"string\", \"length\": \"255\"}")
-            .typeName(ColumnTypeName.STRING)
-            .position(1)
-            .comment("String column")
-            .nullable(true);
-
-    CreateTable createTableRequest =
-        new CreateTable()
-            .name(tableName)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .columns(List.of(columnInfo1, columnInfo2))
-            .properties(TestUtils.PROPERTIES)
-            .comment(TestUtils.COMMENT)
-            .storageLocation(storageLocation)
-            .tableType(TableType.EXTERNAL)
-            .dataSourceFormat(DataSourceFormat.DELTA);
-
-    return tableOperations.createTable(createTableRequest);
   }
 
   protected List<TableInfo> createMultipleTestingTables(int numberOfTables)

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTestEnv.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTestEnv.java
@@ -1,0 +1,109 @@
+package io.unitycatalog.server.base.table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.SchemaInfo;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.BaseCRUDTest;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Abstract base class that provides the test environment setup for table CRUD operations.
+ *
+ * <p>This class extends {@link BaseCRUDTest} and serves as a foundation for testing table-related
+ * operations in Unity Catalog. It's useful for any CRUD test that needs to create test tables.
+ */
+public abstract class BaseTableCRUDTestEnv extends BaseCRUDTest {
+
+  protected SchemaOperations schemaOperations;
+  protected TableOperations tableOperations;
+  protected String schemaId;
+
+  protected abstract SchemaOperations createSchemaOperations(ServerConfig serverConfig);
+
+  protected abstract TableOperations createTableOperations(ServerConfig serverConfig);
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    schemaOperations = createSchemaOperations(serverConfig);
+    tableOperations = createTableOperations(serverConfig);
+    createCommonResources();
+  }
+
+  private void createCommonResources() {
+    CreateCatalog createCatalog =
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
+    try {
+      catalogOperations.createCatalog(createCatalog);
+      SchemaInfo schemaInfo =
+          schemaOperations.createSchema(
+              new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
+      schemaId = schemaInfo.getSchemaId();
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected TableInfo createAndVerifyTable() throws IOException, ApiException {
+    TableInfo tableInfo =
+        createTestingTable(TestUtils.TABLE_NAME, TestUtils.STORAGE_LOCATION, tableOperations);
+    assertThat(tableInfo.getName()).isEqualTo(TestUtils.TABLE_NAME);
+    assertThat(tableInfo.getCatalogName()).isEqualTo(TestUtils.CATALOG_NAME);
+    assertThat(tableInfo.getSchemaName()).isEqualTo(TestUtils.SCHEMA_NAME);
+    assertThat(tableInfo.getTableId()).isNotNull();
+    return tableInfo;
+  }
+
+  public static TableInfo createTestingTable(
+      String tableName, String storageLocation, TableOperations tableOperations)
+      throws IOException, ApiException {
+    ColumnInfo columnInfo1 =
+        new ColumnInfo()
+            .name("as_int")
+            .typeText("INTEGER")
+            .typeJson("{\"type\": \"integer\"}")
+            .typeName(ColumnTypeName.INT)
+            .position(0)
+            .comment("Integer column")
+            .nullable(true);
+
+    ColumnInfo columnInfo2 =
+        new ColumnInfo()
+            .name("as_string")
+            .typeText("VARCHAR(255)")
+            .typeJson("{\"type\": \"string\", \"length\": \"255\"}")
+            .typeName(ColumnTypeName.STRING)
+            .position(1)
+            .comment("String column")
+            .nullable(true);
+
+    CreateTable createTableRequest =
+        new CreateTable()
+            .name(tableName)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(List.of(columnInfo1, columnInfo2))
+            .properties(TestUtils.PROPERTIES)
+            .comment(TestUtils.COMMENT)
+            .storageLocation(storageLocation)
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.DELTA);
+
+    return tableOperations.createTable(createTableRequest);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -73,7 +73,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
 
   @Test
   public void testListTablesWithNoNextPageTokenShouldReturnNull() throws Exception {
-    createCommonResources();
     TableInfo testingTable =
         createTestingTable(TestUtils.TABLE_NAME, TestUtils.STORAGE_LOCATION, tableOperations);
     ListTablesResponse resp =
@@ -90,7 +89,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
 
   @Test
   public void testListTablesWithNextPageTokenShouldReturnNextPageToken() throws Exception {
-    createCommonResources();
     List<TableInfo> testingTables = createMultipleTestingTables(11);
     ListTablesResponse resp =
         localTablesApi.listTables(
@@ -114,7 +112,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
    */
   @Test
   public void testStagingTableCreationAndManagedTableFromStagingLocation() throws Exception {
-    createCommonResources();
     String stagingTableName = "staging_test_table";
 
     // Step 1: Create a staging table
@@ -200,8 +197,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
    */
   @Test
   public void testManagedTableCreationFromNonExistentStagingLocationShouldFail() throws Exception {
-    createCommonResources();
-
     // Use a fake staging location that doesn't exist
     String fakeLocationUuid = "00000000-0000-0000-0000-000000000000";
     String fakeStagingLocation = "file:///tmp/ucroot/tables/" + fakeLocationUuid;
@@ -228,8 +223,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
   /** Test that attempting to create a duplicate staging table fails with ALREADY_EXISTS error. */
   @Test
   public void testDuplicateStagingTableCreationShouldFail() throws Exception {
-    createCommonResources();
-
     // Create an external table
     String externalTableName = "duplicate_table";
     CreateTable createTableRequest =
@@ -286,8 +279,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
    */
   @Test
   public void testMultipleStagingTableCreation() throws Exception {
-    createCommonResources();
-
     String stagingTable1 = "staging_table_1";
     String stagingTable2 = "staging_table_2";
 
@@ -315,8 +306,6 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
   /** Test that staging table creation fails when the schema doesn't exist. */
   @Test
   public void testStagingTableCreationWithNonExistentSchemaShouldFail() throws Exception {
-    createCommonResources();
-
     CreateStagingTable createStagingTableRequest =
         new CreateStagingTable()
             .catalogName(TestUtils.CATALOG_NAME)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1153/files) to review incremental changes.
- [**refactor_base_table_crud_test**](https://github.com/unitycatalog/unitycatalog/pull/1153) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1153/files)]
  - [staging_table_cli_test](https://github.com/unitycatalog/unitycatalog/pull/1136) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1136/files/8c0501897d14d08f1821d8c1cd93975305ebc3d8..95408a203472f015bd63cea1386e1c9134332373)]

---------
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Refactor BaseTableCRUDTest to split the testing table preparation into a new base class BaseTableCRUDTestEnv.
This new base class BaseTableCRUDTestEnv will also be used by a new test for table commits.
The remaining part in BaseTableCRUDTest is the table crud tests.
Also createCommonResources() is called automatically for all tests based on BaseTableCRUDTestEnv.
