### PR TITLE
UI: Display owner and properties in entity detail sidebars

### DIFF
--- a/ui/src/components/PropertiesDisplay.tsx
+++ b/ui/src/components/PropertiesDisplay.tsx
@@ -1,0 +1,23 @@
+import { Flex, Tag, Typography } from 'antd';
+
+interface PropertiesDisplayProps {
+  properties?: { [key: string]: string };
+}
+
+export default function PropertiesDisplay({
+  properties,
+}: PropertiesDisplayProps) {
+  if (!properties || Object.keys(properties).length === 0) return null;
+
+  return (
+    <Flex vertical gap="middle">
+      <Typography.Title level={5}>Properties</Typography.Title>
+      {Object.entries(properties).map(([key, value]) => (
+        <div key={key}>
+          <Typography.Text strong>{key}: </Typography.Text>
+          <Tag>{value}</Tag>
+        </div>
+      ))}
+    </Flex>
+  );
+}

--- a/ui/src/components/catalogs/CatalogSidebar.tsx
+++ b/ui/src/components/catalogs/CatalogSidebar.tsx
@@ -2,12 +2,18 @@ import { Typography } from 'antd';
 import { CatalogInterface, useGetCatalog } from '../../hooks/catalog';
 import { formatTimestamp } from '../../utils/formatTimestamp';
 import MetadataList, { MetadataListType } from '../MetadataList';
+import PropertiesDisplay from '../PropertiesDisplay';
 
 interface CatalogSidebarProps {
   catalog: string;
 }
 
 const CATALOG_METADATA: MetadataListType<CatalogInterface> = [
+  {
+    key: 'owner',
+    label: 'Owner',
+    dataIndex: 'owner',
+  },
   {
     key: 'created_at',
     label: 'Created at',
@@ -32,10 +38,13 @@ export default function CatalogSidebar({ catalog }: CatalogSidebarProps) {
   if (!data) return null;
 
   return (
-    <MetadataList
-      data={data}
-      metadata={CATALOG_METADATA}
-      title="Catalog details"
-    />
+    <>
+      <MetadataList
+        data={data}
+        metadata={CATALOG_METADATA}
+        title="Catalog details"
+      />
+      <PropertiesDisplay properties={data.properties} />
+    </>
   );
 }

--- a/ui/src/components/functions/FunctionSidebar.tsx
+++ b/ui/src/components/functions/FunctionSidebar.tsx
@@ -1,10 +1,17 @@
+import { useMemo } from 'react';
 import { Typography } from 'antd';
 import MetadataList, { MetadataListType } from '../MetadataList';
+import PropertiesDisplay from '../PropertiesDisplay';
 import { formatTimestamp } from '../../utils/formatTimestamp';
 import { FunctionInterface, useGetFunction } from '../../hooks/functions';
 
 const FUNCTION_METADATA: MetadataListType<Omit<FunctionInterface, 'columns'>> =
   [
+    {
+      key: 'owner',
+      label: 'Owner',
+      dataIndex: 'owner',
+    },
     {
       key: 'created_at',
       label: 'Created at',
@@ -43,13 +50,25 @@ export default function FunctionSidebar({
     name: [catalog, schema, ucFunction].join('.'),
   });
 
+  const parsedProperties = useMemo(() => {
+    if (!data?.properties) return undefined;
+    try {
+      return JSON.parse(data.properties);
+    } catch {
+      return undefined;
+    }
+  }, [data?.properties]);
+
   if (!data) return null;
 
   return (
-    <MetadataList
-      title="Function details"
-      metadata={FUNCTION_METADATA}
-      data={data}
-    />
+    <>
+      <MetadataList
+        title="Function details"
+        metadata={FUNCTION_METADATA}
+        data={data}
+      />
+      <PropertiesDisplay properties={parsedProperties} />
+    </>
   );
 }

--- a/ui/src/components/models/ModelSidebar.tsx
+++ b/ui/src/components/models/ModelSidebar.tsx
@@ -5,6 +5,11 @@ import { ModelInterface, useGetModel } from '../../hooks/models';
 
 const MODEL_METADATA: MetadataListType<ModelInterface> = [
   {
+    key: 'owner',
+    label: 'Owner',
+    dataIndex: 'owner',
+  },
+  {
     key: 'created_at',
     label: 'Created at',
     dataIndex: 'created_at',

--- a/ui/src/components/schemas/SchemaSidebar.tsx
+++ b/ui/src/components/schemas/SchemaSidebar.tsx
@@ -1,6 +1,7 @@
 import { Typography } from 'antd';
 import { formatTimestamp } from '../../utils/formatTimestamp';
 import MetadataList, { MetadataListType } from '../MetadataList';
+import PropertiesDisplay from '../PropertiesDisplay';
 import { SchemaInterface, useGetSchema } from '../../hooks/schemas';
 
 interface SchemaSidebarProps {
@@ -9,6 +10,11 @@ interface SchemaSidebarProps {
 }
 
 const SCHEMA_METADATA: MetadataListType<SchemaInterface> = [
+  {
+    key: 'owner',
+    label: 'Owner',
+    dataIndex: 'owner',
+  },
   {
     key: 'created_at',
     label: 'Created at',
@@ -33,10 +39,13 @@ export default function SchemaSidebar({ catalog, schema }: SchemaSidebarProps) {
   if (!data) return null;
 
   return (
-    <MetadataList
-      data={data}
-      metadata={SCHEMA_METADATA}
-      title="Schema details"
-    />
+    <>
+      <MetadataList
+        data={data}
+        metadata={SCHEMA_METADATA}
+        title="Schema details"
+      />
+      <PropertiesDisplay properties={data.properties} />
+    </>
   );
 }

--- a/ui/src/components/tables/TablesSidebar.tsx
+++ b/ui/src/components/tables/TablesSidebar.tsx
@@ -1,6 +1,7 @@
 import { Typography } from 'antd';
 import { formatTimestamp } from '../../utils/formatTimestamp';
 import MetadataList, { MetadataListType } from '../MetadataList';
+import PropertiesDisplay from '../PropertiesDisplay';
 import { TableInterface, useGetTable } from '../../hooks/tables';
 
 interface TableSidebarProps {
@@ -10,6 +11,17 @@ interface TableSidebarProps {
 }
 
 const TABLE_METADATA: MetadataListType<Omit<TableInterface, 'columns'>> = [
+  {
+    key: 'owner',
+    label: 'Owner',
+    dataIndex: 'owner',
+  },
+  {
+    key: 'table_type',
+    label: 'Table type',
+    dataIndex: 'table_type',
+    render: (value) => <Typography.Text code>{value}</Typography.Text>,
+  },
   {
     key: 'created_at',
     label: 'Created at',
@@ -48,10 +60,13 @@ export default function TableSidebar({
   const { columns, ...metadata } = data;
 
   return (
-    <MetadataList
-      data={metadata}
-      metadata={TABLE_METADATA}
-      title="Table details"
-    />
+    <>
+      <MetadataList
+        data={metadata}
+        metadata={TABLE_METADATA}
+        title="Table details"
+      />
+      <PropertiesDisplay properties={metadata.properties} />
+    </>
   );
 }

--- a/ui/src/components/volumes/VolumeSidebar.tsx
+++ b/ui/src/components/volumes/VolumeSidebar.tsx
@@ -11,6 +11,11 @@ interface VolumeSidebarProps {
 
 const VOLUME_METADATA: MetadataListType<VolumeInterface> = [
   {
+    key: 'owner',
+    label: 'Owner',
+    dataIndex: 'owner',
+  },
+  {
     key: 'created_at',
     dataIndex: 'created_at',
     label: 'Created at',


### PR DESCRIPTION
## Summary
- Add **owner** field to all entity detail sidebars (catalog, schema, table, volume, model, function)
- Display **user-defined properties** (key-value pairs) below core metadata for entities that support them (catalog, schema, table, function)
- Add **table_type** field to the table detail sidebar
- Add shared `PropertiesDisplay` component that renders `SecurablePropertiesMap` as labeled tags
- Handle `FunctionInfo.properties` JSON-serialized string format with safe parsing

## Motivation
The Unity Catalog API returns `owner`, `properties`, and `table_type` fields for entities, but the UI sidebar currently only displays timestamps and a few type-specific fields. This PR surfaces all available metadata so users can see ownership and custom properties without needing the API directly.

## Changes
| File | Change |
|------|--------|
| `PropertiesDisplay.tsx` | New shared component for rendering properties key-value map |
| `CatalogSidebar.tsx` | Added owner + PropertiesDisplay |
| `SchemaSidebar.tsx` | Added owner + PropertiesDisplay |
| `TablesSidebar.tsx` | Added owner, table_type + PropertiesDisplay |
| `VolumeSidebar.tsx` | Added owner (VolumeInfo has no properties in spec) |
| `ModelSidebar.tsx` | Added owner (RegisteredModelInfo has no properties in spec) |
| `FunctionSidebar.tsx` | Added owner + PropertiesDisplay (with JSON.parse for string-typed properties) |

## Test plan
- [ ] Verify owner displays correctly when set on catalogs, schemas, tables, volumes, models, functions
- [ ] Verify owner field gracefully hidden when null/undefined
- [ ] Verify properties section renders for catalogs, schemas, and tables with custom properties
- [ ] Verify properties section hidden when no properties are set
- [ ] Verify function properties JSON string is parsed and displayed correctly
- [ ] Run `yarn build` to confirm no TypeScript/compilation errors