### PR TITLE
Refactor: create KeyMapper in Repositories and reuse it everywhere

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -70,7 +70,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new BaseException(ErrorCode.INTERNAL, "Error initializing access evaluator.", e);
     }
-    keyMapper = new KeyMapper(repositories);
+    keyMapper = repositories.getKeyMapper();
     userRepository = repositories.getUserRepository();
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.persist;
 
+import io.unitycatalog.server.auth.decorator.KeyMapper;
 import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.utils.ServerProperties;
 import lombok.Getter;
@@ -27,6 +28,8 @@ public class Repositories {
   private final ExternalLocationRepository externalLocationRepository;
   private final DeltaCommitRepository deltaCommitRepository;
 
+  private final KeyMapper keyMapper;
+
   public Repositories(SessionFactory sessionFactory, ServerProperties serverProperties) {
     this.sessionFactory = sessionFactory;
     this.fileOperations = new FileOperations(serverProperties);
@@ -44,5 +47,8 @@ public class Repositories {
     this.credentialRepository = new CredentialRepository(this, sessionFactory);
     this.externalLocationRepository = new ExternalLocationRepository(this, sessionFactory);
     this.deltaCommitRepository = new DeltaCommitRepository(sessionFactory, serverProperties);
+
+    // KeyMapper uses all the repositories above.
+    this.keyMapper = new KeyMapper(this);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
@@ -1,7 +1,9 @@
 package io.unitycatalog.server.service;
 
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.auth.decorator.KeyMapper;
 import io.unitycatalog.server.auth.decorator.UnityAccessEvaluator;
+import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.persist.model.Privileges;
 import java.util.UUID;
@@ -15,12 +17,14 @@ public abstract class AuthorizedService {
   protected final UnityCatalogAuthorizer authorizer;
   protected final UnityAccessEvaluator evaluator;
   protected final UserRepository userRepository;
+  protected final KeyMapper keyMapper;
 
   @SneakyThrows
-  protected AuthorizedService(UnityCatalogAuthorizer authorizer, UserRepository userRepository) {
+  protected AuthorizedService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
     this.authorizer = authorizer;
     this.evaluator = new UnityAccessEvaluator(authorizer);
-    this.userRepository = userRepository;
+    this.userRepository = repositories.getUserRepository();
+    this.keyMapper = repositories.getKeyMapper();
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
@@ -36,7 +36,7 @@ public class CatalogService extends AuthorizedService {
 
   @SneakyThrows
   public CatalogService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.catalogRepository = repositories.getCatalogRepository();
     this.metastoreRepository = repositories.getMetastoreRepository();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
@@ -35,7 +35,7 @@ public class CredentialService extends AuthorizedService {
 
   @SneakyThrows
   public CredentialService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.credentialRepository = repositories.getCredentialRepository();
     this.metastoreRepository = repositories.getMetastoreRepository();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
@@ -29,7 +29,7 @@ public class DeltaCommitsService extends AuthorizedService {
 
   @SneakyThrows
   public DeltaCommitsService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.deltaCommitRepository = repositories.getDeltaCommitRepository();
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
@@ -38,7 +38,7 @@ public class ExternalLocationService extends AuthorizedService {
 
   @SneakyThrows
   public ExternalLocationService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.externalLocationRepository = repositories.getExternalLocationRepository();
     this.metastoreRepository = repositories.getMetastoreRepository();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
@@ -43,7 +43,7 @@ public class FunctionService extends AuthorizedService {
 
   @SneakyThrows
   public FunctionService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.catalogRepository = repositories.getCatalogRepository();
     this.schemaRepository = repositories.getSchemaRepository();
     this.functionRepository = repositories.getFunctionRepository();

--- a/server/src/main/java/io/unitycatalog/server/service/ModelService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ModelService.java
@@ -54,7 +54,7 @@ public class ModelService extends AuthorizedService {
 
   @SneakyThrows
   public ModelService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.evaluator = new UnityAccessEvaluator(authorizer);
     this.catalogRepository = repositories.getCatalogRepository();
     this.schemaRepository = repositories.getSchemaRepository();

--- a/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
@@ -39,7 +39,7 @@ public class SchemaService extends AuthorizedService {
 
   @SneakyThrows
   public SchemaService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.schemaRepository = repositories.getSchemaRepository();
     this.catalogRepository = repositories.getCatalogRepository();
     this.metastoreRepository = repositories.getMetastoreRepository();

--- a/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
@@ -27,7 +27,7 @@ public class StagingTableService extends AuthorizedService {
   private final SchemaRepository schemaRepository;
 
   public StagingTableService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.stagingTableRepository = repositories.getStagingTableRepository();
     this.schemaRepository = repositories.getSchemaRepository();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -43,7 +43,7 @@ public class TableService extends AuthorizedService {
 
   @SneakyThrows
   public TableService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.tableRepository = repositories.getTableRepository();
     this.schemaRepository = repositories.getSchemaRepository();
     this.catalogRepository = repositories.getCatalogRepository();

--- a/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
@@ -47,7 +47,7 @@ public class VolumeService extends AuthorizedService {
 
   @SneakyThrows
   public VolumeService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories.getUserRepository());
+    super(authorizer, repositories);
     this.volumeRepository = repositories.getVolumeRepository();
     this.schemaRepository = repositories.getSchemaRepository();
     this.catalogRepository = repositories.getCatalogRepository();


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1301/files) to review incremental changes.
- [**stack/path_cred_perm_refactor**](https://github.com/unitycatalog/unitycatalog/pull/1301) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1301/files)]
  - [stack/path_cred_perm](https://github.com/unitycatalog/unitycatalog/pull/1299) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1299/files/59f667d79470d11bbfc251457b1425777940f5e8..aa13b53f63db60e31cb45aeb59028b14f51dd498)]
---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Refactor: create KeyMapper in Repositories and reuse it everywhere

Previously each service that needs a KeyMapper just create one. After this PR they'll grab the only instance from Repositories.
