### PR TITLE
[Backport branch-0.3] RetryHttpClient to enable Retry for UC

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientConf.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientConf.java
@@ -1,0 +1,89 @@
+package io.unitycatalog.spark;
+
+import org.sparkproject.guava.base.Preconditions;
+
+/**
+ * Holds configuration that tweaks the behaviour of the Unity Catalog API client.
+ *
+ * <p>The defaults here are chosen to work out of the box. Callers can override them either
+ * programmatically or via {@link UCHadoopConf#setApiClientConf} when communicating through
+ * Hadoop configuration. These settings are used by {@link RetryingApiClient} to configure the
+ * retry behaviour of the {@link RetryingHttpClient}.</p>
+ *
+ * <p>Retry defaults:</p>
+ * <ul>
+ *   <li>{@link #DEFAULT_REQUEST_MAX_ATTEMPTS}: maximum attempts per request (initial try plus
+ *       retries).</li>
+ *   <li>{@link #DEFAULT_REQUEST_INITIAL_DELAY_MS}: initial backoff delay in milliseconds; later
+ *       attempts scale this using {@code initialDelayMs * multiplier ^ (attempt - 1) *
+ *       (1 ± jitterFactor)}.</li>
+ *   <li>{@link #DEFAULT_REQUEST_DELAY_MULTIPLIER}: exponential multiplier (e.g. {@code 2.0} doubles
+ *       the wait each retry).</li>
+ *   <li>{@link #DEFAULT_REQUEST_DELAY_JITTER_FACTOR}: jitter fraction in {@code [0, 1)} applied to
+ *       the computed delay (e.g. {@code 0.5} randomises by ±50%).</li>
+ * </ul>
+ */
+public class ApiClientConf {
+
+  public static final int DEFAULT_REQUEST_MAX_ATTEMPTS = 3;
+  public static final long DEFAULT_REQUEST_INITIAL_DELAY_MS = 500L;
+  public static final double DEFAULT_REQUEST_DELAY_MULTIPLIER = 2.0;
+  public static final double DEFAULT_REQUEST_DELAY_JITTER_FACTOR = 0.5;
+
+  private int requestMaxAttempts;
+  private long requestInitialDelayMs;
+  private double requestDelayMultiplier;
+  private double requestDelayJitterFactor;
+
+  public ApiClientConf() {
+    this.requestMaxAttempts = DEFAULT_REQUEST_MAX_ATTEMPTS;
+    this.requestInitialDelayMs = DEFAULT_REQUEST_INITIAL_DELAY_MS;
+    this.requestDelayMultiplier = DEFAULT_REQUEST_DELAY_MULTIPLIER;
+    this.requestDelayJitterFactor = DEFAULT_REQUEST_DELAY_JITTER_FACTOR;
+  }
+
+  public int getRequestMaxAttempts() {
+    return requestMaxAttempts;
+  }
+
+  public ApiClientConf setRequestMaxAttempts(int requestMaxAttempts) {
+    Preconditions.checkArgument(requestMaxAttempts >= 1,
+        "Retry max attempts must be at least 1, but got %s", requestMaxAttempts);
+    this.requestMaxAttempts = requestMaxAttempts;
+    return this;
+  }
+
+  public long getRequestInitialDelayMs() {
+    return requestInitialDelayMs;
+  }
+
+  public ApiClientConf setRequestInitialDelayMs(long requestInitialDelayMs) {
+    Preconditions.checkArgument(requestInitialDelayMs > 0,
+        "Retry initial delay must be positive, but got %s", requestInitialDelayMs);
+    this.requestInitialDelayMs = requestInitialDelayMs;
+    return this;
+  }
+
+  public double getRequestDelayMultiplier() {
+    return requestDelayMultiplier;
+  }
+
+  public ApiClientConf setRequestDelayMultiplier(double requestDelayMultiplier) {
+    Preconditions.checkArgument(requestDelayMultiplier > 0,
+        "Retry delay multiplier must be positive, but got %s", requestDelayMultiplier);
+    this.requestDelayMultiplier = requestDelayMultiplier;
+    return this;
+  }
+
+  public double getRequestDelayJitterFactor() {
+    return requestDelayJitterFactor;
+  }
+
+  public ApiClientConf setRequestDelayJitterFactor(double requestDelayJitterFactor) {
+    Preconditions.checkArgument(requestDelayJitterFactor >= 0 && requestDelayJitterFactor < 1,
+        "Retry delay jitter factor must be in [0, 1), but got %s", requestDelayJitterFactor);
+    this.requestDelayJitterFactor = requestDelayJitterFactor;
+    return this;
+  }
+}
+

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
@@ -1,24 +1,24 @@
 package io.unitycatalog.spark;
 
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.spark.utils.Clock;
 
 import java.net.URI;
 
 public class ApiClientFactory {
   private ApiClientFactory() {}
 
-  public static ApiClient createApiClient(URI url, String token) {
-    ApiClient apiClient = new ApiClient()
-        .setHost(url.getHost())
+  public static ApiClient createApiClient(ApiClientConf clientConf, URI url, String token) {
+    RetryingApiClient apiClient = new RetryingApiClient(clientConf, Clock.systemClock());
+    apiClient.setHost(url.getHost())
         .setPort(url.getPort())
         .setScheme(url.getScheme());
 
     if (token != null && !token.isEmpty()) {
-      apiClient = apiClient.setRequestInterceptor(
+      apiClient.setRequestInterceptor(
           request -> request.header("Authorization", "Bearer " + token)
       );
     }
-
     return apiClient;
   }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/HttpRetryHandler.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/HttpRetryHandler.java
@@ -1,0 +1,112 @@
+package io.unitycatalog.spark;
+
+import io.unitycatalog.spark.utils.Clock;
+import org.sparkproject.guava.base.Preconditions;
+import org.sparkproject.guava.base.Throwables;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Retry handler that retries on common recoverable HTTP errors and network exceptions.
+ */
+public class HttpRetryHandler {
+  // Non-5xx server errors are not retried.
+  private static final Set<Integer> RECOVERABLE_STATUS_CODES = Set.of(
+      429  // Too Many Requests
+  );
+
+  private static final Set<Class<? extends Throwable>> RECOVERABLE_EXCEPTIONS = Set.of(
+      java.net.SocketTimeoutException.class,
+      java.net.SocketException.class,
+      java.net.UnknownHostException.class
+  );
+
+  private final Clock clock;
+  private final int maxAttempts;
+  private final long initialDelayMs;
+  private final double delayMultiplier;
+  private final double delayJitterFactor;
+
+
+  HttpRetryHandler(ApiClientConf conf, Clock clock) {
+    Preconditions.checkNotNull(conf, "ApiClientConf must not be null");
+    Preconditions.checkNotNull(clock, "Clock must not be null");
+    this.clock = clock;
+    this.maxAttempts = conf.getRequestMaxAttempts();
+    this.initialDelayMs = conf.getRequestInitialDelayMs();
+    this.delayMultiplier = conf.getRequestDelayMultiplier();
+    this.delayJitterFactor = conf.getRequestDelayJitterFactor();
+  }
+
+  public <T> HttpResponse<T> call(
+      HttpClient delegate,
+      HttpRequest request,
+      HttpResponse.BodyHandler<T> responseBodyHandler) throws IOException, InterruptedException {
+    IOException lastException = null;
+    Instant startTime = clock.now();
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      HttpResponse<T> response;
+      boolean shouldRetry = true;
+      try {
+        response = delegate.send(request, responseBodyHandler);
+        if (!isRetryable(response.statusCode())) {
+          return response;
+        }
+      } catch (IOException e) {
+        lastException = e;
+        shouldRetry = isRecoverableException(e);
+      }
+
+      if (shouldRetry && attempt < maxAttempts) {
+        sleepWithBackoff(attempt);
+      } else {
+        break;
+      }
+    }
+
+    if (lastException != null) {
+      throw lastException;
+    } else {
+      long elapsedMs = Duration.between(startTime, clock.now()).toMillis();
+      throw new IOException(String.format(
+          "Failed HTTP request after %s attempts with elapsed time %s ms",
+          maxAttempts, elapsedMs));
+    }
+  }
+
+  private static boolean isRetryable(int statusCode) {
+    return RECOVERABLE_STATUS_CODES.contains(statusCode) ||
+        (statusCode >= 500 && statusCode < 600);
+  }
+
+  private void sleepWithBackoff(int attempt) throws InterruptedException {
+    long baseDelay = (long) (initialDelayMs * Math.pow(delayMultiplier, attempt - 1));
+    double jitter = delayJitterFactor == 0 ? 0 : (Math.random() - 0.5) * 2 * delayJitterFactor;
+    long delay = (long) (baseDelay * (1 + jitter));
+    if (delay <= 0) {
+      return;
+    }
+
+    try {
+      clock.sleep(Duration.ofMillis(delay));
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      throw interrupted;
+    }
+  }
+
+  private boolean isRecoverableException(Throwable e) {
+    // Check the entire exception cause chain for recoverable exceptions
+    return Throwables.getCausalChain(e).stream()
+        .anyMatch(cause -> RECOVERABLE_EXCEPTIONS.stream()
+            .anyMatch(exceptionClass -> exceptionClass.isInstance(cause)));
+  }
+}
+

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/RetryingApiClient.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/RetryingApiClient.java
@@ -1,0 +1,34 @@
+package io.unitycatalog.spark;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.spark.utils.Clock;
+import java.net.http.HttpClient;
+
+/**
+ * Adds retry handling on top of the generated {@link ApiClient}.
+ *
+ * <p>The base {@link ApiClient} comes from the OpenAPI generator and is overwritten on every regen.
+ * To keep that file untouched, this subclass overrides {@link #getHttpClient()} and wraps the
+ * generated {@link HttpClient} in a {@link RetryingHttpClient} configured through
+ * {@link ApiClientConf} and {@link HttpRetryHandler} (which defines the retry mechanism). Adding
+ * retries at the HTTP layer means every generated API surface (for example {@code
+ * TemporaryCredentialsApi}, {@code TablesApi}, etc.) inherits the same policy
+ * without extra wrappers.</p>
+ */
+public class RetryingApiClient extends ApiClient {
+
+  private final HttpRetryHandler retryHandler;
+
+  public RetryingApiClient(ApiClientConf apiClientConf, Clock clock) {
+    ApiClientConf effectiveConf = apiClientConf != null ? apiClientConf : new ApiClientConf();
+    Clock effectiveClock = clock != null ? clock : Clock.systemClock();
+    this.retryHandler = new HttpRetryHandler(effectiveConf, effectiveClock);
+  }
+
+  @Override
+  public HttpClient getHttpClient() {
+    HttpClient baseClient = super.getHttpClient();
+    return new RetryingHttpClient(baseClient, retryHandler);
+  }
+}
+

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/RetryingHttpClient.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/RetryingHttpClient.java
@@ -1,0 +1,105 @@
+package io.unitycatalog.spark;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+/**
+ * Wraps an {@link HttpClient} to add retries.
+ *
+ * <p>The generated {@link io.unitycatalog.client.ApiClient} is recreated from OpenAPI specs, so we
+ * keep retry state outside of it. Handling retries here means every generated endpoint class that
+ * relies on the shared {@link io.unitycatalog.client.ApiClient} automatically gets the same
+ * behaviour. {@link RetryingApiClient} uses this adapter to run retries through
+ * {@link HttpRetryHandler} by overriding {@link #send(HttpRequest, HttpResponse.BodyHandler)} to
+ * call {@link HttpRetryHandler#call}, which implements exponential backoff while using the
+ * underlying {@link HttpClient#send(HttpRequest, HttpResponse.BodyHandler)} to send the request.
+ * </p>
+ */
+public class RetryingHttpClient extends HttpClient {
+  private final HttpClient delegate;
+  private final HttpRetryHandler retryHandler;
+
+  public RetryingHttpClient(HttpClient delegate, HttpRetryHandler retryHandler) {
+    this.delegate = delegate;
+    this.retryHandler = retryHandler;
+  }
+
+  @Override
+  public Optional<CookieHandler> cookieHandler() {
+    return delegate.cookieHandler();
+  }
+
+  @Override
+  public Optional<Duration> connectTimeout() {
+    return delegate.connectTimeout();
+  }
+
+  @Override
+  public Redirect followRedirects() {
+    return delegate.followRedirects();
+  }
+
+  @Override
+  public Optional<ProxySelector> proxy() {
+    return delegate.proxy();
+  }
+
+  @Override
+  public SSLContext sslContext() {
+    return delegate.sslContext();
+  }
+
+  @Override
+  public SSLParameters sslParameters() {
+    return delegate.sslParameters();
+  }
+
+  @Override
+  public Optional<Authenticator> authenticator() {
+    return delegate.authenticator();
+  }
+
+  @Override
+  public Version version() {
+    return delegate.version();
+  }
+
+  @Override
+  public Optional<Executor> executor() {
+    return delegate.executor();
+  }
+
+  @Override
+  public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler)
+      throws IOException, InterruptedException {
+    return retryHandler.call(delegate, request, handler);
+  }
+
+  @Override
+  public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+      HttpRequest request,
+      HttpResponse.BodyHandler<T> handler) {
+    return delegate.sendAsync(request, handler);
+  }
+
+  @Override
+  public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+      HttpRequest request,
+      HttpResponse.BodyHandler<T> handler,
+      HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+    // Delegate without retry for async calls
+    return delegate.sendAsync(request, handler, pushPromiseHandler);
+  }
+}
+

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCHadoopConf.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCHadoopConf.java
@@ -1,5 +1,7 @@
 package io.unitycatalog.spark;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class UCHadoopConf {
   private UCHadoopConf() {
   }
@@ -50,4 +52,47 @@ public class UCHadoopConf {
   public static final String UC_CREDENTIAL_CACHE_ENABLED_KEY =
       "fs.unitycatalog.credential.cache.enabled";
   public static final boolean UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE = true;
+
+  // Keys for HTTP request configuration - see ApiClientConf for more details.
+  public static final String REQUEST_RETRY_MAX_ATTEMPTS_KEY =
+      "fs.unitycatalog.request.retry.maxAttempts";
+  public static final String REQUEST_RETRY_INITIAL_DELAY_KEY =
+      "fs.unitycatalog.request.retry.initialDelayMs";
+  public static final String REQUEST_RETRY_DELAY_MULTIPLIER_KEY =
+      "fs.unitycatalog.request.retry.delayMultiplier";
+  public static final String REQUEST_RETRY_DELAY_JITTER_FACTOR_KEY =
+      "fs.unitycatalog.request.retry.delayJitterFactor";
+
+  // Sets the HTTP request retry configuration in the Hadoop configuration.
+  public static void setApiClientConf(Configuration conf, ApiClientConf apiClientConf) {
+    if (conf == null || apiClientConf == null) {
+      return;
+    }
+    conf.setInt(
+        REQUEST_RETRY_MAX_ATTEMPTS_KEY, apiClientConf.getRequestMaxAttempts());
+    conf.setLong(
+        REQUEST_RETRY_INITIAL_DELAY_KEY, apiClientConf.getRequestInitialDelayMs());
+    conf.setDouble(
+        REQUEST_RETRY_DELAY_MULTIPLIER_KEY, apiClientConf.getRequestDelayMultiplier());
+    conf.setDouble(
+        REQUEST_RETRY_DELAY_JITTER_FACTOR_KEY, apiClientConf.getRequestDelayJitterFactor());
+  }
+
+  public static ApiClientConf getApiClientConf(Configuration conf) {
+    ApiClientConf apiClientConf = new ApiClientConf();
+    if (conf == null) {
+      return apiClientConf;
+    }
+
+    apiClientConf
+        .setRequestMaxAttempts(conf.getInt(
+            REQUEST_RETRY_MAX_ATTEMPTS_KEY, apiClientConf.getRequestMaxAttempts()))
+        .setRequestInitialDelayMs(conf.getLong(
+            REQUEST_RETRY_INITIAL_DELAY_KEY, apiClientConf.getRequestInitialDelayMs()))
+        .setRequestDelayMultiplier(conf.getDouble(
+            REQUEST_RETRY_DELAY_MULTIPLIER_KEY, apiClientConf.getRequestDelayMultiplier()))
+        .setRequestDelayJitterFactor(conf.getDouble(
+            REQUEST_RETRY_DELAY_JITTER_FACTOR_KEY, apiClientConf.getRequestDelayJitterFactor()));
+    return apiClientConf;
+  }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -49,7 +49,7 @@ class UCSingleCatalog
       OptionsUtil.RENEW_CREDENTIAL_ENABLED,
       OptionsUtil.DEFAULT_RENEW_CREDENTIAL_ENABLED)
 
-    apiClient = ApiClientFactory.createApiClient(uri, token)
+    apiClient = ApiClientFactory.createApiClient(new ApiClientConf(), uri, token)
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     val proxy = new UCProxy(uri, token, renewCredEnabled, apiClient, temporaryCredentialsApi)
     proxy.initialize(name, options)

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/GenericCredentialProvider.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/GenericCredentialProvider.java
@@ -7,6 +7,7 @@ import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.spark.ApiClientConf;
 import io.unitycatalog.spark.ApiClientFactory;
 import io.unitycatalog.spark.UCHadoopConf;
 import io.unitycatalog.spark.utils.Clock;
@@ -97,11 +98,14 @@ public abstract class GenericCredentialProvider {
   }
 
   protected TemporaryCredentialsApi temporaryCredentialsApi() {
+    // Retry is automatically handled by RetryingHttpClient when configured
+    // via fs.unitycatalog.request.retry*
     if (tempCredApi == null) {
       synchronized (this) {
         if (tempCredApi == null) {
+          ApiClientConf clientConf = UCHadoopConf.getApiClientConf(conf);
           tempCredApi = new TemporaryCredentialsApi(
-              ApiClientFactory.createApiClient(ucUri, ucToken));
+              ApiClientFactory.createApiClient(clientConf, ucUri, ucToken));
         }
       }
     }
@@ -133,8 +137,6 @@ public abstract class GenericCredentialProvider {
     // Generate the temporary credential via requesting UnityCatalog.
     TemporaryCredentials tempCred;
     String type = conf.get(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY);
-    // TODO We will need to retry the temporary credential request if any recoverable failure, for
-    // more robustness.
     if (UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
       String path = conf.get(UCHadoopConf.UC_PATH_KEY);
       String pathOperation = conf.get(UCHadoopConf.UC_PATH_OPERATION_KEY);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/utils/Clock.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/utils/Clock.java
@@ -10,10 +10,15 @@ public interface Clock {
   Instant now();
 
   /**
-   * Advances the current time of this clock by the specified duration. After this call,
-   * {@link #now()} should return a time equal to the previous time plus the given {@code duration}.
+   * Sleeps for the given duration.
+   * <p>
+   * For system clock, this performs an actual sleep by calling {@link Thread#sleep}.
+   * For manual clock, this advances the clock time by the given duration without sleeping.
+   *
+   * @param duration the duration to sleep
+   * @throws InterruptedException if the sleep is interrupted (only for system clock)
    */
-  void advance(Duration duration);
+  void sleep(Duration duration) throws InterruptedException;
 
   static Clock systemClock() {
     return SystemClock.SINGLETON;
@@ -32,8 +37,8 @@ public interface Clock {
     }
 
     @Override
-    public void advance(Duration duration) {
-      throw new UnsupportedOperationException("Cannot advance system clock.");
+    public void sleep(Duration duration) throws InterruptedException {
+      Thread.sleep(duration.toMillis());
     }
   }
 
@@ -50,7 +55,8 @@ public interface Clock {
     }
 
     @Override
-    public synchronized void advance(Duration duration) {
+    public synchronized void sleep(Duration duration) {
+      // For manual clock, just advance the time without actual sleeping
       now = now.plus(duration);
     }
   }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/HttpRetryHandlerTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/HttpRetryHandlerTest.java
@@ -1,0 +1,206 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.spark.utils.Clock;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+public class HttpRetryHandlerTest {
+  private Clock.ManualClock clock;
+
+  @BeforeEach
+  public void setUp() {
+    clock = (Clock.ManualClock) Clock.manualClock(Instant.now());
+  }
+
+  @AfterEach
+  public void tearDown() {
+    clock = null;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testRetrySucceedsAfterTwoFailures() throws IOException, InterruptedException {
+    ApiClientConf conf =
+        new ApiClientConf()
+            .setRequestMaxAttempts(5)
+            .setRequestInitialDelayMs(100L)
+            .setRequestDelayMultiplier(2.0)
+            .setRequestDelayJitterFactor(0.0); // Disable jitter
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/test")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response503 = createMockResponse(503, "Service Unavailable");
+    HttpResponse<String> response429 = createMockResponse(429, "Too Many Requests");
+    HttpResponse<String> response200 = createMockResponse(200, "Success");
+
+    // Configure mock to fail twice, then succeed
+    when(mockClient.send(
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(response503)
+        .thenReturn(response429)
+        .thenReturn(response200);
+
+    Instant start = clock.now();
+    HttpRetryHandler handler = new HttpRetryHandler(conf, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    verify(mockClient, times(3))
+        .send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+
+    assertThat(result.statusCode()).isEqualTo(200);
+    assertThat(result.body()).isEqualTo("Success");
+
+    // Verify clock advanced for retries (2 retries)
+    // First retry delay: 100ms * 2^0 = 100ms
+    // Second retry delay: 100ms * 2^1 = 200ms
+    // Total: 300ms
+    Instant expectedTime = start.plusMillis(300);
+    assertThat(clock.now()).isAfterOrEqualTo(expectedTime);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testRetryServerErrorAppliesJitterWithinBounds()
+      throws IOException, InterruptedException {
+    double jitterFactor = 0.5;
+    ApiClientConf conf =
+        new ApiClientConf()
+            .setRequestMaxAttempts(2)
+            .setRequestInitialDelayMs(100L)
+            .setRequestDelayMultiplier(1.0)
+            .setRequestDelayJitterFactor(jitterFactor);
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/server-error")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response503 = createMockResponse(503, "Service Unavailable");
+    HttpResponse<String> response200 = createMockResponse(200, "Recovered");
+
+    when(mockClient.send(
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(response503)
+        .thenReturn(response200);
+
+    Instant start = clock.now();
+    HttpRetryHandler handler = new HttpRetryHandler(conf, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    verify(mockClient, times(2))
+        .send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+
+    assertThat(result.statusCode()).isEqualTo(200);
+    assertThat(result.body()).isEqualTo("Recovered");
+
+    // Verify the elapsed time is within the jitter-adjusted bounds of the base delay.
+    // Calculated as: baseDelay * (1 ± jitterFactor). In this case, the base delay is 100ms and
+    // the jitter factor is 0.5 so the range is [50ms, 150ms].
+    long elapsedMs = Duration.between(start, clock.now()).toMillis();
+    long baseDelay = conf.getRequestInitialDelayMs();
+    long minDelay = (long) Math.floor(baseDelay * (1 - jitterFactor));
+    long maxDelay = (long) Math.ceil(baseDelay * (1 + jitterFactor));
+    assertThat(elapsedMs)
+        .as("retry delay should stay within jitter-adjusted bounds")
+        .isBetween(minDelay, maxDelay);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testMultiplierControlsBackoffScaling() throws IOException, InterruptedException {
+    ApiClientConf conf =
+        new ApiClientConf()
+            .setRequestMaxAttempts(3)
+            .setRequestInitialDelayMs(40L)
+            .setRequestDelayMultiplier(3.0)
+            .setRequestDelayJitterFactor(0.0); // Disable jitter
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/backoff")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response503 = createMockResponse(503, "Service Unavailable");
+    HttpResponse<String> response502 = createMockResponse(502, "Bad Gateway");
+    HttpResponse<String> response200 = createMockResponse(200, "Recovered");
+
+    when(mockClient.send(
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(response503)
+        .thenReturn(response502)
+        .thenReturn(response200);
+
+    Instant start = clock.now();
+    HttpRetryHandler handler = new HttpRetryHandler(conf, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    verify(mockClient, times(3))
+        .send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    assertThat(result.statusCode()).isEqualTo(200);
+
+    // Delays: 40ms * 3^(1-1) = 40ms, then 40ms * 3^(2-1) = 120ms.
+    assertThat(clock.now()).isEqualTo(start.plus(Duration.ofMillis(160)));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testRetriesRecoverableException() throws IOException, InterruptedException {
+    ApiClientConf conf =
+        new ApiClientConf()
+            .setRequestMaxAttempts(3)
+            .setRequestInitialDelayMs(50L)
+            .setRequestDelayMultiplier(2.0)
+            .setRequestDelayJitterFactor(0.0); // Disable jitter
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/simple")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response503 = createMockResponse(503, "Service Unavailable");
+    HttpResponse<String> response200 = createMockResponse(200, "Success");
+
+    when(mockClient.send(
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new java.net.SocketTimeoutException("Transient error"))
+        .thenReturn(response503)
+        .thenReturn(response200);
+
+    Instant start = clock.now();
+    HttpRetryHandler handler = new HttpRetryHandler(conf, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    verify(mockClient, times(3))
+        .send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    assertThat(result.statusCode()).isEqualTo(200);
+    // Retry delays: 50ms (after exception) + 100ms (after 503) = 150ms total.
+    assertThat(clock.now()).isEqualTo(start.plus(Duration.ofMillis(150)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private HttpResponse<String> createMockResponse(int statusCode, String body) {
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(statusCode);
+    when(response.body()).thenReturn(body);
+    return response;
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/AwsCredentialRenewalTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/AwsCredentialRenewalTest.java
@@ -1,0 +1,358 @@
+package io.unitycatalog.spark.auth;
+
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.delta.tables.DeltaTable;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.server.base.BaseCRUDTest;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.aws.CredentialsGenerator;
+import io.unitycatalog.spark.CredentialTestFileSystem;
+import io.unitycatalog.spark.UCHadoopConf;
+import io.unitycatalog.spark.UCSingleCatalog;
+import io.unitycatalog.spark.utils.Clock;
+import java.io.File;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.util.SerializableConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sparkproject.guava.collect.ImmutableList;
+import org.sparkproject.guava.collect.Iterators;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+/**
+ * Integration test to verify that AWS credential renewal works as expected.
+ *
+ * <p>This test sets up the Unity Catalog server and a local Spark cluster, then runs a custom Spark
+ * job to validate credential renewal.
+ *
+ * <p>The approach is as follows: a testing {@link AwsCredentialsProvider} is injected into the
+ * local Unity Catalog server, issuing a new credential every 30-second interval. The Spark job uses
+ * {@link S3CredFileSystem} to check that the credential matches the current time window for each
+ * filesystem access. {@link S3CredFileSystem} also tracks the number of renewals, allowing
+ * verification that credential renewal occurs as expected.
+ */
+public class AwsCredentialRenewalTest extends BaseCRUDTest {
+
+  private static final String CLOCK_NAME = AwsCredentialRenewalTest.class.getSimpleName();
+  private static final String CREDENTIALS_GENERATOR = TimeBasedCredentialsGenerator.class.getName();
+
+  private static final String CATALOG_NAME = "CredRenewalCatalog";
+  private static final String SCHEMA_NAME = "Default";
+  private static final String TABLE_NAME = String.format("%s.%s.demo", CATALOG_NAME, SCHEMA_NAME);
+  private static final String BUCKET_NAME = "test-bucket";
+  private static final String S3_SCHEME = "s3:";
+  private static final long DEFAULT_INTERVAL_MILLIS = 30_000L;
+
+  @TempDir private File dataDir;
+  private SparkSession session;
+  private SdkSchemaOperations schemaOperations;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig config) {
+    return new SdkCatalogOperations(createApiClient(config));
+  }
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    serverProperties.put("s3.bucketPath.0", "s3://" + BUCKET_NAME);
+    serverProperties.put("s3.accessKey.0", "accessKey0");
+    serverProperties.put("s3.secretKey.0", "secretKey0");
+    serverProperties.put("s3.sessionToken.0", "sessionToken0");
+    // Customize the test credential generator to issue a new credential every 30-second interval.
+    // This allows us to verify whether credential renewal is functioning correctly by checking
+    // if the current credential matches the expected time window.
+    serverProperties.put("s3.credentialsGenerator.0", CREDENTIALS_GENERATOR);
+  }
+
+  private SparkSession createSparkSession() {
+    String testCatalogKey = String.format("spark.sql.catalog.%s", CATALOG_NAME);
+    return SparkSession.builder()
+        .appName("test-credential-renewal")
+        .master("local[1]") // Make it single-threaded explicitly.
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.hadoop." + UCHadoopConf.UC_TEST_CLOCK_NAME, CLOCK_NAME)
+        .config("spark.hadoop." + UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 0L)
+        .config("spark.sql.shuffle.partitions", "1")
+        .config(testCatalogKey, UCSingleCatalog.class.getName())
+        .config(testCatalogKey + ".uri", serverConfig.getServerUrl())
+        .config(testCatalogKey + ".token", serverConfig.getAuthToken())
+        .config(testCatalogKey + ".warehouse", CATALOG_NAME)
+        .config(testCatalogKey + ".renewCredential.enabled", "true")
+        .config("fs.s3.impl", S3CredFileSystem.class.getName())
+        .getOrCreate();
+  }
+
+  private interface Callable {
+
+    void call() throws Exception;
+  }
+
+  private void callQuietly(Callable call) {
+    try {
+      call.call();
+    } catch (Exception e) {
+      // ignored.
+    }
+  }
+
+  @BeforeEach
+  public void beforeEach() throws Exception {
+    super.setUp();
+    session = createSparkSession();
+
+    // Initialize the catalog in unity catalog server.
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(CATALOG_NAME).comment("Spark catalog"));
+
+    // Initialize the schema in unity catalog server.
+    schemaOperations = new SdkSchemaOperations(createApiClient(serverConfig));
+    schemaOperations.createSchema(new CreateSchema().name(SCHEMA_NAME).catalogName(CATALOG_NAME));
+  }
+
+  @AfterEach
+  public void afterEach() {
+    // Drop the table.
+    sql("DROP TABLE IF EXISTS %s", TABLE_NAME);
+
+    // Delete the scheme.
+    callQuietly(() -> schemaOperations.deleteSchema(SCHEMA_NAME, Optional.of(true)));
+
+    // Delete the catalog.
+    callQuietly(() -> catalogOperations.deleteCatalog(CATALOG_NAME, Optional.of(true)));
+
+    // Close the session.
+    callQuietly(() -> session.close());
+
+    super.cleanUp();
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    Clock.removeManualClock(CLOCK_NAME);
+  }
+
+  public static Clock testClock() {
+    return Clock.getManualClock(CLOCK_NAME);
+  }
+
+  @Test
+  public void testFileSystemRenewal() throws Exception {
+    String location = String.format("s3://%s%s/fs", BUCKET_NAME, dataDir.getCanonicalPath());
+    Path locPath = new Path(location);
+
+    // Create the external delta table in catalog.
+    sql("CREATE TABLE %s (id INT) USING delta LOCATION '%s'", TABLE_NAME, location);
+
+    // Insert 1 row into the table.
+    sql("INSERT INTO %s VALUES (1)", TABLE_NAME);
+
+    // Generate a table level hadoop configuration, with setting the delta table's all properties.
+    SerializableConfiguration serialConf =
+        new SerializableConfiguration(
+            DeltaTable.forName(session, TABLE_NAME).deltaLog().newDeltaHadoopConf());
+
+    // This Spark job consists of three main steps:
+    // 1. Read RDD to spawn Spark tasks.
+    // 2. Simulate filesystem access using the table-level Hadoop configuration to verify that
+    //    filesystem credentials are renewed the expected number of times.
+    // 3. Collect the credential renewal count.
+    //
+    // The core logic resides in the mapFunction. We use the Delta table’s Hadoop configuration
+    // to initialize the filesystem, simulating Delta table operations within a Spark executor.
+    // This allows us to accurately track how many times credentials are renewed within a task.
+    //
+    // It is possible for a Spark job to create multiple independent filesystem instances,
+    // which may misleadingly appear to renew credentials correctly even when they do not.
+    // We adopt this simulation approach because directly accessing a Spark task’s internal
+    // filesystem instance to measure credential renewals is not feasible.
+    List<Row> rows =
+        session
+            .read()
+            .format("delta")
+            .table(TABLE_NAME)
+            .toJavaRDD()
+            .map(
+                row -> {
+                  Configuration conf = serialConf.value();
+                  S3CredFileSystem fs = (S3CredFileSystem) FileSystem.get(new URI(location), conf);
+
+                  for (int refreshIndex = 0; refreshIndex < 10; refreshIndex += 1) {
+                    // Pre-check before the credential renewal.
+                    fs.getFileStatus(locPath);
+                    assertThat(fs.renewalCount()).isEqualTo(refreshIndex);
+
+                    // Advance the clock to trigger the renewal.
+                    testClock().sleep(Duration.ofMillis(DEFAULT_INTERVAL_MILLIS));
+
+                    // Post-check after the credential renewal.
+                    fs.getFileStatus(locPath);
+                    assertThat(fs.renewalCount()).isEqualTo(refreshIndex + 1);
+                  }
+
+                  return RowFactory.create(10);
+                })
+            .collect();
+
+    assertThat(rows.stream().map(r -> r.getInt(0)).collect(Collectors.toList()))
+        .isEqualTo(ImmutableList.of(10));
+  }
+
+  @Test
+  public void testDeltaReadWriteRenewal() throws Exception {
+    String srcLoc = String.format("s3://%s%s/src", BUCKET_NAME, dataDir.getCanonicalPath());
+    String dstLoc = String.format("s3://%s%s/dst", BUCKET_NAME, dataDir.getCanonicalPath());
+    String srcTable = String.format("%s.%s.src", CATALOG_NAME, SCHEMA_NAME);
+    String dstTable = String.format("%s.%s.dst", CATALOG_NAME, SCHEMA_NAME);
+
+    // Create the source table referring to external table.
+    sql(
+        "CREATE TABLE %s (id INT) USING delta LOCATION '%s' PARTITIONED BY (partition INT)",
+        srcTable, srcLoc);
+    sql("CREATE TABLE %s (id INT) USING delta LOCATION '%s'", dstTable, dstLoc);
+
+    // Insert 1 row into each partition where id equals the partition key.
+    sql("INSERT INTO %s VALUES (1, 1), (2, 2), (3, 3)", srcTable);
+
+    // Read from the Delta table, mapping each partition to a separate task.
+    // With parallelism set to 1, tasks for each partition execute sequentially.
+    // The accumulated 30-second delay advances the clock sufficiently to trigger a
+    // renewal of filesystem credentials.
+
+    // The spark job should be success because we've enabled the credential renewal.
+    session
+        .read()
+        .format("delta")
+        .table(srcTable)
+        .mapPartitions(
+            (MapPartitionsFunction<Row, Integer>)
+                input -> {
+                  // Advance the clock to trigger the credential renewal.
+                  testClock().sleep(Duration.ofMillis(DEFAULT_INTERVAL_MILLIS));
+                  return Iterators.transform(input, row -> row.getInt(0));
+                },
+            Encoders.INT())
+        .withColumnRenamed("value", "id")
+        .write()
+        .format("delta")
+        .mode("append")
+        .saveAsTable(dstTable);
+
+    List<Row> rows = sql("SELECT * FROM %s ORDER BY id ASC", dstTable);
+    assertThat(rows.size()).isEqualTo(3);
+    assertThat(rows.stream().map(r -> r.getInt(0)).collect(Collectors.toList()))
+        .isEqualTo(ImmutableList.of(1, 2, 3));
+  }
+
+  private List<Row> sql(String statement, Object... args) {
+    return session.sql(String.format(statement, args)).collectAsList();
+  }
+
+  /**
+   * A customized {@link CredentialsGenerator} that generates credentials based on time intervals.
+   * The entire timeline is divided into consecutive 30-second windows, and all requests that fall
+   * within the same window will receive the same credential. This generator is dynamically loaded
+   * by the Unity Catalog server and serves credential generation requests from client REST API
+   * calls.
+   */
+  public static class TimeBasedCredentialsGenerator implements CredentialsGenerator {
+
+    @Override
+    public Credentials generate(CredentialContext credentialContext) {
+      long curTsMillis = testClock().now().toEpochMilli();
+      // Align it into the window [starTs, starTs + DEFAULT_INTERVAL_MILLIS].
+      long startTsMillis = curTsMillis / DEFAULT_INTERVAL_MILLIS * DEFAULT_INTERVAL_MILLIS;
+      return Credentials.builder()
+          .accessKeyId("accessKeyId" + startTsMillis)
+          .secretAccessKey("secretAccessKey" + startTsMillis)
+          .sessionToken("sessionToken" + startTsMillis)
+          .expiration(Instant.ofEpochMilli(startTsMillis + DEFAULT_INTERVAL_MILLIS))
+          .build();
+    }
+  }
+
+  /**
+   * A testing S3 filesystem used to verify credential renewal behavior. For each {@code
+   * checkCredentials()} call, the previous credentials should automatically renew as the 30-second
+   * time window advances. The test tracks how many distinct credentials this filesystem receives,
+   * which should match the expected number of credential renewals. We use this filesystem to
+   * accurately track how many renewal happened.
+   */
+  public static class S3CredFileSystem extends CredentialTestFileSystem {
+
+    private final Set<Long> verifiedTs = new HashSet<>();
+    private volatile AwsCredentialsProvider lazyProvider;
+
+    @Override
+    protected void checkCredentials(Path f) {
+      String host = f.toUri().getHost();
+
+      if (credentialCheckEnabled && BUCKET_NAME.equals(host)) {
+        AwsCredentialsProvider provider = accessProvider();
+        assertThat(provider).isNotNull();
+
+        AwsSessionCredentials cred = (AwsSessionCredentials) provider.resolveCredentials();
+        long ts =
+            testClock().now().toEpochMilli() / DEFAULT_INTERVAL_MILLIS * DEFAULT_INTERVAL_MILLIS;
+        assertThat(cred.accessKeyId()).isEqualTo("accessKeyId" + ts);
+        assertThat(cred.secretAccessKey()).isEqualTo("secretAccessKey" + ts);
+        assertThat(cred.sessionToken()).isEqualTo("sessionToken" + ts);
+
+        verifiedTs.add(ts);
+      }
+    }
+
+    public int renewalCount() {
+      return verifiedTs.size() - 1;
+    }
+
+    @Override
+    protected String scheme() {
+      return S3_SCHEME;
+    }
+
+    private synchronized AwsCredentialsProvider accessProvider() {
+      if (lazyProvider != null) {
+        return lazyProvider;
+      }
+
+      String clazz = getConf().get(UCHadoopConf.S3A_CREDENTIALS_PROVIDER);
+      assertThat(clazz).isEqualTo(AwsVendedTokenProvider.class.getName());
+
+      // This will validate if the hadoop configuration is correct or not, since it will fail the
+      // provider constructor if given an incorrect setting here.
+      lazyProvider = new AwsVendedTokenProvider(getConf());
+
+      return lazyProvider;
+    }
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/BaseTokenProviderTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/BaseTokenProviderTest.java
@@ -65,7 +65,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     assertCred(provider, cred1);
 
     // Advance the clock to trigger renewal, cred2 will be valid.
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // Use the cred2 for the 3rd access, since renewal happened.
     assertCred(provider, cred2);
@@ -99,7 +99,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     // cred0 is still valid.
     assertCred(provider, cred0);
 
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // cred0 is invalid while cred1 is valid.
     assertCred(provider, cred1);
@@ -107,7 +107,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     // cred1 is still valid.
     assertCred(provider, cred1);
 
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // cred1 is expired, while cred2 is valid.
     assertCred(provider, cred2);
@@ -137,7 +137,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     assertCred(provider, cred1);
 
     // Advance the clock to renew.
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // Use the cred2 for the 3rd access, since cred1 it's expired.
     assertCred(provider, cred2);
@@ -170,7 +170,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     // cred0 is still valid.
     assertCred(provider, cred0);
 
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // cred0 is invalid while cred1 is valid.
     assertCred(provider, cred1);
@@ -178,7 +178,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     // cred1 is still valid.
     assertCred(provider, cred1);
 
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // cred1 is expired, while cred2 is valid.
     assertCred(provider, cred2);
@@ -266,7 +266,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     assertCred(providerPathA, pathACred1);
     assertGlobalCache(4, tableACred1, tableBCred1, pathACred1, pathBCred1);
 
-    clock.advance(Duration.ofMillis(1000));
+    clock.sleep(Duration.ofMillis(1000));
 
     // TableA: 3rd access. renew tableACred1 to tableACred2.
     assertCred(providerTableA, tableACred2);


### PR DESCRIPTION
Backport of #1145 to `branch-0.3`.

---

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Instead of wrapping each type of Api such as TempCredsApi or TablesApi with a "Retryable" version, we instead create our own RetryableHttpClient and retry at the http level. This way, new Apis just need to pass the necessary configuration to the ApiClientFactory, which creates a RetryingApiClient, which then creates a RetryingHttpClient. The user may pass in a custom interceptor -- a function that defines under which error codes, status codes, and exception they would want the ApiClient to retry.

<!-- Please state what you've changed and how it might affect the users. -->
