### PR TITLE
Add Java and Scala versions to user agent string

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ApiClientFactory.java
@@ -20,14 +20,22 @@ public class ApiClientFactory {
         .tokenProvider(tokenProvider)
         .retryPolicy(retryPolicy);
 
-    // Add Spark to User-Agent, and Delta if available
+    // Add Spark, Delta, Java, and Scala versions to User-Agent
     String sparkVersion = getSparkVersion();
     String deltaVersion = getDeltaVersion();
+    String javaVersion = getJavaVersion();
+    String scalaVersion = getScalaVersion();
+
+    // Add versions in order: Spark, Delta, Java, Scala
+    builder.addAppVersion("Spark", sparkVersion);
     if (deltaVersion != null) {
-      builder.addAppVersion("Spark", sparkVersion)
-          .addAppVersion("Delta", deltaVersion);
-    } else {
-      builder.addAppVersion("Spark", sparkVersion);
+      builder.addAppVersion("Delta", deltaVersion);
+    }
+    if (javaVersion != null) {
+      builder.addAppVersion("Java", javaVersion);
+    }
+    if (scalaVersion != null) {
+      builder.addAppVersion("Scala", scalaVersion);
     }
 
     return builder.build();
@@ -58,6 +66,23 @@ public class ApiClientFactory {
         // Delta not available or version not accessible
         return null;
       }
+    }
+  }
+
+  private static String getJavaVersion() {
+    try {
+      return System.getProperty("java.version");
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static String getScalaVersion() {
+    try {
+      return scala.util.Properties.versionNumberString();
+    } catch (Exception e) {
+      // Scala not available or version not accessible
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR extends the Unity Catalog Spark connector's user agent string to include Java and Scala runtime versions in addition to the existing Spark and Delta versions. This enables better server-side tracking and monitoring of client environments.

## Changes Made

### Implementation (`ApiClientFactory.java`)
- Added `getJavaVersion()` method using `System.getProperty("java.version")`
- Added `getScalaVersion()` method using `scala.util.Properties.versionNumberString()`
- Updated `createApiClient()` to include Java and Scala versions in the user agent
- Version ordering: UC client → Spark → Delta → Java → Scala

### Testing (`ApiClientFactoryTest.java`)
- Renamed `testSparkAndDeltaVersionsInUserAgent()` to `testAllVersionsInUserAgent()` and added checks for Java and Scala versions
- Updated `testTokenNotLeakedInUserAgent()` to verify Java and Scala are present
- Enhanced `testUserAgentFormat()` to verify all versions are present and in the correct order
- Fixed checkstyle error in test class javadoc

## Example Output

**Before:** 
```
UnityCatalog-Java-Client/0.2.0 Spark/4.0.0 Delta/4.0.0
```

**After:**
```
UnityCatalog-Java-Client/0.2.0 Spark/4.0.0 Delta/4.0.0 Java/17.0.15 Scala/2.13.16
```

## Backward Compatibility

✅ Fully backward compatible - this is purely additive:
- No existing fields removed
- No changes to format (still space-separated "Name/Version" pairs)
- Base client unchanged
- Existing user agent parsing logic continues to work

## Test Results

All tests pass successfully:
```
[info] Test run finished: 0 failed, 0 ignored, 3 total, 0.986s
[info] Passed: Total 3, Failed 0, Errors 0, Passed 3
```

## Related

Builds on PR #1179 which originally added user agent support for Spark and Delta versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)