### PR TITLE
[0.3] Backport rename the table property "ucTableId"

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/utils/TableProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/TableProperties.java
@@ -1,0 +1,6 @@
+package io.unitycatalog.server.utils;
+
+public class TableProperties {
+  /** Key for identifying Unity Catalog table ID in Delta commits. */
+  public static final String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Rename the table property "ucTableId" to "io.unitycatalog.tableId" on the server side.

**Related issue**
https://github.com/unitycatalog/unitycatalog/issues/1143
