### PR TITLE
[Backport branch-0.3] Allow providing base path for UC API Client

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
@@ -6,13 +6,21 @@ import io.unitycatalog.spark.utils.Clock;
 import java.net.URI;
 
 public class ApiClientFactory {
+
+  public static final String BASE_PATH = "/api/2.1/unity-catalog";
+
   private ApiClientFactory() {}
 
   public static ApiClient createApiClient(ApiClientConf clientConf, URI url, String token) {
+    // Base path in ApiClient is already set to `BASE_PATH`, so we override it to provide
+    // base path from given `url` but still preserving path suffix.
+    // Expected input for `url` is URL with no "/api/2.1/unity-catalog" in the path.
+    String basePath = url.getPath() + BASE_PATH;
     RetryingApiClient apiClient = new RetryingApiClient(clientConf, Clock.systemClock());
     apiClient.setHost(url.getHost())
         .setPort(url.getPort())
-        .setScheme(url.getScheme());
+        .setScheme(url.getScheme())
+        .setBasePath(basePath);
 
     if (token != null && !token.isEmpty()) {
       apiClient.setRequestInterceptor(

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ApiClientFactoryTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ApiClientFactoryTest.java
@@ -1,0 +1,26 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiClient;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+public class ApiClientFactoryTest extends BaseSparkIntegrationTest {
+  @Test
+  public void testApiClientBaseUri() {
+    ApiClientConf clientConf = new ApiClientConf();
+    String token = "";
+    URI uriNoSuffix = URI.create("https://localhost:8080");
+    ApiClient apiClientNoSuffix = ApiClientFactory.createApiClient(clientConf, uriNoSuffix, token);
+    assertThat(apiClientNoSuffix.getBaseUri())
+        .isEqualTo("https://localhost:8080/api/2.1/unity-catalog");
+
+    URI uriWithSuffix = URI.create("https://localhost:8080/path/to/uc/api");
+    ApiClient apiClientWithSuffix = ApiClientFactory
+        .createApiClient(clientConf, uriWithSuffix, token);
+    assertThat(apiClientWithSuffix.getBaseUri())
+        .isEqualTo("https://localhost:8080/path/to/uc/api/api/2.1/unity-catalog");
+  }
+}


### PR DESCRIPTION
Backport of #1130 to `branch-0.3`.

---

**PR Checklist**
- Certain vendors may register UC API under a certain path (e.g. Microsoft Fabric API registers it under `https://onelake.table.fabric.microsoft.com/delta/<Workspace name or workspace ID>/<Item name or item ID>/api/2.1/unity-catalog/`) 
- New test suite added
- This is a behavioural change, since if someone provided a URL earlier with a specific path, then the path would be just ignored (e.g., the fabric API I provided above would be translated to `https://onelake.table.fabric.microsoft.com/api/2.1/unity-catalog/`). But probably no users provide a URL with a path, since the UC API could not be hit prior to this fix.
- Base URL prior this change was `api/2.1/unity-catalog/`, while now it is `basePathFromProvidedUrl` + `api/2.1/unity-catalog/`

**Description of changes**
- In the API Client factory, set the base path of the provided URL where the UC API is registered. This code path is hit when we initialize `UCSingleCatalog`.
- Behaviour prior this change caused failure on URIs with certain path:
<img width="1852" height="194" alt="image" src="https://github.com/user-attachments/assets/ae2d67cb-2d92-4483-bd4a-07ee961200e6" />
