### PR TITLE
Fix race condition in Javadoc generation for client project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,8 @@ lazy val client = (project in file("clients/java"))
       "org.assertj" % "assertj-core" % "3.26.3" % Test,
     ),
     (Compile / compile) := ((Compile / compile) dependsOn generate).value,
-    
+    (Compile / doc) := ((Compile / doc) dependsOn generate).value,
+
     // Add custom test sources from clients/java directory
     Test / unmanagedSourceDirectories += (file(".") / "clients" / "java" / "src" / "test" / "java"),
 


### PR DESCRIPTION
## Summary

- `client / Compile / doc` (run as part of `publishM2`) was intermittently failing because sbt's parallel task execution could evaluate `Compile/sources` before `generate` populated `clients/java/target/src/main/java` with OpenAPI-generated model files
- This caused javadoc to randomly miss generated classes like `UpdateModelVersion` or `UpdateRegisteredModel`, producing "cannot find symbol" errors
- Fix: add `(Compile / doc) dependsOn generate` to mirror the existing `(Compile / compile) dependsOn generate`

## Test plan

- [ ] Verify CI passes consistently (no more intermittent `(client / Compile / doc) sbt.inc.Doc$JavadocGenerationFailed` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)