### PR TITLE
Implement getCommits for Delta commits retrieval

### DIFF
--- a/api/Models/DeltaGetCommitsResponse.md
+++ b/api/Models/DeltaGetCommitsResponse.md
@@ -3,8 +3,8 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **commits** | [**List**](DeltaCommitInfo.md) | The list of unbackfilled Delta table commits. Can be in arbitrary order. | [optional] [default to null] |
-| **latest\_table\_version** | **Long** | Represents the latest version of the table tracked by UC. If no commits have occurred via UC yet,  then UC cannot determine the latest version and returns -1. Use this field to manage pagination —  if the returned commits don&#39;t cover the range up to latest_table_version or end_version (whichever is smaller),  it indicates that more unbackfilled commits may be available.  | [optional] [default to null] |
+| **commits** | [**List**](DeltaCommitInfo.md) | The list of unbackfilled Delta table commits. Can be in arbitrary order. | [default to null] |
+| **latest\_table\_version** | **Long** | Represents the latest version of the table tracked by UC. If no commits have occurred via UC yet,  then UC cannot determine the latest version and returns -1. Use this field to manage pagination —  if the returned commits don&#39;t cover the range up to latest_table_version or end_version (whichever is smaller),  it indicates that more unbackfilled commits may be available.  | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -3025,6 +3025,9 @@ components:
             then UC cannot determine the latest version and returns -1. Use this field to manage pagination — 
             if the returned commits don't cover the range up to latest_table_version or end_version (whichever is smaller), 
             it indicates that more unbackfilled commits may be available.
+      required:
+        - commits
+        - latest_table_version
 info:
   title: Unity Catalog API
   version: '0.1'

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
@@ -54,6 +54,15 @@ public class DeltaCommitDAO {
   @Column(name = "is_backfilled_latest_commit", nullable = false)
   private boolean isBackfilledLatestCommit;
 
+  public DeltaCommitInfo toCommitInfo() {
+    return new DeltaCommitInfo()
+        .version(commitVersion)
+        .fileName(commitFilename)
+        .fileSize(commitFilesize)
+        .fileModificationTimestamp(commitFileModificationTimestamp.getTime())
+        .timestamp(commitTimestamp.getTime());
+  }
+
   public static DeltaCommitDAO from(UUID tableId, DeltaCommitInfo commitInfo) {
     return DeltaCommitDAO.builder()
         .tableId(tableId)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1170/files) to review incremental changes.
- [**stack/commit_get**](https://github.com/unitycatalog/unitycatalog/pull/1170) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1170/files)]
  - [stack/commit_access_test](https://github.com/unitycatalog/unitycatalog/pull/1178) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1178/files/2170d0bcd2ae26a70bd10d094cf20f968d929874..b9bd7194e2bda546e69e8782cba3da95e1b4c83d)]
    - [stack/ccv2_spark](https://github.com/unitycatalog/unitycatalog/pull/1186) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1186/files/b9bd7194e2bda546e69e8782cba3da95e1b4c83d..1deff5e7a5805b9b1da01e8111a48ba1b8c09216)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This commit adds the ability to retrieve commits for managed Delta tables with coordinated commit semantics, completing the read path for the coordinated commits API.

Key features:
- Version range filtering (inclusive start and end)
- Returns commits in descending order (newest first)
- Returns latestTableVersion even when commit list is empty
- Proper error handling for invalid parameters

**Related issue**
https://github.com/unitycatalog/unitycatalog/issues/1143
