### PR TITLE
Pick available port when starting UC server in test

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -5,7 +5,8 @@ import io.unitycatalog.server.persist.utils.HibernateConfigurator;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ServerProperties.Property;
-import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -78,7 +79,7 @@ public abstract class BaseServerTest {
     if (serverConfig.getServerUrl().contains("localhost")) {
       System.out.println("Running tests on localhost..");
       // start the server on a random port
-      int port = TestUtils.getRandomPort();
+      int port = findAvailablePort();
       Files.createDirectories(testDirectoryRoot);
 
       setUpProperties();
@@ -93,6 +94,13 @@ public abstract class BaseServerTest {
               .build();
       unityCatalogServer.start();
       serverConfig.setServerUrl("http://localhost:" + port);
+    }
+  }
+
+  /** Finds an available port for the UC server. */
+  private int findAvailablePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -54,10 +54,6 @@ public class TestUtils {
       new HashMap<>(Map.of("prop2", "value22", "prop3", "value33"));
   public static final String COMMON_ENTITY_NAME = "zz_uc_common_entity_name";
 
-  public static int getRandomPort() {
-    return (int) (Math.random() * 1000) + 9000;
-  }
-
   public static ApiClient createApiClient(ServerConfig serverConfig) {
     ApiClient apiClient = new ApiClient();
     URI uri = URI.create(serverConfig.getServerUrl());


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Pick available port when starting UC server in test
Current it just picks a random port which may or may not be in use. This PR changes it so that it picks an availalbe port.
