### PR TITLE
Use the CaseInsensitiveStringMap to build the Auth configs.

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/AuthConfigUtils.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/auth/AuthConfigUtils.java
@@ -3,6 +3,7 @@ package io.unitycatalog.spark.auth;
 import io.unitycatalog.client.internal.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class AuthConfigUtils {
   private static final String AUTH_PREFIX = "auth.";
@@ -37,6 +38,6 @@ public class AuthConfigUtils {
       newConfigs.put(STATIC_TOKEN, token);
     }
 
-    return newConfigs;
+    return new CaseInsensitiveStringMap(newConfigs);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/AuthConfigUtilsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/AuthConfigUtilsTest.java
@@ -3,6 +3,7 @@ package io.unitycatalog.spark.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.unitycatalog.client.auth.TokenProvider;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -38,27 +39,72 @@ public class AuthConfigUtilsTest {
   }
 
   @Test
-  public void testLegacyTokenSupport() {
-    assertThat(normalizeConfigs("token", "legacy-token"))
-        .containsEntry("type", "static")
-        .containsEntry("token", "legacy-token");
+  public void testStaticTokenSupport() {
+    Map<String, String> configs = normalizeConfigs("token", "legacy-token");
+    assertMapEquals(
+        TokenProvider.create(configs).configs(), Map.of("type", "static", "token", "legacy-token"));
 
-    assertThat(normalizeConfigs("auth.type", "oauth", "token", "legacy-token"))
-        .containsEntry("type", "static")
-        .containsEntry("token", "legacy-token");
+    configs = normalizeConfigs("auth.type", "static", "token", "legacy-token");
+    assertMapEquals(
+        TokenProvider.create(configs).configs(), Map.of("type", "static", "token", "legacy-token"));
 
-    assertThat(normalizeConfigs("auth.extra", "value", "token", "legacy-token"))
-        .hasSize(3)
-        .containsEntry("type", "static")
-        .containsEntry("token", "legacy-token")
-        .containsEntry("extra", "value");
+    configs = normalizeConfigs("auth.extra", "value", "token", "legacy-token");
+    assertMapEquals(configs, Map.of("type", "static", "token", "legacy-token", "extra", "value"));
+    assertMapEquals(
+        TokenProvider.create(configs).configs(), Map.of("type", "static", "token", "legacy-token"));
+
+    configs = normalizeConfigs("auth.type", "static", "auth.token", "new-token");
+    assertMapEquals(
+        TokenProvider.create(configs).configs(), Map.of("type", "static", "token", "new-token"));
   }
 
   @Test
-  public void testNewStyleToken() {
-    assertThat(normalizeConfigs("auth.type", "static", "auth.token", "new-token"))
-        .containsEntry("type", "static")
-        .containsEntry("token", "new-token");
+  public void testOAuthTokenSupport() {
+    // Case-sensitive OAuth configs.
+    Map<String, String> configs =
+        normalizeConfigs(
+            "auth.type",
+            "oauth",
+            "auth.oauth.uri",
+            "https://auth.example.com",
+            "auth.oauth.clientId",
+            "client-id",
+            "auth.oauth.clientSecret",
+            "client-secret");
+    assertMapEquals(
+        TokenProvider.create(configs).configs(),
+        Map.of(
+            "type",
+            "oauth",
+            "oauth.uri",
+            "https://auth.example.com",
+            "oauth.clientId",
+            "client-id",
+            "oauth.clientSecret",
+            "client-secret"));
+
+    // Case-insensitive OAuth configs.
+    configs =
+        normalizeConfigs(
+            "auth.type",
+            "oauth",
+            "auth.OaUTH.URI",
+            "https://auth.example.com",
+            "auth.oAuth.clientid",
+            "client-id",
+            "auth.oauth.clientsecret",
+            "client-secret");
+    assertMapEquals(
+        TokenProvider.create(configs).configs(),
+        Map.of(
+            "type",
+            "oauth",
+            "oauth.uri",
+            "https://auth.example.com",
+            "oauth.clientId",
+            "client-id",
+            "oauth.clientSecret",
+            "client-secret"));
   }
 
   @Test
@@ -70,10 +116,11 @@ public class AuthConfigUtilsTest {
 
   @Test
   public void testNullAndEdgeCases() {
-    assertThat(normalizeConfigs("auth.type", "oauth", "token", null))
-        .hasSize(1)
-        .containsEntry("type", "oauth");
-
+    assertMapEquals(normalizeConfigs("auth.type", "oauth", "token", null), Map.of("type", "oauth"));
     assertThat(normalizeConfigs("auth.", "value")).hasSize(0);
+  }
+
+  private static void assertMapEquals(Map<String, String> expected, Map<String, String> actual) {
+    assertThat(expected).hasSize(actual.size()).containsAllEntriesOf(actual);
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

During OAuth integration testing, a bug was discovered in UCSingleCatalog related to how authentication configs are processed. The issue occurs because AuthConfigUtils.buildAuthConfigs(options) receives a CaseInsensitiveStringMap, which lowercases all keys. This causes keys like `oauth.clientId` to become `oauth.clientid`, preventing the OAuth token provider from correctly reading the expected key.

It was noted that the token provider should not rely on case-sensitive keys. The bug wasn’t caught earlier because the open-source UC server does not yet support OAuth, making local integration testing difficult.

A one-line fix resolved the issue, and all integration tests passed afterward.
