### PR TITLE
[0.3] Add GenericCredential cache to reuse the table-level / path-level credential in the vended token provider

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCHadoopConf.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCHadoopConf.java
@@ -15,6 +15,11 @@ public class UCHadoopConf {
   public static final String UC_URI_KEY = "unitycatalog.uri";
   public static final String UC_TOKEN_KEY = "unitycatalog.token";
 
+  // Key representing a unique credential ID. It identifies a job-level credential for a specific
+  // table, meaning that the same job–table combination shares the same credential. Cached
+  // credentials are indexed by this key and are not reused across different jobs.
+  public static final String UC_CREDENTIALS_UID_KEY = "unitycatalog.credentials.uid";
+
   // Keys for table based temporary credential requests
   public static final String UC_TABLE_ID_KEY = "unitycatalog.table.id";
   public static final String UC_TABLE_OPERATION_KEY = "unitycatalog.table.operation";
@@ -27,4 +32,9 @@ public class UCHadoopConf {
   public static final String UC_CREDENTIALS_TYPE_KEY = "unitycatalog.credentials.type";
   public static final String UC_CREDENTIALS_TYPE_TABLE_VALUE = "table";
   public static final String UC_CREDENTIALS_TYPE_PATH_VALUE = "path";
+
+  // Key to enable the credential cache.
+  public static final String UC_CREDENTIAL_CACHE_ENABLED_KEY =
+      "unitycatalog.credential.cache.enabled";
+  public static final boolean UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE = true;
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/AwsVendedTokenProvider.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/AwsVendedTokenProvider.java
@@ -2,7 +2,7 @@ package io.unitycatalog.spark.auth;
 
 import io.unitycatalog.spark.UCHadoopConf;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.shaded.com.google.common.base.Preconditions;
+import org.sparkproject.guava.base.Preconditions;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/GenericCredential.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/GenericCredential.java
@@ -2,6 +2,7 @@ package io.unitycatalog.spark.auth;
 
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.Objects;
 
 public class GenericCredential {
   private final TemporaryCredentials tempCred;
@@ -43,5 +44,24 @@ public class GenericCredential {
   public boolean readyToRenew(long renewalLeadTimeMillis) {
     return tempCred.getExpirationTime() != null &&
         tempCred.getExpirationTime() <= System.currentTimeMillis() + renewalLeadTimeMillis;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(tempCred);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GenericCredential that = (GenericCredential) o;
+    return Objects.equals(tempCred, that.tempCred);
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Related issues: 
* https://github.com/unitycatalog/unitycatalog/issues/1103
* https://github.com/unitycatalog/unitycatalog/issues/1163

Backport the PR https://github.com/unitycatalog/unitycatalog/pull/1108 to the branch-0.3 
