### PR TITLE
Set partition index of columns in UCProxy

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -499,15 +499,19 @@ private class UCProxy(
     }
     createTable.setStorageLocation(storageLocation)
 
-    val partitionColNames: Seq[String] = partitions
-      .filter(_.name() == "identity")
-      .map { t =>
-        val fieldNames = t.references().flatMap(_.fieldNames())
-        assert(fieldNames.length == 1,
-          s"Expected single-field partition reference but got: ${fieldNames.mkString(".")}")
-        fieldNames.head
+    val partitionColNames: Seq[String] = partitions.flatMap { t =>
+      t.name() match {
+        case "identity" =>
+          val fieldNames = t.references().flatMap(_.fieldNames())
+          require(fieldNames.length == 1,
+            s"Expected single-field partition reference but got: ${fieldNames.mkString(".")}")
+          Some(fieldNames.head)
+        case "cluster_by" =>
+          None
+        case other =>
+          throw new ApiException(s"Unsupported partition transform: $other")
       }
-      .toSeq
+    }.toSeq
     val columns: Seq[ColumnInfo] = schema.fields.toSeq.zipWithIndex.map { case (field, i) =>
       val column = new ColumnInfo()
       column.setName(field.name)
@@ -519,7 +523,7 @@ private class UCProxy(
       column.setTypeName(convertDataTypeToTypeName(field.dataType))
       column.setTypeJson(field.dataType.json)
       column.setPosition(i)
-      val partitionIdx = partitionColNames.indexOf(field.name)
+      val partitionIdx = partitionColNames.indexWhere(_.equalsIgnoreCase(field.name))
       if (partitionIdx >= 0) column.setPartitionIndex(partitionIdx)
       column
     }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
@@ -441,9 +441,9 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
-   * Specification for one column in testTableWithComplexTypes: its SQL DDL type, the SQL literal
-   * used in the INSERT, the expected toString() from the result row (null = byte-array ref check
-   * via startsWith("[B@")), and the expected UC catalog metadata fields.
+   * Specification for one column in testTableWithSupportedDataTypes: its SQL DDL type, the SQL
+   * literal used in the INSERT, the expected toString() from the result row (null = byte-array ref
+   * check via startsWith("[B@")), and the expected UC catalog metadata fields.
    */
   @AllArgsConstructor
   @Getter
@@ -580,6 +580,22 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
                 "timestamp_ntz",
                 "\"timestamp_ntz\""),
             new ColSpec(
+                "col_daytime_interval",
+                "INTERVAL DAY TO SECOND",
+                "INTERVAL '1 00:00:00' DAY TO SECOND",
+                "PT24H",
+                ColumnTypeName.INTERVAL,
+                "interval day to second",
+                "\"interval day to second\""),
+            new ColSpec(
+                "col_yearmonth_interval",
+                "INTERVAL YEAR TO MONTH",
+                "INTERVAL '0-1' YEAR TO MONTH",
+                "P1M",
+                ColumnTypeName.INTERVAL,
+                "interval year to month",
+                "\"interval year to month\""),
+            new ColSpec(
                 "col_arr",
                 "ARRAY<INT>",
                 "array(1, 2, 3)",
@@ -606,6 +622,7 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
 
     session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
     String tableName = TEST_TABLE + "_complex_type";
+    List<String> partitionColumns = List.of("col_daytime_interval", "col_string", "col_bigint");
     String fullTableName =
         setupTable(
             new TableSetupOptions()
@@ -615,13 +632,16 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
                 .setColumns(
                     cols.stream()
                         .map(c -> Pair.of(c.getName(), c.getSqlType()))
-                        .collect(Collectors.toList())));
+                        .collect(Collectors.toList()))
+                .setPartitionColumns(partitionColumns));
+    String colNames = cols.stream().map(ColSpec::getName).collect(Collectors.joining(", "));
     sql(
-        "INSERT INTO %s VALUES (%s)",
+        "INSERT INTO %s (%s) VALUES (%s)",
         fullTableName,
+        colNames,
         cols.stream().map(ColSpec::getInsertValue).collect(Collectors.joining(", ")));
 
-    List<Row> queryResult = sql("SELECT * FROM %s", fullTableName);
+    List<Row> queryResult = sql("SELECT %s FROM %s", colNames, fullTableName);
     assertThat(queryResult).hasSize(1);
     List<String> row =
         IntStream.range(0, queryResult.get(0).length())
@@ -652,6 +672,12 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
       assertThat(col.getTypeJson())
           .as("typeJson for %s", spec.getName())
           .isEqualTo(spec.getTypeJson());
+      int partitionIndex = partitionColumns.indexOf(col.getName());
+      if (partitionIndex != -1) {
+        assertThat(col.getPartitionIndex()).isEqualTo(partitionIndex);
+      } else {
+        assertThat(col.getPartitionIndex()).isNull();
+      }
     }
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -115,6 +115,12 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
               assertThat(columns.get(0).getTypeName()).isEqualTo(ColumnTypeName.INT);
               assertThat(columns.get(1).getName()).isEqualTo("s");
               assertThat(columns.get(1).getTypeName()).isEqualTo(ColumnTypeName.STRING);
+              assertThat(columns.get(0).getPartitionIndex()).isNull();
+              if (withPartitionColumns) {
+                assertThat(columns.get(1).getPartitionIndex()).isEqualTo(0);
+              } else {
+                assertThat(columns.get(1).getPartitionIndex()).isNull();
+              }
             }
             validateTableSchema(
                 session.table(fullTableName).schema(),


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Set partition index of columns in UCProxy. This is required by Delta to send table schema to UC.