### PR TITLE
Stage UC managed replace target for Delta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,14 @@ lazy val javacRelease17 = Seq("--release", "17")
 
 lazy val scala213 = "2.13.17"
 
-lazy val deltaVersion = "4.1.0"
+lazy val deltaVersion = sys.props.getOrElse("deltaVersion", "4.1.0")
 lazy val sparkVersion = sys.props.getOrElse("sparkVersion", "4.0.0")
 lazy val sparkMajorMinorVersion = sparkVersion.split("\\.").take(2).mkString(".")
 lazy val hadoopVersion = "3.4.2"
+lazy val deltaInternalModuleExclusions = Seq(
+  ExclusionRule("io.delta", s"delta-spark-v1_${sparkMajorMinorVersion}_2.13"),
+  ExclusionRule("io.delta", s"delta-spark-v2_${sparkMajorMinorVersion}_2.13"),
+)
 
 // Library versions
 lazy val jacksonVersion = "2.17.0"
@@ -618,7 +622,8 @@ lazy val spark = (project in file("connectors/spark"))
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % Test,
       "org.projectlombok" % "lombok" % "1.18.32" % Test,
       "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",
-      "io.delta" %% s"delta-spark_$sparkMajorMinorVersion" % deltaVersion % Test,
+      ("io.delta" %% s"delta-spark_$sparkMajorMinorVersion" % deltaVersion % Test)
+        .excludeAll(deltaInternalModuleExclusions: _*),
     ),
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",
@@ -675,7 +680,8 @@ lazy val integrationTests = (project in file("integration-tests"))
       "org.assertj" % "assertj-core" % "3.26.3" % Test,
       "org.projectlombok" % "lombok" % "1.18.32" % Provided,
       "org.apache.spark" %% "spark-sql" % sparkVersion % Test,
-      "io.delta" %% s"delta-spark_$sparkMajorMinorVersion" % deltaVersion % Test,
+      ("io.delta" %% s"delta-spark_$sparkMajorMinorVersion" % deltaVersion % Test)
+        .excludeAll(deltaInternalModuleExclusions: _*),
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % Test,
       "org.apache.hadoop" % "hadoop-azure" % hadoopVersion % Test,
       "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -33,6 +33,8 @@ class UCSingleCatalog
   with SupportsNamespaces
   with Logging {
 
+  private val ucManagedDeltaOnlyMsg = "is only supported for UC-managed Delta tables"
+
   private[this] var uri: URI = null
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
@@ -106,31 +108,7 @@ class UCSingleCatalog
     }
 
     if (UCSingleCatalog.isManagedDeltaTable(properties, ident)) {
-      // Check that caller shouldn't set some properties
-      List(UCTableProperties.UC_TABLE_ID_KEY, UCTableProperties.UC_TABLE_ID_KEY_OLD,
-        TableCatalog.PROP_IS_MANAGED_LOCATION)
-        .filter(properties.containsKey(_))
-        .foreach(p => throw new ApiException(s"Cannot specify property '$p'."))
-      // Setting the catalogManaged table feature is required for creating a managed table.
-      if (!properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY) &&
-        !properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
-        throw new ApiException(
-          s"Managed table creation requires table property " +
-            s"'${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'=" +
-            s"'${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'" +
-            s" to be set.")
-      }
-      // Caller should not set these two table properties to values other than "supported". This is
-      // the only documented value.
-      List(UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
-        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)
-        .foreach(k => {
-          Option(properties.get(k))
-            .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
-            .foreach(v => throw new ApiException(
-              s"Invalid property value '$v' for '$k'."))
-        })
-
+      validateManagedDeltaCreateProperties(properties)
       val newProps = stageManagedDeltaTableAndGetProps(ident, properties)
       delegate.createTable(ident, columns, partitions, newProps)
     } else if (hasLocationClause) {
@@ -146,7 +124,8 @@ class UCSingleCatalog
   /** Prepares properties for managed table creation (staging table + credentials). */
   private def stageManagedDeltaTableAndGetProps(
       ident: Identifier,
-      properties: util.Map[String, String]): util.Map[String, String] = {
+      properties: util.Map[String, String],
+      createWhenMissing: Boolean = false): util.Map[String, String] = {
     // Get staging table location and table id from UC
     val createStagingTable = new CreateStagingTable()
       .catalogName(name())
@@ -165,6 +144,9 @@ class UCSingleCatalog
     // `PROP_IS_MANAGED_LOCATION` is used to indicate that the table location is not
     // user-specified but system-generated, which is exactly the case here.
     newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+    if (createWhenMissing) {
+      newProps.put(UCSingleCatalog.CREATE_WHEN_MISSING_KEY, "true")
+    }
 
     val temporaryCredentials = temporaryCredentialsApi.generateTemporaryTableCredentials(
       new GenerateTemporaryTableCredential().tableId(stagingTableId).operation(TableOperation.READ_WRITE))
@@ -179,6 +161,89 @@ class UCSingleCatalog
     )
     UCSingleCatalog.setCredentialProps(newProps, credentialProps)
     newProps
+  }
+
+  private def validateManagedDeltaCreateProperties(properties: util.Map[String, String]): Unit = {
+    rejectSystemManagedProperties(properties)
+    if (!properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY) &&
+      !properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
+      throw new ApiException(
+        s"Managed table creation requires table property " +
+          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'=" +
+          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'" +
+          s" to be set.")
+    }
+    List(UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)
+      .foreach(k => {
+        Option(properties.get(k))
+          .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+          .foreach(v => throw new ApiException(
+            s"Invalid property value '$v' for '$k'."))
+      })
+  }
+
+  private def loadExistingManagedTablePropsForReplace(
+      ident: Identifier,
+      tableInfo: io.unitycatalog.client.model.TableInfo,
+      properties: util.Map[String, String],
+      operation: String): util.Map[String, String] = {
+    rejectSystemManagedProperties(properties)
+
+    if (tableInfo.getTableType != TableType.MANAGED ||
+      tableInfo.getDataSourceFormat != DataSourceFormat.DELTA) {
+      throw new UnsupportedOperationException(s"$operation $ucManagedDeltaOnlyMsg")
+    }
+
+    val fullTableName = UCSingleCatalog.fullTableNameForApi(name(), ident)
+    val tableLocation = tableInfo.getStorageLocation
+    val tableId = tableInfo.getTableId
+    if (tableLocation == null || tableLocation.isEmpty || tableId == null || tableId.isEmpty) {
+      throw new ApiException(
+        s"Invalid table metadata for $fullTableName: storageLocation/tableId must be set")
+    }
+
+    val newProps = new util.HashMap[String, String]
+    newProps.putAll(properties)
+    Option(tableInfo.getProperties).foreach { existingProps =>
+      List(UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)
+        .find(existingProps.containsKey)
+        .foreach(key => newProps.put(key, existingProps.get(key)))
+    }
+    newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+    newProps.put(UCSingleCatalog.EXISTING_TABLE_LOCATION_KEY, tableLocation)
+    newProps.put(UCSingleCatalog.EXISTING_TABLE_TYPE_KEY, tableInfo.getTableType.name())
+    newProps.put(UCSingleCatalog.EXISTING_TABLE_ID_KEY, tableId)
+
+    val temporaryCredentials = temporaryCredentialsApi.generateTemporaryTableCredentials(
+      new GenerateTemporaryTableCredential().tableId(tableId).operation(TableOperation.READ_WRITE))
+    val tableScheme = new Path(tableLocation).toUri.getScheme
+    val credentialProps = CredPropsUtil.createTableCredProps(
+      renewCredEnabled,
+      tableScheme,
+      uri.toString,
+      tokenProvider,
+      tableId,
+      TableOperation.READ_WRITE,
+      temporaryCredentials,
+    )
+    UCSingleCatalog.setCredentialProps(newProps, credentialProps)
+    newProps
+  }
+
+  private def rejectSystemManagedProperties(properties: util.Map[String, String]): Unit = {
+    List(
+      UCTableProperties.UC_TABLE_ID_KEY,
+      UCTableProperties.UC_TABLE_ID_KEY_OLD,
+      TableCatalog.PROP_IS_MANAGED_LOCATION,
+      UCSingleCatalog.CREATE_WHEN_MISSING_KEY,
+      UCSingleCatalog.EXISTING_TABLE_LOCATION_KEY,
+      UCSingleCatalog.EXISTING_TABLE_TYPE_KEY,
+      UCSingleCatalog.EXISTING_TABLE_ID_KEY
+    ).flatMap(key => Seq(key, TableCatalog.OPTION_PREFIX + key))
+      .filter(properties.containsKey(_))
+      .foreach(p => throw new ApiException(s"Cannot specify property '$p'."))
   }
 
   /** Prepares properties for external table creation (path credentials). */
@@ -248,7 +313,17 @@ class UCSingleCatalog
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
-    throw new UnsupportedOperationException("REPLACE TABLE is not supported")
+    val (stagingCatalog, existingTable) = prepareManagedDeltaReplaceOrCreateOrReplace(
+      ident,
+      properties,
+      "REPLACE TABLE",
+      allowMissingTable = false)
+    val newProps = loadExistingManagedTablePropsForReplace(
+      ident,
+      existingTable.getOrElse(throw new NoSuchTableException(ident)),
+      properties,
+      "REPLACE TABLE")
+    stagingCatalog.stageReplace(ident, schema, partitions, newProps)
   }
 
   /** Only called for CREATE OR REPLACE TABLE ... [AS SELECT] */
@@ -257,7 +332,48 @@ class UCSingleCatalog
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
-    throw new UnsupportedOperationException("REPLACE TABLE AS SELECT (RTAS) is not supported")
+    val (stagingCatalog, existingTable) = prepareManagedDeltaReplaceOrCreateOrReplace(
+      ident,
+      properties,
+      "CREATE OR REPLACE TABLE",
+      allowMissingTable = true)
+    val newProps = existingTable.map(tableInfo => loadExistingManagedTablePropsForReplace(
+      ident,
+      tableInfo,
+      properties,
+      "CREATE OR REPLACE TABLE")).getOrElse {
+      validateManagedDeltaCreateProperties(properties)
+      stageManagedDeltaTableAndGetProps(ident, properties, createWhenMissing = true)
+    }
+    stagingCatalog.stageCreateOrReplace(ident, schema, partitions, newProps)
+  }
+
+  private def prepareManagedDeltaReplaceOrCreateOrReplace(
+      ident: Identifier,
+      properties: util.Map[String, String],
+      operation: String,
+      allowMissingTable: Boolean): (StagingTableCatalog, Option[io.unitycatalog.client.model.TableInfo]) = {
+    UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
+    val stagingCatalog = delegate match {
+      case catalog: StagingTableCatalog => catalog
+      case _ => throw new UnsupportedOperationException(s"$operation is not supported")
+    }
+
+    if (!UCSingleCatalog.isManagedDeltaTable(properties, ident)) {
+      throw new UnsupportedOperationException(s"$operation $ucManagedDeltaOnlyMsg")
+    }
+
+    val fullTableName = UCSingleCatalog.fullTableNameForApi(name(), ident)
+    val existingTable = try {
+      Some(tablesApi.getTable(
+        fullTableName,
+        /* readStreamingTableAsManaged = */ false,
+        /* readMaterializedViewAsManaged = */ false))
+    } catch {
+      case e: ApiException if e.getCode == 404 && allowMissingTable => None
+      case e: ApiException if e.getCode == 404 => throw new NoSuchTableException(ident)
+    }
+    (stagingCatalog, existingTable)
   }
 
   /** Only called for CTAS */
@@ -287,6 +403,10 @@ class UCSingleCatalog
 object UCSingleCatalog {
   val LOAD_DELTA_CATALOG = ThreadLocal.withInitial[Boolean](() => true)
   val DELTA_CATALOG_LOADED = ThreadLocal.withInitial[Boolean](() => false)
+  val CREATE_WHEN_MISSING_KEY = "unitycatalog.internal.delta.replace.createWhenMissing"
+  val EXISTING_TABLE_LOCATION_KEY = "unitycatalog.internal.delta.replace.existingTableLocation"
+  val EXISTING_TABLE_TYPE_KEY = "unitycatalog.internal.delta.replace.existingTableType"
+  val EXISTING_TABLE_ID_KEY = "unitycatalog.internal.delta.replace.existingTableId"
 
   def setCredentialProps(props: util.HashMap[String, String],
                          credentialProps: util.Map[String, String]): Unit = {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteTest {
   private static final String DELTA_TABLE = "test_delta";
+  private static final String EXISTING_TABLE_ID_KEY =
+      "unitycatalog.internal.delta.replace.existingTableId";
 
   @Override
   protected String tableFormat() {
@@ -188,6 +190,197 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
         }
       }
     }
+  }
+
+  @Test
+  public void testReplaceManagedDeltaTablePreservesUcProperties() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+
+    TableSetupOptions options =
+        new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE);
+    String fullTableName = setupTable(options);
+
+    TableOperations tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+    TableInfo tableInfoBeforeReplace = tableOperations.getTable(fullTableName);
+    String expectedTableId = tableInfoBeforeReplace.getTableId();
+
+    for (boolean replaceAsSelect : List.of(true, false)) {
+      if (replaceAsSelect) {
+        sql("REPLACE TABLE %s USING DELTA AS SELECT 2 AS i, 'b' AS s", fullTableName);
+        validateRows(sql("SELECT * FROM %s", fullTableName), Pair.of(2, "b"));
+      } else {
+        sql("REPLACE TABLE %s (i INT, s STRING) USING DELTA", fullTableName);
+        validateTableEmpty(fullTableName);
+      }
+
+      TableInfo tableInfoAfterReplace = tableOperations.getTable(fullTableName);
+      Assertions.assertEquals(expectedTableId, tableInfoAfterReplace.getTableId());
+      Map<String, String> tablePropertiesFromServer = tableInfoAfterReplace.getProperties();
+      Assertions.assertTrue(
+          tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY)
+              || tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY_OLD));
+      boolean hasCatalogManaged =
+          tablePropertiesFromServer.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)
+              || tablePropertiesFromServer.containsKey(
+                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW);
+      Assertions.assertTrue(hasCatalogManaged);
+      String catalogManagedValue =
+          Optional.ofNullable(
+                  tablePropertiesFromServer.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY))
+              .orElseGet(
+                  () ->
+                      tablePropertiesFromServer.get(
+                          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+      Assertions.assertEquals(UCTableProperties.DELTA_CATALOG_MANAGED_VALUE, catalogManagedValue);
+    }
+  }
+
+  @Test
+  public void testCreateOrReplaceManagedDeltaTablePreservesUcProperties() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+
+    TableSetupOptions options =
+        new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE);
+    String fullTableName = setupTable(options);
+
+    TableOperations tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+    TableInfo tableInfoBeforeReplace = tableOperations.getTable(fullTableName);
+    String expectedTableId = tableInfoBeforeReplace.getTableId();
+
+    for (boolean replaceAsSelect : List.of(true, false)) {
+      if (replaceAsSelect) {
+        sql("CREATE OR REPLACE TABLE %s USING DELTA AS SELECT 2 AS i, 'b' AS s", fullTableName);
+        validateRows(sql("SELECT * FROM %s", fullTableName), Pair.of(2, "b"));
+      } else {
+        sql("CREATE OR REPLACE TABLE %s (i INT, s STRING) USING DELTA", fullTableName);
+        validateTableEmpty(fullTableName);
+      }
+
+      TableInfo tableInfoAfterReplace = tableOperations.getTable(fullTableName);
+      Assertions.assertEquals(expectedTableId, tableInfoAfterReplace.getTableId());
+      Map<String, String> tablePropertiesFromServer = tableInfoAfterReplace.getProperties();
+      Assertions.assertTrue(
+          tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY)
+              || tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY_OLD));
+      boolean hasCatalogManaged =
+          tablePropertiesFromServer.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)
+              || tablePropertiesFromServer.containsKey(
+                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW);
+      Assertions.assertTrue(hasCatalogManaged);
+      String catalogManagedValue =
+          Optional.ofNullable(
+                  tablePropertiesFromServer.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY))
+              .orElseGet(
+                  () ->
+                      tablePropertiesFromServer.get(
+                          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+      Assertions.assertEquals(UCTableProperties.DELTA_CATALOG_MANAGED_VALUE, catalogManagedValue);
+    }
+  }
+
+  @Test
+  public void testCreateOrReplaceManagedDeltaTableCreatesWhenMissing() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName = CATALOG_NAME + "." + SCHEMA_NAME + "." + TEST_TABLE;
+    TableOperations tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+
+    sql(
+        "CREATE OR REPLACE TABLE %s (i INT, s STRING) USING DELTA %s",
+        fullTableName, TBLPROPERTIES_CATALOG_OWNED_CLAUSE);
+    validateTableEmpty(fullTableName);
+
+    TableInfo tableInfo = tableOperations.getTable(fullTableName);
+    Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
+    Assertions.assertTrue(
+        tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY)
+            || tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY_OLD));
+    Assertions.assertTrue(
+        tablePropertiesFromServer.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)
+            || tablePropertiesFromServer.containsKey(
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+  }
+
+  @Test
+  public void testCreateOrReplaceManagedDeltaTableAsSelectCreatesWhenMissing() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName = CATALOG_NAME + "." + SCHEMA_NAME + "." + TEST_TABLE;
+    TableOperations tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+
+    sql(
+        "CREATE OR REPLACE TABLE %s USING DELTA %s AS SELECT 2 AS i, 'b' AS s",
+        fullTableName, TBLPROPERTIES_CATALOG_OWNED_CLAUSE);
+    validateRows(sql("SELECT * FROM %s", fullTableName), Pair.of(2, "b"));
+
+    TableInfo tableInfo = tableOperations.getTable(fullTableName);
+    Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
+    Assertions.assertTrue(
+        tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY)
+            || tablePropertiesFromServer.containsKey(UCTableProperties.UC_TABLE_ID_KEY_OLD));
+    Assertions.assertTrue(
+        tablePropertiesFromServer.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)
+            || tablePropertiesFromServer.containsKey(
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+  }
+
+  @Test
+  public void testManagedDeltaReplaceRejectsMetadataChanges() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    List<String> statements =
+        List.of(
+            String.format("REPLACE TABLE %s (i INT, renamed STRING) USING DELTA", fullTableName),
+            String.format(
+                "REPLACE TABLE %s (i INT, s STRING) USING DELTA PARTITIONED BY (s)", fullTableName),
+            String.format(
+                "CREATE OR REPLACE TABLE %s (i INT, s STRING) USING DELTA "
+                    + "TBLPROPERTIES ('delta.appendOnly' = 'true')",
+                fullTableName));
+
+    for (String statement : statements) {
+      assertThatThrownBy(() -> sql(statement))
+          .hasMessageContaining("Replacing a catalog-managed table");
+    }
+  }
+
+  @Test
+  public void testManagedDeltaReplaceRejectsUserSuppliedExistingTableHandoffProperties() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CREATE OR REPLACE TABLE %s USING DELTA "
+                        + "TBLPROPERTIES ('%s' = 'spoofed-id') AS SELECT 2 AS i, 'b' AS s",
+                    fullTableName, EXISTING_TABLE_ID_KEY))
+        .hasMessageContaining(String.format("Cannot specify property '%s'", EXISTING_TABLE_ID_KEY));
+  }
+
+  @Test
+  public void testManagedDeltaReplaceAsSelectRejectsSchemaChanges() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    assertThatThrownBy(
+            () ->
+                sql("REPLACE TABLE %s USING DELTA AS SELECT 1 AS i, 2 AS extra_col", fullTableName))
+        .hasMessageContaining("Replacing a catalog-managed table");
+  }
+
+  @Test
+  public void testManagedCreateOrReplaceRejectsSchemaChanges() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    assertThatThrownBy(
+            () ->
+                sql("CREATE OR REPLACE TABLE %s (i INT, extra_col INT) USING DELTA", fullTableName))
+        .hasMessageContaining("Replacing a catalog-managed table");
   }
 
   @Override

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -5,11 +5,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.model.CreateStagingTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.StagingTableInfo;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.client.model.TemporaryCredentials;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Map;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.StagingTableCatalog;
@@ -20,15 +32,31 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
-/** Tests that stageCreate delegates to the underlying StagingTableCatalog. */
+/** Tests UC staged-table handoff for managed Delta create/replace flows. */
 public class UCSingleCatalogStagingTableTest {
 
+  private static final String EXISTING_TABLE_LOCATION_KEY =
+      "unitycatalog.internal.delta.replace.existingTableLocation";
+  private static final String EXISTING_TABLE_TYPE_KEY =
+      "unitycatalog.internal.delta.replace.existingTableType";
+  private static final String EXISTING_TABLE_ID_KEY =
+      "unitycatalog.internal.delta.replace.existingTableId";
+  private static final String CREATE_WHEN_MISSING_KEY =
+      "unitycatalog.internal.delta.replace.createWhenMissing";
   private static final Identifier IDENT = Identifier.of(new String[] {"schema"}, "table");
   private static final StructType SCHEMA = new StructType().add("id", DataTypes.IntegerType, false);
   private static final Transform[] PARTITIONS = new Transform[0];
-  // PROP_EXTERNAL bypasses the managed-table path in prepareTableProperties.
   private static final Map<String, String> PROPS = Map.of(TableCatalog.PROP_EXTERNAL, "true");
+  private static final Map<String, String> MANAGED_DELTA_PROPS =
+      Map.of(
+          TableCatalog.PROP_PROVIDER,
+          "delta",
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+  private static final Map<String, String> REPLACE_DELTA_PROPS =
+      Map.of(TableCatalog.PROP_PROVIDER, "delta");
 
   private UCSingleCatalog catalog;
   private StagingTableCatalog mockDelegate;
@@ -54,18 +82,13 @@ public class UCSingleCatalogStagingTableTest {
   @Test
   public void testStageCreateFailsWhenDelegateIsNotStagingCatalog() {
     UCSingleCatalog nonStagingCatalog = new UCSingleCatalog();
-    setDelegate(nonStagingCatalog, mock(TableCatalog.class));
+    setField(nonStagingCatalog, "delegate", mock(TableCatalog.class));
 
     assertThatThrownBy(() -> nonStagingCatalog.stageCreate(IDENT, SCHEMA, PARTITIONS, PROPS))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageContaining("not supported");
   }
 
-  /**
-   * When LOAD_DELTA_CATALOG is false, initialize() sets the delegate to UCProxy directly (a plain
-   * TableCatalog, not a StagingTableCatalog). Calling stageCreate should throw
-   * UnsupportedOperationException because UCProxy does not implement StagingTableCatalog.
-   */
   @Test
   public void testStageCreateFailWhenNoDeltaCatalog() {
     UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
@@ -85,11 +108,268 @@ public class UCSingleCatalogStagingTableTest {
     }
   }
 
+  @Test
+  public void testStageCreateOrReplaceMissingManagedTableUsesManagedCreatePath() throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    TemporaryCredentialsApi mockTempCredsApi = mock(TemporaryCredentialsApi.class);
+    StagedTable staged = mock(StagedTable.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any())).thenReturn(staged);
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+    when(mockTablesApi.createStagingTable(any(CreateStagingTable.class)))
+        .thenReturn(
+            new StagingTableInfo().id("staging-id").stagingLocation("file:///tmp/uc-staging"));
+    when(mockTempCredsApi.generateTemporaryTableCredentials(any()))
+        .thenReturn(new TemporaryCredentials());
+
+    setField(catalog, "tablesApi", mockTablesApi);
+    setField(catalog, "temporaryCredentialsApi", mockTempCredsApi);
+    setField(catalog, "uri", URI.create("http://localhost"));
+
+    StagedTable result =
+        catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, MANAGED_DELTA_PROPS);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mockTablesApi).createStagingTable(any(CreateStagingTable.class));
+    verify(mockTempCredsApi).generateTemporaryTableCredentials(any());
+    verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_LOCATION, "file:///tmp/uc-staging")
+        .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+        .containsEntry(CREATE_WHEN_MISSING_KEY, "true")
+        .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, "staging-id")
+        .containsEntry(UCTableProperties.UC_TABLE_ID_KEY_OLD, "staging-id");
+    assertThat(result).isSameAs(staged);
+  }
+
+  @Test
+  public void testStageCreateOrReplaceMissingManagedTableRequiresCatalogManagedFeature()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+
+    setField(catalog, "tablesApi", mockTablesApi);
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT, SCHEMA, PARTITIONS, Map.of(TableCatalog.PROP_PROVIDER, "delta")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Managed table creation requires table property");
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceRejectsUserSuppliedExistingTableHandoffProperties()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+
+    setField(catalog, "tablesApi", mockTablesApi);
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER,
+                        "delta",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE,
+                        EXISTING_TABLE_LOCATION_KEY,
+                        "file:///tmp/uc-managed-table")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Cannot specify property '" + EXISTING_TABLE_LOCATION_KEY + "'");
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceRejectsOptionPrefixedExistingTableHandoffProperties()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+
+    setField(catalog, "tablesApi", mockTablesApi);
+
+    String optionKey = TableCatalog.OPTION_PREFIX + EXISTING_TABLE_ID_KEY;
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER,
+                        "delta",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE,
+                        optionKey,
+                        "table-id")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Cannot specify property '" + optionKey + "'");
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceRejectsUserSuppliedCreateWhenMissingProperty()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+
+    setField(catalog, "tablesApi", mockTablesApi);
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER,
+                        "delta",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE,
+                        CREATE_WHEN_MISSING_KEY,
+                        "true")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Cannot specify property '" + CREATE_WHEN_MISSING_KEY + "'");
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceExistingManagedTablePassesExistingTableHandoff()
+      throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    TemporaryCredentialsApi mockTempCredsApi = mock(TemporaryCredentialsApi.class);
+    StagedTable staged = mock(StagedTable.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any())).thenReturn(staged);
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenReturn(
+            new TableInfo()
+                .tableType(TableType.MANAGED)
+                .dataSourceFormat(DataSourceFormat.DELTA)
+                .storageLocation("file:///tmp/uc-managed-table")
+                .tableId("table-id")
+                .properties(
+                    Map.of(
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)));
+    when(mockTempCredsApi.generateTemporaryTableCredentials(any()))
+        .thenReturn(new TemporaryCredentials());
+
+    setField(catalog, "tablesApi", mockTablesApi);
+    setField(catalog, "temporaryCredentialsApi", mockTempCredsApi);
+    setField(catalog, "uri", URI.create("http://localhost"));
+
+    StagedTable result =
+        catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
+    verify(mockTempCredsApi).generateTemporaryTableCredentials(any());
+    verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+        .containsEntry(EXISTING_TABLE_LOCATION_KEY, "file:///tmp/uc-managed-table")
+        .containsEntry(EXISTING_TABLE_TYPE_KEY, "MANAGED")
+        .containsEntry(EXISTING_TABLE_ID_KEY, "table-id");
+    assertThat(result).isSameAs(staged);
+  }
+
+  @Test
+  public void testStageReplaceExistingManagedTablePassesExistingTableHandoff() throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    TemporaryCredentialsApi mockTempCredsApi = mock(TemporaryCredentialsApi.class);
+    StagedTable staged = mock(StagedTable.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockDelegate.stageReplace(eq(IDENT), eq(SCHEMA), any(), any())).thenReturn(staged);
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenReturn(
+            new TableInfo()
+                .tableType(TableType.MANAGED)
+                .dataSourceFormat(DataSourceFormat.DELTA)
+                .storageLocation("file:///tmp/uc-managed-table")
+                .tableId("table-id")
+                .properties(
+                    Map.of(
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)));
+    when(mockTempCredsApi.generateTemporaryTableCredentials(any()))
+        .thenReturn(new TemporaryCredentials());
+
+    setField(catalog, "tablesApi", mockTablesApi);
+    setField(catalog, "temporaryCredentialsApi", mockTempCredsApi);
+    setField(catalog, "uri", URI.create("http://localhost"));
+
+    StagedTable result = catalog.stageReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mockTempCredsApi).generateTemporaryTableCredentials(any());
+    verify(mockDelegate).stageReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+        .containsEntry(EXISTING_TABLE_LOCATION_KEY, "file:///tmp/uc-managed-table")
+        .containsEntry(EXISTING_TABLE_TYPE_KEY, "MANAGED")
+        .containsEntry(EXISTING_TABLE_ID_KEY, "table-id");
+    assertThat(result).isSameAs(staged);
+  }
+
+  @Test
+  public void testStageReplaceMissingManagedTableThrowsNoSuchTable() throws Exception {
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    when(mockDelegate.name()).thenReturn("main");
+    when(mockTablesApi.getTable(eq("main.schema.table"), eq(false), eq(false)))
+        .thenThrow(new ApiException(404, "not found"));
+
+    setField(catalog, "tablesApi", mockTablesApi);
+
+    assertThatThrownBy(() -> catalog.stageReplace(IDENT, SCHEMA, PARTITIONS, REPLACE_DELTA_PROPS))
+        .isInstanceOf(NoSuchTableException.class);
+
+    verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
   private static void setDelegate(UCSingleCatalog catalog, TableCatalog delegate) {
+    setField(catalog, "delegate", delegate);
+  }
+
+  private static void setField(UCSingleCatalog catalog, String fieldName, Object value) {
     try {
-      Field f = UCSingleCatalog.class.getDeclaredField("delegate");
+      Field f = UCSingleCatalog.class.getDeclaredField(fieldName);
       f.setAccessible(true);
-      f.set(catalog, delegate);
+      f.set(catalog, value);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1394/files) to review incremental changes.
- [**stack/atomic-rtas-v2**](https://github.com/unitycatalog/unitycatalog/pull/1394) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1394/files)]
  - [stack/CI-testing](https://github.com/unitycatalog/unitycatalog/pull/1395) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1395/files/7c8453b7b21a2c4a7bdb03894592baefb3a04efd..a88f9f8eedf981ae1b251fd955cf4bddb3334bce)]

---------
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

UC-managed Delta tables already use a staged create path, but `REPLACE TABLE`, `REPLACE TABLE AS SELECT`, and `CREATE OR REPLACE TABLE` still stop at the Unity Catalog boundary. UC can resolve the existing table and determine whether it is a UC-managed Delta table, but that resolved target is not carried through the staged commit into Delta. That leaves these operations unsupported for managed tables or dependent on a second rediscovery step later in Delta, even though UC has already done the catalog lookup.

This PR changes the architecture so `UCSingleCatalog` resolves the existing UC-managed Delta target once during `stageReplace` and `stageCreateOrReplace`, vends credentials for that target, and passes a narrow internal handoff bundle into Delta containing the existing table location, table type, and stable UC table id. When `CREATE OR REPLACE` targets a missing managed table, UC stays on the managed-create path and marks that it should be treated as create-on-miss rather than replace-on-miss. Delta can then execute the commit against the already-resolved target instead of re-querying UC.

This is necessary to unblock atomic managed `REPLACE TABLE`, RTAS, and `CREATE OR REPLACE TABLE` while keeping the ownership boundary clear: Unity Catalog remains responsible for catalog lookup, staging, and temporary credentials, and Delta remains responsible for commit-time table replacement semantics. The scope here is intentionally limited to UC-managed Delta tables; external tables continue to be rejected until a follow-up design extends the same handoff model to them.