### PR TITLE
[Spark] Implement stageReplace() for atomic RTAS on UC-managed Delta tables

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -7,9 +7,7 @@ public class UCTableProperties {
   private UCTableProperties() {}
 
   // This table property should be set to the table ID assigned by UC for managed tables.
-  // It used to be "ucTableId". The old property is also set while the property is being renamed.
   public static final String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
-  public static final String UC_TABLE_ID_KEY_OLD = "ucTableId";
 
   // This table property should be set in order to enable Delta code to use UC as commit coordinator
   public static final String DELTA_CATALOG_MANAGED_KEY = "delta.feature.catalogOwned-preview";

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -2,7 +2,7 @@ package io.unitycatalog.spark
 
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
-import io.unitycatalog.client.model._
+import io.unitycatalog.client.model.{TableInfo, _}
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
 import io.unitycatalog.spark.auth.{AuthConfigUtils, CredPropsUtil}
@@ -106,31 +106,7 @@ class UCSingleCatalog
     }
 
     if (UCSingleCatalog.isManagedDeltaTable(properties, ident)) {
-      // Check that caller shouldn't set some properties
-      List(UCTableProperties.UC_TABLE_ID_KEY, UCTableProperties.UC_TABLE_ID_KEY_OLD,
-        TableCatalog.PROP_IS_MANAGED_LOCATION)
-        .filter(properties.containsKey(_))
-        .foreach(p => throw new ApiException(s"Cannot specify property '$p'."))
-      // Setting the catalogManaged table feature is required for creating a managed table.
-      if (!properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY) &&
-        !properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
-        throw new ApiException(
-          s"Managed table creation requires table property " +
-            s"'${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'=" +
-            s"'${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'" +
-            s" to be set.")
-      }
-      // Caller should not set these two table properties to values other than "supported". This is
-      // the only documented value.
-      List(UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
-        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)
-        .foreach(k => {
-          Option(properties.get(k))
-            .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
-            .foreach(v => throw new ApiException(
-              s"Invalid property value '$v' for '$k'."))
-        })
-
+      validateManagedDeltaCreateProperties(properties)
       val newProps = stageManagedDeltaTableAndGetProps(ident, properties)
       delegate.createTable(ident, columns, partitions, newProps)
     } else if (hasLocationClause) {
@@ -159,9 +135,8 @@ class UCSingleCatalog
     val newProps = new util.HashMap[String, String]
     newProps.putAll(properties)
     newProps.put(TableCatalog.PROP_LOCATION, stagingTableInfo.getStagingLocation)
-    // Sets both the new and old table ID property while it's being renamed.
+    // Set the UC-assigned table ID so Delta can preserve table identity.
     newProps.put(UCTableProperties.UC_TABLE_ID_KEY, stagingTableInfo.getId)
-    newProps.put(UCTableProperties.UC_TABLE_ID_KEY_OLD, stagingTableInfo.getId)
     // `PROP_IS_MANAGED_LOCATION` is used to indicate that the table location is not
     // user-specified but system-generated, which is exactly the case here.
     newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
@@ -179,6 +154,122 @@ class UCSingleCatalog
     )
     UCSingleCatalog.setCredentialProps(newProps, credentialProps)
     newProps
+  }
+
+  /**
+   * Checks that the user-supplied table properties are valid for creating a new UC-managed Delta
+   * table.
+   *
+   * In this path, UC expects the caller to provide only user-controlled properties. It rejects
+   * properties that UC itself assigns during staging, such as the UC table ID and the
+   * managed-location marker. It also requires the catalog-managed Delta feature flag to be present
+   * and set to the supported value, because that flag determines whether the new table is created
+   * with the coordinated-commit behavior expected for UC-managed Delta tables.
+   */
+  private def validateManagedDeltaCreateProperties(properties: util.Map[String, String]): Unit = {
+    rejectSystemManagedProperties(properties)
+    if (!properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
+      throw new ApiException(
+        s"Managed table creation requires table property " +
+          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'=" +
+          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'" +
+          s" to be set.")
+    }
+    Option(properties.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
+      .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+      .foreach(v => throw new ApiException(
+        s"Invalid property value '$v' for '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'."))
+  }
+
+  /**
+   * Builds the property map for replacing an existing UC-managed Delta table.
+   *
+   * Instead of staging a brand-new managed table, this path starts from the current table metadata
+   * returned by UC and prepares the properties needed to write back to that same managed table. It
+   * preserves the catalog-managed marker, marks the location as system-managed, and vends fresh
+   * READ_WRITE credentials for the existing table. It does not re-send the UC table ID as a
+   * caller-provided property; Delta is expected to preserve the existing table identity from the
+   * current snapshot during replace.
+   */
+  private def loadExistingManagedTablePropsForReplace(
+      ident: Identifier,
+      tableInfo: TableInfo,
+      properties: util.Map[String, String],
+      operation: String): util.Map[String, String] = {
+    val fullTableName = UCSingleCatalog.fullTableNameForApi(name(), ident)
+
+    // First, ensure the caller is not trying to override system-managed properties.
+    rejectSystemManagedProperties(properties)
+    Option(properties.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
+      .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+      .foreach(_ => throw new ApiException(
+        s"Cannot override property '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'."))
+    if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
+      throw new ApiException(
+        s"$operation cannot specify property '${TableCatalog.PROP_LOCATION}' " +
+          s"on an existing UC-managed Delta table.")
+    }
+    // Second, make sure UC says this is an existing catalog-managed Delta table and that the
+    // metadata we need to reuse it for replace (storage location and table ID) is present.
+    if (!isCatalogManagedDeltaTable(tableInfo)) {
+      throw new UnsupportedOperationException(
+        s"$operation is only supported for catalog-managed UC Delta tables")
+    }
+    val tableLocation = tableInfo.getStorageLocation
+    val tableId = tableInfo.getTableId
+    if (tableLocation == null || tableLocation.isEmpty) {
+      throw new ApiException(
+        s"Invalid table metadata for $fullTableName: storageLocation must be set")
+    }
+    if (tableId == null || tableId.isEmpty) {
+      throw new ApiException(
+        s"Invalid table metadata for $fullTableName: tableId must be set")
+    }
+    // Third, build the minimal property set Delta needs in order to write back to the current
+    // managed table. Existing managed REPLACE does not forward arbitrary caller properties
+    // because metadata updates are not supported in this path yet.
+    val newProps = new util.HashMap[String, String]
+    Option(properties.get(TableCatalog.PROP_PROVIDER)).foreach { provider =>
+      newProps.put(TableCatalog.PROP_PROVIDER, provider)
+    }
+    // Preserve the catalog-managed marker on the properties passed to Delta for replace.
+    newProps.put(
+      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+      UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+    // Location intentionally omitted; Delta resolves it from the existing table snapshot.
+    newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+
+    // Finally, vend fresh READ_WRITE credentials for the existing table location.
+    val temporaryCredentials = temporaryCredentialsApi.generateTemporaryTableCredentials(
+      new GenerateTemporaryTableCredential()
+        .tableId(tableId).operation(TableOperation.READ_WRITE))
+    val tableUriScheme = new Path(tableLocation).toUri.getScheme
+    val credentialProps = CredPropsUtil.createTableCredProps(
+      renewCredEnabled,
+      tableUriScheme,
+      uri.toString,
+      tokenProvider,
+      tableId,
+      TableOperation.READ_WRITE,
+      temporaryCredentials,
+    )
+    UCSingleCatalog.setCredentialProps(newProps, credentialProps)
+    newProps
+  }
+
+  private def rejectSystemManagedProperties(properties: util.Map[String, String]): Unit = {
+    List(UCTableProperties.UC_TABLE_ID_KEY, TableCatalog.PROP_IS_MANAGED_LOCATION)
+      .filter(properties.containsKey(_))
+      .foreach(p => throw new ApiException(s"Cannot specify property '$p'."))
+  }
+
+  private def isCatalogManagedDeltaTable(tableInfo: TableInfo): Boolean = {
+    val tableProperties = Option(tableInfo.getProperties)
+    tableInfo.getTableType == TableType.MANAGED &&
+    tableInfo.getDataSourceFormat == DataSourceFormat.DELTA &&
+    tableProperties.exists(
+      _.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW) ==
+        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
   }
 
   /** Prepares properties for external table creation (path credentials). */
@@ -248,7 +339,14 @@ class UCSingleCatalog
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
-    throw new UnsupportedOperationException("REPLACE TABLE is not supported")
+    val stagingCatalog = requireStagingCatalog("REPLACE TABLE")
+    val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = false)
+    val newProps = loadExistingManagedTablePropsForReplace(
+      ident,
+      existingTable.get,
+      properties,
+      "REPLACE TABLE")
+    stagingCatalog.stageReplace(ident, schema, partitions, newProps)
   }
 
   /** Only called for CREATE OR REPLACE TABLE ... [AS SELECT] */
@@ -257,7 +355,44 @@ class UCSingleCatalog
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
-    throw new UnsupportedOperationException("REPLACE TABLE AS SELECT (RTAS) is not supported")
+    val stagingCatalog = requireStagingCatalog("CREATE OR REPLACE TABLE")
+    val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = true)
+    val newProps = existingTable.map { tableInfo =>
+      // Replacing existing table.
+      loadExistingManagedTablePropsForReplace(
+        ident,
+        tableInfo,
+        properties,
+        "CREATE OR REPLACE TABLE")
+    }.getOrElse {
+      // Creating a new table.
+      validateManagedDeltaCreateProperties(properties)
+      stageManagedDeltaTableAndGetProps(ident, properties)
+    }
+    stagingCatalog.stageCreateOrReplace(ident, schema, partitions, newProps)
+  }
+
+  /**
+   * Resolves the existing UC table metadata for REPLACE / CREATE OR REPLACE.
+   */
+  private def resolveExistingTableForReplace(
+      ident: Identifier,
+      allowMissingTable: Boolean): Option[TableInfo] = {
+    UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
+    val fullTableName = UCSingleCatalog.fullTableNameForApi(name(), ident)
+    try {
+      Some(tablesApi.getTable(fullTableName,
+        /* readStreamingTableAsManaged = */ false,
+        /* readMaterializedViewAsManaged = */ false))
+    } catch {
+      case e: ApiException if e.getCode == 404 && allowMissingTable => None
+      case e: ApiException if e.getCode == 404 => throw new NoSuchTableException(ident)
+    }
+  }
+
+  private def requireStagingCatalog(operation: String): StagingTableCatalog = delegate match {
+    case catalog: StagingTableCatalog => catalog
+    case _ => throw new UnsupportedOperationException(s"$operation is not supported")
   }
 
   /** Only called for CTAS */
@@ -267,11 +402,7 @@ class UCSingleCatalog
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
-    if (!delegate.isInstanceOf[StagingTableCatalog]) {
-      throw new UnsupportedOperationException("CREATE TABLE AS SELECT (CTAS) is not supported")
-    }
-
-    val stagingCatalog = delegate.asInstanceOf[StagingTableCatalog]
+    val stagingCatalog = requireStagingCatalog("CREATE TABLE AS SELECT (CTAS)")
     if (UCSingleCatalog.isManagedDeltaTable(properties, ident)) {
       val newProps = stageManagedDeltaTableAndGetProps(ident, properties)
       stagingCatalog.stageCreate(ident, schema, partitions, newProps)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
@@ -35,6 +35,29 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
 
+  protected enum TableDdlMode {
+    CREATE("CREATE", false),
+    REPLACE_EXISTING("REPLACE", true),
+    CREATE_OR_REPLACE_EXISTING("CREATE OR REPLACE", true),
+    CREATE_OR_REPLACE_MISSING("CREATE OR REPLACE", false);
+
+    private final String sql;
+    private final boolean withExistingTable;
+
+    TableDdlMode(String sql, boolean withExistingTable) {
+      this.sql = sql;
+      this.withExistingTable = withExistingTable;
+    }
+
+    public String sql() {
+      return sql;
+    }
+
+    public boolean withExistingTable() {
+      return withExistingTable;
+    }
+  }
+
   protected static final String TEST_TABLE = "test_table";
   protected TableOperations tableOperations;
 
@@ -71,7 +94,8 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
     private List<String> partitionColumns = List.of();
     @With private Optional<Pair<Integer, String>> asSelect = Optional.empty();
     private Optional<String> comment = Optional.empty();
-    private boolean replaceTable = false;
+    private Optional<String> expectedTableId = Optional.empty();
+    private TableDdlMode ddlMode = TableDdlMode.CREATE;
 
     public TableSetupOptions setCatalogName(String name) {
       catalogName = quoteEntityName(name);
@@ -134,7 +158,7 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
     }
 
     public String ddlCommand() {
-      return replaceTable ? "REPLACE" : "CREATE";
+      return ddlMode.sql();
     }
 
     public String createManagedTableSql() {
@@ -225,8 +249,49 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
 
   protected final boolean canUpdateColumnsToUC() {
     // DELTA tables can't update columns to UC yet.
-    return !tableFormat().equalsIgnoreCase("DELTA") || DeltaVersionUtils.isDeltaAtLeast("4.1.1");
+    return !tableFormat().equalsIgnoreCase("DELTA") || DeltaVersionUtils.isDeltaAtLeast("4.2.0");
   }
+
+  protected List<TableDdlMode> supportedTableDdlModes() {
+    return List.of(TableDdlMode.CREATE);
+  }
+
+  protected List<String> supportedCatalogNames() {
+    return List.of(SPARK_CATALOG, CATALOG_NAME);
+  }
+
+  protected List<String> sessionCatalogNames() {
+    return List.of(SPARK_CATALOG, CATALOG_NAME);
+  }
+
+  protected void prepareExistingTableForDdl(TableSetupOptions options) {
+    throw new UnsupportedOperationException("Existing-table DDL setup is not supported");
+  }
+
+  protected void validateCreatedTable(String fullTableName, TableSetupOptions options)
+      throws ApiException {}
+
+  protected String qualifiedTableName(String catalogName, String tableName) {
+    return String.join(".", catalogName, SCHEMA_NAME, tableName);
+  }
+
+  /**
+   * Returns the expected failure messages for a table setup attempt.
+   *
+   * @return {@code null} if success is expected, an empty list to expect any failure without
+   *     checking the message, or a non-empty list to expect a failure whose message contains at
+   *     least one of the strings.
+   */
+  protected List<String> expectedCreateFailureMessages(TableSetupOptions options) {
+    // Non-Delta tables only support plain CREATE TABLE.
+    if (!testingDelta()
+        && (options.getDdlMode() != TableDdlMode.CREATE || options.getAsSelect().isPresent())) {
+      return List.of();
+    }
+    return null;
+  }
+
+  protected void initializeSessionForTableTests() {}
 
   /**
    * This test creates table in different ways:
@@ -241,44 +306,50 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
    * For all the 16 (2^4) tables it does a simple read and write test to make sure they all work.
    */
   @Test
-  public void testTableCreateReadWrite() {
+  public void testTableCreateReadWrite() throws ApiException {
     // Test both `spark_catalog` and other catalog names.
-    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    session = createSparkSessionWithCatalogs(sessionCatalogNames().toArray(new String[0]));
+    initializeSessionForTableTests();
 
     int tableNameCounter = 0;
-    for (String catalogName : List.of(SPARK_CATALOG, CATALOG_NAME)) {
+    for (String catalogName : supportedCatalogNames()) {
       for (boolean withPartitionColumns : List.of(true, false)) {
         for (boolean withCtas : List.of(true, false)) {
-          for (boolean replaceTable : List.of(true, false)) {
+          for (TableDdlMode ddlMode : supportedTableDdlModes()) {
             String tableName = TEST_TABLE + tableNameCounter;
             tableNameCounter++;
-            if (replaceTable) {
-              if (withCtas && !testingDelta()) {
-                // "REPLACE TABLE AS SELECT" is only supported for Delta.
-                continue;
-              }
-              // First, create a different table to replace.
-              sql(
-                  "CREATE TABLE %s.%s.%s (col1 DOUBLE) USING DELTA %s",
-                  catalogName, SCHEMA_NAME, tableName, TBLPROPERTIES_CATALOG_OWNED_CLAUSE);
-              sql("INSERT INTO %s.%s.%s (col1) VALUES (0.1)", catalogName, SCHEMA_NAME, tableName);
-            }
             TableSetupOptions options =
                 new TableSetupOptions()
                     .setCatalogName(catalogName)
                     .setTableName(tableName)
-                    .setReplaceTable(replaceTable);
+                    .setDdlMode(ddlMode);
             if (withPartitionColumns) {
               options.setPartitionColumn("s");
             }
             if (withCtas) {
               options.setAsSelect(1, "a");
             }
+            List<String> expectedFailureMessages = expectedCreateFailureMessages(options);
+            if (ddlMode.withExistingTable()) {
+              prepareExistingTableForDdl(options);
+              options.setExpectedTableId(
+                  Optional.of(
+                      tableOperations
+                          .getTable(qualifiedTableName(catalogName, tableName))
+                          .getTableId()));
+            }
 
-            // TODO: Enable REPLACE TABLE once it is supported.
-            // CTAS is only supported for Delta format.
-            if (replaceTable || (withCtas && !testingDelta())) {
-              assertThatThrownBy(() -> setupTable(options));
+            if (expectedFailureMessages != null) {
+              if (expectedFailureMessages.isEmpty()) {
+                assertThatThrownBy(() -> setupTable(options));
+              } else {
+                List<String> expected = expectedFailureMessages;
+                assertThatThrownBy(() -> setupTable(options))
+                    .satisfies(
+                        t ->
+                            assertThat(t.getMessage())
+                                .containsAnyOf(expected.toArray(new CharSequence[0])));
+              }
               continue;
             }
 
@@ -288,6 +359,7 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
             } else {
               testTableReadWrite(t1);
             }
+            validateCreatedTable(t1, options);
           }
         }
       }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -14,7 +14,6 @@ import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.spark.sql.Row;
@@ -40,6 +39,26 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
   private static final String DELTA_TABLE = "test_delta";
 
   @Override
+  protected List<TableDdlMode> supportedTableDdlModes() {
+    return List.of(TableDdlMode.CREATE);
+  }
+
+  @Override
+  protected List<String> supportedCatalogNames() {
+    return List.of(CATALOG_NAME);
+  }
+
+  @Override
+  protected List<String> sessionCatalogNames() {
+    return List.of(SPARK_CATALOG, CATALOG_NAME);
+  }
+
+  @Override
+  protected void initializeSessionForTableTests() {
+    ensureSparkCatalogSchemaExists();
+  }
+
+  @Override
   protected String tableFormat() {
     return "DELTA";
   }
@@ -47,6 +66,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
   @Test
   public void testCreateManagedTableErrors() {
     session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
     String fullTableName = CATALOG_NAME + "." + SCHEMA_NAME + "." + DELTA_TABLE;
     assertThatThrownBy(
             () ->
@@ -54,27 +74,21 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
                     "CREATE TABLE %s(name STRING) USING parquet %s",
                     fullTableName, TBLPROPERTIES_CATALOG_OWNED_CLAUSE))
         .hasMessageContaining("not support non-Delta managed table");
-    for (String featureProperty :
-        List.of(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
-      assertThatThrownBy(
-              () ->
-                  sql(
-                      "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'disabled')",
-                      fullTableName, featureProperty))
-          .hasMessageContaining(
-              String.format("Invalid property value 'disabled' for '%s'", featureProperty));
-    }
-    for (String ucTableIdProperty :
-        List.of(UCTableProperties.UC_TABLE_ID_KEY, UCTableProperties.UC_TABLE_ID_KEY_OLD)) {
-      assertThatThrownBy(
-              () ->
-                  sql(
-                      "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'some_id')",
-                      fullTableName, ucTableIdProperty))
-          .hasMessageContaining(ucTableIdProperty);
-    }
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'disabled')",
+                    fullTableName, UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
+        .hasMessageContaining(
+            String.format(
+                "Invalid property value 'disabled' for '%s'",
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'some_id')",
+                    fullTableName, UCTableProperties.UC_TABLE_ID_KEY))
+        .hasMessageContaining(UCTableProperties.UC_TABLE_ID_KEY);
     assertThatThrownBy(
             () ->
                 sql(
@@ -94,6 +108,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
   public void testCreateManagedDeltaTable(String scheme, boolean renewCredEnabled)
       throws ApiException {
     session = createSparkSessionWithCatalogs(renewCredEnabled, SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
 
     int counter = 0;
     final String comment = "This is comment.";
@@ -135,25 +150,14 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
           assertThat(describeResult.get("Provider")).isEqualToIgnoringCase("delta");
           assertThat(describeResult.get("Is_managed_location")).isEqualTo("true");
           assertThat(describeResult).containsKey("Table Properties");
-          // Check that it either has the old table ID key or the new one. Doesn't matter if it
-          // has both.
           String tableProperties = describeResult.get("Table Properties");
-          Assertions.assertTrue(
-              tableProperties.contains(UCTableProperties.UC_TABLE_ID_KEY)
-                  || tableProperties.contains(UCTableProperties.UC_TABLE_ID_KEY_OLD));
-          // Check that it either has the old feature name or the new one. We don't care if it
-          // has both but Delta won't allow that.
-          Assertions.assertTrue(
-              tableProperties.contains(
-                      String.format(
-                          "%s=%s",
-                          UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
-                          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE))
-                  || tableProperties.contains(
-                      String.format(
-                          "%s=%s",
-                          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
-                          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)));
+          assertThat(tableProperties).contains(UCTableProperties.UC_TABLE_ID_KEY);
+          assertThat(tableProperties)
+              .contains(
+                  String.format(
+                      "%s=%s",
+                      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                      UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
           // Check schema of table
           validateTableSchema(
               session.table(fullTableName).schema(),
@@ -169,25 +173,102 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
           assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.DELTA);
           assertThat(tableInfo.getComment()).isEqualTo(comment);
           Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
-          Assertions.assertTrue(
-              tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY)
-                  || tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY_OLD));
-          Assertions.assertTrue(
-              tablePropertiesFromServer.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)
-                  || tablePropertiesFromServer.containsKey(
-                      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
-          assertThat(
-                  Optional.ofNullable(
-                          tablePropertiesFromServer.get(
-                              UCTableProperties.DELTA_CATALOG_MANAGED_KEY))
-                      .orElseGet(
-                          () ->
-                              tablePropertiesFromServer.get(
-                                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)))
-              .isEqualTo(UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+          assertThat(tablePropertiesFromServer)
+              .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, tableInfo.getTableId())
+              .containsEntry(
+                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                  UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
         }
       }
     }
+  }
+
+  @Test
+  public void testManagedDeltaReplaceRejectsMetadataChanges() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    assertManagedReplaceRejected(
+        List.of(
+            String.format("REPLACE TABLE %s (i INT, renamed STRING) USING DELTA", fullTableName),
+            String.format(
+                "REPLACE TABLE %s (i INT, s STRING) USING DELTA PARTITIONED BY (s)", fullTableName),
+            String.format(
+                "CREATE OR REPLACE TABLE %s (i INT COMMENT 'new comment', s STRING) USING DELTA",
+                fullTableName),
+            String.format(
+                "REPLACE TABLE %s USING DELTA AS SELECT 1 AS i, 2 AS extra_col", fullTableName),
+            String.format(
+                "CREATE OR REPLACE TABLE %s (i INT, extra_col INT) USING DELTA", fullTableName)));
+  }
+
+  @Override
+  protected void prepareExistingTableForDdl(TableSetupOptions options) {
+    TableSetupOptions existingOptions =
+        new TableSetupOptions()
+            .setCatalogName(options.getCatalogName())
+            .setTableName(options.getTableName())
+            .setCloudScheme(options.getCloudScheme())
+            .setComment("existing table");
+    if (!options.getPartitionColumns().isEmpty()) {
+      existingOptions.setPartitionColumn(options.getPartitionColumns().get(0));
+    }
+    if (options.getAsSelect().isPresent()) {
+      existingOptions.setAsSelect(0, "existing");
+    }
+    String fullTableName = setupTable(existingOptions);
+    if (options.getAsSelect().isEmpty()) {
+      sql("INSERT INTO %s SELECT 0, 'existing'", fullTableName);
+    }
+  }
+
+  @Override
+  protected void validateCreatedTable(String fullTableName, TableSetupOptions options)
+      throws ApiException {
+    assertManagedTableHasUcProperties(
+        loadTableInfo(fullTableName), options.getExpectedTableId().orElse(null));
+  }
+
+  @Override
+  protected List<String> expectedCreateFailureMessages(TableSetupOptions options) {
+    return super.expectedCreateFailureMessages(options);
+  }
+
+  private TableInfo loadTableInfo(String fullTableName) throws ApiException {
+    TableOperations tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+    return tableOperations.getTable(fullTableName);
+  }
+
+  private void assertManagedTableHasUcProperties(TableInfo tableInfo, String expectedTableId) {
+    if (expectedTableId != null) {
+      Assertions.assertEquals(expectedTableId, tableInfo.getTableId());
+    }
+
+    Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
+    assertThat(tablePropertiesFromServer).containsKey(UCTableProperties.UC_TABLE_ID_KEY);
+    assertThat(tablePropertiesFromServer)
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+  }
+
+  private void assertManagedReplaceRejected(List<String> statements) {
+    for (String statement : statements) {
+      Throwable thrown = org.assertj.core.api.Assertions.catchThrowable(() -> sql(statement));
+      assertThat(thrown).isNotNull();
+      assertThat(thrown.getMessage())
+          .containsAnyOf(
+              "DELTA_OPERATION_NOT_ALLOWED",
+              "DELTA_CANNOT_REPLACE_MISSING_TABLE",
+              "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG",
+              "SCHEMA_NOT_FOUND");
+    }
+  }
+
+  private void ensureSparkCatalogSchemaExists() {
+    sql("CREATE DATABASE IF NOT EXISTS spark_catalog.%s", SCHEMA_NAME);
   }
 
   @Override

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -5,10 +5,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.model.CreateStagingTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.StagingTableInfo;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.client.model.TemporaryCredentials;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Map;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.StagedTable;
@@ -20,6 +31,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /** Tests that stageCreate delegates to the underlying StagingTableCatalog. */
 public class UCSingleCatalogStagingTableTest {
@@ -29,6 +41,28 @@ public class UCSingleCatalogStagingTableTest {
   private static final Transform[] PARTITIONS = new Transform[0];
   // PROP_EXTERNAL bypasses the managed-table path in prepareTableProperties.
   private static final Map<String, String> PROPS = Map.of(TableCatalog.PROP_EXTERNAL, "true");
+  private static final Map<String, String> MANAGED_DELTA_PROPS =
+      Map.of(
+          TableCatalog.PROP_PROVIDER,
+          "delta",
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+  private static final Map<String, String> MANAGED_DELTA_REPLACE_OVERRIDE_PROPS =
+      Map.of(
+          TableCatalog.PROP_PROVIDER,
+          "delta",
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+          "disabled");
+  private static final Map<String, String> REPLACE_DELTA_PROPS =
+      Map.of(TableCatalog.PROP_PROVIDER, "delta");
+  private static final String EXTERNAL_LOCATION = "file:///tmp/uc-external-table";
+  private static final String MANAGED_LOCATION = "file:///tmp/uc-managed-table";
+
+  private static final class ManagedReplaceMocks {
+    final TablesApi tablesApi = mock(TablesApi.class);
+    final TemporaryCredentialsApi tempCredsApi = mock(TemporaryCredentialsApi.class);
+    final StagedTable staged = mock(StagedTable.class);
+  }
 
   private UCSingleCatalog catalog;
   private StagingTableCatalog mockDelegate;
@@ -85,11 +119,263 @@ public class UCSingleCatalogStagingTableTest {
     }
   }
 
+  @Test
+  public void testStageCreateOrReplaceMissingManagedTableUsesManagedCreatePath() throws Exception {
+    ManagedReplaceMocks mocks = new ManagedReplaceMocks();
+    mockMissingTableLookup(mocks.tablesApi);
+    when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any()))
+        .thenReturn(mocks.staged);
+    when(mocks.tablesApi.createStagingTable(any(CreateStagingTable.class)))
+        .thenReturn(
+            new StagingTableInfo().id("staging-id").stagingLocation("file:///tmp/uc-staging"));
+    setTemporaryCredentialsApi(mocks.tempCredsApi);
+
+    StagedTable result =
+        catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, MANAGED_DELTA_PROPS);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mocks.tablesApi).createStagingTable(any(CreateStagingTable.class));
+    verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
+    verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_LOCATION, "file:///tmp/uc-staging")
+        .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+        .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, "staging-id");
+    assertThat(result).isSameAs(mocks.staged);
+  }
+
+  @Test
+  public void testStageCreateOrReplaceMissingManagedTableRequiresCatalogManagedFeature()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    mockMissingTableLookup(mockTablesApi);
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT, SCHEMA, PARTITIONS, Map.of(TableCatalog.PROP_PROVIDER, "delta")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Managed table creation requires table property");
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceExistingManagedTableAvoidsPathBasedReplace()
+      throws Exception {
+    assertExistingManagedTableReplaceUsesManagedProps(true);
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedTableAvoidsPathBasedReplace() throws Exception {
+    assertExistingManagedTableReplaceUsesManagedProps(false);
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedTableRejectsUserSpecifiedLocation() throws Exception {
+    TablesApi mockTablesApi = mockExistingTableLookup(existingManagedDeltaTableInfo());
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageReplace(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER,
+                        "delta",
+                        TableCatalog.PROP_LOCATION,
+                        "file:///tmp/other-location")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("cannot specify property 'location'");
+
+    verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedTableDropsUserProperties() throws Exception {
+    ManagedReplaceMocks mocks = mockExistingManagedReplace(false);
+
+    catalog.stageReplace(
+        IDENT,
+        SCHEMA,
+        PARTITIONS,
+        Map.of(TableCatalog.PROP_PROVIDER, "delta", "delta.appendOnly", "true"));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mockDelegate).stageReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
+        .doesNotContainKey("delta.appendOnly");
+    verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
+  }
+
+  private void assertExistingManagedTableReplaceUsesManagedProps(boolean createOrReplace)
+      throws Exception {
+    ManagedReplaceMocks mocks = mockExistingManagedReplace(createOrReplace);
+
+    StagedTable result =
+        createOrReplace
+            ? catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS)
+            : catalog.stageReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mocks.tablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
+    if (createOrReplace) {
+      verify(mockDelegate)
+          .stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    } else {
+      verify(mockDelegate).stageReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    }
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
+        .doesNotContainKey(TableCatalog.PROP_LOCATION)
+        .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+        .doesNotContainKey(UCTableProperties.UC_TABLE_ID_KEY)
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+    assertThat(result).isSameAs(mocks.staged);
+  }
+
+  private ManagedReplaceMocks mockExistingManagedReplace(boolean createOrReplace) throws Exception {
+    ManagedReplaceMocks mocks = new ManagedReplaceMocks();
+    mockExistingTableLookup(mocks.tablesApi, existingManagedDeltaTableInfo());
+    setTemporaryCredentialsApi(mocks.tempCredsApi);
+    if (createOrReplace) {
+      when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any()))
+          .thenReturn(mocks.staged);
+    } else {
+      when(mockDelegate.stageReplace(eq(IDENT), eq(SCHEMA), any(), any())).thenReturn(mocks.staged);
+    }
+    return mocks;
+  }
+
+  private static TableInfo existingManagedDeltaTableInfo() {
+    return new TableInfo()
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .storageLocation("file:///tmp/uc-managed-table")
+        .tableId("table-id")
+        .properties(
+            Map.of(
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedTableRejectsCatalogManagedOverrides()
+      throws Exception {
+    TablesApi mockTablesApi = mockExistingTableLookup(existingManagedDeltaTableInfo());
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageReplace(
+                    IDENT, SCHEMA, PARTITIONS, MANAGED_DELTA_REPLACE_OVERRIDE_PROPS))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining(
+            "Cannot override property '" + UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW + "'");
+
+    verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedNonCatalogManagedTableIsRejected() throws Exception {
+    TablesApi mockTablesApi =
+        mockExistingTableLookup(existingDeltaTableInfo(TableType.MANAGED, Map.of()));
+
+    assertThatThrownBy(() -> catalog.stageReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("only supported for catalog-managed UC Delta tables");
+
+    verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageReplaceExistingExternalTableIsRejected() throws Exception {
+    TablesApi mockTablesApi =
+        mockExistingTableLookup(existingDeltaTableInfo(TableType.EXTERNAL, null));
+
+    assertThatThrownBy(() -> catalog.stageReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("only supported for catalog-managed UC Delta tables");
+
+    verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceExistingExternalTableIsRejected() throws Exception {
+    TablesApi mockTablesApi =
+        mockExistingTableLookup(existingDeltaTableInfo(TableType.EXTERNAL, null));
+
+    assertThatThrownBy(
+            () -> catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("only supported for catalog-managed UC Delta tables");
+
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  private TablesApi mockExistingTableLookup(TableInfo tableInfo) throws Exception {
+    TablesApi tablesApi = mock(TablesApi.class);
+    mockExistingTableLookup(tablesApi, tableInfo);
+    return tablesApi;
+  }
+
+  private void mockExistingTableLookup(TablesApi tablesApi, TableInfo tableInfo) throws Exception {
+    when(mockDelegate.name()).thenReturn("main");
+    when(tablesApi.getTable(eq("main.schema.table"), eq(false), eq(false))).thenReturn(tableInfo);
+    setField(catalog, "tablesApi", tablesApi);
+  }
+
+  private void mockMissingTableLookup(TablesApi tablesApi) throws Exception {
+    when(mockDelegate.name()).thenReturn("main");
+    when(tablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+    setField(catalog, "tablesApi", tablesApi);
+  }
+
+  private void setTemporaryCredentialsApi(TemporaryCredentialsApi tempCredsApi) throws Exception {
+    when(tempCredsApi.generateTemporaryTableCredentials(any()))
+        .thenReturn(new TemporaryCredentials());
+    setField(catalog, "temporaryCredentialsApi", tempCredsApi);
+    setField(catalog, "uri", URI.create("http://localhost"));
+  }
+
   private static void setDelegate(UCSingleCatalog catalog, TableCatalog delegate) {
+    setField(catalog, "delegate", delegate);
+  }
+
+  private static TableInfo existingDeltaTableInfo(
+      TableType tableType, Map<String, String> properties) {
+    TableInfo tableInfo =
+        new TableInfo()
+            .tableType(tableType)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation(
+                tableType == TableType.EXTERNAL ? EXTERNAL_LOCATION : MANAGED_LOCATION);
+    if (tableType == TableType.MANAGED) {
+      tableInfo.tableId("table-id");
+    }
+    if (properties != null) {
+      tableInfo.properties(properties);
+    }
+    return tableInfo;
+  }
+
+  private static void setField(UCSingleCatalog catalog, String fieldName, Object value) {
     try {
-      Field f = UCSingleCatalog.class.getDeclaredField("delegate");
+      Field f = UCSingleCatalog.class.getDeclaredField(fieldName);
       f.setAccessible(true);
-      f.set(catalog, delegate);
+      f.set(catalog, value);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -103,6 +103,7 @@ public class AuthService {
    * @return The token exchange response
    */
   @Post("/tokens")
+  @com.linecorp.armeria.server.annotation.Blocking
   public HttpResponse grantToken(
       @Param("ext") Optional<TokenEndpointExtensionType> ext,
       @RequestConverter(ToOAuthTokenExchangeFormConverter.class) OAuthTokenExchangeForm form) {

--- a/server/src/test/java/io/unitycatalog/server/base/auth/BaseAuthCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/auth/BaseAuthCRUDTest.java
@@ -17,6 +17,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -73,6 +74,15 @@ public abstract class BaseAuthCRUDTest extends BaseServerTest {
     // Use the JDK built-in HttpServer instead of Armeria to avoid shared
     // event-loop threads that prevent the forked test JVM from exiting.
     mockOidcServer = HttpServer.create(new InetSocketAddress(0), 0);
+    // The executor must use daemon threads so the JVM can exit even if
+    // stop() does not fully terminate all internal threads.
+    mockOidcServer.setExecutor(
+        Executors.newCachedThreadPool(
+            r -> {
+              Thread t = new Thread(r);
+              t.setDaemon(true);
+              return t;
+            }));
 
     mockOidcServer.createContext(
         "/.well-known/openid-configuration",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1373/files) to review incremental changes.
- [**atomic-rtas**](https://github.com/unitycatalog/unitycatalog/pull/1373) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1373/files)]
  - [codex/atomic-rtas-ci](https://github.com/unitycatalog/unitycatalog/pull/1391) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1391/files/7eccd2510dbc8fa3838fff3605d5475436139f38..25f678ddf9417e84b9b6e828d8cf417d0a549390)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

## Description
**Delta side PR:** https://github.com/delta-io/delta/pull/6166
 
Currently, `UCSingleCatalog` can stage Delta table creation, but staged `REPLACE TABLE`, `REPLACE TABLE AS SELECT`, and `CREATE OR REPLACE TABLE` still need UC-specific target resolution before Delta can perform the commit-time replace.

In particular, on replace paths UC needs to answer:

- what is the existing target table in UC?
- is it a supported UC Delta table?
- if it is managed, what table credentials should be used?

This PR adds that staging-side logic in `UCSingleCatalog`.

### What this PR changes

For `REPLACE TABLE` and `CREATE OR REPLACE TABLE`, `UCSingleCatalog` now:

- resolves the existing target from UC with `tablesApi.getTable(...)`
- validates that the target is a supported Unity Catalog Delta table
- routes managed tables through different replace-preparation paths

For existing **managed** UC Delta tables, this PR:

- preserves the UC-managed Delta marker
- vends fresh `READ_WRITE` table credentials for the existing table
- marks the location as system-managed so Delta can treat it as the same managed table

For `CREATE OR REPLACE TABLE`, this PR also supports:

- create-on-missing for UC-managed Delta tables

### Why this is needed

We configure Spark like this:

```sh
"$SPARK_HOME/bin/spark-shell" --master "local[*]" \
  --jars "$KERNEL_UC_JAR" \
  --packages "$DELTA_PKGS" \
  --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
  --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
  --conf "spark.sql.catalog.main=io.unitycatalog.spark.UCSingleCatalog" \
  --conf "spark.sql.catalog.main.uri=${UC_URI%/}" \
  --conf "spark.sql.catalog.main.token=${UC_TOKEN}" \
  --conf "spark.sql.defaultCatalog=main" \
```

Note the catalog plugin:

```sh
--conf "spark.sql.catalog.main=io.unitycatalog.spark.UCSingleCatalog"
```

If we run a staged replace like:

```sql
REPLACE TABLE main.demo_zh.t_rtas USING DELTA
TBLPROPERTIES ('delta.feature.catalogManaged'='supported')
AS SELECT 2 AS i, 'new' AS s;
```

then UC needs to resolve `main.demo_zh.t_rtas` as the existing UC table and prepare the correct credentials/properties for Delta to write back to that same table.

In this case, UC must reuse the existing registered location and vend path credentials for that location, rather than allowing the replace path to drift to a different path.

### Ownership split

This PR is the UC staging side of the feature:

- UC resolves the existing target table and vends credentials
- Delta performs the commit-time replace logic after Spark commits the staged table

Paired Delta PR:
- [delta-io/delta#6166](https://github.com/delta-io/delta/pull/6166)

### Scope

This PR supports:

- existing UC-managed Delta table replace
- `CREATE OR REPLACE` create-on-missing for managed tables

This PR does not add arbitrary metadata-changing replace semantics. Those remain guarded by the paired Delta changes.

**TLDR:** Teach `UCSingleCatalog` how to resolve the existing UC Delta target and stage the correct credentials/properties for managed replace.