### PR TITLE
[0.3] Require setting delta.feature.catalogOwned-preview for managed table creation by user.

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
@@ -182,7 +182,8 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
    *
    * @param location Set to the location of external, or empty if it needs to be a managed table.
    */
-  public void testHyphenInTableNameBase(Optional<String> location) {
+  public void testHyphenInTableNameBase(
+      Optional<String> location, Optional<String> tblpropertiesClause) {
     String catalogName = "test-catalog-name";
     String schemaName = "test-schema-name";
     String tableName = "test-table-name";
@@ -191,8 +192,8 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
     String fullTableName = String.format("%s.%s.%s", catalogName, schemaName, tableName);
     String locationClause = location.map(l -> String.format("LOCATION '%s'", l)).orElse("");
     sql(
-        "CREATE TABLE %s(i INT, s STRING) USING DELTA %s",
-        quoteEntityName(fullTableName), locationClause);
+        "CREATE TABLE %s(i INT, s STRING) USING DELTA %s %s",
+        quoteEntityName(fullTableName), locationClause, tblpropertiesClause.orElse(""));
 
     testTableReadWrite(fullTableName);
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -264,7 +264,7 @@ public class ExternalTableReadWriteTest extends BaseTableReadWriteTest {
   @Test
   public void hyphenInTableName() throws IOException {
     String location = new File(dataDir, UUID.randomUUID().toString()).getCanonicalPath();
-    testHyphenInTableNameBase(Optional.of(location));
+    testHyphenInTableNameBase(Optional.of(location), Optional.empty());
   }
 
   private String generateTableLocation(String catalogName, String tableName) throws IOException {


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Require setting delta.feature.catalogOwned-preview for managed table creation by user.

Stop automatically setting this feature property in UCSingleCatalog when creating a UC managed table. Instead require user to specify it explicitly.
