### PR TITLE
Implement authorization filtering for LIST operations

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -123,7 +123,12 @@ public class UnityCatalogServer {
     BaseExceptionHandler.setIncludeStackTrace(
         unityCatalogServerBuilder.serverProperties.isIncludeStackTraceInError());
     // Init services
-    addApiServices(armeriaServerBuilder, unityCatalogServerBuilder, authorizer, repositories);
+    addApiServices(
+        armeriaServerBuilder,
+        unityCatalogServerBuilder,
+        unityCatalogServerBuilder.serverProperties,
+        authorizer,
+        repositories);
     // Init security decorators
     addSecurityDecorators(
         armeriaServerBuilder, unityCatalogServerBuilder.serverProperties, authorizer, repositories);
@@ -153,33 +158,37 @@ public class UnityCatalogServer {
   private void addApiServices(
       ServerBuilder armeriaServerBuilder,
       UnityCatalogServer.Builder unityCatalogServerBuilder,
+      ServerProperties serverProperties,
       UnityCatalogAuthorizer authorizer,
       Repositories repositories) {
     LOGGER.info("Adding Unity Catalog API services...");
     CloudCredentialVendor cloudCredentialVendor =
         unityCatalogServerBuilder.cloudCredentialVendor != null
             ? unityCatalogServerBuilder.cloudCredentialVendor
-            : new CloudCredentialVendor(unityCatalogServerBuilder.serverProperties);
+            : new CloudCredentialVendor(serverProperties);
     StorageCredentialVendor storageCredentialVendor =
         new StorageCredentialVendor(cloudCredentialVendor, repositories.getExternalLocationUtils());
 
     // Add support for Unity Catalog APIs
-    AuthService authService =
-        new AuthService(securityContext, unityCatalogServerBuilder.serverProperties, repositories);
+    AuthService authService = new AuthService(securityContext, serverProperties, repositories);
     PermissionService permissionService = new PermissionService(authorizer, repositories);
     Scim2UserService scim2UserService = new Scim2UserService(authorizer, repositories);
     Scim2SelfService scim2SelfService = new Scim2SelfService(authorizer, repositories);
-    CatalogService catalogService = new CatalogService(authorizer, repositories);
-    SchemaService schemaService = new SchemaService(authorizer, repositories);
-    VolumeService volumeService = new VolumeService(authorizer, repositories);
-    TableService tableService = new TableService(authorizer, repositories);
-    StagingTableService stagingTableService = new StagingTableService(authorizer, repositories);
-    FunctionService functionService = new FunctionService(authorizer, repositories);
-    ModelService modelService = new ModelService(authorizer, repositories);
-    CredentialService credentialService = new CredentialService(authorizer, repositories);
+    CatalogService catalogService = new CatalogService(authorizer, repositories, serverProperties);
+    SchemaService schemaService = new SchemaService(authorizer, repositories, serverProperties);
+    VolumeService volumeService = new VolumeService(authorizer, repositories, serverProperties);
+    TableService tableService = new TableService(authorizer, repositories, serverProperties);
+    StagingTableService stagingTableService =
+        new StagingTableService(authorizer, repositories, serverProperties);
+    FunctionService functionService =
+        new FunctionService(authorizer, repositories, serverProperties);
+    ModelService modelService = new ModelService(authorizer, repositories, serverProperties);
+    CredentialService credentialService =
+        new CredentialService(authorizer, repositories, serverProperties);
     ExternalLocationService externalLocationService =
-        new ExternalLocationService(authorizer, repositories);
-    DeltaCommitsService deltaCommitsService = new DeltaCommitsService(authorizer, repositories);
+        new ExternalLocationService(authorizer, repositories, serverProperties);
+    DeltaCommitsService deltaCommitsService =
+        new DeltaCommitsService(authorizer, repositories, serverProperties);
     MetastoreService metastoreService = new MetastoreService(repositories);
     // TODO: combine these into a single service in a follow-up PR
     TemporaryTableCredentialsService temporaryTableCredentialsService =
@@ -248,7 +257,7 @@ public class UnityCatalogServer {
             BASE_PATH + "external-locations", externalLocationService, requestConverterFunction);
     addIcebergApiServices(
         armeriaServerBuilder,
-        unityCatalogServerBuilder.serverProperties,
+        serverProperties,
         storageCredentialVendor,
         catalogService,
         schemaService,

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -263,7 +263,8 @@ public class UnityCatalogServer {
         schemaService,
         tableService,
         repositories);
-    addDeltaApiServices(armeriaServerBuilder, authorizer, repositories, storageCredentialVendor);
+    addDeltaApiServices(
+        armeriaServerBuilder, authorizer, repositories, serverProperties, storageCredentialVendor);
   }
 
   private void addIcebergApiServices(
@@ -299,10 +300,12 @@ public class UnityCatalogServer {
       ServerBuilder armeriaServerBuilder,
       UnityCatalogAuthorizer authorizer,
       Repositories repositories,
+      ServerProperties serverProperties,
       StorageCredentialVendor storageCredentialVendor) {
     LOGGER.info("Adding Delta REST Catalog API services...");
     DeltaRestCatalogService deltaRestService =
-        new DeltaRestCatalogService(authorizer, repositories, storageCredentialVendor);
+        new DeltaRestCatalogService(
+            authorizer, repositories, serverProperties, storageCredentialVendor);
     // Omit null fields to match the Delta protocol wire format.
     ObjectMapper deltaMapper =
         JsonMapper.builder().serializationInclusion(JsonInclude.Include.NON_NULL).build();

--- a/server/src/main/java/io/unitycatalog/server/auth/annotation/AuthorizeExpression.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/annotation/AuthorizeExpression.java
@@ -24,7 +24,6 @@ import java.lang.annotation.Target;
  * <ul>
  *   <li>#principal - the (UUID) of the principal making the request
  *   <li>#deny - constant evaluating to false
- *   <li>#defer - constant evaluating to true - a marker to note authorization happens elsewhere
  *   <li>#permit - constant evaluating to true - always allow access
  *   <li>#catalog - the ID of the catalog associated with the request (if applicable)
  *   <li>#schema - the ID of the schema associated with the request (if applicable)

--- a/server/src/main/java/io/unitycatalog/server/auth/annotation/ResponseAuthorizeFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/annotation/ResponseAuthorizeFilter.java
@@ -1,0 +1,50 @@
+package io.unitycatalog.server.auth.annotation;
+
+import io.unitycatalog.server.auth.decorator.ResultFilter;
+import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
+import io.unitycatalog.server.service.AuthorizedService;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark service methods that require response filtering for authorization.
+ *
+ * <p>When a method is annotated with {@code @ResponseAuthorizeFilter}, it indicates that the method
+ * returns a list of resources that must be filtered based on the user's permissions. The service
+ * method MUST call {@code applyResponseFilter()} to filter the results before returning them to the
+ * client.
+ *
+ * <p>This annotation works in conjunction with {@link AuthorizeExpression} to implement
+ * authorization for LIST operations. The {@link UnityAccessDecorator} creates a {@link
+ * ResultFilter} instance and stores it in the request context. The service method retrieves this
+ * filter and applies it to the response list by calling {@code applyResponseFilter()}.
+ *
+ * <p><b>Security Enforcement:</b> If a method is annotated with {@code @ResponseAuthorizeFilter}
+ * but does not call the filter on successful responses, the decorator will throw a security
+ * exception to prevent unauthorized data leakage.
+ *
+ * <p><b>Usage Example:</b>
+ *
+ * <pre>{@code
+ * @Get("/tables")
+ * @AuthorizeExpression("""#authorize(#principal, #catalog, USE_CATALOG) &&
+ *                         #authorize(#principal, #schema, USE_SCHEMA)""")
+ * @ResponseAuthorizeFilter
+ * public HttpResponse listTables(
+ *     @AuthorizeResourceKey(CATALOG) String catalogName,
+ *     @AuthorizeResourceKey(SCHEMA) String schemaName) {
+ *   List<TableInfo> tables = tableRepository.listTables(catalogName, schemaName);
+ *   applyResponseFilter(TABLE, tables);  // REQUIRED - filters based on user permissions
+ *   return HttpResponse.ofJson(new ListTablesResponse().tables(tables));
+ * }
+ * }</pre>
+ *
+ * @see AuthorizeExpression
+ * @see ResultFilter
+ * @see AuthorizedService#applyResponseFilter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ResponseAuthorizeFilter {}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/KeyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/KeyMapper.java
@@ -139,8 +139,8 @@ public class KeyMapper {
     this.credentialRepository = repositories.getCredentialRepository();
   }
 
-  public Map<SecurableType, Object> mapResourceKeys(Map<SecurableType, Object> resourceKeys) {
-    Map<SecurableType, Object> resourceIds = new HashMap<>();
+  public Map<SecurableType, UUID> mapResourceKeys(Map<SecurableType, Object> resourceKeys) {
+    Map<SecurableType, UUID> resourceIds = new HashMap<>();
 
     if (resourceKeys.containsKey(CATALOG)
         && resourceKeys.containsKey(SCHEMA)
@@ -308,7 +308,7 @@ public class KeyMapper {
       if (resourceObject == null) {
         // External location is explicitly null (not set), don't add to resourceIds
       } else if (resourceObject instanceof UUID) {
-        resourceIds.put(EXTERNAL_LOCATION, resourceObject);
+        resourceIds.put(EXTERNAL_LOCATION, (UUID) resourceObject);
       } else {
         String nameOrPath = (String) resourceObject;
         if (nameOrPath.contains("/")) {
@@ -335,7 +335,7 @@ public class KeyMapper {
       if (resourceObject == null) {
         // Credential is explicitly null (e.g., not being updated), don't add to resourceIds
       } else if (resourceObject instanceof UUID) {
-        resourceIds.put(CREDENTIAL, resourceObject);
+        resourceIds.put(CREDENTIAL, (UUID) resourceObject);
       } else {
         String name = (String) resourceObject;
         String credentialId = credentialRepository.getCredential(name).getId();

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -1,0 +1,195 @@
+package io.unitycatalog.server.auth.decorator;
+
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
+import io.unitycatalog.server.model.CatalogInfo;
+import io.unitycatalog.server.model.CredentialInfo;
+import io.unitycatalog.server.model.ExternalLocationInfo;
+import io.unitycatalog.server.model.FunctionInfo;
+import io.unitycatalog.server.model.RegisteredModelInfo;
+import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.SecurableType;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.VolumeInfo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.unitycatalog.server.service.AuthorizedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+
+/**
+ * Filters list responses based on user authorization permissions.
+ *
+ * <p>This class is used in the authorization decorator layer to filter LIST operation results. When
+ * a service method is annotated with {@code @ResponseAuthorizeFilter}, the {@link
+ * UnityAccessDecorator} creates a ResultFilter instance and stores it in the request context. The
+ * service method then retrieves this filter and calls it to remove items that the user is not
+ * authorized to access.
+ *
+ * <p><b>How It Works:</b>
+ *
+ * <ol>
+ *   <li>UnityAccessDecorator intercepts HTTP requests and extracts authorization parameters
+ *       (principal ID, expression, resource IDs) from method annotations
+ *   <li>It creates a ResultFilter with these parameters and stores it in the request context
+ *   <li>The service method retrieves the filter via {@code applyResponseFilter()} and applies it to
+ *       the response list
+ *   <li>The filter evaluates authorization for each item and removes unauthorized items
+ * </ol>
+ *
+ * <p><b>Resource ID Resolution:</b><br>
+ * For each item in the list, the filter resolves resource IDs of items but expect the catalog and
+ * schema IDs to be provided in the request already. Special handling exists for REGISTERED_MODEL
+ * because models can be listed without specifying catalog/schema filters. In this case, the filter
+ * extracts the catalog and schema names from each model and resolves them to IDs.
+ *
+ * <p><b>Security:</b><br>
+ * The {@code wasCalled()} method allows UnityAccessDecorator to verify that the filter was actually
+ * used. If a method is annotated with {@code @ResponseAuthorizeFilter} but doesn't call the filter,
+ * a security exception is thrown to prevent data leakage.
+ *
+ * @see ResponseAuthorizeFilter
+ * @see UnityAccessDecorator
+ * @see AuthorizedService#applyResponseFilter
+ */
+public class ResultFilter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResultFilter.class);
+
+  private final UUID principalId;
+  private final String expression;
+  private final UnityAccessEvaluator evaluator;
+  private final Map<SecurableType, UUID> resourceIds;
+  private final Map<String, Object> nonResourceValues;
+  private final KeyMapper keyMapper;
+  private boolean called = false;
+
+  public ResultFilter(
+      UnityAccessEvaluator evaluator,
+      UUID principalId,
+      String expression,
+      Map<SecurableType, UUID> resourceIds,
+      Map<String, Object> nonResourceValues,
+      KeyMapper keyMapper) {
+    this.principalId = principalId;
+    this.expression = expression;
+    this.evaluator = evaluator;
+    this.resourceIds = resourceIds;
+    this.nonResourceValues = nonResourceValues;
+    this.keyMapper = keyMapper;
+  }
+
+  /**
+   * Filters a list of resources based on the user's authorization permissions.
+   *
+   * <p>This method evaluates the authorization expression for each item in the list and removes
+   * items that the user is not authorized to access. For each item, it:
+   *
+   * <ol>
+   *   <li>Resolves the item's resource ID (e.g., table ID, volume ID)
+   *   <li>Resolves parent (catalog and schema) resource IDs if it's registered model
+   *   <li>Evaluates the authorization expression with all resolved and provided IDs
+   *   <li>Removes the item if the expression evaluates to false
+   * </ol>
+   *
+   * <p>If an error occurs during authorization evaluation for an item, that item is filtered out
+   * (removed from the list) as a security precaution.
+   *
+   * @param securableType The type of resources being filtered (TABLE, VOLUME, FUNCTION, etc.)
+   * @param items The list of items to filter in-place. This list is modified by removing
+   *     unauthorized items.
+   * @param <T> The type of items in the list (e.g., TableInfo, VolumeInfo)
+   * @throws RuntimeException if the securableType is already resolved in the pre-resolved IDs,
+   *     which indicates a programming error
+   */
+  public <T> void filter(SecurableType securableType, List<T> items) {
+    called = true;
+
+    if (items == null || items.isEmpty()) {
+      return;
+    }
+
+    LOGGER.debug("Filtering {} items with authorization expression", items.size());
+    if (resourceIds.containsKey(securableType)) {
+      // This simply indicates a bug in code.
+      throw new RuntimeException("Securable type " + securableType + " is already resolved");
+    }
+
+    items.removeIf(
+        item -> {
+          try {
+            // Resolve the item's resource ID and any parent resource IDs to make a complete
+            // collection of all needed resource IDs for this item.
+            Map<SecurableType, UUID> resourceIdsForItem =
+                resolveResourceIdsForItem(securableType, item, resourceIds);
+            boolean authorized =
+                evaluator.evaluate(principalId, expression, resourceIdsForItem, nonResourceValues);
+            if (!authorized) {
+              LOGGER.debug("Item filtered out: {}", item.getClass().getSimpleName());
+            }
+            return !authorized;
+          } catch (Exception e) {
+            LOGGER.warn(
+                "Error evaluating authorization for item, filtering out: {}", e.getMessage());
+            return true;
+          }
+        });
+
+    LOGGER.debug("After filtering: {} items remain", items.size());
+  }
+
+  private Map<SecurableType, UUID> resolveResourceIdsForItem(
+      SecurableType securableType, Object item, Map<SecurableType, UUID> preResolvedIds) {
+    // First, resolve the item's own resource ID
+    UUID itemId = resolveResourceId(securableType, item);
+    Map<SecurableType, UUID> combined = new HashMap<>(preResolvedIds);
+    combined.put(securableType, itemId);
+    // For REGISTERED_MODEL, resolve catalog and schema if both are not present.
+    if (securableType == REGISTERED_MODEL
+        && !preResolvedIds.containsKey(CATALOG)
+        && !preResolvedIds.containsKey(SCHEMA)) {
+      RegisteredModelInfo model = (RegisteredModelInfo) item;
+      combined.putAll(
+          keyMapper.mapResourceKeys(
+              Map.of(CATALOG, model.getCatalogName(), SCHEMA, model.getSchemaName())));
+    }
+    // For everything else, the catalog and schema IDs are already included in preResolvedIds
+    // if needed.
+    return combined;
+  }
+
+  private UUID resolveResourceId(SecurableType securableType, Object item) {
+    String id = switch (securableType) {
+      case TABLE -> ((TableInfo)item).getTableId();
+      case VOLUME -> ((VolumeInfo)item).getVolumeId();
+      case FUNCTION -> ((FunctionInfo)item).getFunctionId();
+      case REGISTERED_MODEL -> ((RegisteredModelInfo)item).getId();
+      case CATALOG -> ((CatalogInfo)item).getId();
+      case SCHEMA -> ((SchemaInfo)item).getSchemaId();
+      case CREDENTIAL -> ((CredentialInfo)item).getId();
+      case EXTERNAL_LOCATION -> ((ExternalLocationInfo)item).getId();
+      default -> throw new RuntimeException("Unsupported securable type: " + securableType);
+    };
+    return UUID.fromString(id);
+  }
+
+  /**
+   * Returns whether the filter has been called.
+   *
+   * <p>This method is used by {@link UnityAccessDecorator} to verify that methods annotated with
+   * {@code @ResponseAuthorizeFilter} actually call the filter on successful responses. This is a
+   * security enforcement mechanism to prevent data leakage when developers forget to filter
+   * results.
+   *
+   * @return true if {@link #filter} has been called at least once, false otherwise
+   */
+  public boolean wasCalled() {
+    return called;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -68,7 +68,7 @@ public class ResultFilter {
   private final Map<SecurableType, UUID> resourceIds;
   private final Map<String, Object> nonResourceValues;
   private final KeyMapper keyMapper;
-  private boolean called = false;
+  private volatile boolean called = false;
 
   public ResultFilter(
       UnityAccessEvaluator evaluator,

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.unitycatalog.server.service.AuthorizedService;
 import org.slf4j.Logger;
@@ -68,7 +69,7 @@ public class ResultFilter {
   private final Map<SecurableType, UUID> resourceIds;
   private final Map<String, Object> nonResourceValues;
   private final KeyMapper keyMapper;
-  private volatile boolean called = false;
+  private final AtomicBoolean called;
 
   public ResultFilter(
       UnityAccessEvaluator evaluator,
@@ -83,6 +84,7 @@ public class ResultFilter {
     this.resourceIds = resourceIds;
     this.nonResourceValues = nonResourceValues;
     this.keyMapper = keyMapper;
+    this.called = new AtomicBoolean(false);
   }
 
   /**
@@ -109,7 +111,7 @@ public class ResultFilter {
    *     which indicates a programming error
    */
   public <T> void filter(SecurableType securableType, List<T> items) {
-    called = true;
+    called.set(true);
 
     if (items == null || items.isEmpty()) {
       return;
@@ -190,6 +192,6 @@ public class ResultFilter {
    * @return true if {@link #filter} has been called at least once, false otherwise
    */
   public boolean wasCalled() {
-    return called;
+    return called.get();
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -11,10 +11,12 @@ import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import io.netty.util.AttributeKey;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.SecurableType;
@@ -69,6 +71,10 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private final UnityAccessEvaluator evaluator;
 
+  // Context attribute key for passing ResultFilter to service methods
+  public static final AttributeKey<ResultFilter> RESULT_FILTER_ATTR =
+      AttributeKey.valueOf(ResultFilter.class, "RESULT_FILTER");
+
   public UnityAccessDecorator(UnityCatalogAuthorizer authorizer, Repositories repositories)
       throws BaseException {
     try {
@@ -86,26 +92,28 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     LOGGER.debug("AccessDecorator checking {}", req.path());
 
     Method method = findServiceMethod(ctx.config().service());
+    if (method == null) {
+      throw new RuntimeException("Couldn't unwrap service.");
+    }
 
-    if (method != null) {
+    // Find the authorization parameters to use for this service method.
+    String expression = findAuthorizeExpression(method);
+    List<AuthorizeKeyLocator> locators = findAuthorizeKeys(method);
 
-      // Find the authorization parameters to use for this service method.
-      String expression = findAuthorizeExpression(method);
-      List<AuthorizeKeyLocator> locators = findAuthorizeKeys(method);
+    // Check for response filtering annotation
+    Optional<ResponseAuthorizeFilter> filterAnnotation =
+        Optional.ofNullable(method.getAnnotation(ResponseAuthorizeFilter.class));
 
-      if (expression != null) {
-        if (!locators.isEmpty()) {
-          UUID principal = userRepository.findPrincipalId();
-          return authorizeByRequest(delegate, ctx, req, principal, locators, expression);
-        } else {
-          LOGGER.warn("No authorization resource(s) found.");
-          // going to assume the expression is just #deny, #permit or #defer
-        }
-      } else {
-        LOGGER.debug("No authorization expression found.");
-      }
+    if (expression == null) {
+      throw new RuntimeException("No authorization expression found.");
+    }
+    if (!locators.isEmpty()) {
+      UUID principal = userRepository.findPrincipalId();
+      return authorizeByRequest(
+          delegate, ctx, method, req, principal, locators, expression, filterAnnotation);
     } else {
-      LOGGER.warn("Couldn't unwrap service.");
+      LOGGER.warn("No authorization resource(s) found.");
+      // going to assume the expression is just #deny or #permit
     }
 
     return delegate.serve(ctx, req);
@@ -114,10 +122,12 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
   private HttpResponse authorizeByRequest(
       HttpService delegate,
       ServiceRequestContext ctx,
+      Method method,
       HttpRequest req,
       UUID principal,
       List<AuthorizeKeyLocator> locators,
-      String expression) throws Exception {
+      String expression,
+      Optional<ResponseAuthorizeFilter> filterAnnotation) throws Exception {
     //
     // Based on the query and payload parameters defined on the service method (that
     // have been gathered as Locators), we'll attempt to find the entity/resource that
@@ -154,13 +164,14 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
       }
     });
 
-    if (payloadLocators.isEmpty()) {
-      // If we don't have any PAYLOAD locators, we're ready to evaluate the authorization and allow
-      // or deny the request.
-      LOGGER.debug("Checking authorization before method.");
-      checkAuthorization(principal, expression, resourceKeys, nonResourceValues);
+    AbstractEvaluationAction evaluateAction =
+        filterAnnotation
+            .<AbstractEvaluationAction>map(x -> new ResultFilterAction(ctx, method))
+            .orElseGet(() -> new RequestEvaluationAction(method));
 
-      return delegate.serve(ctx, req);
+    if (payloadLocators.isEmpty()) {
+      Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
+      evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
     } else {
       // Since we have PAYLOAD locators, we can only interrogate the payload while the request
       // is being evaluated, via peekData()
@@ -174,16 +185,18 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
       // Note that peekData only gets called for requests that actually have data (like PUT&POST)
 
-      var peekReq = req.peekData(data -> {
+      req = req.peekData(data -> {
+        // This code block is not called immediately. It is called later as part of delegate.serve()
         LOGGER.debug("Authorization peekData invoked.");
 
-        if (peekDataHandler.processPeekData(data)) {
-          checkAuthorization(principal, expression, resourceKeys, nonResourceValues);
-        }
+        peekDataHandler.processPeekData(data);
+        Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
+        evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
       });
-
-      return delegate.serve(ctx, peekReq);
     }
+
+    HttpResponse response = delegate.serve(ctx, req);
+    return evaluateAction.afterRequest(response);
   }
 
   private static Object findPayloadValue(String key, Map<String, Object> payload) {
@@ -202,14 +215,107 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
   }
 
-  private void checkAuthorization(
-      UUID principal,
-      String expression,
-      Map<SecurableType, Object> resourceKeys,
-      Map<String, Object> nonResourceValues) {
-    LOGGER.debug("resourceKeys = {}", resourceKeys);
+  private abstract static class AbstractEvaluationAction {
+    private boolean beforeRequestWasCalled = false;
+    protected Method method;
+    protected static final String ERR_AUTH_NOT_EXECUTED =
+        "Authorization required but failed to execute";
 
-    Map<SecurableType, Object> resourceIds = keyMapper.mapResourceKeys(resourceKeys);
+    AbstractEvaluationAction(Method method) {
+      this.method = method;
+    }
+
+    void beforeRequest(
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues) {
+      beforeRequestWasCalled = true;
+      evaluateBeforeRequest(principal, expression, resourceIds, nonResourceValues);
+    }
+
+    abstract void evaluateBeforeRequest(
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues);
+
+    HttpResponse afterRequest(HttpResponse response) {
+      return HttpResponse.of(response.aggregate().thenApply(
+        aggregated -> {
+          if (aggregated.status().isSuccess()) {
+            if (!beforeRequestWasCalled) {
+              LOGGER.error(
+                  "SECURITY VIOLATION: Method {} did not execute evaluateAction",
+                  method.getName());
+              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+            }
+            evaluateAfterRequest();
+          }
+          return aggregated.toHttpResponse();
+        }));
+    }
+
+    abstract void evaluateAfterRequest();
+  }
+
+  private class RequestEvaluationAction extends AbstractEvaluationAction {
+
+    RequestEvaluationAction(Method method) {
+      super(method);
+    }
+
+    @Override
+    public void evaluateBeforeRequest(
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues) {
+      if (!evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
+        throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
+      }
+    }
+
+    @Override
+    public void evaluateAfterRequest() {}
+  }
+
+  private class ResultFilterAction extends AbstractEvaluationAction {
+    private final ServiceRequestContext ctx;
+    private ResultFilter resultFilter = null;
+
+    ResultFilterAction(ServiceRequestContext ctx, Method method) {
+      super(method);
+      this.ctx = ctx;
+    }
+
+    @Override
+    public void evaluateBeforeRequest(
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues) {
+      resultFilter =
+          new ResultFilter(
+              evaluator, principal, expression, resourceIds, nonResourceValues, keyMapper);
+      ctx.setAttr(RESULT_FILTER_ATTR, resultFilter);
+    }
+
+    @Override
+    public void evaluateAfterRequest() {
+      if (!resultFilter.wasCalled()) {
+        LOGGER.error(
+            "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
+                + "applyResponseFilter(). This is a security vulnerability!",
+            method.getName());
+        throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+      }
+    }
+  }
+
+  private Map<SecurableType, UUID> mapResourceKeys(
+      Map<SecurableType, Object> resourceKeys, Map<String, Object> nonResourceValues) {
+    Map<SecurableType, UUID> resourceIds = keyMapper.mapResourceKeys(resourceKeys);
 
     if (resourceKeys.containsKey(SecurableType.EXTERNAL_LOCATION)) {
       // KeyMapper will try to map a path of EXTERNAL_LOCATION to any data securable if the path
@@ -226,11 +332,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     LOGGER.debug("resourceIds = {}", resourceIds);
-    LOGGER.debug("nonResourceValues = {}", nonResourceValues);
-
-    if (!evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
-      throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
-    }
+    return resourceIds;
   }
 
   private static String findAuthorizeExpression(Method method) {

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -107,16 +107,9 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     if (expression == null) {
       throw new RuntimeException("No authorization expression found.");
     }
-    if (!locators.isEmpty()) {
-      UUID principal = userRepository.findPrincipalId();
-      return authorizeByRequest(
-          delegate, ctx, method, req, principal, locators, expression, filterAnnotation);
-    } else {
-      LOGGER.warn("No authorization resource(s) found.");
-      // going to assume the expression is just #deny or #permit
-    }
-
-    return delegate.serve(ctx, req);
+    UUID principal = userRepository.findPrincipalId();
+    return authorizeByRequest(
+        delegate, ctx, method, req, principal, locators, expression, filterAnnotation);
   }
 
   private HttpResponse authorizeByRequest(
@@ -167,7 +160,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     AbstractEvaluationAction evaluateAction =
         filterAnnotation
             .<AbstractEvaluationAction>map(x -> new ResultFilterAction(ctx, method))
-            .orElseGet(() -> new RequestEvaluationAction(method));
+            .orElseGet(RequestEvaluationAction::new);
 
     if (payloadLocators.isEmpty()) {
       Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
@@ -216,57 +209,22 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
   }
 
   private abstract static class AbstractEvaluationAction {
-    private boolean beforeRequestWasCalled = false;
-    protected Method method;
     protected static final String ERR_AUTH_NOT_EXECUTED =
         "Authorization required but failed to execute";
 
-    AbstractEvaluationAction(Method method) {
-      this.method = method;
-    }
-
-    void beforeRequest(
-        UUID principal,
-        String expression,
-        Map<SecurableType, UUID> resourceIds,
-        Map<String, Object> nonResourceValues) {
-      beforeRequestWasCalled = true;
-      evaluateBeforeRequest(principal, expression, resourceIds, nonResourceValues);
-    }
-
-    abstract void evaluateBeforeRequest(
+    abstract void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
         Map<String, Object> nonResourceValues);
 
-    HttpResponse afterRequest(HttpResponse response) {
-      return HttpResponse.of(response.aggregate().thenApply(
-        aggregated -> {
-          if (aggregated.status().isSuccess()) {
-            if (!beforeRequestWasCalled) {
-              LOGGER.error(
-                  "SECURITY VIOLATION: Method {} did not execute evaluateAction",
-                  method.getName());
-              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
-            }
-            evaluateAfterRequest();
-          }
-          return aggregated.toHttpResponse();
-        }));
-    }
-
-    abstract void evaluateAfterRequest();
+    abstract HttpResponse afterRequest(HttpResponse response);
   }
 
   private class RequestEvaluationAction extends AbstractEvaluationAction {
 
-    RequestEvaluationAction(Method method) {
-      super(method);
-    }
-
     @Override
-    public void evaluateBeforeRequest(
+    void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
@@ -277,20 +235,23 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    public void evaluateAfterRequest() {}
+    HttpResponse afterRequest(HttpResponse response) {
+      return response;
+    }
   }
 
   private class ResultFilterAction extends AbstractEvaluationAction {
     private final ServiceRequestContext ctx;
-    private ResultFilter resultFilter = null;
+    private final Method method;
+    private volatile ResultFilter resultFilter = null;
 
     ResultFilterAction(ServiceRequestContext ctx, Method method) {
-      super(method);
       this.ctx = ctx;
+      this.method = method;
     }
 
     @Override
-    public void evaluateBeforeRequest(
+    void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
@@ -302,14 +263,26 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    public void evaluateAfterRequest() {
-      if (!resultFilter.wasCalled()) {
-        LOGGER.error(
-            "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
-                + "applyResponseFilter(). This is a security vulnerability!",
-            method.getName());
-        throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
-      }
+    HttpResponse afterRequest(HttpResponse response) {
+      return HttpResponse.of(response.aggregate().thenApply(
+        aggregated -> {
+          if (aggregated.status().isSuccess()) {
+            if (resultFilter == null) {
+              LOGGER.error(
+                  "SECURITY VIOLATION: Method {} did not execute evaluateAction",
+                  method.getName());
+              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+            }
+            if (!resultFilter.wasCalled()) {
+              LOGGER.error(
+                  "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
+                      + "applyResponseFilter(). This is a security vulnerability!",
+                  method.getName());
+              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+            }
+          }
+          return aggregated.toHttpResponse();
+        }));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -6,6 +6,7 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SplitHttpResponse;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
@@ -263,16 +264,22 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
     @Override
     public HttpResponse afterRequest(HttpResponse response) {
-      return HttpResponse.of(response.aggregate().thenApply(
-        aggregated -> {
-          if (aggregated.status().isSuccess()) {
+      // Wait only for response headers (not the full body) to run the enforcement check,
+      // then stream the body through. This avoids buffering large LIST responses just to
+      // check a flag that would allocate O(response size) per concurrent request.
+      SplitHttpResponse split = response.split();
+      return HttpResponse.of(split.headers().thenApply(
+        headers -> {
+          if (headers.status().isSuccess()) {
             if (resultFilter == null) {
+              split.body().abort();
               LOGGER.error(
                   "SECURITY VIOLATION: Method {} did not execute evaluateAction",
                   method.getName());
               throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
             }
             if (!resultFilter.wasCalled()) {
+              split.body().abort();
               LOGGER.error(
                   "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
                       + "applyResponseFilter(). This is a security vulnerability!",
@@ -280,7 +287,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
               throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
             }
           }
-          return aggregated.toHttpResponse();
+          return HttpResponse.of(headers, split.body());
         }));
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -157,9 +157,9 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
       }
     });
 
-    AbstractEvaluationAction evaluateAction =
+    EvaluationAction evaluateAction =
         filterAnnotation
-            .<AbstractEvaluationAction>map(x -> new ResultFilterAction(ctx, method))
+            .<EvaluationAction>map(x -> new ResultFilterAction(ctx, method))
             .orElseGet(RequestEvaluationAction::new);
 
     if (payloadLocators.isEmpty()) {
@@ -208,23 +208,20 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
   }
 
-  private abstract static class AbstractEvaluationAction {
-    protected static final String ERR_AUTH_NOT_EXECUTED =
-        "Authorization required but failed to execute";
-
-    abstract void beforeRequest(
+  private interface EvaluationAction {
+    void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
         Map<String, Object> nonResourceValues);
 
-    abstract HttpResponse afterRequest(HttpResponse response);
+    HttpResponse afterRequest(HttpResponse response);
   }
 
-  private class RequestEvaluationAction extends AbstractEvaluationAction {
+  private class RequestEvaluationAction implements EvaluationAction {
 
     @Override
-    void beforeRequest(
+    public void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
@@ -235,12 +232,14 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    HttpResponse afterRequest(HttpResponse response) {
+    public HttpResponse afterRequest(HttpResponse response) {
       return response;
     }
   }
 
-  private class ResultFilterAction extends AbstractEvaluationAction {
+  private class ResultFilterAction implements EvaluationAction {
+    protected static final String ERR_AUTH_NOT_EXECUTED =
+        "Authorization required but failed to execute";
     private final ServiceRequestContext ctx;
     private final Method method;
     private volatile ResultFilter resultFilter = null;
@@ -251,11 +250,11 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    void beforeRequest(
-        UUID principal,
-        String expression,
-        Map<SecurableType, UUID> resourceIds,
-        Map<String, Object> nonResourceValues) {
+    public void beforeRequest(
+      UUID principal,
+      String expression,
+      Map<SecurableType, UUID> resourceIds,
+      Map<String, Object> nonResourceValues) {
       resultFilter =
           new ResultFilter(
               evaluator, principal, expression, resourceIds, nonResourceValues, keyMapper);
@@ -263,7 +262,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    HttpResponse afterRequest(HttpResponse response) {
+    public HttpResponse afterRequest(HttpResponse response) {
       return HttpResponse.of(response.aggregate().thenApply(
         aggregated -> {
           if (aggregated.status().isSuccess()) {

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -31,6 +31,7 @@ import io.unitycatalog.control.model.OAuthTokenExchangeInfo;
 import io.unitycatalog.control.model.TokenEndpointExtensionType;
 import io.unitycatalog.control.model.TokenType;
 import io.unitycatalog.control.model.User;
+import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.OAuthInvalidRequestException;
@@ -213,6 +214,7 @@ public class AuthService {
   }
 
   @Post("/logout")
+  @AuthorizeExpression("#principal != null")
   public HttpResponse logout(HttpRequest request) {
     return request.headers().cookies().stream()
         .filter(c -> c.name().equals(AuthDecorator.UC_TOKEN_KEY))

--- a/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
@@ -5,6 +5,8 @@ import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.decorator.KeyMapper;
 import io.unitycatalog.server.auth.decorator.ResultFilter;
 import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
@@ -99,6 +101,11 @@ public abstract class AuthorizedService {
     if (serverProperties.isAuthorizationEnabled()) {
       ResultFilter resultFilter =
           ServiceRequestContext.current().attr(UnityAccessDecorator.RESULT_FILTER_ATTR);
+      if (resultFilter == null) {
+        throw new BaseException(
+            ErrorCode.INTERNAL,
+            "Authorization filter not initialized — ensure the request goes through UnityAccessDecorator.");
+      }
       resultFilter.filter(securableType, items);
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
@@ -8,12 +8,12 @@ import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.DeltaCommit;
 import io.unitycatalog.server.model.DeltaGetCommits;
 import io.unitycatalog.server.persist.DeltaCommitRepository;
 import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.utils.ServerProperties;
 import lombok.SneakyThrows;
 
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
@@ -28,8 +28,11 @@ public class DeltaCommitsService extends AuthorizedService {
   private final DeltaCommitRepository deltaCommitRepository;
 
   @SneakyThrows
-  public DeltaCommitsService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories);
+  public DeltaCommitsService(
+      UnityCatalogAuthorizer authorizer,
+      Repositories repositories,
+      ServerProperties serverProperties) {
+    super(authorizer, repositories, serverProperties);
     this.deltaCommitRepository = repositories.getDeltaCommitRepository();
   }
 
@@ -41,7 +44,7 @@ public class DeltaCommitsService extends AuthorizedService {
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse postCommit(
-      @AuthorizeResourceKeys({@AuthorizeResourceKey(value = TABLE, key = "table_id")})
+      @AuthorizeResourceKey(value = TABLE, key = "table_id")
       DeltaCommit commit) {
     deltaCommitRepository.postCommit(commit);
     return HttpResponse.of(HttpStatus.OK);
@@ -55,7 +58,7 @@ public class DeltaCommitsService extends AuthorizedService {
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse getCommits(
-    @AuthorizeResourceKeys({@AuthorizeResourceKey(value = TABLE, key = "table_id")})
+    @AuthorizeResourceKey(value = TABLE, key = "table_id")
     DeltaGetCommits rpc) {
     return HttpResponse.ofJson(deltaCommitRepository.getCommits(rpc));
   }

--- a/server/src/main/java/io/unitycatalog/server/service/MetastoreService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/MetastoreService.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
+import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.persist.MetastoreRepository;
 import io.unitycatalog.server.persist.Repositories;
@@ -16,6 +17,7 @@ public class MetastoreService {
   }
 
   @Get("/metastore_summary")
+  @AuthorizeExpression("#principal != null")
   public HttpResponse getMetastoreSummary() {
     return HttpResponse.ofJson(metastoreRepository.getMetastoreSummary());
   }

--- a/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
@@ -15,6 +15,7 @@ import io.unitycatalog.server.model.StagingTableInfo;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
+import io.unitycatalog.server.utils.ServerProperties;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
@@ -26,8 +27,11 @@ public class StagingTableService extends AuthorizedService {
   private final StagingTableRepository stagingTableRepository;
   private final SchemaRepository schemaRepository;
 
-  public StagingTableService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories);
+  public StagingTableService(
+      UnityCatalogAuthorizer authorizer,
+      Repositories repositories,
+      ServerProperties serverProperties) {
+    super(authorizer, repositories, serverProperties);
     this.stagingTableRepository = repositories.getStagingTableRepository();
     this.schemaRepository = repositories.getSchemaRepository();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -8,24 +8,21 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
-import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.TableInfo;
-import io.unitycatalog.server.persist.CatalogRepository;
-import io.unitycatalog.server.persist.MetastoreRepository;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.TableRepository;
-import java.util.List;
-import java.util.Map;
+import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
-import java.util.UUID;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
@@ -40,16 +37,15 @@ public class TableService extends AuthorizedService {
 
   private final TableRepository tableRepository;
   private final SchemaRepository schemaRepository;
-  private final CatalogRepository catalogRepository;
-  private final MetastoreRepository metastoreRepository;
 
   @SneakyThrows
-  public TableService(UnityCatalogAuthorizer authorizer, Repositories repositories) {
-    super(authorizer, repositories);
+  public TableService(
+      UnityCatalogAuthorizer authorizer,
+      Repositories repositories,
+      ServerProperties serverProperties) {
+    super(authorizer, repositories, serverProperties);
     this.tableRepository = repositories.getTableRepository();
     this.schemaRepository = repositories.getSchemaRepository();
-    this.catalogRepository = repositories.getCatalogRepository();
-    this.metastoreRepository = repositories.getMetastoreRepository();
   }
 
   /**
@@ -124,10 +120,20 @@ public class TableService extends AuthorizedService {
   }
 
   @Get("")
-  @AuthorizeExpression("#defer")
+  @AuthorizeExpression("""
+      #authorize(#principal, #metastore, OWNER) ||
+      #authorize(#principal, #catalog, OWNER) ||
+      (#authorize(#principal, #schema, OWNER) &&
+          #authorize(#principal, #catalog, USE_CATALOG)) ||
+      (#authorize(#principal, #schema, USE_SCHEMA) &&
+          #authorize(#principal, #catalog, USE_CATALOG) &&
+          #authorizeAny(#principal, #table, OWNER, SELECT, MODIFY))
+      """)
+  @ResponseAuthorizeFilter
+  @AuthorizeResourceKey(METASTORE)
   public HttpResponse listTables(
-      @Param("catalog_name") String catalogName,
-      @Param("schema_name") String schemaName,
+      @Param("catalog_name") @AuthorizeResourceKey(CATALOG) String catalogName,
+      @Param("schema_name") @AuthorizeResourceKey(SCHEMA) String schemaName,
       @Param("max_results") Optional<Integer> maxResults,
       @Param("page_token") Optional<String> pageToken,
       @Param("omit_properties") Optional<Boolean> omitProperties,
@@ -141,15 +147,7 @@ public class TableService extends AuthorizedService {
         omitProperties.orElse(false),
         omitColumns.orElse(false));
 
-    filterTables("""
-        #authorize(#principal, #metastore, OWNER) ||
-        #authorize(#principal, #catalog, OWNER) ||
-        (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
-        (#authorize(#principal, #schema, USE_SCHEMA) &&
-            #authorize(#principal, #catalog, USE_CATALOG) &&
-            #authorizeAny(#principal, #table, OWNER, SELECT, MODIFY))
-        """, listTablesResponse.getTables());
-
+    applyResponseFilter(SecurableType.TABLE, listTablesResponse.getTables());
     return HttpResponse.ofJson(listTablesResponse);
   }
 
@@ -171,29 +169,5 @@ public class TableService extends AuthorizedService {
     removeHierarchicalAuthorizations(tableInfo.getTableId(), schemaInfo.getSchemaId());
 
     return HttpResponse.of(HttpStatus.OK);
-  }
-
-  public void filterTables(String expression, List<TableInfo> entries) {
-    // TODO: would be nice to move this to filtering in the Decorator response
-    UUID principalId = userRepository.findPrincipalId();
-
-    evaluator.filter(
-        principalId,
-        expression,
-        entries,
-        ti -> {
-          CatalogInfo catalogInfo = catalogRepository.getCatalog(ti.getCatalogName());
-          SchemaInfo schemaInfo =
-              schemaRepository.getSchema(ti.getCatalogName() + "." + ti.getSchemaName());
-          return Map.of(
-              METASTORE,
-              metastoreRepository.getMetastoreId(),
-              CATALOG,
-              UUID.fromString(catalogInfo.getId()),
-              SCHEMA,
-              UUID.fromString(schemaInfo.getSchemaId()),
-              TABLE,
-              UUID.fromString(ti.getTableId()));
-        });
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -22,6 +22,8 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.service.AuthorizedService;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.utils.ServerProperties;
+
 import java.util.List;
 
 /**
@@ -54,8 +56,9 @@ public class DeltaRestCatalogService extends AuthorizedService {
   public DeltaRestCatalogService(
       UnityCatalogAuthorizer authorizer,
       Repositories repositories,
+      ServerProperties serverProperties,
       StorageCredentialVendor storageCredentialVendor) {
-    super(authorizer, repositories);
+    super(authorizer, repositories, serverProperties);
     this.catalogRepository = repositories.getCatalogRepository();
     this.tableRepository = repositories.getTableRepository();
   }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Implement authorization filtering for LIST operations

This commit introduces a new authorization filtering mechanism for LIST operations that filters response items based on user permissions.
Previously, LIST operations can not have the auth expression annotated in the method. Instead, they had to resolve the user principal and resource IDs then call `evaluator.filter` from each function body.

Key Changes:

1. New `ResultFilter` class
   - Filters list responses by evaluating authorization expressions for each item
   - Tracks whether filter was called to enable security enforcement

2. New `@ResponseAuthorizeFilter` annotation
   - Marks service methods that return filtered lists
   - Required for any LIST operation that needs item-level filtering

3. Enhanced `UnityAccessDecorator`
   - Creates ResultFilter instance from authorization parameters
   - Now enforces that all methods must have authorization annotated

4. New `applyResponseFilter()` method in `AuthorizedService`
   - Convenience method for services to apply filtering
   - Services can extend `AuthorizedService` and call this method

Addresses https://github.com/unitycatalog/unitycatalog/pull/1292/changes/BASE..788af87ef37e40581437cc4d7904be6197fde3ac#r2677860675
