### PR TITLE
[Build] Fix snapshot publishing URL to use new Sonatype Central endpoint

### DIFF
--- a/project/ReleaseSettings.scala
+++ b/project/ReleaseSettings.scala
@@ -58,12 +58,17 @@ object ReleaseSettings {
       sys.env.getOrElse("SONATYPE_USERNAME", ""),
       sys.env.getOrElse("SONATYPE_PASSWORD", "")
     ),
+    credentials += Credentials(
+      "Sonatype Nexus Repository Manager",
+      "central.sonatype.com",
+      sys.env.getOrElse("SONATYPE_USERNAME", ""),
+      sys.env.getOrElse("SONATYPE_PASSWORD", "")
+    ),
     publishTo := {
-      val ossrhBase = "https://ossrh-staging-api.central.sonatype.com/"
       if (isSnapshot.value) {
-        Some("snapshots" at ossrhBase + "content/repositories/snapshots")
+        Some("snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")
       } else {
-        Some("releases" at ossrhBase + "service/local/staging/deploy/maven2")
+        Some("releases" at "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2")
       }
     },
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -100,7 +105,7 @@ object ReleaseSettings {
   lazy val rootReleaseSettings = Seq(
     publishArtifact := false,
     publish / skip := true,
-    publishTo := Some("snapshots" at "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots"),
+    publishTo := Some("snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"),
     releaseCrossBuild := false,
     crossScalaVersions := Nil,
     releaseProcess := Seq[ReleaseStep](


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The old OSSRH snapshot endpoint (ossrh-staging-api.central.sonatype.com/ content/repositories/snapshots) now returns HTTP 400 and no longer accepts uploads. Update to the new Sonatype Central Portal snapshot URL (central.sonatype.com/repository/maven-snapshots/) and add the corresponding credentials entry for the new host.


After this fix,  I can successfully build the `io.unitycatalog:unitycatalig-client:0.5.0-SNAPSHOT`, and also upload them into the public maven snapshots repo now. 

the command to upload is here: 

```bash
SONATYPE_USERNAME=<username> \
SONATYPE_PASSWORD=<password> \
PGP_PASSPHRASE=<passphrase> \
build/sbt +publishSigned
```

After the command, actually it will upload those artifacts to central maven snapshots repos.

Based on the published output, the direct download URLs are:                                                                                                                                                   

* Server:                                                                                                                                                                                                        
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-server/0.5.0-SNAPSHOT/unitycatalog-server-0.5.0-SNAPSHOT.jar
                                                                                                                                                                                                                 
* Client:                    
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-client/0.5.0-SNAPSHOT/unitycatalog-client-0.5.0-SNAPSHOT.jar

* Spark:
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-spark_2.13/0.5.0-SNAPSHOT/unitycatalog-spark_2.13-0.5.0-SNAPSHOT.jar

* For POMs:
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-server/0.5.0-SNAPSHOT/unitycatalog-server-0.5.0-SNAPSHOT.pom
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-client/0.5.0-SNAPSHOT/unitycatalog-client-0.5.0-SNAPSHOT.pom
  https://central.sonatype.com/repository/maven-snapshots/io/unitycatalog/unitycatalog-spark_2.13/0.5.0-SNAPSHOT/unitycatalog-spark_2.13-0.5.0-SNAPSHOT.pom


And actualy, we can use the command to start the spark shell then. 


```bash
export CATALOG_NAME=main
export UC_URI=$UC_URI
export UC_TOKEN=$UC_TOKEN

/Users/zheng.hu/soft/spark-4.1.0/spark-4.1.0-bin-hadoop3/bin/spark-sql --name "local-uc-test" \
    --master "local[*]" \
    --packages "org.apache.hadoop:hadoop-aws:3.4.2,io.delta:delta-spark_2.13:4.1.0,io.unitycatalog:unitycatalog-spark_2.13:0.5.0-SNAPSHOT" \
    --repositories "https://central.sonatype.com/repository/maven-snapshots/" \
    --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
    --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
    --conf "spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem" \
    --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
    --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
    --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN"
    --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
```