### PR TITLE
Call DeltaCatalog.initialize from UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -62,6 +62,7 @@ class UCSingleCatalog
         delegate = Class.forName("org.apache.spark.sql.delta.catalog.DeltaCatalog")
           .getDeclaredConstructor().newInstance().asInstanceOf[TableCatalog]
         delegate.asInstanceOf[DelegatingCatalogExtension].setDelegateCatalog(proxy)
+        delegate.initialize(name, options)
         UCSingleCatalog.DELTA_CATALOG_LOADED.set(true)
       } catch {
         case e: ClassNotFoundException =>


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Call DeltaCatalog.initialize from UCSingleCatalog.
This is currently a NO-OP as the function DeltaCatalog.initialize right now is a NO-OP.
It will be useful later when DeltaCatalog decides to check some of the catalog Spark configs.