### PR TITLE
Allow staging table creation with the same name.

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
@@ -21,7 +21,6 @@ import lombok.experimental.SuperBuilder;
 @Table(
     name = "uc_staging_tables",
     indexes = {
-      @Index(name = "idx_name", columnList = "name"),
       @Index(name = "idx_staging_location", columnList = "staging_location"),
     })
 // Lombok annotations

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -268,25 +268,14 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
     assertThat(tableInfo.getStorageLocation()).isEqualTo(stagingLocation);
   }
 
-  /** Test that attempting to create a duplicate staging table fails with ALREADY_EXISTS error. */
+  /**
+   * Test that attempting to create a staging table duplicate with existing table (not staging
+   * table) fails with ALREADY_EXISTS error. But creating multiple staging tables with the same name
+   * is allowed.
+   */
   @Test
-  public void testDuplicateStagingTableCreationShouldFail() throws Exception {
-    // Create an external table
-    String externalTableName = "duplicate_table";
-    CreateTable createTableRequest =
-        new CreateTable()
-            .name(externalTableName)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .columns(columns)
-            .tableType(TableType.EXTERNAL)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .storageLocation("file:///tmp/ucroot/tables/external_path")
-            .comment("Table created from external location");
-    TableInfo tableInfo = localTablesApi.createTable(createTableRequest);
-    assertThat(tableInfo).isNotNull();
-
-    // Also create the first staging table
+  public void testDuplicateStagingTableCreation() throws Exception {
+    // Create the first staging table
     String stagingTableName = "duplicate_staging_table";
     CreateStagingTable createStagingTableRequest =
         new CreateStagingTable()
@@ -296,25 +285,35 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
     StagingTableInfo stagingTableInfo =
         localTablesApi.createStagingTable(createStagingTableRequest);
     assertThat(stagingTableInfo).isNotNull();
+    assertThat(stagingTableInfo.getStagingLocation()).isNotNull();
 
-    // Try to create another staging table with the same name
-    CreateStagingTable duplicateRequest =
-        new CreateStagingTable()
+    // Create a 2nd staging table with the same name should return a different staging location
+    StagingTableInfo stagingTableInfo2 =
+        localTablesApi.createStagingTable(createStagingTableRequest);
+    assertThat(stagingTableInfo2).isNotNull();
+    assertThat(stagingTableInfo2.getStagingLocation()).isNotNull();
+    assertThat(stagingTableInfo2.getStagingLocation())
+        .isNotEqualTo(stagingTableInfo.getStagingLocation());
+
+    // Create a table using the 1st staging table. The 2nd staging table becomes useless.
+    CreateTable createTableRequest =
+        new CreateTable()
+            .name(stagingTableName)
             .catalogName(TestUtils.CATALOG_NAME)
             .schemaName(TestUtils.SCHEMA_NAME)
-            .name(stagingTableName);
-    // This should fail with ALREADY_EXISTS
-    assertThatExceptionOfType(ApiException.class)
-        .isThrownBy(() -> localTablesApi.createStagingTable(duplicateRequest))
-        .satisfies(
-            ex ->
-                assertThat(ex.getCode()).isEqualTo(ErrorCode.ALREADY_EXISTS.getHttpStatus().code()))
-        .withMessageContaining("already exists");
+            .columns(columns)
+            .tableType(TableType.MANAGED)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation(stagingTableInfo.getStagingLocation());
+    TableInfo tableInfo = localTablesApi.createTable(createTableRequest);
+    assertThat(tableInfo).isNotNull();
+    assertThat(tableInfo.getStorageLocation()).isEqualTo(stagingTableInfo.getStagingLocation());
+    assertThat(tableInfo.getTableId()).isEqualTo(stagingTableInfo.getId());
 
-    // The same story if the duplicate name is an external table
+    // Create a 3rd staging table with the same name, and now it fails with ALREADY_EXISTS because
+    // the table has already been created using that name.
     assertThatExceptionOfType(ApiException.class)
-        .isThrownBy(
-            () -> localTablesApi.createStagingTable(duplicateRequest.name("duplicate_table")))
+        .isThrownBy(() -> localTablesApi.createStagingTable(createStagingTableRequest))
         .satisfies(
             ex ->
                 assertThat(ex.getCode()).isEqualTo(ErrorCode.ALREADY_EXISTS.getHttpStatus().code()))


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This is to fix a bug that UC didn't allow a 2nd staging table to be created using the same name. However this is actually a valid use case. When the table creation failed after the staging table is created but before the table creation, the dangling staging table would prevent retrying effort to create the table using the same name again. We have to allow the staging table to be created again using the same name to get it through. The new staging table will have new ID and location so it won't be a problem anyway.

**Related issue**
https://github.com/unitycatalog/unitycatalog/issues/1143