### PR TITLE
[Build] Fix the Javadoc generation issue and add the github check.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Compile integration tests to verify compilation and checkstyle issues.
       run: build/sbt integrationTests/test:compile
 
+    - name: Build and verify the local deployment.
+      run: build/sbt clean package publishM2
+
     - name: Run tests with coverage
       run: build/sbt -J-Xmx2G +jacoco
 

--- a/server/src/main/java/io/unitycatalog/server/auth/annotation/AuthorizeResourceKey.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/annotation/AuthorizeResourceKey.java
@@ -13,8 +13,8 @@ import java.lang.annotation.Target;
  * <p>Unlike {@link AuthorizeKey} which only exposes the raw value of ANY request field, this class
  * only annotates request fields that reference to resources and maps them to resource identifiers
  * (UUIDs). The resource key is used to retrieve the resource identifier, which is then used to
- * authorize the request. As an example, suppose you are making a request the retrieve a schema,
- * the parameter that contains the schema name might be defined in the request as:
+ * authorize the request. As an example, suppose you are making a request the retrieve a schema, the
+ * parameter that contains the schema name might be defined in the request as:
  *
  * <p>@AuthorizeResourceKey(SCHEMA) @Param("full_Name") String fullName
  *
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  * <pre>{@code
  * public void serviceMethod(
  *   @AuthorizeResourceKey(value = CATALOG, key = "catalog") CreateSchemaRequest request) { }
- * </pre>
+ * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.PARAMETER})

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
@@ -77,7 +77,7 @@ public class ExternalLocationUtils {
    *   <li>If the URL is a parent path of one or more securable, we can not figure out the actual
    *       owner but have to deny the access
    *   <li>If the URL is under or the same path of any data securable, we'll figure out the UUID of
-   *       that data securable along with its catalog&schema UUIDs and return the result.
+   *       that data securable along with its catalog and schema UUIDs and return the result.
    *   <li>If the URL is not owned by any data securable but only by external locations, return UUID
    *       of that external location.
    *   <li>Lastly if no securable is found, return empty map.


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Currently the `./build/sbt clean package publishM2` will report the error because the javadoc invalidation.  The error looks like the following:

```
[error] sbt.inc.Doc$JavadocGenerationFailed
[error] 	at sbt.inc.Doc$.sbt$inc$Doc$$$anonfun$cachedJavadoc$1(Doc.scala:51)
[error] 	at sbt.inc.Doc$$anonfun$cachedJavadoc$2.run(Doc.scala:41)
[error] 	at sbt.inc.Doc$.sbt$inc$Doc$$$anonfun$prepare$1(Doc.scala:62)
[error] 	at sbt.inc.Doc$$anonfun$prepare$5.run(Doc.scala:57)
[error] 	at sbt.inc.Doc$.go$1(Doc.scala:73)
[error] 	at sbt.inc.Doc$.$anonfun$cached$5(Doc.scala:82)
[error] 	at sbt.inc.Doc$.$anonfun$cached$5$adapted(Doc.scala:81)
[error] 	at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:220)
[error] 	at sbt.inc.Doc$.sbt$inc$Doc$$$anonfun$cached$1(Doc.scala:85)
[error] 	at sbt.inc.Doc$$anonfun$cached$7.run(Doc.scala:68)
[error] 	at sbt.Defaults$.$anonfun$docTaskSettings$4(Defaults.scala:2180)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[error] 	at java.base/java.lang.Thread.run(Thread.java:1583)
[error] (server / Compile / doc) sbt.inc.Doc$JavadocGenerationFailed
[error] Total time: 1 s, completed Feb 2, 2026, 9:24:33 AM
```

This PR will fix this javadoc break, and also add the github checks so that we won't break it again. 
