### PR TITLE
feat: add all-in-one target to Dockerfile with bundled envoy proxy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,8 @@ on:
       - version.sbt
       - build.sbt
       - Dockerfile
+      - bin/start-all-in-one
+      - etc/envoy/**
   pull_request:
     branches:
       - main
@@ -29,6 +31,8 @@ on:
       - version.sbt
       - build.sbt
       - Dockerfile
+      - bin/start-all-in-one
+      - etc/envoy/**
   workflow_dispatch: {}
 
 env:
@@ -99,6 +103,16 @@ jobs:
             type=ref,event=tag,suffix=-distroless
             type=sha,enable=${{ github.ref == 'refs/heads/main' }},prefix={{branch}}-,suffix=-distroless
 
+      - name: Generate Metadata and Tags (all-in-one)
+        id: meta-all-in-one
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch,suffix=-all-in-one
+            type=ref,event=tag,suffix=-all-in-one
+            type=sha,enable=${{ github.ref == 'refs/heads/main' }},prefix={{branch}}-,suffix=-all-in-one
+
       - name: Login to Docker Hub
         if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') }}
         uses: docker/login-action@v3
@@ -133,5 +147,20 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-distroless.outputs.tags }}
           labels: ${{ steps.meta-distroless.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and Push Docker Image (all-in-one)
+        if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: all-in-one
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-all-in-one.outputs.tags }}
+          labels: ${{ steps.meta-all-in-one.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,3 +73,32 @@ LABEL org.opencontainers.image.title="Unity Catalog" \
 
 EXPOSE 8080
 ENTRYPOINT ["java", "@/opt/unitycatalog/jars/args"]
+
+# --- jdk-debian: glibc-compatible JDK for use in the Ubuntu-based envoy image
+FROM eclipse-temurin:17-jre-jammy AS jdk-debian
+
+# --- all-in-one: UC + Envoy in a single container — docker build --target all-in-one
+#     The envoy base image sets ENV HOME=/home/envoy which shadows the global
+#     ARG HOME, so we use literal paths here to avoid the collision.
+FROM envoyproxy/envoy:v1.32-latest AS all-in-one
+ARG VERSION
+
+COPY --from=jdk-debian /opt/java/openjdk /opt/java/openjdk
+ENV HOME=/opt/unitycatalog JAVA_HOME=/opt/java/openjdk PATH="/opt/java/openjdk/bin:${PATH}"
+WORKDIR /opt/unitycatalog
+
+COPY --from=builder /opt/unitycatalog/dist/ /opt/unitycatalog/
+COPY bin/start-all-in-one /opt/unitycatalog/bin/start-all-in-one
+COPY etc/envoy/ /opt/unitycatalog/etc/envoy/
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget gettext-base openssl && rm -rf /var/lib/apt/lists/* && \
+    chmod +x /opt/unitycatalog/bin/start-all-in-one /opt/unitycatalog/bin/start-uc-server && \
+    chown -R envoy:envoy /opt/unitycatalog
+
+LABEL org.opencontainers.image.title="Unity Catalog (All-in-One with Envoy)" \
+      org.opencontainers.image.version="${VERSION}"
+
+EXPOSE 8080 9901
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
+CMD ["./bin/start-all-in-one"]

--- a/bin/start-all-in-one
+++ b/bin/start-all-in-one
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+UC_PORT="${UC_PORT:-8081}"
+ENVOY_AUTH_TEMPLATE="${ENVOY_AUTH_TEMPLATE:-${ROOT_DIR}/etc/envoy/envoy.auth.yaml.tmpl}"
+
+prepare_envoy_config() {
+  if [ -n "${OIDC_CLIENT_ID:-}" ]; then
+    echo "Auth mode enabled -- rendering envoy config from template..."
+
+    OIDC_SCOPES="${OIDC_SCOPES:-openid profile email}"
+    OIDC_CALLBACK_PATH="${OIDC_CALLBACK_PATH:-/callback}"
+    export OIDC_SCOPES OIDC_CALLBACK_PATH
+
+    for var in OIDC_PROVIDER_DOMAIN OIDC_AUTHORIZATION_ENDPOINT OIDC_TOKEN_ENDPOINT \
+               OIDC_JWKS_URI OIDC_ISSUER OIDC_CLIENT_ID OIDC_CLIENT_SECRET; do
+      if [ -z "${!var:-}" ]; then
+        echo "ERROR: required variable ${var} is not set" >&2
+        exit 1
+      fi
+    done
+
+    if [ -z "${OIDC_HMAC_SECRET:-}" ]; then
+      OIDC_HMAC_SECRET="$(openssl rand -hex 32)"
+      export OIDC_HMAC_SECRET
+      echo "Generated random OIDC_HMAC_SECRET for cookie signing."
+    fi
+
+    mkdir -p /tmp/envoy-secrets
+    printf '%s' "$OIDC_CLIENT_SECRET" > /tmp/envoy-secrets/token
+    printf '%s' "$OIDC_HMAC_SECRET"   > /tmp/envoy-secrets/hmac
+    chmod 600 /tmp/envoy-secrets/*
+
+    local VARS='${OIDC_PROVIDER_DOMAIN} ${OIDC_AUTHORIZATION_ENDPOINT} ${OIDC_TOKEN_ENDPOINT}'
+    VARS="${VARS} "'${OIDC_JWKS_URI} ${OIDC_ISSUER} ${OIDC_CLIENT_ID}'
+    VARS="${VARS} "'${OIDC_SCOPES} ${OIDC_CALLBACK_PATH}'
+
+    envsubst "$VARS" < "$ENVOY_AUTH_TEMPLATE" > /tmp/envoy.yaml
+    ENVOY_CONFIG="/tmp/envoy.yaml"
+    echo "Rendered auth config to ${ENVOY_CONFIG}"
+  else
+    ENVOY_CONFIG="${ENVOY_CONFIG:-${ROOT_DIR}/etc/envoy/envoy.yaml}"
+    echo "No OIDC_CLIENT_ID set -- using no-auth config at ${ENVOY_CONFIG}"
+  fi
+}
+
+cleanup() {
+  echo "Shutting down..."
+  kill "$UC_PID" 2>/dev/null || true
+  kill "$ENVOY_PID" 2>/dev/null || true
+  wait "$UC_PID" 2>/dev/null
+  wait "$ENVOY_PID" 2>/dev/null
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+prepare_envoy_config
+
+echo "Starting Unity Catalog server on port ${UC_PORT}..."
+./bin/start-uc-server -p "$UC_PORT" &
+UC_PID=$!
+
+echo "Starting Envoy proxy with config ${ENVOY_CONFIG}..."
+envoy -c "$ENVOY_CONFIG" &
+ENVOY_PID=$!
+
+while true; do
+  if ! kill -0 "$UC_PID" 2>/dev/null; then
+    echo "Unity Catalog server exited unexpectedly"
+    kill "$ENVOY_PID" 2>/dev/null || true
+    exit 1
+  fi
+  if ! kill -0 "$ENVOY_PID" 2>/dev/null; then
+    echo "Envoy proxy exited unexpectedly"
+    kill "$UC_PID" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 2
+done

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ name: unitycatalog
 services:
 
   server:
-    image: unitycatalog/unitycatalog:latest
+    image: unitycatalog/unitycatalog:local-distroless
     ports:
       - "8080:8080"
     volumes:
@@ -22,6 +22,27 @@ services:
     depends_on:
       - server
 
+  # all-in-one: UC + Envoy in a single container (build from source)
+  # all-in-one:
+  #   build:
+  #     context: .
+  #     target: all-in-one
+  #   ports:
+  #     - "8080:8080"
+  #     - "9901:9901"
+  #   volumes:
+  #     - type: bind
+  #       source: ./etc/conf
+  #       target: /opt/unitycatalog/etc/conf
+  #     - type: bind
+  #       source: ./etc/envoy
+  #       target: /opt/unitycatalog/etc/envoy
+  #     - type: volume
+  #       source: unitycatalog_data
+  #       target: /opt/unitycatalog/etc/data
+
 volumes:
   # Persist docker volume across container restarts
   unitycatalog_data:
+
+https://dev.to/gravitino/apache-gravitino-iceberg-rest-catalog-access-control-deployment-guide-4ck

--- a/docs/all-in-one.md
+++ b/docs/all-in-one.md
@@ -1,0 +1,234 @@
+# All-in-One with Envoy Proxy
+
+The all-in-one Docker image bundles [Envoy Proxy](https://www.envoyproxy.io/)
+alongside the Unity Catalog server in a single container. Envoy handles external
+traffic on port `8080` and proxies requests to the UC server on `localhost:8081`
+inside the container.
+
+This is useful for local development and for getting started quickly with
+features such as OIDC authentication, rate limiting, and access logging that
+Envoy can provide at the network layer without modifying the UC server itself.
+
+```mermaid
+graph LR
+    Client["Client :8080"] --> Envoy
+    Envoy -->|localhost:8081| UC["UC Server"]
+    Admin["Admin :9901"] -.-> Envoy
+```
+
+!!! note "Production deployments"
+    For production use, consider running Envoy and Unity Catalog as separate
+    containers or services. The all-in-one image is designed for development
+    convenience and as a starting point for Envoy configuration.
+
+## Quick start
+
+Pull or build the image, then run it:
+
+```sh
+docker run -p 8080:8080 -p 9901:9901 unitycatalog/unitycatalog:all-in-one
+```
+
+The catalog API is available at `http://localhost:8080` and the Envoy admin
+interface at `http://localhost:9901`.
+
+### Building from source
+
+```sh
+docker build --target all-in-one -t unitycatalog/unitycatalog:all-in-one .
+```
+
+## Configuration
+
+The container supports two modes: **no-auth** (default) and **auth** (OIDC).
+The mode is selected automatically based on whether the `OIDC_CLIENT_ID`
+environment variable is set.
+
+### No-auth mode
+
+When no OIDC variables are set, Envoy acts as a plain reverse proxy using the
+baseline config at `etc/envoy/envoy.yaml`. All requests are forwarded to the UC
+server without authentication.
+
+```sh
+docker run -p 8080:8080 -p 9901:9901 \
+  unitycatalog/unitycatalog:all-in-one
+```
+
+### Auth mode (OIDC)
+
+Setting `OIDC_CLIENT_ID` activates auth mode. The entrypoint renders the
+template at `etc/envoy/envoy.auth.yaml.tmpl` using `envsubst`, writes client and
+HMAC secrets to temporary files, and starts Envoy with the rendered config.
+
+Two Envoy HTTP filters are configured in the filter chain:
+
+1. **JWT Authentication** (`jwt_authn`) -- validates `Authorization: Bearer`
+   tokens against the provider's JWKS endpoint. Requests without a token are
+   allowed through so the OAuth2 filter can handle them.
+2. **OAuth2** -- redirects unauthenticated browser requests to the provider's
+   authorization endpoint, exchanges authorization codes for tokens, and stores
+   session state in signed cookies.
+
+This means API clients that send a valid Bearer token are authenticated by the
+JWT filter, while browser users without a token are redirected through the OAuth2
+login flow.
+
+#### Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OIDC_PROVIDER_DOMAIN` | yes | | Hostname of the identity provider (used for TLS cluster routing) |
+| `OIDC_AUTHORIZATION_ENDPOINT` | yes | | Full URL of the OAuth2 authorization endpoint |
+| `OIDC_TOKEN_ENDPOINT` | yes | | Full URL of the OAuth2 token endpoint |
+| `OIDC_JWKS_URI` | yes | | Full URL of the JWKS endpoint |
+| `OIDC_ISSUER` | yes | | Expected `iss` claim in JWTs |
+| `OIDC_CLIENT_ID` | yes | | OAuth2 client ID |
+| `OIDC_CLIENT_SECRET` | yes | | OAuth2 client secret |
+| `OIDC_HMAC_SECRET` | no | random | HMAC key for signing Envoy auth cookies. Auto-generated if not set. |
+| `OIDC_SCOPES` | no | `openid profile email` | Space-separated OAuth2 scopes |
+| `OIDC_CALLBACK_PATH` | no | `/callback` | Path the provider redirects to after login |
+
+#### Provider examples
+
+Example `.env` files are included for common identity providers. Copy one, fill
+in your values, and pass it to `docker run`:
+
+=== "Keycloak"
+
+    ```sh
+    docker run --env-file etc/envoy/examples/keycloak.env \
+      -e OIDC_CLIENT_ID=unity-catalog \
+      -e OIDC_CLIENT_SECRET=your-secret \
+      -p 8080:8080 -p 9901:9901 \
+      unitycatalog/unitycatalog:all-in-one
+    ```
+
+    Endpoints follow the pattern
+    `https://<host>/realms/<realm>/protocol/openid-connect/*`.
+
+=== "Azure Entra ID"
+
+    ```sh
+    docker run --env-file etc/envoy/examples/entra-id.env \
+      -e OIDC_CLIENT_ID=your-app-client-id \
+      -e OIDC_CLIENT_SECRET=your-secret \
+      -p 8080:8080 -p 9901:9901 \
+      unitycatalog/unitycatalog:all-in-one
+    ```
+
+    Endpoints follow the pattern
+    `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/*`.
+
+=== "Okta"
+
+    ```sh
+    docker run --env-file etc/envoy/examples/okta.env \
+      -e OIDC_CLIENT_ID=your-client-id \
+      -e OIDC_CLIENT_SECRET=your-secret \
+      -p 8080:8080 -p 9901:9901 \
+      unitycatalog/unitycatalog:all-in-one
+    ```
+
+    Endpoints follow the pattern
+    `https://<org-domain>/oauth2/default/v1/*`.
+
+## Customization
+
+### Mounting a custom Envoy config
+
+To bypass the template system entirely, mount your own `envoy.yaml` and set the
+`ENVOY_CONFIG` environment variable:
+
+```sh
+docker run \
+  -v ./my-envoy.yaml:/opt/unitycatalog/etc/envoy/custom.yaml \
+  -e ENVOY_CONFIG=/opt/unitycatalog/etc/envoy/custom.yaml \
+  -p 8080:8080 -p 9901:9901 \
+  unitycatalog/unitycatalog:all-in-one
+```
+
+As long as `OIDC_CLIENT_ID` is not set, the entrypoint uses the config pointed
+to by `ENVOY_CONFIG` without any template rendering.
+
+### Mounting UC server configuration
+
+UC server configuration files can be bind-mounted the same way as with other
+images:
+
+```sh
+docker run \
+  -v ./etc/conf:/opt/unitycatalog/etc/conf \
+  -p 8080:8080 -p 9901:9901 \
+  unitycatalog/unitycatalog:all-in-one
+```
+
+### Docker Compose
+
+A commented-out `all-in-one` service is included in `compose.yaml`. Uncomment it
+to use the all-in-one image instead of the default server:
+
+```yaml
+all-in-one:
+  build:
+    context: .
+    target: all-in-one
+  ports:
+    - "8080:8080"
+    - "9901:9901"
+  volumes:
+    - type: bind
+      source: ./etc/conf
+      target: /opt/unitycatalog/etc/conf
+    - type: bind
+      source: ./etc/envoy
+      target: /opt/unitycatalog/etc/envoy
+    - type: volume
+      source: unitycatalog_data
+      target: /opt/unitycatalog/etc/data
+```
+
+To enable auth mode in Compose, add an `env_file` and override the secrets:
+
+```yaml
+all-in-one:
+  # ...
+  env_file: ./etc/envoy/examples/keycloak.env
+  environment:
+    OIDC_CLIENT_ID: unity-catalog
+    OIDC_CLIENT_SECRET: your-secret
+```
+
+## Ports
+
+| Port | Service | Description |
+|---|---|---|
+| `8080` | Envoy | External-facing HTTP port (proxies to UC) |
+| `9901` | Envoy Admin | Admin interface for stats, clusters, and config dump |
+| `8081` | UC Server | Internal only (localhost inside the container) |
+
+## Envoy admin interface
+
+The admin interface at `http://localhost:9901` is useful for debugging. Some
+helpful endpoints:
+
+| Path | Description |
+|---|---|
+| `/ready` | Readiness check |
+| `/clusters` | Upstream cluster health and stats |
+| `/config_dump` | Full rendered Envoy configuration |
+| `/stats` | Envoy metrics |
+
+## Architecture
+
+The `all-in-one` Dockerfile target is based on the official
+`envoyproxy/envoy:v1.32-latest` image. It copies in a glibc-compatible JDK
+(Eclipse Temurin 17) and the UC distribution artifacts from the build stage.
+
+The entrypoint script (`bin/start-all-in-one`) starts both processes and monitors
+them:
+
+- The UC server runs in the background on port `8081`.
+- Envoy runs in the background with the selected configuration.
+- A monitoring loop checks both processes and exits if either one dies.
+- `SIGTERM` and `SIGINT` are trapped to shut down both processes cleanly.

--- a/etc/envoy/envoy.auth.yaml.tmpl
+++ b/etc/envoy/envoy.auth.yaml.tmpl
@@ -1,0 +1,157 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+static_resources:
+  secrets:
+    - name: token
+      generic_secret:
+        secret:
+          filename: /tmp/envoy-secrets/token
+    - name: hmac
+      generic_secret:
+        secret:
+          filename: /tmp/envoy-secrets/hmac
+
+  listeners:
+    - name: uc_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: uc_http
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: uc_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: uc_cluster
+                http_filters:
+                  - name: envoy.filters.http.jwt_authn
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                      providers:
+                        oidc_provider:
+                          issuer: "${OIDC_ISSUER}"
+                          audiences:
+                            - "${OIDC_CLIENT_ID}"
+                          remote_jwks:
+                            http_uri:
+                              uri: "${OIDC_JWKS_URI}"
+                              cluster: jwks_cluster
+                              timeout: 5s
+                            cache_duration:
+                              seconds: 300
+                          forward: true
+                          forward_payload_header: x-jwt-payload
+                          from_headers:
+                            - name: Authorization
+                              value_prefix: "Bearer "
+                      rules:
+                        - match:
+                            prefix: "/"
+                          requires:
+                            requires_any:
+                              requirements:
+                                - provider_name: oidc_provider
+                                - allow_missing: {}
+
+                  - name: envoy.filters.http.oauth2
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
+                      config:
+                        token_endpoint:
+                          cluster: oidc_cluster
+                          uri: "${OIDC_TOKEN_ENDPOINT}"
+                          timeout: 5s
+                        authorization_endpoint: "${OIDC_AUTHORIZATION_ENDPOINT}"
+                        redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%${OIDC_CALLBACK_PATH}"
+                        redirect_path_matcher:
+                          path:
+                            exact: "${OIDC_CALLBACK_PATH}"
+                        signout_path:
+                          path:
+                            exact: "/signout"
+                        credentials:
+                          client_id: "${OIDC_CLIENT_ID}"
+                          token_secret:
+                            name: token
+                          hmac_secret:
+                            name: hmac
+                        forward_bearer_token: true
+                        auth_scopes:
+                          - "${OIDC_SCOPES}"
+                        pass_through_matcher:
+                          - name: ":path"
+                            string_match:
+                              prefix: "/api/2.1/unity-catalog"
+                              ignore_case: true
+
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: uc_cluster
+      connect_timeout: 5s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: uc_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8081
+
+    - name: oidc_cluster
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: oidc_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: "${OIDC_PROVIDER_DOMAIN}"
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: "${OIDC_PROVIDER_DOMAIN}"
+
+    - name: jwks_cluster
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: jwks_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: "${OIDC_PROVIDER_DOMAIN}"
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: "${OIDC_PROVIDER_DOMAIN}"

--- a/etc/envoy/envoy.yaml
+++ b/etc/envoy/envoy.yaml
@@ -1,0 +1,49 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+static_resources:
+  listeners:
+    - name: uc_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: uc_http
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: uc_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: uc_cluster
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: uc_cluster
+      connect_timeout: 5s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: uc_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8081

--- a/etc/envoy/examples/entra-id.env
+++ b/etc/envoy/examples/entra-id.env
@@ -1,0 +1,30 @@
+# Azure Entra ID (formerly Azure AD) OIDC configuration for Unity Catalog + Envoy
+#
+# Replace the placeholder values below with your Azure tenant details.
+# Endpoint pattern: https://login.microsoftonline.com/<TENANT_ID>/oauth2/v2.0/*
+#
+# Find your tenant ID in the Azure Portal under "Azure Active Directory > Overview".
+# Register an application under "App registrations" and note the Application (client) ID.
+
+# Microsoft login hostname
+OIDC_PROVIDER_DOMAIN=login.microsoftonline.com
+
+# Standard OIDC endpoints -- replace <TENANT_ID> with your Azure tenant ID
+OIDC_AUTHORIZATION_ENDPOINT=https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/authorize
+OIDC_TOKEN_ENDPOINT=https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token
+OIDC_JWKS_URI=https://login.microsoftonline.com/TENANT_ID/discovery/v2.0/keys
+OIDC_ISSUER=https://login.microsoftonline.com/TENANT_ID/v2.0
+
+# Client credentials (from Azure Portal > App registrations > your app)
+OIDC_CLIENT_ID=REPLACE_WITH_APPLICATION_CLIENT_ID
+OIDC_CLIENT_SECRET=REPLACE_WITH_CLIENT_SECRET
+
+# Optional: HMAC secret for signing Envoy auth cookies.
+# If left empty, a random value is generated at startup.
+# OIDC_HMAC_SECRET=
+
+# OAuth scopes to request (space-separated)
+OIDC_SCOPES=openid profile email
+
+# Path where the provider redirects after login
+OIDC_CALLBACK_PATH=/callback

--- a/etc/envoy/examples/keycloak.env
+++ b/etc/envoy/examples/keycloak.env
@@ -1,0 +1,27 @@
+# Keycloak OIDC configuration for Unity Catalog + Envoy
+#
+# Replace the placeholder values below with your Keycloak deployment details.
+# Endpoint pattern: https://<HOST>/realms/<REALM>/protocol/openid-connect/*
+
+# Hostname of the Keycloak server (used for TLS cluster routing)
+OIDC_PROVIDER_DOMAIN=keycloak.example.com
+
+# Standard OIDC endpoints
+OIDC_AUTHORIZATION_ENDPOINT=https://keycloak.example.com/realms/unity-catalog/protocol/openid-connect/auth
+OIDC_TOKEN_ENDPOINT=https://keycloak.example.com/realms/unity-catalog/protocol/openid-connect/token
+OIDC_JWKS_URI=https://keycloak.example.com/realms/unity-catalog/protocol/openid-connect/certs
+OIDC_ISSUER=https://keycloak.example.com/realms/unity-catalog
+
+# Client credentials (created in Keycloak admin under Clients)
+OIDC_CLIENT_ID=unity-catalog
+OIDC_CLIENT_SECRET=REPLACE_WITH_CLIENT_SECRET
+
+# Optional: HMAC secret for signing Envoy auth cookies.
+# If left empty, a random value is generated at startup.
+# OIDC_HMAC_SECRET=
+
+# OAuth scopes to request (space-separated)
+OIDC_SCOPES=openid profile email
+
+# Path where the provider redirects after login
+OIDC_CALLBACK_PATH=/callback

--- a/etc/envoy/examples/okta.env
+++ b/etc/envoy/examples/okta.env
@@ -1,0 +1,30 @@
+# Okta OIDC configuration for Unity Catalog + Envoy
+#
+# Replace the placeholder values below with your Okta org details.
+# Endpoint pattern: https://<ORG_DOMAIN>/oauth2/default/v1/*
+#
+# Your Okta domain looks like: dev-12345.okta.com (or your custom domain).
+# Create an application in the Okta admin console under Applications > Create App Integration.
+
+# Okta organization hostname
+OIDC_PROVIDER_DOMAIN=dev-EXAMPLE.okta.com
+
+# Standard OIDC endpoints -- replace the domain with your Okta org domain
+OIDC_AUTHORIZATION_ENDPOINT=https://dev-EXAMPLE.okta.com/oauth2/default/v1/authorize
+OIDC_TOKEN_ENDPOINT=https://dev-EXAMPLE.okta.com/oauth2/default/v1/token
+OIDC_JWKS_URI=https://dev-EXAMPLE.okta.com/oauth2/default/v1/keys
+OIDC_ISSUER=https://dev-EXAMPLE.okta.com/oauth2/default
+
+# Client credentials (from Okta admin console > your application > General tab)
+OIDC_CLIENT_ID=REPLACE_WITH_CLIENT_ID
+OIDC_CLIENT_SECRET=REPLACE_WITH_CLIENT_SECRET
+
+# Optional: HMAC secret for signing Envoy auth cookies.
+# If left empty, a random value is generated at startup.
+# OIDC_HMAC_SECRET=
+
+# OAuth scopes to request (space-separated)
+OIDC_SCOPES=openid profile email
+
+# Path where the provider redirects after login
+OIDC_CALLBACK_PATH=/callback

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Getting Started:
       - Quickstart: quickstart.md
       - Docker Compose: docker_compose.md
+      - All-in-One with Envoy: all-in-one.md
   - Usage:
       - CLI: usage/cli.md
       - UI: usage/ui.md


### PR DESCRIPTION
Stacked-PR:
- #1374
- #1372
- __-->__ #1370
- #1363

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR adds an additional target called `all-in-one` to the docker build. This target bundles unity catalog with an envoy proxy and starts both services in a single container.

The purpose if this new build is to provide a simple way to get a production-like environment set up and running locally. It also helps us demonstrate how production grade features can be build in on-prem scenarios.

The base idea is to leverage the many features provided by using a reverse proxy in front of a service to eliminate the need for more complex implementations inside the service. We also want to demonstrate patterns that can be used to enable many more platform level features.

Examples of this will be added in later PRs.
