### PR TITLE
When creating a managed table, standardize URL before looking for staging table

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -186,6 +186,8 @@ public class TableRepository {
           String schemaName = createTable.getSchemaName();
           UUID schemaId =
               repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+          String storageLocation =
+              FileOperations.toStandardizedURIString(createTable.getStorageLocation());
 
           // Check if table already exists
           TableInfoDAO existingTable =
@@ -210,7 +212,7 @@ public class TableRepository {
             StagingTableDAO stagingTableDAO =
                 repositories
                     .getStagingTableRepository()
-                    .commitStagingTable(session, callerId, createTable.getStorageLocation());
+                    .commitStagingTable(session, callerId, storageLocation);
             tableID = stagingTableDAO.getId().toString();
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
@@ -238,8 +240,7 @@ public class TableRepository {
                   .createdBy(callerId)
                   .updatedAt(createTime)
                   .updatedBy(callerId)
-                  .storageLocation(
-                      FileOperations.toStandardizedURIString(createTable.getStorageLocation()))
+                  .storageLocation(storageLocation)
                   .tableId(tableID);
 
           TableInfoDAO tableInfoDAO = TableInfoDAO.from(tableInfo, schemaId);

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
@@ -241,6 +241,9 @@ public class FileOperations {
    * </pre>
    */
   public static String toStandardizedURIString(String inputPath) {
+    if (inputPath == null) {
+      return null;
+    }
     // Check if the path is already a URI with a valid scheme
     URI uri;
     try {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
When creating a managed table, standardize URL before looking for staging table.
This is needed because certain clients like Delta Spark may send local path URLs in non-standard form (e.g. file:/tmp) despite that UC returned a staging location in standard form (e.g. file:///tmp). UC needs to tolerate it.

**Related issue**
https://github.com/unitycatalog/unitycatalog/issues/1143
