### PR TITLE
[Spark] Separate the java files into java folder so that we can reformat all Java classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,7 +313,7 @@ lazy val server = (project in file("server"))
     mainClass := Some(orgName + ".server.UnityCatalogServer"),
     commonSettings,
     javaOnlyReleaseSettings,
-    javafmtCheckSettings,
+    javafmtCheckSettings(),
     javaCheckstyleSettings("dev/checkstyle-config.xml"),
     Compile / compile / javacOptions ++= Seq(
       "-processor",
@@ -503,7 +503,7 @@ lazy val cli = (project in file("examples") / "cli")
     mainClass := Some(orgName + ".cli.UnityCatalogCli"),
     commonSettings,
     skipReleaseSettings,
-    javafmtCheckSettings,
+    javafmtCheckSettings(),
     javaCheckstyleSettings("dev/checkstyle-config.xml"),
     Compile / compile / javacOptions ++= javacRelease17,
     libraryDependencies ++= Seq(
@@ -573,6 +573,7 @@ lazy val spark = (project in file("connectors/spark"))
     javaOptions ++= Seq(
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
     ),
+    javafmtCheckSettings(),
     javaCheckstyleSettings("dev/checkstyle-config.xml"),
     Compile / compile / javacOptions ++= javacRelease11,
     Test / compile / javacOptions := {
@@ -658,7 +659,7 @@ lazy val integrationTests = (project in file("integration-tests"))
     javaOptions ++= Seq(
       "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
     ),
-    javafmtCheckSettings,
+    javafmtCheckSettings(),
     javaCheckstyleSettings("dev/checkstyle-config.xml"),
     skipReleaseSettings,
     libraryDependencies ++= Seq(

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/ApiClientFactory.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/ApiClientFactory.java
@@ -8,17 +8,14 @@ import java.net.URI;
 
 public class ApiClientFactory {
 
-  private ApiClientFactory() {
-  }
+  private ApiClientFactory() {}
 
   public static ApiClient createApiClient(
       RetryPolicy retryPolicy, URI uri, TokenProvider tokenProvider) {
 
     // Create a new ApiClient Builder.
-    ApiClientBuilder builder = ApiClientBuilder.create()
-        .uri(uri)
-        .tokenProvider(tokenProvider)
-        .retryPolicy(retryPolicy);
+    ApiClientBuilder builder =
+        ApiClientBuilder.create().uri(uri).tokenProvider(tokenProvider).retryPolicy(retryPolicy);
 
     // Add Spark, Delta, Java, and Scala versions to User-Agent
     String sparkVersion = getSparkVersion();
@@ -59,8 +56,8 @@ public class ApiClientFactory {
       // Fall back to io.delta.VERSION constant (older versions)
       try {
         Class<?> packageClass = Class.forName("io.delta.package$");
-        Object versionObj = packageClass.getMethod("VERSION").invoke(
-            packageClass.getField("MODULE$").get(null));
+        Object versionObj =
+            packageClass.getMethod("VERSION").invoke(packageClass.getField("MODULE$").get(null));
         return versionObj != null ? versionObj.toString() : null;
       } catch (Exception e2) {
         // Delta not available or version not accessible

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCHadoopConf.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCHadoopConf.java
@@ -5,8 +5,7 @@ import io.unitycatalog.client.retry.RetryPolicy;
 import org.apache.hadoop.conf.Configuration;
 
 public class UCHadoopConf {
-  private UCHadoopConf() {
-  }
+  private UCHadoopConf() {}
 
   // Key for the AWS S3 credential provider, same as org.apache.hadoop.fs.s3a.Constants
   // #AWS_CREDENTIALS_PROVIDER, but defined here to avoid an extra hadoop-aws dependency.
@@ -108,22 +107,21 @@ public class UCHadoopConf {
       return builder.build();
     }
 
-    builder.maxAttempts(conf.getInt(
-        REQUEST_RETRY_MAX_ATTEMPTS_KEY,
-        JitterDelayRetryPolicy.DEFAULT_MAX_ATTEMPTS));
+    builder.maxAttempts(
+        conf.getInt(REQUEST_RETRY_MAX_ATTEMPTS_KEY, JitterDelayRetryPolicy.DEFAULT_MAX_ATTEMPTS));
 
-    builder.initDelayMs(conf.getLong(
-        REQUEST_RETRY_INITIAL_DELAY_KEY,
-        JitterDelayRetryPolicy.DEFAULT_INITIAL_DELAY_MS));
+    builder.initDelayMs(
+        conf.getLong(
+            REQUEST_RETRY_INITIAL_DELAY_KEY, JitterDelayRetryPolicy.DEFAULT_INITIAL_DELAY_MS));
 
-    builder.delayMultiplier(conf.getDouble(
-        REQUEST_RETRY_DELAY_MULTIPLIER_KEY,
-        JitterDelayRetryPolicy.DEFAULT_DELAY_MULTIPLIER));
+    builder.delayMultiplier(
+        conf.getDouble(
+            REQUEST_RETRY_DELAY_MULTIPLIER_KEY, JitterDelayRetryPolicy.DEFAULT_DELAY_MULTIPLIER));
 
-    builder.delayJitterFactor(conf.getDouble(
-        REQUEST_RETRY_DELAY_JITTER_FACTOR_KEY,
-        JitterDelayRetryPolicy.DEFAULT_DELAY_JITTER_FACTOR
-    ));
+    builder.delayJitterFactor(
+        conf.getDouble(
+            REQUEST_RETRY_DELAY_JITTER_FACTOR_KEY,
+            JitterDelayRetryPolicy.DEFAULT_DELAY_JITTER_FACTOR));
 
     return builder.build();
   }

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -1,8 +1,7 @@
 package io.unitycatalog.spark;
 
-import org.apache.spark.sql.connector.catalog.TableCatalog;
-
 import java.util.Set;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 public class UCTableProperties {
   private UCTableProperties() {}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/AuthConfigUtils.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/AuthConfigUtils.java
@@ -11,8 +11,7 @@ public class AuthConfigUtils {
   private static final String STATIC_TYPE = "static";
   private static final String STATIC_TOKEN = "token";
 
-  private AuthConfigUtils() {
-  }
+  private AuthConfigUtils() {}
 
   public static Map<String, String> buildAuthConfigs(Map<String, String> configs) {
     Map<String, String> newConfigs = new HashMap<>();
@@ -31,7 +30,8 @@ public class AuthConfigUtils {
     // backward compatibility, we also copy the legacy 'token' key directly into the new config map.
     String token = configs.get(AuthConfigUtils.STATIC_TOKEN);
     if (token != null) {
-      Preconditions.checkArgument(!newConfigs.containsKey(AuthConfigUtils.STATIC_TOKEN),
+      Preconditions.checkArgument(
+          !newConfigs.containsKey(AuthConfigUtils.STATIC_TOKEN),
           "Static token was configured twice, choose only one: 'token' (legacy) or 'auth.token' (new-style).");
 
       newConfigs.put(TYPE, STATIC_TYPE);

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/CredPropsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/CredPropsUtil.java
@@ -21,8 +21,7 @@ import org.sparkproject.guava.base.Preconditions;
 import org.sparkproject.guava.collect.ImmutableMap;
 
 public class CredPropsUtil {
-  private CredPropsUtil() {
-  }
+  private CredPropsUtil() {}
 
   private abstract static class PropsBuilder<T extends PropsBuilder<T>> {
     private final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
@@ -40,7 +39,8 @@ public class CredPropsUtil {
     public T tokenProvider(TokenProvider tokenProvider) {
       // As we can only propagate the properties with prefix 'fs.*' to the FileSystem
       // implementation. So let's add the prefix here.
-      tokenProvider.configs()
+      tokenProvider
+          .configs()
           .forEach((key, value) -> builder.put(UCHadoopConf.UC_AUTH_PREFIX + key, value));
       return self();
     }
@@ -54,7 +54,8 @@ public class CredPropsUtil {
       Preconditions.checkArgument(
           UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(credType)
               || UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(credType),
-          "Invalid credential type '%s', must be either 'path' or 'table'.", credType);
+          "Invalid credential type '%s', must be either 'path' or 'table'.",
+          credType);
       builder.put(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, credType);
       return self();
     }
@@ -140,23 +141,22 @@ public class CredPropsUtil {
   }
 
   private static S3PropsBuilder s3TempCredPropsBuilder(
-      String uri,
-      TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      String uri, TokenProvider tokenProvider, TemporaryCredentials tempCreds) {
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
-    S3PropsBuilder builder = new S3PropsBuilder()
-        .set(UCHadoopConf.S3A_CREDENTIALS_PROVIDER, AwsVendedTokenProvider.class.getName())
-        .uri(uri)
-        .tokenProvider(tokenProvider)
-        .uid(UUID.randomUUID().toString())
-        .set(UCHadoopConf.S3A_INIT_ACCESS_KEY, awsCred.getAccessKeyId())
-        .set(UCHadoopConf.S3A_INIT_SECRET_KEY, awsCred.getSecretAccessKey())
-        .set(UCHadoopConf.S3A_INIT_SESSION_TOKEN, awsCred.getSessionToken());
+    S3PropsBuilder builder =
+        new S3PropsBuilder()
+            .set(UCHadoopConf.S3A_CREDENTIALS_PROVIDER, AwsVendedTokenProvider.class.getName())
+            .uri(uri)
+            .tokenProvider(tokenProvider)
+            .uid(UUID.randomUUID().toString())
+            .set(UCHadoopConf.S3A_INIT_ACCESS_KEY, awsCred.getAccessKeyId())
+            .set(UCHadoopConf.S3A_INIT_SECRET_KEY, awsCred.getSecretAccessKey())
+            .set(UCHadoopConf.S3A_INIT_SESSION_TOKEN, awsCred.getSessionToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
-      builder.set(UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME,
-          String.valueOf(tempCreds.getExpirationTime()));
+      builder.set(
+          UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME, String.valueOf(tempCreds.getExpirationTime()));
     }
 
     return builder;
@@ -190,32 +190,30 @@ public class CredPropsUtil {
 
   private static Map<String, String> gsFixedCredProps(TemporaryCredentials tempCreds) {
     GcpOauthToken gcpOauthToken = tempCreds.getGcpOauthToken();
-    Long expirationTime = tempCreds.getExpirationTime() == null
-        ? Long.MAX_VALUE
-        : tempCreds.getExpirationTime();
+    Long expirationTime =
+        tempCreds.getExpirationTime() == null ? Long.MAX_VALUE : tempCreds.getExpirationTime();
     return new GcsPropsBuilder()
         .set(GcsVendedTokenProvider.ACCESS_TOKEN_KEY, gcpOauthToken.getOauthToken())
-        .set(GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY,
-            String.valueOf(expirationTime))
+        .set(GcsVendedTokenProvider.ACCESS_TOKEN_EXPIRATION_KEY, String.valueOf(expirationTime))
         .build();
   }
 
   private static GcsPropsBuilder gcsTempCredPropsBuilder(
-      String uri,
-      TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      String uri, TokenProvider tokenProvider, TemporaryCredentials tempCreds) {
     GcpOauthToken gcpToken = tempCreds.getGcpOauthToken();
-    GcsPropsBuilder builder = new GcsPropsBuilder()
-        .set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
-        .set("fs.gs.auth.access.token.provider", GcsVendedTokenProvider.class.getName())
-        .uri(uri)
-        .tokenProvider(tokenProvider)
-        .uid(UUID.randomUUID().toString())
-        .set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN, gcpToken.getOauthToken());
+    GcsPropsBuilder builder =
+        new GcsPropsBuilder()
+            .set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
+            .set("fs.gs.auth.access.token.provider", GcsVendedTokenProvider.class.getName())
+            .uri(uri)
+            .tokenProvider(tokenProvider)
+            .uid(UUID.randomUUID().toString())
+            .set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN, gcpToken.getOauthToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
-      builder.set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
+      builder.set(
+          UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
           String.valueOf(tempCreds.getExpirationTime()));
     }
 
@@ -256,20 +254,20 @@ public class CredPropsUtil {
   }
 
   private static AbfsPropsBuilder abfsTempCredPropsBuilder(
-      String uri,
-      TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      String uri, TokenProvider tokenProvider, TemporaryCredentials tempCreds) {
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
-    AbfsPropsBuilder builder = new AbfsPropsBuilder()
-        .set(FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, AbfsVendedTokenProvider.class.getName())
-        .uri(uri)
-        .tokenProvider(tokenProvider)
-        .uid(UUID.randomUUID().toString())
-        .set(UCHadoopConf.AZURE_INIT_SAS_TOKEN, azureSas.getSasToken());
+    AbfsPropsBuilder builder =
+        new AbfsPropsBuilder()
+            .set(FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, AbfsVendedTokenProvider.class.getName())
+            .uri(uri)
+            .tokenProvider(tokenProvider)
+            .uid(UUID.randomUUID().toString())
+            .set(UCHadoopConf.AZURE_INIT_SAS_TOKEN, azureSas.getSasToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
-      builder.set(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
+      builder.set(
+          UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
           String.valueOf(tempCreds.getExpirationTime()));
     }
 

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/AbfsVendedTokenProvider.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/AbfsVendedTokenProvider.java
@@ -2,15 +2,14 @@ package io.unitycatalog.spark.auth.storage;
 
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.spark.UCHadoopConf;
-import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
 import org.apache.hadoop.shaded.com.google.common.base.Preconditions;
 
 public class AbfsVendedTokenProvider extends GenericCredentialProvider implements SASTokenProvider {
   public static final String ACCESS_TOKEN_KEY = "fs.azure.sas.fixed.token";
 
-  public AbfsVendedTokenProvider() {
-  }
+  public AbfsVendedTokenProvider() {}
 
   @Override
   public void initialize(Configuration conf, String accountName) {
@@ -23,13 +22,17 @@ public class AbfsVendedTokenProvider extends GenericCredentialProvider implement
         && conf.get(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME) != null) {
 
       String sasToken = conf.get(UCHadoopConf.AZURE_INIT_SAS_TOKEN);
-      Preconditions.checkNotNull(sasToken, "Azure SAS token not set, please check " +
-          "'%s' in hadoop configuration", UCHadoopConf.AZURE_INIT_SAS_TOKEN);
+      Preconditions.checkNotNull(
+          sasToken,
+          "Azure SAS token not set, please check " + "'%s' in hadoop configuration",
+          UCHadoopConf.AZURE_INIT_SAS_TOKEN);
 
       long expiredTimeMillis = conf.getLong(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, 0L);
-      Preconditions.checkState(expiredTimeMillis > 0,
-          "Azure SAS token expired time must be greater than 0, please check '%s' in hadoop " +
-              "configuration", UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME);
+      Preconditions.checkState(
+          expiredTimeMillis > 0,
+          "Azure SAS token expired time must be greater than 0, please check '%s' in hadoop "
+              + "configuration",
+          UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME);
 
       return GenericCredential.forAzure(sasToken, expiredTimeMillis);
     } else {

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/AwsVendedTokenProvider.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/AwsVendedTokenProvider.java
@@ -27,11 +27,13 @@ public class AwsVendedTokenProvider extends GenericCredentialProvider
       String secretKey = conf.get(UCHadoopConf.S3A_INIT_SECRET_KEY);
       String sessionToken = conf.get(UCHadoopConf.S3A_INIT_SESSION_TOKEN);
 
-      long expiredTimeMillis = conf.getLong(
-          UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME,
-          Long.MAX_VALUE);
-      Preconditions.checkState(expiredTimeMillis > 0, "Expired time %s must be greater than 0, " +
-          "please check configure key '%s'", expiredTimeMillis, UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME);
+      long expiredTimeMillis =
+          conf.getLong(UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME, Long.MAX_VALUE);
+      Preconditions.checkState(
+          expiredTimeMillis > 0,
+          "Expired time %s must be greater than 0, " + "please check configure key '%s'",
+          expiredTimeMillis,
+          UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME);
 
       return GenericCredential.forAws(accessKey, secretKey, sessionToken, expiredTimeMillis);
     } else {
@@ -44,11 +46,10 @@ public class AwsVendedTokenProvider extends GenericCredentialProvider
     GenericCredential generic = accessCredentials();
 
     // Wrap the GenericCredential as an AwsCredentials.
-    io.unitycatalog.client.model.AwsCredentials awsTempCred = generic
-        .temporaryCredentials()
-        .getAwsTempCredentials();
-    Preconditions.checkNotNull(awsTempCred,
-        "AWS temp credential of generic credentials cannot be null");
+    io.unitycatalog.client.model.AwsCredentials awsTempCred =
+        generic.temporaryCredentials().getAwsTempCredentials();
+    Preconditions.checkNotNull(
+        awsTempCred, "AWS temp credential of generic credentials cannot be null");
 
     return AwsSessionCredentials.builder()
         .accessKeyId(awsTempCred.getAccessKeyId())

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/GcsVendedTokenProvider.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/GcsVendedTokenProvider.java
@@ -1,13 +1,12 @@
 package io.unitycatalog.spark.auth.storage;
 
-import io.unitycatalog.spark.UCHadoopConf;
-import org.apache.hadoop.conf.Configuration;
-import org.sparkproject.guava.base.Preconditions;
-import io.unitycatalog.client.model.GcpOauthToken;
 import com.google.cloud.hadoop.util.AccessTokenProvider;
-
+import io.unitycatalog.client.model.GcpOauthToken;
+import io.unitycatalog.spark.UCHadoopConf;
 import java.io.IOException;
 import java.time.Instant;
+import org.apache.hadoop.conf.Configuration;
+import org.sparkproject.guava.base.Preconditions;
 
 public class GcsVendedTokenProvider extends GenericCredentialProvider
     implements AccessTokenProvider {
@@ -16,28 +15,30 @@ public class GcsVendedTokenProvider extends GenericCredentialProvider
   public static final String ACCESS_TOKEN_EXPIRATION_KEY = "fs.gs.auth.access.token.expiration";
   private Configuration conf;
 
-  public GcsVendedTokenProvider() {
-  }
+  public GcsVendedTokenProvider() {}
 
   @Override
   public GenericCredential initGenericCredential(Configuration conf) {
     if (conf.get(UCHadoopConf.GCS_INIT_OAUTH_TOKEN) != null) {
       String oauthToken = conf.get(UCHadoopConf.GCS_INIT_OAUTH_TOKEN);
-      Preconditions.checkNotNull(oauthToken, "GCS OAuth token not set, please check '%s' in hadoop "
-          + "configuration", UCHadoopConf.GCS_INIT_OAUTH_TOKEN);
+      Preconditions.checkNotNull(
+          oauthToken,
+          "GCS OAuth token not set, please check '%s' in hadoop " + "configuration",
+          UCHadoopConf.GCS_INIT_OAUTH_TOKEN);
 
-      long expiredTimeMillis = conf.getLong(
-            UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
-            Long.MAX_VALUE);
-      Preconditions.checkState(expiredTimeMillis > 0, "Expired time %s must be greater than 0, " +
-          "please check configure key '%s'", expiredTimeMillis, UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME);
+      long expiredTimeMillis =
+          conf.getLong(UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, Long.MAX_VALUE);
+      Preconditions.checkState(
+          expiredTimeMillis > 0,
+          "Expired time %s must be greater than 0, " + "please check configure key '%s'",
+          expiredTimeMillis,
+          UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME);
 
       return GenericCredential.forGcs(oauthToken, expiredTimeMillis);
     } else {
       return null;
     }
   }
-
 
   @Override
   public AccessToken getAccessToken() {
@@ -50,9 +51,8 @@ public class GcsVendedTokenProvider extends GenericCredentialProvider
     Preconditions.checkNotNull(tokenValue, "GCS OAuth token value cannot be null");
 
     Long expirationMillis = generic.temporaryCredentials().getExpirationTime();
-    Instant expirationInstant = expirationMillis == null
-        ? null
-        : Instant.ofEpochMilli(expirationMillis);
+    Instant expirationInstant =
+        expirationMillis == null ? null : Instant.ofEpochMilli(expirationMillis);
     return new AccessToken(tokenValue, expirationInstant);
   }
 
@@ -74,4 +74,3 @@ public class GcsVendedTokenProvider extends GenericCredentialProvider
     return conf;
   }
 }
-

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/GenericCredential.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/storage/GenericCredential.java
@@ -1,10 +1,10 @@
 package io.unitycatalog.spark.auth.storage;
 
+import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.client.internal.Clock;
 import java.util.Objects;
 
 public class GenericCredential {
@@ -15,10 +15,7 @@ public class GenericCredential {
   }
 
   public static GenericCredential forAws(
-      String accessKey,
-      String secretKey,
-      String sessionToken,
-      long expiredTimeMillis) {
+      String accessKey, String secretKey, String sessionToken, long expiredTimeMillis) {
     // Initialize the aws credentials.
     AwsCredentials awsCredentials = new AwsCredentials();
     awsCredentials.setAccessKeyId(accessKey);
@@ -62,14 +59,14 @@ public class GenericCredential {
   /**
    * Decide whether it's time to renew the credential/token in advance.
    *
-   * @param clock                 to get the latest timestamp.
+   * @param clock to get the latest timestamp.
    * @param renewalLeadTimeMillis The amount of time before something expires when the renewal
-   *                              process should start.
+   *     process should start.
    * @return true if it's ready to renew.
    */
   public boolean readyToRenew(Clock clock, long renewalLeadTimeMillis) {
-    return tempCred.getExpirationTime() != null &&
-        tempCred.getExpirationTime() <= clock.now().toEpochMilli() + renewalLeadTimeMillis;
+    return tempCred.getExpirationTime() != null
+        && tempCred.getExpirationTime() <= clock.now().toEpochMilli() + renewalLeadTimeMillis;
   }
 
   @Override

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -3,8 +3,7 @@ package io.unitycatalog.spark.utils;
 import java.util.Map;
 
 public class OptionsUtil {
-  private OptionsUtil() {
-  }
+  private OptionsUtil() {}
 
   public static final String URI = "uri";
   public static final String TOKEN = "token";

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1,15 +1,12 @@
 package io.unitycatalog.spark
 
-import io.unitycatalog.client.{ApiClient, ApiException}
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
-import io.unitycatalog.client.model.{ColumnInfo, ColumnTypeName, CreateSchema, CreateStagingTable, CreateTable, DataSourceFormat, GenerateTemporaryPathCredential, GenerateTemporaryTableCredential, ListTablesResponse, PathOperation, SchemaInfo, TableOperation, TableType}
+import io.unitycatalog.client.model._
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
+import io.unitycatalog.client.{ApiClient, ApiException}
 import io.unitycatalog.spark.auth.{AuthConfigUtils, CredPropsUtil}
 import io.unitycatalog.spark.utils.OptionsUtil
-
-import java.net.URI
-import java.util
 import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -17,12 +14,14 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchT
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.sparkproject.guava.base.Preconditions
 
-import scala.collection.convert.ImplicitConversions._
+import java.net.URI
+import java.util
 import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions._
 import scala.language.existentials
 
 /**


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

In this PR,  I moved all the java files under the `connectors/spark/src/scala/io/unitycatalog/spark` to the `connectors/spark/src/java/io/unitycatalog/spark`.  And also enabled the automatic `javafmtAll`, so that we can automatically reformat all the unitycatalog spark connector's java files. 

After this PR, it will be much more easier to get this PR in https://github.com/unitycatalog/unitycatalog/pull/1320/changes,  because we can focus the `UCSingleCatalog` changes in that PR, without distraction from other Java files changes. 

