### PR TITLE
[Spark] Preserve Delta provider on managed replace

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -231,9 +231,10 @@ class UCSingleCatalog
     Option(properties.get(TableCatalog.PROP_PROVIDER))
       .filterNot(_.equalsIgnoreCase(existingProvider))
       .foreach(provider => throw new ApiException(
-        s"$operation on existing UC-managed Delta table $fullTableName cannot change provider " +
-          s"from ${existingProvider.toUpperCase(Locale.ROOT)} to " +
-          s"${provider.toUpperCase(Locale.ROOT)}."))
+        s"$operation is only supported for Unity Catalog managed Delta tables and requires " +
+          s"USING DELTA. Cannot change table format from " +
+          s"${existingProvider.toUpperCase(Locale.ROOT)} to " +
+          s"${provider.toUpperCase(Locale.ROOT)} for $fullTableName."))
     val newProps = new util.HashMap[String, String]
     newProps.putAll(properties)
     newProps.put(TableCatalog.PROP_PROVIDER, existingProvider)
@@ -351,7 +352,7 @@ class UCSingleCatalog
       existingTable.get,
       properties,
       "REPLACE TABLE")
-    assertProviderSpecified("REPLACE TABLE", newProps)
+    UCSingleCatalog.requireProviderSpecified("REPLACE TABLE", newProps)
     stagingCatalog.stageReplace(ident, schema, partitions, newProps)
   }
 
@@ -375,7 +376,7 @@ class UCSingleCatalog
       validateManagedDeltaCreateProperties(properties)
       stageManagedDeltaTableAndGetProps(ident, properties)
     }
-    assertProviderSpecified("CREATE OR REPLACE TABLE", newProps)
+    UCSingleCatalog.requireProviderSpecified("CREATE OR REPLACE TABLE", newProps)
     stagingCatalog.stageCreateOrReplace(ident, schema, partitions, newProps)
   }
 
@@ -420,16 +421,6 @@ class UCSingleCatalog
       stagingCatalog.stageCreate(ident, schema, partitions, properties)
     }
   }
-
-  private def assertProviderSpecified(
-      operation: String,
-      properties: util.Map[String, String]): Unit = {
-    Preconditions.checkArgument(
-      properties.get(TableCatalog.PROP_PROVIDER) != null,
-      "%s requires '%s' to be set",
-      operation,
-      TableCatalog.PROP_PROVIDER)
-  }
 }
 
 object UCSingleCatalog {
@@ -445,6 +436,15 @@ object UCSingleCatalog {
     props.putAll(credentialProps.map {
       case (k, v) => (prefix + k, v)
     }.asJava)
+  }
+
+  def requireProviderSpecified(
+      operation: String,
+      properties: util.Map[String, String]): Unit = {
+    Preconditions.checkArgument(
+      properties.get(TableCatalog.PROP_PROVIDER) != null,
+      "%s requires USING <format> (for example, USING DELTA)",
+      operation)
   }
 
   /**
@@ -623,11 +623,7 @@ private class UCProxy(
 
   override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): Table = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
-    Preconditions.checkArgument(
-      properties.get(TableCatalog.PROP_PROVIDER) != null,
-      "%s requires '%s' to be set",
-      "CREATE TABLE",
-      TableCatalog.PROP_PROVIDER)
+    UCSingleCatalog.requireProviderSpecified("CREATE TABLE", properties)
 
     val createTable = new CreateTable()
     createTable.setName(ident.name())

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -204,6 +204,25 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
                 "CREATE OR REPLACE TABLE %s (i INT, extra_col INT) USING DELTA", fullTableName)));
   }
 
+  @Test
+  public void testManagedDeltaReplaceRejectsProviderChangeWithoutDroppingTable()
+      throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+    sql("INSERT INTO %s SELECT 1, 'old'", fullTableName);
+    String originalTableId = loadTableInfo(fullTableName).getTableId();
+
+    assertThatThrownBy(
+            () -> sql("REPLACE TABLE %s USING PARQUET AS SELECT 2 AS i, 'new' AS s", fullTableName))
+        .hasMessageContaining("requires USING DELTA")
+        .hasMessageContaining("Cannot change table format from DELTA to PARQUET");
+
+    validateRows(sql("SELECT * FROM %s", fullTableName), Pair.of(1, "old"));
+    assertManagedTableHasUcProperties(loadTableInfo(fullTableName), originalTableId);
+  }
+
   @Override
   protected void prepareExistingTableForDdl(TableSetupOptions options) {
     TableSetupOptions existingOptions =

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -256,9 +256,57 @@ public class UCSingleCatalogStagingTableTest {
                         UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
                         UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)))
         .isInstanceOf(ApiException.class)
-        .hasMessageContaining("cannot change provider from DELTA to PARQUET");
+        .hasMessageContaining("requires USING DELTA")
+        .hasMessageContaining("Cannot change table format from DELTA to PARQUET");
 
     verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceExistingManagedTableInjectsDeltaProviderWhenOmitted()
+      throws Exception {
+    ManagedReplaceMocks mocks = mockExistingManagedReplace(true);
+
+    catalog.stageCreateOrReplace(
+        IDENT,
+        SCHEMA,
+        PARTITIONS,
+        Map.of(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+
+    verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    assertThat(propsCaptor.getValue())
+        .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+    verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
+  }
+
+  @Test
+  public void testStageCreateOrReplaceExistingManagedTableRejectsProviderChange() throws Exception {
+    mockExistingManagedReplace(true);
+
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreateOrReplace(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER,
+                        "parquet",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("requires USING DELTA")
+        .hasMessageContaining("Cannot change table format from DELTA to PARQUET");
+
+    verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
   }
 
   private void assertExistingManagedTableReplaceUsesManagedProps(boolean createOrReplace)


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
- preserve the existing Delta provider for replace on existing UC-managed Delta tables when the caller omits `USING DELTA`
- reject explicit provider changes on existing UC-managed Delta replace paths
- add staging-table coverage for omitted-provider normalization and provider-mismatch rejection

essentially what can happen is:
```sql
-- create a UC-managed delta table
spark-sql ()> CREATE TABLE main.demo_zh.t_rtas USING DELTA
            >   TBLPROPERTIES ('delta.feature.catalogManaged'='supported')
            >   AS SELECT 1 AS i, 'old' AS s;

-- replace without specifying USING DELTA
spark-sql ()> REPLACE TABLE main.demo_zh.t_rtas
            >   TBLPROPERTIES ('delta.feature.catalogManaged'='supported')
            >   AS SELECT 2 AS i, 'new' AS s;
[FAILURE FOR REPLACE]

-- look at table 
spark-sql ()> SELECT * FROM main.demo_zh.t_rtas;
--> TABLE IS NOT FOUND AND IT HAS BEEN DROPPED
```

this is because it was default to regular drop, create table replace path instead of using Delta staging atomic replace path.
```java
override def stageReplace(
      ident: Identifier,
      schema: StructType,
      partitions: Array[Transform],
      properties: util.Map[String, String]): StagedTable =
    recordFrameProfile("DeltaCatalog", "stageReplace") {
      if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
        new StagedDeltaTableV2(
          ident,
          schema,
          partitions,
          properties,
          TableCreationModes.Replace
        )
      } else {
        super.dropTable(ident)
        val table = createCatalogTable(ident, schema, partitions, properties
        )
        BestEffortStagedTable(ident, table, this)
      }
    }
```

This is now working because we pass in the provider `DELTA`. If the user specifies any other format, it will fail on the UC side.

<!-- Please state what you've changed and how it might affect the users. -->
**Testing**
- build/sbt -J-Xmx4g -J-XX:+UseG1GC -DsparkVersion=4.0.0 'spark/testOnly io.unitycatalog.spark.UCSingleCatalogStagingTableTest'