### PR TITLE
Prevent concurrent duplicate writes with serializable isolation and unique constraints

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -122,11 +122,7 @@ public class DeltaCommitRepository {
           return query.list();
         },
         "Failed to get latest commits",
-        /* readOnly= */ true,
-        // Use REPEATABLE_READ isolation to ensure consistent snapshot and prevent version numbers
-        // from appearing to go backwards during concurrent writes. This is critical for get
-        // commits that expect monotonic version progression after posting a commit.
-        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
+        /* readOnly= */ true);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
@@ -19,6 +19,7 @@ import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
 import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.persist.utils.RepositoryUtils;
+import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
@@ -30,7 +31,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,7 +89,7 @@ public class ModelRepository {
         "FROM ModelVersionInfoDAO t WHERE t.registeredModelId = :registeredModelId AND t.version = :version";
     Query<ModelVersionInfoDAO> query = session.createQuery(hql, ModelVersionInfoDAO.class);
     query.setParameter("registeredModelId", modelId);
-    query.setParameter("version", version.toString());
+    query.setParameter("version", version);
     query.setMaxResults(1);
     LOGGER.info("Finding model version by registeredModelId: {} and version: {}", modelId, version);
     return query.uniqueResult(); // Returns null if no result is found
@@ -152,33 +152,26 @@ public class ModelRepository {
   /** **************** Registered Model handlers ***************** */
   public RegisteredModelInfo getRegisteredModel(String fullName) {
     LOGGER.info("Getting registered model: {}", fullName);
-    RegisteredModelInfo registeredModelInfo = null;
-    try (Session session = sessionFactory.openSession()) {
-      session.setDefaultReadOnly(true);
-      Transaction tx = session.beginTransaction();
-      try {
-        String[] parts = RepositoryUtils.parseFullName(fullName);
-        String catalogName = parts[0];
-        String schemaName = parts[1];
-        String registeredModelName = parts[2];
-        RegisteredModelInfoDAO registeredModelInfoDAO =
-            findRegisteredModel(session, catalogName, schemaName, registeredModelName);
-        if (registeredModelInfoDAO == null) {
-          throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
-        }
-        registeredModelInfo = registeredModelInfoDAO.toRegisteredModelInfo();
-        registeredModelInfo.setCatalogName(catalogName);
-        registeredModelInfo.setSchemaName(schemaName);
-        registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
-        tx.commit();
-        return registeredModelInfo;
-      } catch (Exception e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    }
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          String[] parts = RepositoryUtils.parseFullName(fullName);
+          String catalogName = parts[0];
+          String schemaName = parts[1];
+          String registeredModelName = parts[2];
+          RegisteredModelInfoDAO registeredModelInfoDAO =
+              findRegisteredModel(session, catalogName, schemaName, registeredModelName);
+          if (registeredModelInfoDAO == null) {
+            throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
+          }
+          RegisteredModelInfo registeredModelInfo = registeredModelInfoDAO.toRegisteredModelInfo();
+          registeredModelInfo.setCatalogName(catalogName);
+          registeredModelInfo.setSchemaName(schemaName);
+          registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
+          return registeredModelInfo;
+        },
+        "Failed to get registered model",
+        /* readOnly = */ true);
   }
 
   private RegisteredModelInfoDAO findRegisteredModel(
@@ -209,58 +202,35 @@ public class ModelRepository {
     registeredModelInfo.setFullName(fullName);
     LOGGER.info("Creating Registered Model: {}", fullName);
 
-    Transaction tx;
-    try (Session session = sessionFactory.openSession()) {
-      tx = session.beginTransaction();
-      String catalogName = registeredModelInfo.getCatalogName();
-      String schemaName = registeredModelInfo.getSchemaName();
-      RepositoryUtils.CatalogAndSchemaDao catalogAndSchemaDao =
-          RepositoryUtils.getCatalogAndSchemaDaoOrThrow(session, catalogName, schemaName);
-      NormalizedURL parentStorageLocation =
-          ExternalLocationUtils.getManagedStorageLocation(
-              catalogAndSchemaDao, this::getDefaultModelsStorageRoot);
-      NormalizedURL storageLocation =
-          ExternalLocationUtils.getManagedLocationForModel(parentStorageLocation, modelId);
-      SchemaInfoDAO schemaInfoDAO = catalogAndSchemaDao.schemaInfoDAO();
-      try {
-        // Check if registered model already exists
-        RegisteredModelInfoDAO existingRegisteredModel =
-            getRegisteredModelDao(session, schemaInfoDAO.getId(), registeredModelInfo.getName());
-        if (existingRegisteredModel != null) {
-          throw new BaseException(
-              ErrorCode.ALREADY_EXISTS, "Registered model already exists: " + fullName);
-        }
-        registeredModelInfo.setStorageLocation(storageLocation.toString());
-        RegisteredModelInfoDAO registeredModelInfoDAO =
-            RegisteredModelInfoDAO.from(registeredModelInfo);
-        registeredModelInfoDAO.setSchemaId(schemaInfoDAO.getId());
-        registeredModelInfoDAO.setMaxVersionNumber(0L);
-        session.persist(registeredModelInfoDAO);
-        FileOperations.createStorageLocationDir(storageLocation);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          try {
-            // For now, never delete.  We will implement a soft delete later.
-            // UriUtils.deleteStorageLocationPath(storageLocation);
-          } catch (Exception deleteErr) {
-            LOGGER.error(
-                "Unable to delete storage location {} during rollback: {}",
-                storageLocation,
-                deleteErr.getMessage());
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          String catalogName = registeredModelInfo.getCatalogName();
+          String schemaName = registeredModelInfo.getSchemaName();
+          RepositoryUtils.CatalogAndSchemaDao catalogAndSchemaDao =
+              RepositoryUtils.getCatalogAndSchemaDaoOrThrow(session, catalogName, schemaName);
+          NormalizedURL parentStorageLocation =
+              ExternalLocationUtils.getManagedStorageLocation(
+                  catalogAndSchemaDao, this::getDefaultModelsStorageRoot);
+          NormalizedURL storageLocation =
+              ExternalLocationUtils.getManagedLocationForModel(parentStorageLocation, modelId);
+          SchemaInfoDAO schemaInfoDAO = catalogAndSchemaDao.schemaInfoDAO();
+          if (getRegisteredModelDao(session, schemaInfoDAO.getId(), registeredModelInfo.getName())
+              != null) {
+            throw new BaseException(
+                ErrorCode.ALREADY_EXISTS, "Registered model already exists: " + fullName);
           }
-          tx.rollback();
-        }
-        throw e;
-      }
-    } catch (RuntimeException e) {
-      if (e instanceof BaseException) {
-        throw e;
-      }
-      throw new BaseException(
-          ErrorCode.INTERNAL, "Error creating registered model: " + fullName, e);
-    }
-    return registeredModelInfo;
+          registeredModelInfo.setStorageLocation(storageLocation.toString());
+          RegisteredModelInfoDAO registeredModelInfoDAO =
+              RegisteredModelInfoDAO.from(registeredModelInfo);
+          registeredModelInfoDAO.setSchemaId(schemaInfoDAO.getId());
+          registeredModelInfoDAO.setMaxVersionNumber(0L);
+          session.persist(registeredModelInfoDAO);
+          FileOperations.createStorageLocationDir(storageLocation);
+          return registeredModelInfo;
+        },
+        "Failed to create registered model",
+        /* readOnly = */ false);
   }
 
   public ListRegisteredModelsResponse listRegisteredModels(
@@ -268,66 +238,62 @@ public class ModelRepository {
       Optional<String> schemaName,
       Optional<Integer> maxResults,
       Optional<String> pageToken) {
-    catalogName = catalogName.filter(name -> !name.isEmpty());
-    schemaName = schemaName.filter(name -> !name.isEmpty());
-    if (catalogName.isPresent() && schemaName.isEmpty()) {
+    final Optional<String> filteredCatalog = catalogName.filter(name -> !name.isEmpty());
+    final Optional<String> filteredSchema = schemaName.filter(name -> !name.isEmpty());
+    if (filteredCatalog.isPresent() && filteredSchema.isEmpty()) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
           "Cannot specify catalog w/o schema for list registered models.");
     }
-    if (catalogName.isEmpty() && schemaName.isPresent()) {
+    if (filteredCatalog.isEmpty() && filteredSchema.isPresent()) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
           "Cannot specify schema w/o catalog for list registered models.");
     }
-    try (Session session = sessionFactory.openSession()) {
-      session.setDefaultReadOnly(true);
-      Transaction tx = session.beginTransaction();
-      try {
-        ListRegisteredModelsResponse response = new ListRegisteredModelsResponse();
-        if (catalogName.isEmpty() || schemaName.isEmpty()) {
-          // Run the custom query to pull all models back from all catalogs/schemas
-          LOGGER.info("Listing all registered models in the metastore.");
-          List<RegisteredModelInfoDAO> registeredModelInfoDAOList =
-              getAllRegisteredModelsDao(session, pageToken, maxResults);
-          String nextPageToken =
-              REGISTERED_MODEL_LISTING_HELPER.getNextPageToken(
-                  registeredModelInfoDAOList, maxResults);
-          List<RegisteredModelInfo> result = new ArrayList<>();
-          for (RegisteredModelInfoDAO registeredModelInfoDAO : registeredModelInfoDAOList) {
-            RepositoryUtils.CatalogAndSchemaNames names =
-                RepositoryUtils.getCatalogAndSchemaNames(
-                    session, registeredModelInfoDAO.getSchemaId());
-
-            RegisteredModelInfo registeredModelInfo =
-                registeredModelInfoDAO.toRegisteredModelInfo();
-            registeredModelInfo.setCatalogName(names.catalogName());
-            registeredModelInfo.setSchemaName(names.schemaName());
-            registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
-            result.add(registeredModelInfo);
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          if (filteredCatalog.isEmpty() || filteredSchema.isEmpty()) {
+            // Run the custom query to pull all models back from all catalogs/schemas
+            LOGGER.info("Listing all registered models in the metastore.");
+            List<RegisteredModelInfoDAO> registeredModelInfoDAOList =
+                getAllRegisteredModelsDao(session, pageToken, maxResults);
+            String nextPageToken =
+                REGISTERED_MODEL_LISTING_HELPER.getNextPageToken(
+                    registeredModelInfoDAOList, maxResults);
+            List<RegisteredModelInfo> result = new ArrayList<>();
+            for (RegisteredModelInfoDAO registeredModelInfoDAO : registeredModelInfoDAOList) {
+              RepositoryUtils.CatalogAndSchemaNames names =
+                  RepositoryUtils.getCatalogAndSchemaNames(
+                      session, registeredModelInfoDAO.getSchemaId());
+              RegisteredModelInfo registeredModelInfo =
+                  registeredModelInfoDAO.toRegisteredModelInfo();
+              registeredModelInfo.setCatalogName(names.catalogName());
+              registeredModelInfo.setSchemaName(names.schemaName());
+              registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
+              result.add(registeredModelInfo);
+            }
+            return new ListRegisteredModelsResponse()
+                .registeredModels(result)
+                .nextPageToken(nextPageToken);
+          } else {
+            LOGGER.info(
+                "Listing registered models in {}.{}", filteredCatalog.get(), filteredSchema.get());
+            UUID schemaId =
+                repositories
+                    .getSchemaRepository()
+                    .getSchemaIdOrThrow(session, filteredCatalog.get(), filteredSchema.get());
+            return listRegisteredModels(
+                session,
+                schemaId,
+                filteredCatalog.get(),
+                filteredSchema.get(),
+                maxResults,
+                pageToken);
           }
-          return new ListRegisteredModelsResponse()
-              .registeredModels(result)
-              .nextPageToken(nextPageToken);
-        } else {
-          LOGGER.info("Listing registered models in {}.{}", catalogName.get(), schemaName.get());
-          UUID schemaId =
-              repositories
-                  .getSchemaRepository()
-                  .getSchemaIdOrThrow(session, catalogName.get(), schemaName.get());
-          response =
-              listRegisteredModels(
-                  session, schemaId, catalogName.get(), schemaName.get(), maxResults, pageToken);
-        }
-        tx.commit();
-        return response;
-      } catch (Exception e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    }
+        },
+        "Failed to list registered models",
+        /* readOnly = */ true);
   }
 
   public ListRegisteredModelsResponse listRegisteredModels(
@@ -365,91 +331,75 @@ public class ModelRepository {
     }
 
     LOGGER.info("Updating Registered Model: {}", fullName);
-    RegisteredModelInfo registeredModelInfo;
     String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String[] parts = RepositoryUtils.parseFullName(fullName);
+    String catalogName = parts[0];
+    String schemaName = parts[1];
+    String registeredModelName = parts[2];
 
-    Transaction tx;
-    try (Session session = sessionFactory.openSession()) {
-      String[] parts = RepositoryUtils.parseFullName(fullName);
-      String catalogName = parts[0];
-      String schemaName = parts[1];
-      String registeredModelName = parts[2];
-      tx = session.beginTransaction();
-      try {
-        // Verify that the new model name does not already exist in the database
-        if (updateRegisteredModel.getNewName() != null) {
-          String newFullName =
-              getRegisteredModelFullName(
-                  catalogName, schemaName, updateRegisteredModel.getNewName());
-          RegisteredModelInfoDAO newRegisteredModelInfoDAO =
-              findRegisteredModel(
-                  session, catalogName, schemaName, updateRegisteredModel.getNewName());
-          if (newRegisteredModelInfoDAO != null) {
-            throw new BaseException(
-                ErrorCode.ALREADY_EXISTS, "Registered model already exists: " + newFullName);
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          if (updateRegisteredModel.getNewName() != null) {
+            String newFullName =
+                getRegisteredModelFullName(
+                    catalogName, schemaName, updateRegisteredModel.getNewName());
+            RegisteredModelInfoDAO newRegisteredModelInfoDAO =
+                findRegisteredModel(
+                    session, catalogName, schemaName, updateRegisteredModel.getNewName());
+            if (newRegisteredModelInfoDAO != null) {
+              throw new BaseException(
+                  ErrorCode.ALREADY_EXISTS, "Registered model already exists: " + newFullName);
+            }
           }
-        }
-        // Get the record from the database
-        RegisteredModelInfoDAO origRegisteredModelInfoDAO =
-            findRegisteredModel(session, catalogName, schemaName, registeredModelName);
-        if (origRegisteredModelInfoDAO == null) {
-          throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
-        }
-        if (updateRegisteredModel.getNewName() != null) {
-          origRegisteredModelInfoDAO.setName(updateRegisteredModel.getNewName());
-        }
-        if (updateRegisteredModel.getComment() != null) {
-          origRegisteredModelInfoDAO.setComment(updateRegisteredModel.getComment());
-        }
-        long updatedTime = System.currentTimeMillis();
-        origRegisteredModelInfoDAO.setUpdatedAt(new Date(updatedTime));
-        origRegisteredModelInfoDAO.setUpdatedBy(callerId);
-        session.persist(origRegisteredModelInfoDAO);
-        registeredModelInfo = origRegisteredModelInfoDAO.toRegisteredModelInfo();
-        registeredModelInfo.setCatalogName(catalogName);
-        registeredModelInfo.setSchemaName(schemaName);
-        registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    } catch (RuntimeException e) {
-      if (e instanceof BaseException) {
-        throw e;
-      }
-      throw new BaseException(
-          ErrorCode.INTERNAL, "Error updating registered model: " + fullName, e);
-    }
-    return registeredModelInfo;
+          RegisteredModelInfoDAO origRegisteredModelInfoDAO =
+              findRegisteredModel(session, catalogName, schemaName, registeredModelName);
+          if (origRegisteredModelInfoDAO == null) {
+            throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
+          }
+          if (updateRegisteredModel.getNewName() != null) {
+            origRegisteredModelInfoDAO.setName(updateRegisteredModel.getNewName());
+          }
+          if (updateRegisteredModel.getComment() != null) {
+            origRegisteredModelInfoDAO.setComment(updateRegisteredModel.getComment());
+          }
+          long updatedTime = System.currentTimeMillis();
+          origRegisteredModelInfoDAO.setUpdatedAt(new Date(updatedTime));
+          origRegisteredModelInfoDAO.setUpdatedBy(callerId);
+          session.persist(origRegisteredModelInfoDAO);
+          RegisteredModelInfo registeredModelInfo =
+              origRegisteredModelInfoDAO.toRegisteredModelInfo();
+          registeredModelInfo.setCatalogName(catalogName);
+          registeredModelInfo.setSchemaName(schemaName);
+          registeredModelInfo.setFullName(getRegisteredModelFullName(registeredModelInfo));
+          return registeredModelInfo;
+        },
+        "Failed to update registered model",
+        /* readOnly = */ false);
   }
 
   public void deleteRegisteredModel(String fullName, boolean force) {
     LOGGER.info("Deleting Registered Model: {}", fullName);
-    try (Session session = sessionFactory.openSession()) {
-      Transaction tx = session.beginTransaction();
-      String[] parts = fullName.split("\\.");
-      if (parts.length != 3) {
-        throw new BaseException(
-            ErrorCode.INVALID_ARGUMENT, "Invalid registered model name: " + fullName);
-      }
-      String catalogName = parts[0];
-      String schemaName = parts[1];
-      String registeredModelName = parts[2];
-      try {
-        UUID schemaId =
-            repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-        deleteRegisteredModel(session, schemaId, registeredModelName, force);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
+    String[] parts = fullName.split("\\.");
+    if (parts.length != 3) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "Invalid registered model name: " + fullName);
     }
+    String catalogName = parts[0];
+    String schemaName = parts[1];
+    String registeredModelName = parts[2];
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          deleteRegisteredModel(session, schemaId, registeredModelName, force);
+          return null;
+        },
+        "Failed to delete registered model",
+        /* readOnly = */ false);
   }
 
   public void deleteRegisteredModel(
@@ -483,39 +433,32 @@ public class ModelRepository {
   /** **************** Model version handlers ***************** */
   public ModelVersionInfo getModelVersion(String fullName, long version) {
     LOGGER.info("Getting model version: {}/{}", fullName, version);
-    ModelVersionInfo modelVersionInfo = null;
-    try (Session session = sessionFactory.openSession()) {
-      session.setDefaultReadOnly(true);
-      Transaction tx = session.beginTransaction();
-      try {
-        String[] parts = RepositoryUtils.parseFullName(fullName);
-        String catalogName = parts[0];
-        String schemaName = parts[1];
-        String registeredModelName = parts[2];
-        RegisteredModelInfoDAO registeredModelInfoDAO =
-            findRegisteredModel(session, catalogName, schemaName, registeredModelName);
-        if (registeredModelInfoDAO == null) {
-          throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
-        }
-        ModelVersionInfoDAO modelVersionDao =
-            getModelVersionDao(session, registeredModelInfoDAO.getId(), version);
-        if (modelVersionDao == null) {
-          throw new BaseException(
-              ErrorCode.NOT_FOUND, "Model version not found: " + fullName + "/" + version);
-        }
-        modelVersionInfo = modelVersionDao.toModelVersionInfo();
-        modelVersionInfo.setModelName(registeredModelName);
-        modelVersionInfo.setCatalogName(catalogName);
-        modelVersionInfo.setSchemaName(schemaName);
-        tx.commit();
-        return modelVersionInfo;
-      } catch (Exception e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    }
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          String[] parts = RepositoryUtils.parseFullName(fullName);
+          String catalogName = parts[0];
+          String schemaName = parts[1];
+          String registeredModelName = parts[2];
+          RegisteredModelInfoDAO registeredModelInfoDAO =
+              findRegisteredModel(session, catalogName, schemaName, registeredModelName);
+          if (registeredModelInfoDAO == null) {
+            throw new BaseException(ErrorCode.NOT_FOUND, "Registered model not found: " + fullName);
+          }
+          ModelVersionInfoDAO modelVersionDao =
+              getModelVersionDao(session, registeredModelInfoDAO.getId(), version);
+          if (modelVersionDao == null) {
+            throw new BaseException(
+                ErrorCode.NOT_FOUND, "Model version not found: " + fullName + "/" + version);
+          }
+          ModelVersionInfo modelVersionInfo = modelVersionDao.toModelVersionInfo();
+          modelVersionInfo.setModelName(registeredModelName);
+          modelVersionInfo.setCatalogName(catalogName);
+          modelVersionInfo.setSchemaName(schemaName);
+          return modelVersionInfo;
+        },
+        "Failed to get model version",
+        /* readOnly = */ true);
   }
 
   public ModelVersionInfo createModelVersion(CreateModelVersion createModelVersion) {
@@ -540,65 +483,41 @@ public class ModelRepository {
             .updatedAt(createTime)
             .updatedBy(callerId);
     String registeredModelFullName = getRegisteredModelFullName(catalogName, schemaName, modelName);
-    LOGGER.info("Creating Registered Model: {}", registeredModelFullName);
+    LOGGER.info("Creating Model Version for: {}", registeredModelFullName);
 
-    Transaction tx;
-    try (Session session = sessionFactory.openSession()) {
-      tx = session.beginTransaction();
-      UUID schemaId =
-          repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-      NormalizedURL storageLocation = null;
-      try {
-        // Check if registered model already exists
-        RegisteredModelInfoDAO existingRegisteredModel =
-            getRegisteredModelDaoOrThrow(session, schemaId, modelName);
-        if (existingRegisteredModel.getMaxVersionNumber() == null
-            || existingRegisteredModel.getMaxVersionNumber() < 0) {
-          throw new BaseException(
-              ErrorCode.OUT_OF_RANGE,
-              "Registered model has invalid max model version: "
-                  + existingRegisteredModel.getMaxVersionNumber());
-        }
-        UUID modelId = existingRegisteredModel.getId();
-        Long version = existingRegisteredModel.getMaxVersionNumber() + 1;
-        storageLocation =
-            ExternalLocationUtils.getManagedLocationForModelVersion(
-                NormalizedURL.from(existingRegisteredModel.getUrl()), modelVersionId);
-        modelVersionInfo.setVersion(version);
-        modelVersionInfo.setStorageLocation(storageLocation.toString());
-        ModelVersionInfoDAO modelVersionInfoDAO = ModelVersionInfoDAO.from(modelVersionInfo);
-        modelVersionInfoDAO.setRegisteredModelId(modelId);
-        session.persist(modelVersionInfoDAO);
-        FileOperations.createStorageLocationDir(storageLocation);
-        // update the registered model
-        existingRegisteredModel.setMaxVersionNumber(version);
-        session.persist(existingRegisteredModel);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          try {
-            // For now, never delete.  We will implement a soft delete later.
-            // UriUtils.deleteStorageLocationPath(storageLocation);
-          } catch (Exception deleteErr) {
-            LOGGER.error(
-                "Unable to delete storage location {} during rollback: {}",
-                storageLocation,
-                deleteErr.getMessage());
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          RegisteredModelInfoDAO existingRegisteredModel =
+              getRegisteredModelDaoOrThrow(session, schemaId, modelName);
+          if (existingRegisteredModel.getMaxVersionNumber() == null
+              || existingRegisteredModel.getMaxVersionNumber() < 0) {
+            throw new BaseException(
+                ErrorCode.OUT_OF_RANGE,
+                "Registered model has invalid max model version: "
+                    + existingRegisteredModel.getMaxVersionNumber());
           }
-          tx.rollback();
-        }
-        throw e;
-      }
-    } catch (RuntimeException e) {
-      if (e instanceof BaseException) {
-        throw e;
-      }
-      throw new BaseException(
-          ErrorCode.INTERNAL,
-          "Error creating model version for model: " + registeredModelFullName,
-          e);
-    }
-    return modelVersionInfo;
+          UUID modelId = existingRegisteredModel.getId();
+          Long version = existingRegisteredModel.getMaxVersionNumber() + 1;
+          NormalizedURL storageLocation =
+              ExternalLocationUtils.getManagedLocationForModelVersion(
+                  NormalizedURL.from(existingRegisteredModel.getUrl()), modelVersionId);
+          modelVersionInfo.setVersion(version);
+          modelVersionInfo.setStorageLocation(storageLocation.toString());
+          ModelVersionInfoDAO modelVersionInfoDAO = ModelVersionInfoDAO.from(modelVersionInfo);
+          modelVersionInfoDAO.setRegisteredModelId(modelId);
+          session.persist(modelVersionInfoDAO);
+          FileOperations.createStorageLocationDir(storageLocation);
+          existingRegisteredModel.setMaxVersionNumber(version);
+          session.persist(existingRegisteredModel);
+          return modelVersionInfo;
+        },
+        "Failed to create model version for model: " + registeredModelFullName,
+        /* readOnly = */ false);
   }
 
   public ListModelVersionsResponse listModelVersions(
@@ -616,55 +535,48 @@ public class ModelRepository {
             ErrorCode.INVALID_ARGUMENT, "Invalid page token received: " + pageToken.get());
       }
     }
-    try (Session session = sessionFactory.openSession()) {
-      session.setDefaultReadOnly(true);
-      Transaction tx = session.beginTransaction();
-      try {
-        // Check if registered model already exists
-        String[] parts = registeredModelFullName.split("\\.");
-        if (parts.length != 3) {
-          throw new BaseException(
-              ErrorCode.INVALID_ARGUMENT,
-              "Invalid registered model name: " + registeredModelFullName);
-        }
-        String catalogName = parts[0];
-        String schemaName = parts[1];
-        String registeredModelName = parts[2];
-        UUID schemaId =
-            repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-        RegisteredModelInfoDAO existingRegisteredModel =
-            getRegisteredModelDaoOrThrow(session, schemaId, registeredModelName);
-        UUID registeredModelId = existingRegisteredModel.getId();
-        List<ModelVersionInfoDAO> modelVersions =
-            getModelVersionsDao(
-                session,
-                registeredModelId,
-                pageToken.orElse("0"),
-                PagedListingHelper.getPageSize(maxResults));
-        String nextPageToken = getNextPageToken(modelVersions, maxResults);
-        List<ModelVersionInfo> modelVersionInfoList = new ArrayList<ModelVersionInfo>();
-        if (modelVersions != null) {
-          for (ModelVersionInfoDAO curDao : modelVersions) {
-            ModelVersionInfo curInfo = curDao.toModelVersionInfo();
-            curInfo.setCatalogName(catalogName);
-            curInfo.setSchemaName(schemaName);
-            curInfo.setModelName(registeredModelName);
-            modelVersionInfoList.add(curInfo);
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          String[] parts = registeredModelFullName.split("\\.");
+          if (parts.length != 3) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Invalid registered model name: " + registeredModelFullName);
           }
-        }
-        ListModelVersionsResponse response =
-            new ListModelVersionsResponse()
-                .modelVersions(modelVersionInfoList)
-                .nextPageToken(nextPageToken);
-        tx.commit();
-        return response;
-      } catch (Exception e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    }
+          String catalogName = parts[0];
+          String schemaName = parts[1];
+          String registeredModelName = parts[2];
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          RegisteredModelInfoDAO existingRegisteredModel =
+              getRegisteredModelDaoOrThrow(session, schemaId, registeredModelName);
+          UUID registeredModelId = existingRegisteredModel.getId();
+          List<ModelVersionInfoDAO> modelVersions =
+              getModelVersionsDao(
+                  session,
+                  registeredModelId,
+                  pageToken.orElse("0"),
+                  PagedListingHelper.getPageSize(maxResults));
+          String nextPageToken = getNextPageToken(modelVersions, maxResults);
+          List<ModelVersionInfo> modelVersionInfoList = new ArrayList<>();
+          if (modelVersions != null) {
+            for (ModelVersionInfoDAO curDao : modelVersions) {
+              ModelVersionInfo curInfo = curDao.toModelVersionInfo();
+              curInfo.setCatalogName(catalogName);
+              curInfo.setSchemaName(schemaName);
+              curInfo.setModelName(registeredModelName);
+              modelVersionInfoList.add(curInfo);
+            }
+          }
+          return new ListModelVersionsResponse()
+              .modelVersions(modelVersionInfoList)
+              .nextPageToken(nextPageToken);
+        },
+        "Failed to list model versions",
+        /* readOnly = */ true);
   }
 
   public ModelVersionInfo updateModelVersion(
@@ -681,47 +593,34 @@ public class ModelRepository {
     }
 
     LOGGER.info("Updating Model Version: {}/{}", fullName, version);
-    ModelVersionInfo modelVersionInfo;
     String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String[] parts = RepositoryUtils.parseFullName(fullName);
+    String catalogName = parts[0];
+    String schemaName = parts[1];
+    String registeredModelName = parts[2];
 
-    Transaction tx;
-    try (Session session = sessionFactory.openSession()) {
-      String[] parts = RepositoryUtils.parseFullName(fullName);
-      String catalogName = parts[0];
-      String schemaName = parts[1];
-      String registeredModelName = parts[2];
-      tx = session.beginTransaction();
-      try {
-        // Get the registered model record from the database
-        UUID schemaId =
-            repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-        // Get the model version record from the database
-        ModelVersionInfoDAO origModelVersionInfoDAO =
-            getModelVersionDaoOrThrow(session, schemaId, fullName, registeredModelName, version);
-        origModelVersionInfoDAO.setComment(updateModelVersion.getComment());
-        long updatedTime = System.currentTimeMillis();
-        origModelVersionInfoDAO.setUpdatedAt(new Date(updatedTime));
-        origModelVersionInfoDAO.setUpdatedBy(callerId);
-        session.persist(origModelVersionInfoDAO);
-        modelVersionInfo = origModelVersionInfoDAO.toModelVersionInfo();
-        modelVersionInfo.setCatalogName(catalogName);
-        modelVersionInfo.setSchemaName(schemaName);
-        modelVersionInfo.setModelName(registeredModelName);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    } catch (RuntimeException e) {
-      if (e instanceof BaseException) {
-        throw e;
-      }
-      throw new BaseException(
-          ErrorCode.INTERNAL, "Error updating model version: " + fullName + "/" + version, e);
-    }
-    return modelVersionInfo;
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          ModelVersionInfoDAO origModelVersionInfoDAO =
+              getModelVersionDaoOrThrow(session, schemaId, fullName, registeredModelName, version);
+          origModelVersionInfoDAO.setComment(updateModelVersion.getComment());
+          long updatedTime = System.currentTimeMillis();
+          origModelVersionInfoDAO.setUpdatedAt(new Date(updatedTime));
+          origModelVersionInfoDAO.setUpdatedBy(callerId);
+          session.persist(origModelVersionInfoDAO);
+          ModelVersionInfo modelVersionInfo = origModelVersionInfoDAO.toModelVersionInfo();
+          modelVersionInfo.setCatalogName(catalogName);
+          modelVersionInfo.setSchemaName(schemaName);
+          modelVersionInfo.setModelName(registeredModelName);
+          return modelVersionInfo;
+        },
+        "Failed to update model version",
+        /* readOnly = */ false);
   }
 
   public void deleteModelVersion(String fullName, Long version) {
@@ -734,22 +633,20 @@ public class ModelRepository {
     String catalogName = parts[0];
     String schemaName = parts[1];
     String registeredModelName = parts[2];
-    try (Session session = sessionFactory.openSession()) {
-      Transaction tx = session.beginTransaction();
-      try {
-        UUID schemaId =
-            repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-        RegisteredModelInfoDAO existingRegisteredModel =
-            getRegisteredModelDaoOrThrow(session, schemaId, registeredModelName);
-        deleteModelVersion(session, existingRegisteredModel.getId(), fullName, version);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    }
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          RegisteredModelInfoDAO existingRegisteredModel =
+              getRegisteredModelDaoOrThrow(session, schemaId, registeredModelName);
+          deleteModelVersion(session, existingRegisteredModel.getId(), fullName, version);
+          return null;
+        },
+        "Failed to delete model version",
+        /* readOnly = */ false);
   }
 
   public void deleteModelVersion(
@@ -774,53 +671,40 @@ public class ModelRepository {
     String fullName = finalizeModelVersion.getFullName();
     Long version = finalizeModelVersion.getVersion();
     LOGGER.info("Finalize Model Version: {}/{}", fullName, version);
-    ModelVersionInfo modelVersionInfo;
     String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String[] parts = RepositoryUtils.parseFullName(fullName);
+    String catalogName = parts[0];
+    String schemaName = parts[1];
+    String registeredModelName = parts[2];
 
-    Transaction tx;
-    try (Session session = sessionFactory.openSession()) {
-      String[] parts = RepositoryUtils.parseFullName(fullName);
-      String catalogName = parts[0];
-      String schemaName = parts[1];
-      String registeredModelName = parts[2];
-      tx = session.beginTransaction();
-      try {
-        // Get the registered model record from the database
-        UUID schemaId =
-            repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-        ModelVersionInfoDAO origModelVersionInfoDAO =
-            getModelVersionDaoOrThrow(session, schemaId, fullName, registeredModelName, version);
-
-        if (ModelVersionStatus.valueOf(origModelVersionInfoDAO.getStatus())
-            != ModelVersionStatus.PENDING_REGISTRATION) {
-          throw new BaseException(
-              ErrorCode.INVALID_ARGUMENT,
-              "Model version not in a pending registration state: " + fullName + "/" + version);
-        }
-        origModelVersionInfoDAO.setStatus(ModelVersionStatus.READY.toString());
-        long updatedTime = System.currentTimeMillis();
-        origModelVersionInfoDAO.setUpdatedAt(new Date(updatedTime));
-        origModelVersionInfoDAO.setUpdatedBy(callerId);
-        session.persist(origModelVersionInfoDAO);
-        modelVersionInfo = origModelVersionInfoDAO.toModelVersionInfo();
-        modelVersionInfo.setCatalogName(catalogName);
-        modelVersionInfo.setSchemaName(schemaName);
-        modelVersionInfo.setModelName(registeredModelName);
-        tx.commit();
-      } catch (RuntimeException e) {
-        if (tx != null && tx.getStatus().canRollback()) {
-          tx.rollback();
-        }
-        throw e;
-      }
-    } catch (RuntimeException e) {
-      if (e instanceof BaseException) {
-        throw e;
-      }
-      throw new BaseException(
-          ErrorCode.INTERNAL, "Error updating model version: " + fullName + "/" + version, e);
-    }
-    return modelVersionInfo;
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          ModelVersionInfoDAO origModelVersionInfoDAO =
+              getModelVersionDaoOrThrow(session, schemaId, fullName, registeredModelName, version);
+          if (ModelVersionStatus.valueOf(origModelVersionInfoDAO.getStatus())
+              != ModelVersionStatus.PENDING_REGISTRATION) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Model version not in a pending registration state: " + fullName + "/" + version);
+          }
+          origModelVersionInfoDAO.setStatus(ModelVersionStatus.READY.toString());
+          long updatedTime = System.currentTimeMillis();
+          origModelVersionInfoDAO.setUpdatedAt(new Date(updatedTime));
+          origModelVersionInfoDAO.setUpdatedBy(callerId);
+          session.persist(origModelVersionInfoDAO);
+          ModelVersionInfo modelVersionInfo = origModelVersionInfoDAO.toModelVersionInfo();
+          modelVersionInfo.setCatalogName(catalogName);
+          modelVersionInfo.setSchemaName(schemaName);
+          modelVersionInfo.setModelName(registeredModelName);
+          return modelVersionInfo;
+        },
+        "Failed to finalize model version",
+        /* readOnly = */ false);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/CatalogInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/CatalogInfoDAO.java
@@ -4,6 +4,7 @@ import io.unitycatalog.server.model.CatalogInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
@@ -15,7 +16,13 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "uc_catalogs")
+@Table(
+    name = "uc_catalogs",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_catalog_name",
+          columnNames = {"name"})
+    })
 // Lombok
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/CredentialDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/CredentialDAO.java
@@ -17,6 +17,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,7 +38,13 @@ import lombok.experimental.SuperBuilder;
  * @see AwsCredentialVendor
  */
 @Entity
-@Table(name = "uc_credentials")
+@Table(
+    name = "uc_credentials",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_credential_name",
+          columnNames = {"name"}),
+    })
 // Lombok
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ExternalLocationDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ExternalLocationDAO.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,11 @@ import lombok.experimental.SuperBuilder;
     indexes = {
       @Index(name = "idx_url", columnList = "url"),
       @Index(name = "idx_credential_id", columnList = "credential_id"),
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_external_location_name",
+          columnNames = {"name"}),
     })
 // Lombok
 @Getter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/FunctionInfoDAO.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -20,7 +21,13 @@ import org.hibernate.annotations.SQLRestriction;
 
 // Hibernate annotations
 @Entity
-@Table(name = "uc_functions")
+@Table(
+    name = "uc_functions",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_function_schema_id_name",
+          columnNames = {"schema_id", "name"})
+    })
 // Lombok annotations
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
@@ -5,8 +5,8 @@ import io.unitycatalog.server.model.ModelVersionStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -19,8 +19,10 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Table(
     name = "uc_model_versions",
-    indexes = {
-      @Index(name = "idx_model_version", columnList = "registered_model_id,version"),
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_model_version_model_id_version",
+          columnNames = {"registered_model_id", "version"}),
     })
 // Lombok annotations
 @Getter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,11 @@ import lombok.experimental.SuperBuilder;
     name = "uc_registered_models",
     indexes = {
       @Index(name = "uc_registered_models_name_idx", columnList = "name"),
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_registered_model_schema_id_name",
+          columnNames = {"schema_id", "name"})
     })
 // Lombok annotations
 @Getter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/SchemaInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/SchemaInfoDAO.java
@@ -4,6 +4,7 @@ import io.unitycatalog.server.model.SchemaInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
@@ -15,7 +16,13 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "uc_schemas")
+@Table(
+    name = "uc_schemas",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_schema_catalog_id_name",
+          columnNames = {"catalog_id", "name"})
+    })
 // Lombok
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -27,6 +28,11 @@ import lombok.experimental.SuperBuilder;
     name = "uc_tables",
     indexes = {
       @Index(name = "idx_name", columnList = "name"),
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_table_schema_id_name",
+          columnNames = {"schema_id", "name"})
     })
 // Lombok annotations
 @Getter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/UserDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/UserDAO.java
@@ -4,6 +4,7 @@ import io.unitycatalog.control.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -14,7 +15,13 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "uc_users")
+@Table(
+    name = "uc_users",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_user_email",
+          columnNames = {"email"}),
+    })
 // Lombok annotations
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
@@ -6,6 +6,7 @@ import io.unitycatalog.server.utils.NormalizedURL;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -16,7 +17,13 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "uc_volumes")
+@Table(
+    name = "uc_volumes",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_volume_schema_id_name",
+          columnNames = {"schema_id", "name"})
+    })
 // lombok annotations
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
@@ -2,16 +2,21 @@ package io.unitycatalog.server.persist.utils;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import java.util.Optional;
+import java.sql.Connection;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Utility class for managing database transactions. */
 public class TransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(TransactionManager.class);
+
+  /** Maximum number of times a transaction is tried (including the first attempt). */
+  private static final int MAX_TRANSACTION_TRY_COUNT = 3;
 
   /**
    * Functional interface for database operations that return a result.
@@ -26,6 +31,27 @@ public class TransactionManager {
   /**
    * Executes a database operation with transaction management.
    *
+   * <p><b>Read transactions</b> ({@code readOnly=true}) run at {@code REPEATABLE_READ} isolation.
+   * This ensures a stable snapshot for the entire transaction so that multiple reads within the
+   * same transaction see consistent data. Without it, a {@code READ_COMMITTED} database (such as
+   * H2's default) refreshes its snapshot on every statement, which can cause a single logical
+   * operation that issues multiple queries (e.g. listing commits while new commits are being
+   * posted) to observe version numbers that appear to go backwards or skip, breaking monotonicity
+   * assumptions.
+   *
+   * <p><b>Write transactions</b> ({@code readOnly=false}) run at {@code SERIALIZABLE} isolation. On
+   * production databases that implement Serializable Snapshot Isolation (SSI), such as PostgreSQL,
+   * this detects dangerous read-write anti-dependency cycles between concurrent transactions and
+   * aborts one of them, preventing phantom writes. The aborted transaction is retried by this
+   * method so that the business logic re-runs with a fresh snapshot and produces the correct
+   * application-level error (e.g. {@code ALREADY_EXISTS} or {@code NOT_FOUND}) rather than a raw
+   * database error. Unique constraints on the entity tables serve as an additional safety net that
+   * catches concurrent duplicate inserts even when SSI is unavailable (e.g. H2).
+   *
+   * <p>On a serialization conflict ({@link LockAcquisitionException}) or unique-constraint
+   * violation ({@link ConstraintViolationException}) the transaction is tried up to {@link
+   * #MAX_TRANSACTION_TRY_COUNT} times.
+   *
    * @param sessionFactory the Hibernate session factory
    * @param operation the database operation to execute
    * @param errorMessage the error message to use if the operation fails
@@ -38,59 +64,50 @@ public class TransactionManager {
       DatabaseOperation<R> operation,
       String errorMessage,
       boolean readOnly) {
-    return executeWithTransaction(
-        sessionFactory, operation, errorMessage, readOnly, Optional.empty());
-  }
+    int isolationLevel =
+        readOnly ? Connection.TRANSACTION_REPEATABLE_READ : Connection.TRANSACTION_SERIALIZABLE;
+    for (int attempt = 0; attempt < MAX_TRANSACTION_TRY_COUNT; attempt++) {
+      try (Session session = sessionFactory.openSession()) {
+        if (readOnly) {
+          session.setDefaultReadOnly(true);
+        }
 
-  /**
-   * Executes a database operation with transaction management and optional custom isolation level.
-   *
-   * @param sessionFactory the Hibernate session factory
-   * @param operation the database operation to execute
-   * @param errorMessage the error message to use if the operation fails
-   * @param readOnly whether the session should be read-only
-   * @param isolationLevel optional transaction isolation level (e.g.,
-   *     Connection.TRANSACTION_REPEATABLE_READ). If present, the original isolation level will be
-   *     saved and restored after the transaction to avoid affecting pooled connections.
-   * @param <R> the result type
-   * @return the result of the operation
-   */
-  public static <R> R executeWithTransaction(
-      SessionFactory sessionFactory,
-      DatabaseOperation<R> operation,
-      String errorMessage,
-      boolean readOnly,
-      Optional<Integer> isolationLevel) {
-    try (Session session = sessionFactory.openSession()) {
-      if (readOnly) {
-        session.setDefaultReadOnly(true);
-      }
-
-      // Save and set custom isolation level if specified
-      final int[] originalIsolation = new int[1];
-      if (isolationLevel.isPresent()) {
+        // Save and set custom isolation level
+        final int[] originalIsolation = new int[1];
         session.doWork(
             connection -> {
               originalIsolation[0] = connection.getTransactionIsolation();
-              connection.setTransactionIsolation(isolationLevel.get());
+              connection.setTransactionIsolation(isolationLevel);
             });
-      }
 
-      Transaction tx = session.beginTransaction();
-      try {
-        R result = operation.execute(session);
-        tx.commit();
-        return result;
-      } catch (Exception e) {
-        tx.rollback();
-        LOGGER.debug(errorMessage, e);
-        if (e instanceof BaseException) {
-          throw (BaseException) e;
-        }
-        throw new BaseException(ErrorCode.INTERNAL, errorMessage, e);
-      } finally {
-        // Restore original isolation level to avoid polluting connection pool
-        if (isolationLevel.isPresent()) {
+        Transaction tx = session.beginTransaction();
+        try {
+          R result = operation.execute(session);
+          tx.commit();
+          return result;
+        } catch (LockAcquisitionException | ConstraintViolationException e) {
+          tx.rollback();
+          if (attempt < MAX_TRANSACTION_TRY_COUNT - 1) {
+            LOGGER.debug(
+                "Serialization conflict on attempt {}/{}, retrying: {}",
+                attempt + 1,
+                MAX_TRANSACTION_TRY_COUNT,
+                errorMessage);
+          } else {
+            LOGGER.warn(
+                "Transaction aborted after {} attempt(s) due to serialization conflict: {}",
+                MAX_TRANSACTION_TRY_COUNT,
+                errorMessage);
+          }
+        } catch (Exception e) {
+          tx.rollback();
+          LOGGER.debug(errorMessage, e);
+          if (e instanceof BaseException) {
+            throw (BaseException) e;
+          }
+          throw new BaseException(ErrorCode.INTERNAL, errorMessage, e);
+        } finally {
+          // Restore original isolation level to avoid polluting connection pool
           session.doWork(
               connection -> {
                 connection.setTransactionIsolation(originalIsolation[0]);
@@ -98,5 +115,7 @@ public class TransactionManager {
         }
       }
     }
+    throw new BaseException(
+        ErrorCode.INTERNAL, errorMessage + ": serialization conflict, max retries exceeded");
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
@@ -87,7 +87,7 @@ public class TransactionManager {
         if (e instanceof BaseException) {
           throw (BaseException) e;
         }
-        throw new BaseException(ErrorCode.INTERNAL, errorMessage + ": " + e.getMessage());
+        throw new BaseException(ErrorCode.INTERNAL, errorMessage, e);
       } finally {
         // Restore original isolation level to avoid polluting connection pool
         if (isolationLevel.isPresent()) {

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
@@ -101,7 +101,7 @@ public class TransactionManagerTest {
                     false))
         .isInstanceOf(BaseException.class)
         .hasMessageContaining(errorMessage)
-        .hasMessageContaining(testException.getMessage());
+        .hasCause(testException);
 
     verify(transaction).rollback();
     verify(transaction, never()).commit();
@@ -156,7 +156,7 @@ public class TransactionManagerTest {
                     /* readOnly = */ true))
         .isInstanceOf(BaseException.class)
         .hasMessageContaining(errorMessage)
-        .hasMessageContaining(hibernateException.getMessage());
+        .hasCause(hibernateException);
 
     // Verify the transaction was rolled back
     verify(transaction).rollback();

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -21,13 +21,16 @@ import io.unitycatalog.server.base.table.BaseTableCRUDTest;
 import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import org.hibernate.Session;
 import org.junit.jupiter.api.Test;
 
@@ -271,8 +274,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
 
   /**
    * Test that attempting to create a staging table duplicate with existing table (not staging
-   * table) fails with ALREADY_EXISTS error. But creating multiple staging tables with the same name
-   * is allowed.
+   * table) fails with TABLE_ALREADY_EXISTS error. But creating multiple staging tables with the
+   * same name is allowed.
    */
   @Test
   public void testDuplicateStagingTableCreation() throws Exception {
@@ -367,6 +370,100 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
         .satisfies(
             ex -> assertThat(ex.getCode()).isEqualTo(ErrorCode.NOT_FOUND.getHttpStatus().code()))
         .withMessageContaining("not found");
+  }
+
+  private class ConcurrentCreateTableWorker {
+    CountDownLatch startLatch;
+    CreateTable request;
+    TableInfo result = null;
+    ApiException error = null;
+    Thread thread;
+
+    ConcurrentCreateTableWorker(CountDownLatch startLatch, CreateTable request) {
+      TablesApi api = new TablesApi(TestUtils.createApiClient(serverConfig));
+      this.startLatch = startLatch;
+      this.request = request;
+      this.thread =
+          new Thread(
+              () -> {
+                try {
+                  startLatch.await();
+                  result = api.createTable(request);
+                } catch (ApiException e) {
+                  error = e;
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+      this.thread.start();
+    }
+  }
+
+  /**
+   * Test that two concurrent create-table requests for the same table name result in exactly one
+   * success and one TABLE_ALREADY_EXISTS failure.
+   */
+  @Test
+  public void testConcurrentCreateTableRequests() throws Exception {
+    String tableName = "table-concurrent";
+    // Latch to kick off all threads to race to the server at the same time.
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<ConcurrentCreateTableWorker> workers = new ArrayList<>();
+
+    for (int i = 0; i < 2; i++) {
+      String storageLocation =
+          Files.createTempDirectory(testDirectoryRoot, "concurrent-").toString();
+      CreateTable request =
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .columns(COLUMNS)
+              .tableType(TableType.EXTERNAL)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .storageLocation(storageLocation);
+
+      workers.add(new ConcurrentCreateTableWorker(startLatch, request));
+    }
+    startLatch.countDown(); // Kick off both threads at the same time
+    for (ConcurrentCreateTableWorker worker : workers) {
+      worker.thread.join();
+    }
+
+    // Inspect the raw DB state to can see exactly how many rows landed in the table regardless of
+    // what the HTTP layer reported.
+    List<TableInfoDAO> dbRows = findAllTablesBySchemaAndName(tableName);
+    // Primary assertion: the DB must always have exactly one row for this table name.
+    assertThat(dbRows).hasSize(1);
+
+    // Secondary assertion: exactly one HTTP request should have succeeded.
+    long success = workers.stream().filter(x -> x.result != null).count();
+    assertThat(success).isEqualTo(1);
+
+    // The failing thread must have received TABLE_ALREADY_EXISTS (400).
+    workers.stream()
+        .filter(x -> x.result == null)
+        .map(x -> x.error.getCode())
+        .forEach(
+            errorCode ->
+                assertThat(errorCode)
+                    .isEqualTo(ErrorCode.TABLE_ALREADY_EXISTS.getHttpStatus().code()));
+  }
+
+  /**
+   * Returns ALL DB rows for the given table name within the test schema. When duplicate tables with
+   * the same name exist, return all of them.
+   */
+  private List<TableInfoDAO> findAllTablesBySchemaAndName(String tableName) {
+    try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+      return session
+          .createQuery(
+              "FROM TableInfoDAO t WHERE t.schemaId = :schemaId AND t.name = :name",
+              TableInfoDAO.class)
+          .setParameter("schemaId", UUID.fromString(schemaId))
+          .setParameter("name", tableName)
+          .getResultList();
+    }
   }
 
   /** Test that staging table creation fails when the catalog doesn't exist. */


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1380/files/c00cc26683498b2efa08c5b9bda322b00e4f3611..f4609279fd2bb6415f2e66382dc308f2a3994cab) to review incremental changes.
- [stack/model_repo_tx](https://github.com/unitycatalog/unitycatalog/pull/1379) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1379/files)]
  - [**stack/concurrent_tx**](https://github.com/unitycatalog/unitycatalog/pull/1380) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1380/files/c00cc26683498b2efa08c5b9bda322b00e4f3611..f4609279fd2bb6415f2e66382dc308f2a3994cab)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Prevent concurrent duplicate writes with serializable isolation and unique constraints

TransactionManager now uses `REPEATABLE_READ` for reads and `SERIALIZABLE` for writes, retrying up to 3 times on serialization conflicts or unique-constraint violations. Added `@UniqueConstraint` to all entity DAOs as a safety net for databases without SSI (e.g. H2). Added a concurrent create-table test to verify correctness.
