### PR TITLE
drop mysql specific column identifier to allow hibernate to choose.

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
@@ -30,10 +30,10 @@ public class DeltaCommitDAO {
   // optionally commit_version. But this is a required field as a unique ID in the database.
   @Id
   @UuidGenerator
-  @Column(name = "id", columnDefinition = "BINARY(16)")
+  @Column(name = "id")
   private UUID id;
 
-  @Column(name = "table_id", nullable = false, columnDefinition = "BINARY(16)")
+  @Column(name = "table_id", nullable = false)
   private UUID tableId;
 
   @Column(name = "commit_version", nullable = false)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Drop Column identifier defining the column type as BINARY as this is only supported by MySQL. Instead, by not defining, Hibernate will choose either `binary` for MySQL or `bytea` for PG.

Issue #1364 

This threw an exception in the log as described in the Issue. Tested that the uc server initializes properly and without error.