### PR TITLE
[Build] Upgrade the hadoop version to hadoop 3.4.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val scala213 = "2.13.16"
 
 lazy val deltaVersion = "4.0.1"
 lazy val sparkVersion = "4.0.0"
-lazy val hadoopVersion = "3.4.0"
+lazy val hadoopVersion = "3.4.2"
 
 // Library versions
 lazy val jacksonVersion = "2.17.0"


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

(Related issue is: https://github.com/unitycatalog/unitycatalog/issues/1175) 

Upgrade the default hadoop version from `hadoop 3.4.0` to `hadoop 3.4.2`, reason:

1.  when I run the [integration tests](https://github.com/unitycatalog/unitycatalog/tree/main/integration-tests/src/test/java/io/unitycatalog/integrationtests) with azure cloud storage, the hadoop 3.4.0 always report the error.

```bash
source ~/.uc-it-env.sh
unset S3_BASE_LOCATION
unset GS_BASE_LOCATION

export CATALOG_NAME=main
export SCHEMA_NAME=demo_zh
export CATALOG_URI=$AZURE_CATALOG_URI
export CATALOG_AUTH_TOKEN=$AZURE_CATALOG_AUTH_TOKEN
export ABFSS_BASE_LOCATION=$ABFSS_BASE_LOCATION
export CREDENTIAL_RENEWAL_TEST_DURATION_SECONDS=100

./build/sbt -mem 4096 "integrationTests/testOnly io.unitycatalog.integrationtests.SparkCredentialRenewalTest"


Caused by: java.io.IOException: Operation failed: "Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.", 403, HEAD, https://***/*****, rId: 1864c91e-d01f-006c-6657-a18fbe000000
```

But after upgrade to use the `hadoop 3.4.1` and above, then everything works as expected. 

2.  As we are planning to support both [spark 4.1 and spark 4.0](https://github.com/unitycatalog/unitycatalog/pull/1345/changes) for unitycatalog next release,  actually, the spark 4.1 requires hadoop 3.4.2, otherwise it will have a minor class incompability issue. 

3.  Usually Apache Hadoop bugfix upgrade follow the bugfix guidelines, and we should always use the latest version of the bugfix release. 
