### PR TITLE
Refactor schema&catalog repo: centralize DAO lookups and improve null-safety

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/FunctionRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/FunctionRepository.java
@@ -86,10 +86,9 @@ public class FunctionRepository {
           String catalogName = createFunction.getCatalogName();
           String schemaName = createFunction.getSchemaName();
           SchemaInfoDAO schemaInfo =
-              repositories.getSchemaRepository().getSchemaDAO(session, catalogName, schemaName);
-          if (schemaInfo == null) {
-            throw new BaseException(ErrorCode.NOT_FOUND, "Schema not found: " + schemaName);
-          }
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaDaoOrThrow(session, catalogName, schemaName);
           if (getFunctionDAO(session, catalogName, schemaName, createFunction.getName()) != null) {
             throw new BaseException(
                 ErrorCode.ALREADY_EXISTS, "Function already exists: " + createFunction.getName());
@@ -139,7 +138,9 @@ public class FunctionRepository {
         sessionFactory,
         session -> {
           UUID schemaId =
-              repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
           return listFunctions(session, schemaId, catalogName, schemaName, maxResults, pageToken);
         },
         "Failed to list functions",
@@ -198,7 +199,7 @@ public class FunctionRepository {
   public FunctionInfoDAO getFunctionDAO(
       Session session, String catalogName, String schemaName, String functionName) {
     UUID schemaId =
-        repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+        repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
     return getFunctionDAO(session, schemaId, functionName);
   }
 
@@ -222,12 +223,11 @@ public class FunctionRepository {
             throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid function name: " + name);
           }
           String catalogName = parts[0], schemaName = parts[1], functionName = parts[2];
-          SchemaInfoDAO schemaInfo =
-              repositories.getSchemaRepository().getSchemaDAO(session, catalogName, schemaName);
-          if (schemaInfo == null) {
-            throw new BaseException(ErrorCode.NOT_FOUND, "Schema not found: " + schemaName);
-          }
-          deleteFunction(session, schemaInfo.getId(), functionName);
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          deleteFunction(session, schemaId, functionName);
           LOGGER.info("Deleted function: {}", functionName);
           return null;
         },

--- a/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
@@ -93,7 +93,7 @@ public class StagingTableRepository {
           UUID schemaId =
               repositories
                   .getSchemaRepository()
-                  .getSchemaId(
+                  .getSchemaIdOrThrow(
                       session,
                       createStagingTable.getCatalogName(),
                       createStagingTable.getSchemaName());

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -165,7 +165,7 @@ public class TableRepository {
   private TableInfoDAO findTable(
       Session session, String catalogName, String schemaName, String tableName) {
     UUID schemaId =
-        repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+        repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
     return findBySchemaIdAndName(session, schemaId, tableName);
   }
 
@@ -186,7 +186,9 @@ public class TableRepository {
           String catalogName = createTable.getCatalogName();
           String schemaName = createTable.getSchemaName();
           UUID schemaId =
-              repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
           NormalizedURL storageLocation = NormalizedURL.from(createTable.getStorageLocation());
 
           // Check if table already exists
@@ -301,7 +303,9 @@ public class TableRepository {
         sessionFactory,
         session -> {
           UUID schemaId =
-              repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
           return listTables(
               session,
               schemaId,
@@ -352,7 +356,9 @@ public class TableRepository {
           String schemaName = parts[1];
           String tableName = parts[2];
           UUID schemaId =
-              repositories.getSchemaRepository().getSchemaId(session, catalogName, schemaName);
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
           deleteTable(session, schemaId, tableName);
           return null;
         },


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1312/files) to review incremental changes.
- [**stack/catalog_schema_repo**](https://github.com/unitycatalog/unitycatalog/pull/1312) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1312/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Refactor schema&catalog repo: centralize DAO lookups and improve null-safety

Key Changes

- The lookups of schema by name is actually involving finding both catalog and schema. Often callers will need to find both. This PR moves the lookup to RepositoryUtils.
- Add `getCatalogDaoOpt()` and `getSchemaDaoOpt()` returning Optional<DAO> for safe lookups
- Add `getCatalogAndSchemaDaoOpt()` and `getCatalogAndSchemaDaoOrThrow()` for combined lookups
- Add `getXOrThrow()` to automatically fail with NOT_FOUND. Remove repetitive null-check-and-throw patterns throughout repositories
- Replace `Pair<String, String>` with `CatalogAndSchemaNames` record for better semantics
- Rename `processChild*` methods to `deleteChild*` for clarity (tables, volumes, functions, models)
