### PR TITLE
Add a unit test to validate io.unitycatalog.server.persist.model.Privileges.

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/persist/model/PrivilegesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/model/PrivilegesTest.java
@@ -1,0 +1,25 @@
+package io.unitycatalog.server.persist.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.unitycatalog.server.model.Privilege;
+import org.junit.jupiter.api.Test;
+
+public class PrivilegesTest {
+
+  @Test
+  public void testPrivilegesIsSupersetOfPrivilege() {
+    // Verify that all generated privileges exist in the persist model
+    for (Privilege generatedPrivilege : Privilege.values()) {
+      Privileges persistPrivilege = Privileges.fromPrivilege(generatedPrivilege);
+      if (persistPrivilege == null) {
+        fail(
+            String.format(
+                "Generated privilege '%s' is not mappable to Privileges enum", generatedPrivilege));
+      }
+      assertThat(persistPrivilege.name()).isEqualTo(generatedPrivilege.name());
+      assertThat(persistPrivilege.getValue()).isEqualTo(generatedPrivilege.getValue());
+    }
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Add a unit test to validate io.unitycatalog.server.persist.model.Privileges.

This class is meant to be a superset of io.unitycatalog.server.persist.model. But there was no mechanism to enforce that. This unit test fills in the gap.
