### PR TITLE
Add Spark catalog aliasing to UC catalog support

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -39,6 +39,7 @@ class UCSingleCatalog
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
+  private[this] var catalogName: String = null
 
   @volatile private var delegate: TableCatalog = null
 
@@ -47,6 +48,7 @@ class UCSingleCatalog
     Preconditions.checkArgument(urlStr != null,
       "uri must be specified for Unity Catalog '%s'", name)
     uri = new URI(urlStr)
+    catalogName = Option(options.get(OptionsUtil.WAREHOUSE)).getOrElse(name)
     tokenProvider = TokenProvider.create(AuthConfigUtils.buildAuthConfigs(options));
     renewCredEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.RENEW_CREDENTIAL_ENABLED,
@@ -149,7 +151,7 @@ class UCSingleCatalog
       properties: util.Map[String, String]): util.Map[String, String] = {
     // Get staging table location and table id from UC
     val createStagingTable = new CreateStagingTable()
-      .catalogName(name())
+      .catalogName(catalogName)
       .schemaName(ident.namespace().head)
       .name(ident.name())
     val stagingTableInfo = tablesApi.createStagingTable(createStagingTable)
@@ -357,10 +359,12 @@ private class UCProxy(
     tablesApi: TablesApi,
     temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
   private[this] var name: String = null
+  private[this] var catalogName: String = null
   private[this] var schemasApi: SchemasApi = null
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name
+    this.catalogName = Option(options.get(OptionsUtil.WAREHOUSE)).getOrElse(name)
     schemasApi = new SchemasApi(apiClient)
   }
 
@@ -372,7 +376,6 @@ private class UCProxy(
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(namespace)
 
-    val catalogName = this.name
     val schemaName = namespace.head
     val maxResults = 0
     val pageToken = null
@@ -383,14 +386,15 @@ private class UCProxy(
   override def loadTable(ident: Identifier): Table = {
     val t = try {
       tablesApi.getTable(
-        UCSingleCatalog.fullTableNameForApi(this.name, ident),
+        UCSingleCatalog.fullTableNameForApi(catalogName, ident),
         /* readStreamingTableAsManaged = */ true,
         /* readMaterializedViewAsManaged = */ true)
     } catch {
       case e: ApiException if e.getCode == 404 =>
         throw new NoSuchTableException(ident)
     }
-    val identifier = TableIdentifier(t.getName, Some(t.getSchemaName), Some(t.getCatalogName))
+    // Keep Spark facing identifiers in the configured catalog name for alias support
+    val identifier = TableIdentifier(t.getName, Some(t.getSchemaName), Some(name()))
     val partitionCols = scala.collection.mutable.ArrayBuffer.empty[(String, Int)]
     val fields = t.getColumns.asScala.map { col =>
       Option(col.getPartitionIndex).foreach { index =>
@@ -480,7 +484,7 @@ private class UCProxy(
     val createTable = new CreateTable()
     createTable.setName(ident.name())
     createTable.setSchemaName(ident.namespace().head)
-    createTable.setCatalogName(this.name)
+    createTable.setCatalogName(catalogName)
 
     val hasExternalClause = properties.containsKey(TableCatalog.PROP_EXTERNAL)
     val storageLocation = properties.get(TableCatalog.PROP_LOCATION)
@@ -606,7 +610,7 @@ private class UCProxy(
   }
 
   override def dropTable(ident: Identifier): Boolean = {
-    val ret = tablesApi.deleteTable(UCSingleCatalog.fullTableNameForApi(this.name, ident))
+    val ret = tablesApi.deleteTable(UCSingleCatalog.fullTableNameForApi(catalogName, ident))
     if (ret == 200) true else false
   }
 
@@ -615,7 +619,7 @@ private class UCProxy(
   }
 
   override def listNamespaces(): Array[Array[String]] = {
-    schemasApi.listSchemas(name, 0, null).getSchemas.asScala.map { schema =>
+    schemasApi.listSchemas(catalogName, 0, null).getSchemas.asScala.map { schema =>
       Array(schema.getName)
     }.toArray
   }
@@ -627,7 +631,7 @@ private class UCProxy(
   override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(namespace)
     val schema = try {
-      schemasApi.getSchema(name + "." + namespace(0))
+      schemasApi.getSchema(catalogName + "." + namespace(0))
     } catch {
       case e: ApiException if e.getCode == 404 =>
         throw new NoSuchNamespaceException(namespace)
@@ -649,7 +653,7 @@ private class UCProxy(
   override def createNamespace(namespace: Array[String], metadata: util.Map[String, String]): Unit = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(namespace)
     val createSchema = new CreateSchema()
-    createSchema.setCatalogName(this.name)
+    createSchema.setCatalogName(catalogName)
     createSchema.setName(namespace.head)
     createSchema.setProperties(metadata)
     schemasApi.createSchema(createSchema)
@@ -661,7 +665,7 @@ private class UCProxy(
 
   override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(namespace)
-    schemasApi.deleteSchema(name + "." + namespace.head, cascade)
+    schemasApi.deleteSchema(catalogName + "." + namespace.head, cascade)
     true
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
@@ -2,12 +2,18 @@ package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
+import io.unitycatalog.spark.utils.OptionsUtil;
 import java.util.List;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +32,50 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
     assertThat(session.catalog().databaseExists("my_test_database")).isTrue();
     sql("DROP DATABASE %s.my_test_database;", SPARK_CATALOG);
     assertThat(session.catalog().databaseExists("my_test_database")).isFalse();
+  }
+
+  @Test
+  public void testCatalogAliasing() {
+    String aliasedCatalog = "alias_catalog";
+    String tableName = "alias_table";
+    String fullTableName = aliasedCatalog + "." + SCHEMA_NAME + "." + tableName;
+    String catalogConf = "spark.sql.catalog." + aliasedCatalog;
+    session =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config(catalogConf, UCSingleCatalog.class.getName())
+            .config(catalogConf + "." + OptionsUtil.URI, serverConfig.getServerUrl())
+            .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
+            .config(catalogConf + "." + OptionsUtil.WAREHOUSE, CATALOG_NAME)
+            .getOrCreate();
+
+    session.catalog().setCurrentCatalog(aliasedCatalog);
+    List<Row> schemas = sql("SHOW SCHEMAS");
+    assertThat(schemas.get(0).getString(0)).isEqualTo(SCHEMA_NAME);
+
+    List<Row> rows = sql("DESC SCHEMA %s", SCHEMA_NAME);
+    assertThat(rows.get(0).getString(0)).isEqualTo("Catalog Name");
+    assertThat(rows.get(0).getString(1)).isEqualTo(aliasedCatalog);
+    assertThat(rows.get(1).getString(0)).isEqualTo("Namespace Name");
+    assertThat(rows.get(1).getString(1)).isEqualTo(SCHEMA_NAME);
+
+    sql(
+        "CREATE TABLE %s (id INT) USING PARQUET LOCATION 's3://test-bucket0/%s'",
+        fullTableName, tableName);
+    List<Row> tableDescRows = sql("DESC EXTENDED %s", fullTableName);
+    Row nameRow =
+        tableDescRows.stream()
+            .filter(row -> "Name".equals(row.getString(0)))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected Name row in DESCRIBE TABLE EXTENDED"));
+    assertThat(nameRow.getString(1)).isIn(fullTableName, SCHEMA_NAME + "." + tableName);
+
+    SdkSchemaOperations schemaOperations = new SdkSchemaOperations(createApiClient(serverConfig));
+    assertThatCode(() -> schemaOperations.getSchema(CATALOG_NAME + "." + SCHEMA_NAME))
+        .doesNotThrowAnyException();
+    assertThatThrownBy(() -> schemaOperations.getSchema(aliasedCatalog + "." + SCHEMA_NAME))
+        .isInstanceOf(ApiException.class);
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The Spark UC connector currently does not correctly alias 3-part identifiers. The catalog name that would be used would be the Spark catalog name and not the actual warehouse catalog name. 

When:

```
"spark.sql.catalog.target.warehouse": "actual"
```

is set `target.schema.table` identifiers should resolve to `actual.schema.table` but currently resolves instead to the Spark catalog name of `target`. This change keeps track of the resolved catalog so we can use the warehouse option. 