### PR TITLE
[Spark] Preserve caller properties on managed replace

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -225,13 +225,9 @@ class UCSingleCatalog
       throw new ApiException(
         s"Invalid table metadata for $fullTableName: tableId must be set")
     }
-    // Third, build the minimal property set Delta needs in order to write back to the current
-    // managed table. Existing managed REPLACE does not forward arbitrary caller properties
-    // because metadata updates are not supported in this path yet.
+    // Third, build the properties Delta needs in order to write back to the current managed table.
     val newProps = new util.HashMap[String, String]
-    Option(properties.get(TableCatalog.PROP_PROVIDER)).foreach { provider =>
-      newProps.put(TableCatalog.PROP_PROVIDER, provider)
-    }
+    newProps.putAll(properties)
     // Preserve the catalog-managed marker on the properties passed to Delta for replace.
     newProps.put(
       UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -196,7 +196,7 @@ public class UCSingleCatalogStagingTableTest {
   }
 
   @Test
-  public void testStageReplaceExistingManagedTableDropsUserProperties() throws Exception {
+  public void testStageReplaceExistingManagedTablePreservesUserProperties() throws Exception {
     ManagedReplaceMocks mocks = mockExistingManagedReplace(false);
 
     catalog.stageReplace(
@@ -211,7 +211,7 @@ public class UCSingleCatalogStagingTableTest {
     verify(mockDelegate).stageReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
     assertThat(propsCaptor.getValue())
         .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
-        .doesNotContainKey("delta.appendOnly");
+        .containsEntry("delta.appendOnly", "true");
     verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
   }
 


### PR DESCRIPTION
## Summary
Preserve caller-supplied properties on the existing managed-table replace path in `UCSingleCatalog`.

## Testing
- `build/sbt -J-Xmx4g -J-XX:+UseG1GC -DsparkVersion=4.0.0 'spark/testOnly io.unitycatalog.spark.UCSingleCatalogStagingTableTest'`
