### PR TITLE
[Spark] Enable the credential renewal by default

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -11,7 +11,7 @@ public class OptionsUtil {
   public static final String WAREHOUSE = "warehouse";
 
   public static final String RENEW_CREDENTIAL_ENABLED = "renewCredential.enabled";
-  public static final boolean DEFAULT_RENEW_CREDENTIAL_ENABLED = false;
+  public static final boolean DEFAULT_RENEW_CREDENTIAL_ENABLED = true;
 
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

In unitycatalog 0.3.1, we introduced the `renewalCredential.enable` for the catalog properties, to renewal credential automatically. Considered the compatibility to unitycatalog 0.3.0, we just introduced this catalog property, but disable it by default ( to have the same behavior and semantic to the 0.3.1 by default). 

And in future, if we want to release the unitycatalog 0.4.0,  then I think we are safe to enable this switch by default. Then for every long-running job,  it will automaitcally enjoy the credential renwal feature by default. 

In this PR,  I just set the `renewalCredential.enable` to be `true`,  let's see if there is any github check failure. 

