### PR TITLE
Fix the static members in BaseServerTest

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -20,11 +20,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 public abstract class BaseServerTest {
 
-  public static ServerConfig serverConfig = new ServerConfig("http://localhost", "");
-  protected static UnityCatalogServer unityCatalogServer;
-  protected static Properties serverProperties;
-  protected static HibernateConfigurator hibernateConfigurator;
-  protected static CloudCredentialVendor cloudCredentialVendor;
+  public static final ServerConfig serverConfig = new ServerConfig("http://localhost", "");
+  protected UnityCatalogServer unityCatalogServer;
+  protected Properties serverProperties;
+  protected HibernateConfigurator hibernateConfigurator;
+  protected CloudCredentialVendor cloudCredentialVendor;
 
   // All test data should be written under this directory. It will be cleaned up.
   @TempDir protected Path testDirectoryRoot;


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Fix the static members in BaseServerTest

The static member objects, especially cloudCredentialVendor, would cause a problem when multiple tests accesses it. They should not be static. This PR fixes them.
