### PR TITLE
[Infra] Fixed backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -46,6 +46,7 @@ jobs:
     # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
     # own PAT as `github_token`, that you should replace this id with yours.
     # https://github.com/korthout/backport-action for more details.
+    if: >
       (
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.merged


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Previous PR https://github.com/unitycatalog/unitycatalog/pull/1172 broke the backport action. It was not caught because the backport action does not run pre-merge, only post-merge. This PR fixes it.