### PR TITLE
create shaded connector jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -589,8 +589,26 @@ lazy val spark = (project in file("connectors/spark"))
         lombokPath
       )
     },
+    // Assembly / shading configuration
+    // Produce a shaded uber JAR as the default package output
+    Compile / packageBin := assembly.value,
+    assembly / logLevel := Level.Warn,
+    assembly / test := {},
+    assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("org.apache.logging.**" -> "shaded.@0").inAll,
+      ShadeRule.rename("com.fasterxml.**" -> "shaded.@0").inAll,
+      ShadeRule.rename("org.apache.hadoop.**" -> "shaded.@0").inAll,
+    ),
+    assemblyPackageScala / assembleArtifact := false,
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "services", _*) => MergeStrategy.concat
+      case PathList("META-INF", _*) => MergeStrategy.discard
+      case "module-info.class" => MergeStrategy.discard
+      case _ => MergeStrategy.first
+    },
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
+      // Jackson dependencies (shaded in assembly)
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.0",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
@@ -598,9 +616,15 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
       "org.antlr" % "antlr4-runtime" % "4.13.1",
       "org.antlr" % "antlr4" % "4.13.1",
+      // Hadoop dependencies (shaded in assembly)
+      "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2" % Provided,
       "org.apache.hadoop" % "hadoop-azure" % hadoopVersion % Provided,
       "software.amazon.awssdk" % "auth" % "2.25.37" % Provided,
+      // Logging dependencies (shaded in assembly)
+      "org.apache.logging.log4j" % "log4j-slf4j2-impl" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
     ),
     libraryDependencies ++= Seq(
       // Test dependencies
@@ -610,7 +634,6 @@ lazy val spark = (project in file("connectors/spark"))
       "org.mockito" % "mockito-inline" % "5.2.0" % Test,
       "org.mockito" % "mockito-junit-jupiter" % "5.12.0" % Test,
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
-      "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % Test,
       "org.projectlombok" % "lombok" % "1.18.32" % Test,
       "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",

--- a/docs/integrations/unity-catalog-spark.md
+++ b/docs/integrations/unity-catalog-spark.md
@@ -123,13 +123,14 @@ You can run the code below to work with data stored in a Unity Catalog server.
     --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
     ```
 
-Notice the following packages (`--packages`) and configurations (`--conf`)
+Notice the following packages (`--packages`) vs. jars (`--jars`) and configurations (`--conf`)
 
 - `--packages` points to the delta-spark and unitycatalog-spark packages; update the version numbers to your current versions.
+- `--jars` can be used instead to provide a file (or s3) location for Spark to obtain the connector which is useful in air-gapped environments.
 - `spark.sql.catalog.<catalog_name>.uri` points to your local development UC instance
 - `spark.sql.catalog.<catalog_name>.token` is empty indicating there is no authentication; refer to [auth](../server/auth.md) for more information.
 - `spark.sql.defaultCatalog=<catalog_name>` must be filled out to indicate the default catalog.
-
+the
 ??? note "Three-part and two-part naming conventions"
 
     ![](https://cdn.prod.website-files.com/66954b344e907bd91f1c8027/66e2bafe16edde34db6395f2_AD_4nXdgqGKSeR2abf7zutk0fiALAs6vejg6EgUDgD_Ud9Xjy7nNkapMePCNH0zJw9Wv0uh6LYn7vlGYrRn4H74G9d0CouV0PWKsUTGkjfBKM5y4Br64B2P5Eapv97bCw0swV4pddsemaWU2zyYYlkKT6Ymxu2YO.png)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Created a Connector JAR that includes and shades dependencies needed by the Connector. This allows projects to simply define the connector artifact in the project and avoid using `--packages` to pull in the dependencies, which does not work easily in air-gapped environments.
Instead, `--jars` can be used to provide the connector jar at runtime, if needed. This works well in air-gapped Kubernetes.

This does not supercede `--packages` which would still work, but notably we avoid the log dependency conflict with Spark by use of a shaded Jar whether using `--packages` or `--jars`.

Tested using Spark 4.0.2.

Issue #1366 

Added a minor footnote for `--jars` alongside the current notes concerning `--packages` in the spark connector doc.