### PR TITLE
[0.2] Backport fix the name quote bug in UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -161,7 +161,6 @@ object UCSingleCatalog {
   val LOAD_DELTA_CATALOG = ThreadLocal.withInitial[Boolean](() => true)
   val DELTA_CATALOG_LOADED = ThreadLocal.withInitial[Boolean](() => false)
 
-<<<<<<< HEAD
   def generateCredentialProps(
       scheme: String,
       temporaryCredentials: TemporaryCredentials): Map[String, String] = {
@@ -200,7 +199,7 @@ object UCSingleCatalog {
       Map.empty
     }
   }
-=======
+
   def checkUnsupportedNestedNamespace(namespace: Array[String]): Unit = {
     if (namespace.length > 1) {
       throw new ApiException("Nested namespaces are not supported: " + namespace.mkString("."))
@@ -230,7 +229,6 @@ object UCSingleCatalog {
     checkUnsupportedNestedNamespace(ident.namespace())
     Seq(catalogName, ident.namespace()(0), ident.name()).mkString(".")
   }
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
 }
 
 // An internal proxy to talk to the UC client.
@@ -266,14 +264,7 @@ private class UCProxy(
 
   override def loadTable(ident: Identifier): Table = {
     val t = try {
-<<<<<<< HEAD
-      tablesApi.getTable(name + "." + ident.toString)
-=======
-      tablesApi.getTable(
-        UCSingleCatalog.fullTableNameForApi(this.name, ident),
-        /* readStreamingTableAsManaged = */ true,
-        /* readMaterializedViewAsManaged = */ true)
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
+      tablesApi.getTable(UCSingleCatalog.fullTableNameForApi(this.name, ident))
     } catch {
       case e: ApiException if e.getCode == 404 =>
         throw new NoSuchTableException(ident)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -11,16 +11,9 @@ import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
-<<<<<<< HEAD
 import java.util.*;
-=======
-import io.unitycatalog.spark.utils.OptionsUtil;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import org.apache.spark.sql.Row;
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
 import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
@@ -51,19 +44,12 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
       builder =
           builder
               .config(catalogConf, UCSingleCatalog.class.getName())
-<<<<<<< HEAD
               .config(catalogConf + ".uri", serverConfig.getServerUrl())
               .config(catalogConf + ".token", serverConfig.getAuthToken())
               .config(catalogConf + ".warehouse", catalog);
-=======
-              .config(catalogConf + "." + OptionsUtil.URI, serverConfig.getServerUrl())
-              .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
-              .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog)
-              .config(catalogConf + "." + OptionsUtil.RENEW_CREDENTIAL_ENABLED, renewCred);
       if (!List.of(SPARK_CATALOG, CATALOG_NAME).contains(catalog)) {
         createTestCatalog(catalog);
       }
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
     }
     // Use fake file system for cloud storage so that we can test credentials.
     builder.config("fs.s3.impl", S3CredentialTestFileSystem.class.getName());
@@ -90,8 +76,6 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
     return new SdkCatalogOperations(createApiClient(serverConfig));
   }
 
-<<<<<<< HEAD
-=======
   private void createTestCatalog(String catalogName) {
     try {
       catalogOperations.createCatalog(
@@ -103,7 +87,6 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
   }
 
   @AfterEach
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
   @Override
   public void cleanUp() {
     for (String catalogName : createdCatalogs) {
@@ -113,18 +96,7 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
         // Ignore
       }
     }
-<<<<<<< HEAD
-=======
     createdCatalogs.clear();
-    try {
-      if (session != null) {
-        session.close();
-        session = null;
-      }
-    } catch (Exception e) {
-      // Ignore
-    }
->>>>>>> 73f3de13 (Fix the name quote bug in UCSingleCatalog. (#1248))
     super.cleanUp();
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fix the name quote bug in UCSingleCatalog.
UCSingleCatalog should not quote schema and table names with backtick before sending out an RPC to UC server.