### PR TITLE
[CI/CD] Upload test artifacts in GitHub Actions Unit Tests pipeline.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   test:
@@ -32,6 +33,19 @@ jobs:
 
     - name: Run tests with coverage
       run: build/sbt -J-Xmx2G +jacoco
-
+    - name: Upload test artifacts for manual inspection
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbt-test-results
+        path: |
+          connectors/spark/target/test-reports/**/*.xml
+          examples/cli/target/test-reports/**/*.xml
+          server/target/test-reports/**/*.xml
+    - name: Publish Test Report
+      if: always()
+      uses: scacap/action-surefire-report@v1
+      with:
+        report_paths: 'connectors/spark/target/test-reports/**/*.xml,examples/cli/target/test-reports/**/*.xml,server/target/test-reports/**/*.xml'
     - name: Run license check
       run: build/sbt licenseCheck


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Sometimes the tests fail and in the stream of logs it is difficult to find which tests failed and what succeeded. The test framework generates tests report which can be read and we don't have to filter the entire stream of logs to find the precise logs and stack traces.

I've run across the problem of identifying what was wrong when developing https://github.com/unitycatalog/unitycatalog/pull/1003 and couldn't trace the problem with the logs only.
