### PR TITLE
Refactor volume repository and DAO

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
@@ -52,10 +52,13 @@ public class VolumeInfoDAO extends IdentifiableDAO {
   @Column(name = "volume_type")
   private String volumeType;
 
-  public VolumeInfo toVolumeInfo() {
+  public VolumeInfo toVolumeInfo(String catalogName, String schemaName) {
     return new VolumeInfo()
         .volumeId(getId().toString())
         .name(getName())
+        .catalogName(catalogName)
+        .schemaName(schemaName)
+        .fullName(catalogName + "." + schemaName + "." + getName())
         .comment(comment)
         .storageLocation(NormalizedURL.normalize(storageLocation))
         .owner(owner)
@@ -64,24 +67,5 @@ public class VolumeInfoDAO extends IdentifiableDAO {
         .updatedAt(updatedAt != null ? updatedAt.getTime() : null)
         .updatedBy(updatedBy)
         .volumeType(VolumeType.valueOf(volumeType));
-  }
-
-  public static VolumeInfoDAO from(VolumeInfo volumeInfo) {
-    if (volumeInfo == null) {
-      return null;
-    }
-    return VolumeInfoDAO.builder()
-        .id(UUID.fromString(volumeInfo.getVolumeId()))
-        .name(volumeInfo.getName())
-        .comment(volumeInfo.getComment())
-        .storageLocation(volumeInfo.getStorageLocation())
-        .owner(volumeInfo.getOwner())
-        .createdAt(
-            volumeInfo.getCreatedAt() != null ? new Date(volumeInfo.getCreatedAt()) : new Date())
-        .createdBy(volumeInfo.getCreatedBy())
-        .updatedAt(volumeInfo.getUpdatedAt() != null ? new Date(volumeInfo.getUpdatedAt()) : null)
-        .updatedBy(volumeInfo.getUpdatedBy())
-        .volumeType(volumeInfo.getVolumeType().getValue())
-        .build();
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1314/files) to review incremental changes.
- [**stack/volume_dao**](https://github.com/unitycatalog/unitycatalog/pull/1314) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1314/files)]
  - [stack/managed_location_api](https://github.com/unitycatalog/unitycatalog/pull/1315) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1315/files/58f494bd85e9aa424397c2fec48c4c09417b3c10..0a0223b2f7a1949cb797252aa4b3d517a2f79dc4)]
    - [stack/managed_location_server](https://github.com/unitycatalog/unitycatalog/pull/1317) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1317/files/0a0223b2f7a1949cb797252aa4b3d517a2f79dc4..6727b6b8378d4a0a94a517f633003c92526c23d1)]
      - [stack/managed_location_cli](https://github.com/unitycatalog/unitycatalog/pull/1318) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1318/files/6727b6b8378d4a0a94a517f633003c92526c23d1..61a5c49ce4e5e285426c126526dd77793851e614)]
        - [stack/managed_location_access](https://github.com/unitycatalog/unitycatalog/pull/1321) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1321/files/61a5c49ce4e5e285426c126526dd77793851e614..5d8634b7372803dd871029799c5c4a33e99ab974)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Refactor volume repository and DAO

- Cut the extra middle hop of `CreateVolumeRequestContent` --> `VolumeInfo` --> `VolumeInfoDAO`
- Reduce duplicate code
