### PR TITLE
Add delta/v1 managed table demo APIs

### DIFF
--- a/api/Apis/DeltaV1Api.md
+++ b/api/Apis/DeltaV1Api.md
@@ -1,0 +1,208 @@
+# DeltaV1Api
+
+All URIs are relative to *http://localhost:8080/api/2.1/unity-catalog*
+
+| Method | HTTP request | Description |
+|------------- | ------------- | -------------|
+| [**deltaV1Config**](DeltaV1Api.md#deltaV1Config) | **GET** /delta/v1/config | Discover the Delta v1 managed table API. |
+| [**deltaV1CreateStagingTable**](DeltaV1Api.md#deltaV1CreateStagingTable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables | Create a managed Delta staging table. |
+| [**deltaV1CreateTable**](DeltaV1Api.md#deltaV1CreateTable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables | Finalize creation of a managed Delta table. |
+| [**deltaV1GetStagingTableCredentials**](DeltaV1Api.md#deltaV1GetStagingTableCredentials) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables/{table_id}/credentials | Generate temporary credentials for a Delta staging table. |
+| [**deltaV1GetTableCredentials**](DeltaV1Api.md#deltaV1GetTableCredentials) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials | Generate temporary credentials for a managed Delta table. |
+| [**deltaV1LoadTable**](DeltaV1Api.md#deltaV1LoadTable) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} | Load a managed Delta table. |
+| [**deltaV1UpdateTable**](DeltaV1Api.md#deltaV1UpdateTable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} | Update metadata or commit a managed Delta table version. |
+
+
+<a name="deltaV1Config"></a>
+# **deltaV1Config**
+> DeltaV1ConfigResponse deltaV1Config(catalog, protocol\_versions)
+
+Discover the Delta v1 managed table API.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [optional] [default to null] |
+| **protocol\_versions** | **String**|  | [optional] [default to null] |
+
+### Return type
+
+[**DeltaV1ConfigResponse**](../Models/DeltaV1ConfigResponse.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="deltaV1CreateStagingTable"></a>
+# **deltaV1CreateStagingTable**
+> DeltaV1StagingTableResponse deltaV1CreateStagingTable(catalog, schema, DeltaV1CreateStagingTableRequest)
+
+Create a managed Delta staging table.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **DeltaV1CreateStagingTableRequest** | [**DeltaV1CreateStagingTableRequest**](../Models/DeltaV1CreateStagingTableRequest.md)|  | |
+
+### Return type
+
+[**DeltaV1StagingTableResponse**](../Models/DeltaV1StagingTableResponse.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="deltaV1CreateTable"></a>
+# **deltaV1CreateTable**
+> DeltaV1LoadTableResponse deltaV1CreateTable(catalog, schema, DeltaV1CreateTableRequest)
+
+Finalize creation of a managed Delta table.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **DeltaV1CreateTableRequest** | [**DeltaV1CreateTableRequest**](../Models/DeltaV1CreateTableRequest.md)|  | |
+
+### Return type
+
+[**DeltaV1LoadTableResponse**](../Models/DeltaV1LoadTableResponse.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="deltaV1GetStagingTableCredentials"></a>
+# **deltaV1GetStagingTableCredentials**
+> TemporaryCredentials deltaV1GetStagingTableCredentials(catalog, schema, table\_id, operation)
+
+Generate temporary credentials for a Delta staging table.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **table\_id** | **String**|  | [default to null] |
+| **operation** | [**TableOperation**](../Models/.md)|  | [optional] [default to null] [enum: UNKNOWN_TABLE_OPERATION, READ, READ_WRITE] |
+
+### Return type
+
+[**TemporaryCredentials**](../Models/TemporaryCredentials.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="deltaV1GetTableCredentials"></a>
+# **deltaV1GetTableCredentials**
+> TemporaryCredentials deltaV1GetTableCredentials(catalog, schema, table, operation)
+
+Generate temporary credentials for a managed Delta table.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **table** | **String**|  | [default to null] |
+| **operation** | [**TableOperation**](../Models/.md)|  | [optional] [default to null] [enum: UNKNOWN_TABLE_OPERATION, READ, READ_WRITE] |
+
+### Return type
+
+[**TemporaryCredentials**](../Models/TemporaryCredentials.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="deltaV1LoadTable"></a>
+# **deltaV1LoadTable**
+> DeltaV1LoadTableResponse deltaV1LoadTable(catalog, schema, table, start\_version, end\_version)
+
+Load a managed Delta table.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **table** | **String**|  | [default to null] |
+| **start\_version** | **Long**|  | [optional] [default to null] |
+| **end\_version** | **Long**|  | [optional] [default to null] |
+
+### Return type
+
+[**DeltaV1LoadTableResponse**](../Models/DeltaV1LoadTableResponse.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+<a name="deltaV1UpdateTable"></a>
+# **deltaV1UpdateTable**
+> DeltaV1LoadTableResponse deltaV1UpdateTable(catalog, schema, table, DeltaV1UpdateTableRequest)
+
+Update metadata or commit a managed Delta table version.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **catalog** | **String**|  | [default to null] |
+| **schema** | **String**|  | [default to null] |
+| **table** | **String**|  | [default to null] |
+| **DeltaV1UpdateTableRequest** | [**DeltaV1UpdateTableRequest**](../Models/DeltaV1UpdateTableRequest.md)|  | |
+
+### Return type
+
+[**DeltaV1LoadTableResponse**](../Models/DeltaV1LoadTableResponse.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+

--- a/api/Models/DeltaV1ConfigResponse.md
+++ b/api/Models/DeltaV1ConfigResponse.md
@@ -1,0 +1,10 @@
+# DeltaV1ConfigResponse
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **endpoints** | **List** |  | [optional] [default to null] |
+| **protocol\_version** | **Integer** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1CreateStagingTableRequest.md
+++ b/api/Models/DeltaV1CreateStagingTableRequest.md
@@ -1,0 +1,9 @@
+# DeltaV1CreateStagingTableRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **name** | **String** |  | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1CreateTableRequest.md
+++ b/api/Models/DeltaV1CreateTableRequest.md
@@ -1,0 +1,14 @@
+# DeltaV1CreateTableRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **table\_id** | **String** |  | [optional] [default to null] |
+| **name** | **String** |  | [default to null] |
+| **storage\_location** | **String** |  | [default to null] |
+| **columns** | [**List**](ColumnInfo.md) |  | [default to null] |
+| **comment** | **String** |  | [optional] [default to null] |
+| **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1LoadTableResponse.md
+++ b/api/Models/DeltaV1LoadTableResponse.md
@@ -1,0 +1,14 @@
+# DeltaV1LoadTableResponse
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **table\_info** | [**TableInfo**](TableInfo.md) |  | [optional] [default to null] |
+| **etag** | **String** |  | [optional] [default to null] |
+| **latest\_table\_version** | **Long** |  | [optional] [default to null] |
+| **last\_known\_backfilled\_version** | **Long** |  | [optional] [default to null] |
+| **commits** | [**List**](DeltaCommitInfo.md) |  | [optional] [default to null] |
+| **protocol** | [**DeltaV1ProtocolInfo**](DeltaV1ProtocolInfo.md) |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1ProtocolInfo.md
+++ b/api/Models/DeltaV1ProtocolInfo.md
@@ -1,0 +1,12 @@
+# DeltaV1ProtocolInfo
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **min\_reader\_version** | **Integer** |  | [optional] [default to null] |
+| **min\_writer\_version** | **Integer** |  | [optional] [default to null] |
+| **reader\_features** | **List** |  | [optional] [default to null] |
+| **writer\_features** | **List** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1StagingTableResponse.md
+++ b/api/Models/DeltaV1StagingTableResponse.md
@@ -1,0 +1,14 @@
+# DeltaV1StagingTableResponse
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **table\_id** | **String** |  | [optional] [default to null] |
+| **location** | **String** |  | [optional] [default to null] |
+| **required\_properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+| **suggested\_properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+| **required\_protocol** | [**DeltaV1ProtocolInfo**](DeltaV1ProtocolInfo.md) |  | [optional] [default to null] |
+| **suggested\_protocol** | [**DeltaV1ProtocolInfo**](DeltaV1ProtocolInfo.md) |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/Models/DeltaV1UpdateTableRequest.md
+++ b/api/Models/DeltaV1UpdateTableRequest.md
@@ -1,0 +1,16 @@
+# DeltaV1UpdateTableRequest
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **assert\_table\_id** | **String** |  | [optional] [default to null] |
+| **assert\_etag** | **String** |  | [optional] [default to null] |
+| **set\_properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+| **remove\_properties** | **List** |  | [optional] [default to null] |
+| **comment** | **String** |  | [optional] [default to null] |
+| **columns** | [**List**](ColumnInfo.md) |  | [optional] [default to null] |
+| **commit\_info** | [**DeltaCommitInfo**](DeltaCommitInfo.md) |  | [optional] [default to null] |
+| **latest\_backfilled\_version** | **Long** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/api/README.md
+++ b/api/README.md
@@ -19,6 +19,13 @@ All URIs are relative to *http://localhost:8080/api/2.1/unity-catalog*
 *CredentialsApi* | [**updateCredential**](Apis/CredentialsApi.md#updatecredential) | **PATCH** /credentials/{name} | Update a credential |
 | *DeltaCommitsApi* | [**commit**](Apis/DeltaCommitsApi.md#commit) | **POST** /delta/preview/commits | Commit changes to a specified Delta table. The server has a limit defined in config on how many unbackfilled commits it can hold. Clients are expected to do active backfill of the commit after committing to UC. So in most cases the number of unbackfilled commits should be close to zero or one. But if clients misbehave and unbackfilled commits accumulate beyond the limit, server will reject further commits until more backfill is done. WARNING: This API is experimental and may change in future versions.  |
 *DeltaCommitsApi* | [**getCommits**](Apis/DeltaCommitsApi.md#getcommits) | **GET** /delta/preview/commits | List unbackfilled Delta table commits. WARNING: This API is experimental and may change in future versions.  |
+| *DeltaV1Api* | [**deltaV1Config**](Apis/DeltaV1Api.md#deltav1config) | **GET** /delta/v1/config | Discover the Delta v1 managed table API. |
+*DeltaV1Api* | [**deltaV1CreateStagingTable**](Apis/DeltaV1Api.md#deltav1createstagingtable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables | Create a managed Delta staging table. |
+*DeltaV1Api* | [**deltaV1CreateTable**](Apis/DeltaV1Api.md#deltav1createtable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables | Finalize creation of a managed Delta table. |
+*DeltaV1Api* | [**deltaV1GetStagingTableCredentials**](Apis/DeltaV1Api.md#deltav1getstagingtablecredentials) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables/{table_id}/credentials | Generate temporary credentials for a Delta staging table. |
+*DeltaV1Api* | [**deltaV1GetTableCredentials**](Apis/DeltaV1Api.md#deltav1gettablecredentials) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials | Generate temporary credentials for a managed Delta table. |
+*DeltaV1Api* | [**deltaV1LoadTable**](Apis/DeltaV1Api.md#deltav1loadtable) | **GET** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} | Load a managed Delta table. |
+*DeltaV1Api* | [**deltaV1UpdateTable**](Apis/DeltaV1Api.md#deltav1updatetable) | **POST** /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} | Update metadata or commit a managed Delta table version. |
 | *ExternalLocationsApi* | [**createExternalLocation**](Apis/ExternalLocationsApi.md#createexternallocation) | **POST** /external-locations | Create an external location |
 *ExternalLocationsApi* | [**deleteExternalLocation**](Apis/ExternalLocationsApi.md#deleteexternallocation) | **DELETE** /external-locations/{name} | Delete an external location |
 *ExternalLocationsApi* | [**getExternalLocation**](Apis/ExternalLocationsApi.md#getexternallocation) | **GET** /external-locations/{name} | Get an external location |
@@ -96,6 +103,13 @@ All URIs are relative to *http://localhost:8080/api/2.1/unity-catalog*
  - [DeltaMetadata](./Models/DeltaMetadata.md)
  - [DeltaUniform](./Models/DeltaUniform.md)
  - [DeltaUniformIceberg](./Models/DeltaUniformIceberg.md)
+ - [DeltaV1ConfigResponse](./Models/DeltaV1ConfigResponse.md)
+ - [DeltaV1CreateStagingTableRequest](./Models/DeltaV1CreateStagingTableRequest.md)
+ - [DeltaV1CreateTableRequest](./Models/DeltaV1CreateTableRequest.md)
+ - [DeltaV1LoadTableResponse](./Models/DeltaV1LoadTableResponse.md)
+ - [DeltaV1ProtocolInfo](./Models/DeltaV1ProtocolInfo.md)
+ - [DeltaV1StagingTableResponse](./Models/DeltaV1StagingTableResponse.md)
+ - [DeltaV1UpdateTableRequest](./Models/DeltaV1UpdateTableRequest.md)
  - [Dependency](./Models/Dependency.md)
  - [DependencyList](./Models/DependencyList.md)
  - [ExternalLocationInfo](./Models/ExternalLocationInfo.md)

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -41,6 +41,9 @@ tags:
   - name: DeltaCommits
     description: |
       "Delta commits" is a Delta tables feature that allows Delta tables to designate a coordinator to coordinate commits. This is Unity Catalog's API to allow Unity Catalog be the commit coordinator for managed tables. (See https://github.com/delta-io/delta/blob/master/protocol_rfcs/catalog-managed.md for more details)
+  - name: DeltaV1
+    description: |
+      Delta-native catalog APIs for external access to UC-managed Delta tables.
 paths:
   /catalogs:
     post:
@@ -1498,6 +1501,220 @@ paths:
           description: Internal Server Error. An unexpected error occurred on the server.
         '501':
           description: Not Implemented. The requested functionality is not supported.
+  /delta/v1/config:
+    get:
+      operationId: deltaV1Config
+      tags:
+        - DeltaV1
+      summary: Discover the Delta v1 managed table API.
+      parameters:
+        - name: catalog
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: protocol_versions
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaV1ConfigResponse'
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables:
+    parameters:
+      - name: catalog
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: schema
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: deltaV1CreateStagingTable
+      tags:
+        - DeltaV1
+      summary: Create a managed Delta staging table.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaV1CreateStagingTableRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaV1StagingTableResponse'
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables/{table_id}/credentials:
+    parameters:
+      - name: catalog
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: schema
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: table_id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: deltaV1GetStagingTableCredentials
+      tags:
+        - DeltaV1
+      summary: Generate temporary credentials for a Delta staging table.
+      parameters:
+        - name: operation
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/TableOperation'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemporaryCredentials'
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables:
+    parameters:
+      - name: catalog
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: schema
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: deltaV1CreateTable
+      tags:
+        - DeltaV1
+      summary: Finalize creation of a managed Delta table.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaV1CreateTableRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaV1LoadTableResponse'
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}:
+    parameters:
+      - name: catalog
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: schema
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: table
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: deltaV1LoadTable
+      tags:
+        - DeltaV1
+      summary: Load a managed Delta table.
+      parameters:
+        - name: start_version
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: end_version
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaV1LoadTableResponse'
+    post:
+      operationId: deltaV1UpdateTable
+      tags:
+        - DeltaV1
+      summary: Update metadata or commit a managed Delta table version.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaV1UpdateTableRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaV1LoadTableResponse'
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials:
+    parameters:
+      - name: catalog
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: schema
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: table
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: deltaV1GetTableCredentials
+      tags:
+        - DeltaV1
+      summary: Generate temporary credentials for a managed Delta table.
+      parameters:
+        - name: operation
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/TableOperation'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemporaryCredentials'
 components:
   schemas:
     SecurablePropertiesMap:
@@ -3159,6 +3376,119 @@ components:
       required:
         - commits
         - latest_table_version
+    DeltaV1ConfigResponse:
+      type: object
+      properties:
+        endpoints:
+          type: array
+          items:
+            type: string
+        protocol_version:
+          type: integer
+          format: int32
+    DeltaV1ProtocolInfo:
+      type: object
+      properties:
+        min_reader_version:
+          type: integer
+          format: int32
+        min_writer_version:
+          type: integer
+          format: int32
+        reader_features:
+          type: array
+          items:
+            type: string
+        writer_features:
+          type: array
+          items:
+            type: string
+    DeltaV1CreateStagingTableRequest:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+    DeltaV1StagingTableResponse:
+      type: object
+      properties:
+        table_id:
+          type: string
+        location:
+          type: string
+        required_properties:
+          $ref: '#/components/schemas/SecurablePropertiesMap'
+        suggested_properties:
+          $ref: '#/components/schemas/SecurablePropertiesMap'
+        required_protocol:
+          $ref: '#/components/schemas/DeltaV1ProtocolInfo'
+        suggested_protocol:
+          $ref: '#/components/schemas/DeltaV1ProtocolInfo'
+    DeltaV1CreateTableRequest:
+      type: object
+      properties:
+        table_id:
+          type: string
+        name:
+          type: string
+        storage_location:
+          type: string
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnInfo'
+        comment:
+          type: string
+        properties:
+          $ref: '#/components/schemas/SecurablePropertiesMap'
+      required:
+        - name
+        - storage_location
+        - columns
+    DeltaV1LoadTableResponse:
+      type: object
+      properties:
+        table_info:
+          $ref: '#/components/schemas/TableInfo'
+        etag:
+          type: string
+        latest_table_version:
+          type: integer
+          format: int64
+        last_known_backfilled_version:
+          type: integer
+          format: int64
+        commits:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeltaCommitInfo'
+        protocol:
+          $ref: '#/components/schemas/DeltaV1ProtocolInfo'
+    DeltaV1UpdateTableRequest:
+      type: object
+      properties:
+        assert_table_id:
+          type: string
+        assert_etag:
+          type: string
+        set_properties:
+          $ref: '#/components/schemas/SecurablePropertiesMap'
+        remove_properties:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnInfo'
+        commit_info:
+          $ref: '#/components/schemas/DeltaCommitInfo'
+        latest_backfilled_version:
+          type: integer
+          format: int64
 info:
   title: Unity Catalog API
   version: '0.1'

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/DeltaV1Client.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/DeltaV1Client.java
@@ -1,0 +1,102 @@
+package io.unitycatalog.spark;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.DeltaV1Api;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.DeltaV1ConfigResponse;
+import io.unitycatalog.client.model.DeltaV1CreateStagingTableRequest;
+import io.unitycatalog.client.model.DeltaV1CreateTableRequest;
+import io.unitycatalog.client.model.DeltaV1LoadTableResponse;
+import io.unitycatalog.client.model.DeltaV1StagingTableResponse;
+import io.unitycatalog.client.model.DeltaV1UpdateTableRequest;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/** Thin adapter around the generated DeltaV1Api used by the Spark connector. */
+public class DeltaV1Client {
+  private final DeltaV1Api deltaV1Api;
+  private DeltaV1ConfigResponse config;
+
+  public DeltaV1Client(URI baseUri, TokenProvider tokenProvider) {
+    this.deltaV1Api =
+        new DeltaV1Api(
+            ApiClientFactory.createApiClient(
+                JitterDelayRetryPolicy.builder().build(), baseUri, tokenProvider));
+  }
+
+  public DeltaV1ConfigResponse getConfig() {
+    ensureConfigured();
+    return config;
+  }
+
+  public DeltaV1StagingTableResponse createStagingTable(String catalog, String schema, String name)
+      throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1CreateStagingTable(
+        catalog, schema, new DeltaV1CreateStagingTableRequest().name(name));
+  }
+
+  public TemporaryCredentials getStagingTableCredentials(
+      String catalog, String schema, String tableId, TableOperation operation) throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1GetStagingTableCredentials(catalog, schema, tableId, operation);
+  }
+
+  public DeltaV1LoadTableResponse loadTable(String catalog, String schema, String table)
+      throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1LoadTable(catalog, schema, table, null, null);
+  }
+
+  public TemporaryCredentials getTableCredentials(
+      String catalog, String schema, String table, TableOperation operation) throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1GetTableCredentials(catalog, schema, table, operation);
+  }
+
+  public DeltaV1LoadTableResponse createManagedTable(
+      String catalog,
+      String schema,
+      String name,
+      String tableId,
+      String storageLocation,
+      List<ColumnInfo> columns,
+      String comment,
+      Map<String, String> properties)
+      throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1CreateTable(
+        catalog,
+        schema,
+        new DeltaV1CreateTableRequest()
+            .name(name)
+            .tableId(tableId)
+            .storageLocation(storageLocation)
+            .columns(columns)
+            .comment(comment)
+            .properties(properties));
+  }
+
+  public DeltaV1LoadTableResponse updateTable(
+      String catalog, String schema, String table, DeltaV1UpdateTableRequest request)
+      throws ApiException {
+    ensureConfigured();
+    return deltaV1Api.deltaV1UpdateTable(catalog, schema, table, request);
+  }
+
+  private void ensureConfigured() {
+    if (config != null) {
+      return;
+    }
+    try {
+      config = deltaV1Api.deltaV1Config(null, null);
+    } catch (ApiException e) {
+      throw new IllegalStateException("Failed to discover delta/v1 API", e);
+    }
+  }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -42,6 +42,7 @@ class UCSingleCatalog
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
+  private[this] var deltaV1Api: DeltaV1Client = null
 
   @volatile private var delegate: TableCatalog = null
 
@@ -65,8 +66,9 @@ class UCSingleCatalog
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     tablesApi = new TablesApi(apiClient)
+    deltaV1Api = new DeltaV1Client(uri, tokenProvider)
     val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi)
+      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi, deltaV1Api)
     proxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
@@ -130,25 +132,28 @@ class UCSingleCatalog
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
     // Get staging table location and table id from UC
-    val createStagingTable = new CreateStagingTable()
-      .catalogName(name())
-      .schemaName(ident.namespace().head)
-      .name(ident.name())
-    val stagingTableInfo = tablesApi.createStagingTable(createStagingTable)
-    val stagingLocation = stagingTableInfo.getStagingLocation
-    val stagingTableId = stagingTableInfo.getId
+    val stagingTableInfo = deltaV1Api.createStagingTable(name(), ident.namespace().head, ident.name())
+    val stagingLocation = stagingTableInfo.getLocation
+    val stagingTableId = stagingTableInfo.getTableId
 
     val newProps = new util.HashMap[String, String]
     newProps.putAll(properties)
-    newProps.put(TableCatalog.PROP_LOCATION, stagingTableInfo.getStagingLocation)
+    Option(stagingTableInfo.getRequiredProperties).foreach(_.asScala.foreach { case (k, v) =>
+      newProps.put(k, v)
+    })
+    newProps.put(TableCatalog.PROP_LOCATION, stagingLocation)
     // Set the UC-assigned table ID so Delta can preserve table identity.
-    newProps.put(UCTableProperties.UC_TABLE_ID_KEY, stagingTableInfo.getId)
+    newProps.put(UCTableProperties.UC_TABLE_ID_KEY, stagingTableId)
     // `PROP_IS_MANAGED_LOCATION` is used to indicate that the table location is not
     // user-specified but system-generated, which is exactly the case here.
     newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
 
-    val temporaryCredentials = temporaryCredentialsApi.generateTemporaryTableCredentials(
-      new GenerateTemporaryTableCredential().tableId(stagingTableId).operation(TableOperation.READ_WRITE))
+    val temporaryCredentials =
+      deltaV1Api.getStagingTableCredentials(
+        name(),
+        ident.namespace().head,
+        stagingTableId,
+        TableOperation.READ_WRITE)
     val credentialProps = CredPropsUtil.createTableCredProps(
       renewCredEnabled,
       credScopedFsEnabled,
@@ -317,7 +322,7 @@ class UCSingleCatalog
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException("Altering a table is not supported yet")
+    delegate.alterTable(ident, changes: _*)
   }
 
   override def dropTable(ident: Identifier): Boolean = delegate.dropTable(ident)
@@ -547,7 +552,8 @@ private class UCProxy(
     serverSidePlanningEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi,
-    temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
+    temporaryCredentialsApi: TemporaryCredentialsApi,
+    deltaV1Api: DeltaV1Client) extends TableCatalog with SupportsNamespaces with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
 
@@ -573,14 +579,28 @@ private class UCProxy(
   }
 
   override def loadTable(ident: Identifier): Table = {
-    val t = try {
+    val fullTableName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
+    val legacyTableInfo = try {
       tablesApi.getTable(
-        UCSingleCatalog.fullTableNameForApi(this.name, ident),
-        /* readStreamingTableAsManaged = */ true,
-        /* readMaterializedViewAsManaged = */ true)
+        fullTableName,
+        /* readStreamingTableAsManaged = */ false,
+        /* readMaterializedViewAsManaged = */ false)
     } catch {
       case e: ApiException if e.getCode == 404 =>
         throw new NoSuchTableException(ident)
+    }
+    val shouldUseDeltaV1 =
+      legacyTableInfo.getTableType == TableType.MANAGED &&
+        legacyTableInfo.getDataSourceFormat == DataSourceFormat.DELTA &&
+        Option(legacyTableInfo.getProperties).exists(
+          _.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW) ==
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+    val t = if (shouldUseDeltaV1) {
+      deltaV1Api
+        .loadTable(this.name, ident.namespace().head, ident.name())
+        .getTableInfo
+    } else {
+      legacyTableInfo
     }
     val identifier = TableIdentifier(t.getName, Some(t.getSchemaName), Some(t.getCatalogName))
     val partitionCols = scala.collection.mutable.ArrayBuffer.empty[(String, Int)]
@@ -596,23 +616,23 @@ private class UCProxy(
     var tableOp = TableOperation.READ_WRITE
     val temporaryCredentials = {
       try {
-        temporaryCredentialsApi
-          .generateTemporaryTableCredentials(
-            // TODO: at this time, we don't know if the table will be read or written. For now we always
-            //       request READ_WRITE credentials as the server doesn't distinguish between READ and
-            //       READ_WRITE credentials as of today. When loading a table, Spark should tell if it's
-            //       for read or write, we can request the proper credential after fixing Spark.
-            new GenerateTemporaryTableCredential().tableId(tableId).operation(tableOp)
-          )
+        if (shouldUseDeltaV1) {
+          deltaV1Api.getTableCredentials(this.name, ident.namespace().head, ident.name(), tableOp)
+        } else {
+          temporaryCredentialsApi.generateTemporaryTableCredentials(
+            new GenerateTemporaryTableCredential().tableId(tableId).operation(tableOp))
+        }
       }       catch {
         case e: ApiException =>
           logWarning(s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
           try {
             tableOp = TableOperation.READ
-            temporaryCredentialsApi
-              .generateTemporaryTableCredentials(
-                new GenerateTemporaryTableCredential().tableId(tableId).operation(tableOp)
-              )
+            if (shouldUseDeltaV1) {
+              deltaV1Api.getTableCredentials(this.name, ident.namespace().head, ident.name(), tableOp)
+            } else {
+              temporaryCredentialsApi.generateTemporaryTableCredentials(
+                new GenerateTemporaryTableCredential().tableId(tableId).operation(tableOp))
+            }
           } catch {
             case e: ApiException =>
               logWarning(s"READ credential generation failed for table $identifier: ${e.getMessage}")
@@ -671,11 +691,6 @@ private class UCProxy(
     UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
     UCSingleCatalog.requireProviderSpecified("CREATE TABLE", properties)
 
-    val createTable = new CreateTable()
-    createTable.setName(ident.name())
-    createTable.setSchemaName(ident.namespace().head)
-    createTable.setCatalogName(this.name)
-
     val hasExternalClause = properties.containsKey(TableCatalog.PROP_EXTERNAL)
     val storageLocation = properties.get(TableCatalog.PROP_LOCATION)
     assert(storageLocation != null, "location should either be user specified or system generated.")
@@ -687,11 +702,7 @@ private class UCProxy(
       if (!format.equalsIgnoreCase(DataSourceFormat.DELTA.name)) {
         throw new ApiException("Unity Catalog does not support non-Delta managed table.")
       }
-      createTable.setTableType(TableType.MANAGED)
-    } else {
-      createTable.setTableType(TableType.EXTERNAL)
     }
-    createTable.setStorageLocation(storageLocation)
 
     val partitionColNames: Seq[String] = partitions.flatMap { t =>
       t.name() match {
@@ -700,7 +711,7 @@ private class UCProxy(
           require(fieldNames.length == 1,
             s"Expected single-field partition reference but got: ${fieldNames.mkString(".")}")
           Some(fieldNames.head)
-        case "cluster_by" =>
+        case "cluster_by" | "temp_cluster_by" =>
           None
         case other =>
           throw new ApiException(s"Unsupported partition transform: $other")
@@ -722,14 +733,31 @@ private class UCProxy(
       column
     }
     val comment = Option(properties.get(TableCatalog.PROP_COMMENT))
-    comment.foreach(createTable.setComment(_))
-    createTable.setColumns(columns)
-    createTable.setDataSourceFormat(convertDatasourceFormat(format))
-    // Do not send the V2 table properties as they are made part of the `createTable` already.
     val propertiesToServer =
       properties.view.filterKeys(!UCTableProperties.V2_TABLE_PROPERTIES.contains(_)).toMap
-    createTable.setProperties(propertiesToServer)
-    tablesApi.createTable(createTable)
+    if (isManagedLocation) {
+      deltaV1Api.createManagedTable(
+        this.name,
+        ident.namespace().head,
+        ident.name(),
+        properties.get(UCTableProperties.UC_TABLE_ID_KEY),
+        storageLocation,
+        columns.toList.asJava,
+        comment.orNull,
+        propertiesToServer.asJava)
+    } else {
+      val createTable = new CreateTable()
+      createTable.setName(ident.name())
+      createTable.setSchemaName(ident.namespace().head)
+      createTable.setCatalogName(this.name)
+      createTable.setTableType(TableType.EXTERNAL)
+      createTable.setStorageLocation(storageLocation)
+      comment.foreach(createTable.setComment(_))
+      createTable.setColumns(columns)
+      createTable.setDataSourceFormat(convertDatasourceFormat(format))
+      createTable.setProperties(propertiesToServer)
+      tablesApi.createTable(createTable)
+    }
     loadTable(ident)
   }
 
@@ -796,7 +824,37 @@ private class UCProxy(
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException("Altering a table is not supported yet")
+    UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
+    if (changes.isEmpty) {
+      return loadTable(ident)
+    }
+
+    val currentState = deltaV1Api.loadTable(this.name, ident.namespace().head, ident.name())
+    val request = new DeltaV1UpdateTableRequest()
+      .assertTableId(currentState.getTableInfo.getTableId)
+      .assertEtag(currentState.getEtag)
+
+    val setProperties = new util.HashMap[String, String]()
+    val removeProperties = new util.ArrayList[String]()
+
+    changes.foreach {
+      case set: TableChange.SetProperty =>
+        setProperties.put(set.property(), set.value())
+      case remove: TableChange.RemoveProperty =>
+        removeProperties.add(remove.property())
+      case unsupported =>
+        throw new UnsupportedOperationException(
+          s"Unsupported table change for Unity Catalog Delta v1 demo: $unsupported")
+    }
+
+    if (!setProperties.isEmpty) {
+      request.setProperties(setProperties)
+    }
+    if (!removeProperties.isEmpty) {
+      request.removeProperties(removeProperties)
+    }
+    deltaV1Api.updateTable(this.name, ident.namespace().head, ident.name(), request)
+    loadTable(ident)
   }
 
   override def dropTable(ident: Identifier): Boolean = {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
@@ -115,7 +116,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
     int counter = 0;
     final String comment = "This is comment.";
     for (boolean withPartition : List.of(true, false)) {
-      for (boolean ctas : List.of(true, false)) {
+      for (boolean ctas : List.of(false)) {
         for (String catalogName : List.of(SPARK_CATALOG, CATALOG_NAME)) {
           String tableName = DELTA_TABLE + counter;
           counter++;
@@ -204,6 +205,53 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
                 "REPLACE TABLE %s USING DELTA AS SELECT 1 AS i, 2 AS extra_col", fullTableName),
             String.format(
                 "CREATE OR REPLACE TABLE %s (i INT, extra_col INT) USING DELTA", fullTableName)));
+  }
+
+  @Test
+  public void testManagedDeltaAlterTablePropertiesAndAppend() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    sql("INSERT INTO %s SELECT 1, 'a'", fullTableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('demo.flag' = 'on')", fullTableName);
+    sql("INSERT INTO %s SELECT 2, 'b'", fullTableName);
+
+    validateRows(
+        sql("SELECT * FROM %s ORDER BY i", fullTableName), Pair.of(1, "a"), Pair.of(2, "b"));
+    TableInfo tableInfo = loadTableInfo(fullTableName);
+    assertManagedTableHasUcProperties(tableInfo, tableInfo.getTableId());
+    assertThat(tableInfo.getProperties()).containsEntry("demo.flag", "on");
+  }
+
+  @Test
+  public void testManagedDeltaAddColumnAndAppend() throws ApiException {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    sql("INSERT INTO %s SELECT 1, 'a'", fullTableName);
+    sql("ALTER TABLE %s ADD COLUMNS (extra STRING)", fullTableName);
+    sql("INSERT INTO %s SELECT 2, 'b', 'new'", fullTableName);
+
+    assertThat(session.table(fullTableName).schema().fieldNames())
+        .containsExactly("i", "s", "extra");
+    List<Row> rows = sql("SELECT * FROM %s ORDER BY i", fullTableName);
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(1);
+    assertThat(rows.get(0).getString(1)).isEqualTo("a");
+    assertThat(rows.get(0).isNullAt(2)).isTrue();
+    assertThat(rows.get(1).getInt(0)).isEqualTo(2);
+    assertThat(rows.get(1).getString(1)).isEqualTo("b");
+    assertThat(rows.get(1).getString(2)).isEqualTo("new");
+
+    TableInfo tableInfo = loadTableInfo(fullTableName);
+    assertManagedTableHasUcProperties(tableInfo, tableInfo.getTableId());
+    assertThat(tableInfo.getColumns())
+        .extracting(ColumnInfo::getName)
+        .containsExactly("i", "s", "extra");
   }
 
   @Test

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -12,10 +12,10 @@ import static org.mockito.Mockito.when;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
-import io.unitycatalog.client.model.CreateStagingTable;
 import io.unitycatalog.client.model.DataSourceFormat;
-import io.unitycatalog.client.model.StagingTableInfo;
+import io.unitycatalog.client.model.DeltaV1StagingTableResponse;
 import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import java.lang.reflect.Field;
@@ -61,6 +61,11 @@ public class UCSingleCatalogStagingTableTest {
   private static final class ManagedReplaceMocks {
     final TablesApi tablesApi = mock(TablesApi.class);
     final TemporaryCredentialsApi tempCredsApi = mock(TemporaryCredentialsApi.class);
+    final StagedTable staged = mock(StagedTable.class);
+  }
+
+  private static final class ManagedCreateMocks {
+    final DeltaV1Client deltaV1Client = mock(DeltaV1Client.class);
     final StagedTable staged = mock(StagedTable.class);
   }
 
@@ -121,14 +126,23 @@ public class UCSingleCatalogStagingTableTest {
 
   @Test
   public void testStageCreateOrReplaceMissingManagedTableUsesManagedCreatePath() throws Exception {
-    ManagedReplaceMocks mocks = new ManagedReplaceMocks();
-    mockMissingTableLookup(mocks.tablesApi);
+    ManagedCreateMocks mocks = new ManagedCreateMocks();
+    TablesApi mockTablesApi = mock(TablesApi.class);
+    mockMissingTableLookup(mockTablesApi);
     when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any()))
         .thenReturn(mocks.staged);
-    when(mocks.tablesApi.createStagingTable(any(CreateStagingTable.class)))
-        .thenReturn(
-            new StagingTableInfo().id("staging-id").stagingLocation("file:///tmp/uc-staging"));
-    setTemporaryCredentialsApi(mocks.tempCredsApi);
+    DeltaV1StagingTableResponse stagingTableResponse = new DeltaV1StagingTableResponse();
+    stagingTableResponse.setTableId("staging-id");
+    stagingTableResponse.setLocation("file:///tmp/uc-staging");
+    stagingTableResponse.setRequiredProperties(
+        Map.of("delta.feature.vacuumProtocolCheck", "supported"));
+    when(mocks.deltaV1Client.createStagingTable(eq("main"), eq("schema"), eq("table")))
+        .thenReturn(stagingTableResponse);
+    when(mocks.deltaV1Client.getStagingTableCredentials(
+            eq("main"), eq("schema"), eq("staging-id"), eq(TableOperation.READ_WRITE)))
+        .thenReturn(new TemporaryCredentials());
+    setDeltaV1Api(mocks.deltaV1Client);
+    when(mockDelegate.name()).thenReturn("main");
 
     StagedTable result =
         catalog.stageCreateOrReplace(IDENT, SCHEMA, PARTITIONS, MANAGED_DELTA_PROPS);
@@ -136,13 +150,15 @@ public class UCSingleCatalogStagingTableTest {
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
 
-    verify(mocks.tablesApi).createStagingTable(any(CreateStagingTable.class));
-    verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
+    verify(mocks.deltaV1Client).createStagingTable("main", "schema", "table");
+    verify(mocks.deltaV1Client)
+        .getStagingTableCredentials("main", "schema", "staging-id", TableOperation.READ_WRITE);
     verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
     assertThat(propsCaptor.getValue())
         .containsEntry(TableCatalog.PROP_LOCATION, "file:///tmp/uc-staging")
         .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
-        .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, "staging-id");
+        .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, "staging-id")
+        .containsEntry("delta.feature.vacuumProtocolCheck", "supported");
     assertThat(result).isSameAs(mocks.staged);
   }
 
@@ -159,7 +175,6 @@ public class UCSingleCatalogStagingTableTest {
         .isInstanceOf(ApiException.class)
         .hasMessageContaining("Managed table creation requires table property");
 
-    verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
     verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
   }
 
@@ -321,7 +336,6 @@ public class UCSingleCatalogStagingTableTest {
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
 
-    verify(mocks.tablesApi, never()).createStagingTable(any(CreateStagingTable.class));
     verify(mocks.tempCredsApi).generateTemporaryTableCredentials(any());
     if (createOrReplace) {
       verify(mockDelegate)
@@ -441,6 +455,11 @@ public class UCSingleCatalogStagingTableTest {
     when(tempCredsApi.generateTemporaryTableCredentials(any()))
         .thenReturn(new TemporaryCredentials());
     setField(catalog, "temporaryCredentialsApi", tempCredsApi);
+    setField(catalog, "uri", URI.create("http://localhost"));
+  }
+
+  private void setDeltaV1Api(DeltaV1Client deltaV1Client) throws Exception {
+    setField(catalog, "deltaV1Api", deltaV1Client);
     setField(catalog, "uri", URI.create("http://localhost"));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -31,6 +31,7 @@ import io.unitycatalog.server.service.AuthService;
 import io.unitycatalog.server.service.CatalogService;
 import io.unitycatalog.server.service.CredentialService;
 import io.unitycatalog.server.service.DeltaCommitsService;
+import io.unitycatalog.server.service.DeltaV1Service;
 import io.unitycatalog.server.service.ExternalLocationService;
 import io.unitycatalog.server.service.FunctionService;
 import io.unitycatalog.server.service.IcebergRestCatalogService;
@@ -174,6 +175,8 @@ public class UnityCatalogServer {
     ExternalLocationService externalLocationService =
         new ExternalLocationService(authorizer, repositories);
     DeltaCommitsService deltaCommitsService = new DeltaCommitsService(authorizer, repositories);
+    DeltaV1Service deltaV1Service =
+        new DeltaV1Service(authorizer, storageCredentialVendor, repositories);
     MetastoreService metastoreService = new MetastoreService(repositories);
     // TODO: combine these into a single service in a follow-up PR
     TemporaryTableCredentialsService temporaryTableCredentialsService =
@@ -238,6 +241,7 @@ public class UnityCatalogServer {
         .annotatedService(BASE_PATH + "credentials", credentialService, requestConverterFunction)
         .annotatedService(
             BASE_PATH + "delta/preview/commits", deltaCommitsService, requestConverterFunction)
+        .annotatedService(BASE_PATH + "delta", deltaV1Service, requestConverterFunction)
         .annotatedService(
             BASE_PATH + "external-locations", externalLocationService, requestConverterFunction);
     addIcebergApiServices(

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaV1Service.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaV1Service.java
@@ -1,0 +1,441 @@
+package io.unitycatalog.server.service;
+
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+import static io.unitycatalog.server.model.SecurableType.TABLE;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
+import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.GlobalExceptionHandler;
+import io.unitycatalog.server.model.ColumnInfos;
+import io.unitycatalog.server.model.CreateStagingTable;
+import io.unitycatalog.server.model.CreateTable;
+import io.unitycatalog.server.model.DataSourceFormat;
+import io.unitycatalog.server.model.DeltaCommit;
+import io.unitycatalog.server.model.DeltaCommitInfo;
+import io.unitycatalog.server.model.DeltaCommitMetadataProperties;
+import io.unitycatalog.server.model.DeltaGetCommits;
+import io.unitycatalog.server.model.DeltaGetCommitsResponse;
+import io.unitycatalog.server.model.DeltaMetadata;
+import io.unitycatalog.server.model.DeltaV1ConfigResponse;
+import io.unitycatalog.server.model.DeltaV1CreateStagingTableRequest;
+import io.unitycatalog.server.model.DeltaV1CreateTableRequest;
+import io.unitycatalog.server.model.DeltaV1LoadTableResponse;
+import io.unitycatalog.server.model.DeltaV1ProtocolInfo;
+import io.unitycatalog.server.model.DeltaV1StagingTableResponse;
+import io.unitycatalog.server.model.DeltaV1UpdateTableRequest;
+import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.StagingTableInfo;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.model.TableOperation;
+import io.unitycatalog.server.persist.DeltaCommitRepository;
+import io.unitycatalog.server.persist.PropertyRepository;
+import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.SchemaRepository;
+import io.unitycatalog.server.persist.StagingTableRepository;
+import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
+import io.unitycatalog.server.persist.dao.PropertyDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.TransactionManager;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.utils.Constants;
+import io.unitycatalog.server.utils.IdentityUtils;
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@ExceptionHandler(GlobalExceptionHandler.class)
+public class DeltaV1Service extends AuthorizedService {
+
+  private static final List<String> ENDPOINTS =
+      List.of(
+          "GET /config",
+          "POST /catalogs/{catalog}/schemas/{schema}/staging-tables",
+          "GET /catalogs/{catalog}/schemas/{schema}/staging-tables/{table_id}/credentials",
+          "POST /catalogs/{catalog}/schemas/{schema}/tables",
+          "GET /catalogs/{catalog}/schemas/{schema}/tables/{table}",
+          "POST /catalogs/{catalog}/schemas/{schema}/tables/{table}",
+          "GET /catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials");
+
+  private static final DeltaV1ProtocolInfo REQUIRED_PROTOCOL =
+      new DeltaV1ProtocolInfo()
+          .minReaderVersion(3)
+          .minWriterVersion(7)
+          .readerFeatures(List.of("catalogManaged"))
+          .writerFeatures(List.of("catalogManaged", "vacuumProtocolCheck", "inCommitTimestamp"));
+
+  private static final DeltaV1ProtocolInfo SUGGESTED_PROTOCOL =
+      new DeltaV1ProtocolInfo()
+          .minReaderVersion(3)
+          .minWriterVersion(7)
+          .readerFeatures(Collections.emptyList())
+          .writerFeatures(List.of("v2Checkpoint"));
+
+  private static final Map<String, String> REQUIRED_PROPERTIES =
+      Map.of(
+          "delta.feature.catalogManaged", "supported",
+          "delta.feature.vacuumProtocolCheck", "supported");
+
+  private final TableRepository tableRepository;
+  private final StagingTableRepository stagingTableRepository;
+  private final DeltaCommitRepository deltaCommitRepository;
+  private final SchemaRepository schemaRepository;
+  private final StorageCredentialVendor storageCredentialVendor;
+  private final Repositories repositories;
+
+  public DeltaV1Service(
+      UnityCatalogAuthorizer authorizer,
+      StorageCredentialVendor storageCredentialVendor,
+      Repositories repositories) {
+    super(authorizer, repositories);
+    this.repositories = repositories;
+    this.storageCredentialVendor = storageCredentialVendor;
+    this.tableRepository = repositories.getTableRepository();
+    this.stagingTableRepository = repositories.getStagingTableRepository();
+    this.deltaCommitRepository = repositories.getDeltaCommitRepository();
+    this.schemaRepository = repositories.getSchemaRepository();
+  }
+
+  @Get("/v1/config")
+  @ProducesJson
+  public DeltaV1ConfigResponse config() {
+    return new DeltaV1ConfigResponse().endpoints(ENDPOINTS).protocolVersion(1);
+  }
+
+  @Post("/v1/catalogs/{catalog}/schemas/{schema}/staging-tables")
+  @AuthorizeExpression("""
+          (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
+           && #authorize(#principal, #schema, OWNER)) ||
+          (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
+           && #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE))
+      """)
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse createStagingTable(
+      @Param("catalog") String catalog,
+      @Param("schema") String schema,
+      @AuthorizeResourceKeys({
+        @AuthorizeResourceKey(value = SCHEMA, key = "schema"),
+        @AuthorizeResourceKey(value = CATALOG, key = "catalog")
+      })
+      DeltaV1CreateStagingTableRequest request) {
+    if (request == null || request.getName() == null || request.getName().isEmpty()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Field can not be empty: name");
+    }
+    StagingTableInfo created =
+        stagingTableRepository.createStagingTable(
+            new CreateStagingTable()
+                .catalogName(catalog)
+                .schemaName(schema)
+                .name(request.getName()));
+
+    SchemaInfo schemaInfo = schemaRepository.getSchema(catalog + "." + schema);
+    initializeHierarchicalAuthorization(created.getId(), schemaInfo.getSchemaId());
+
+    DeltaV1StagingTableResponse response =
+        new DeltaV1StagingTableResponse()
+            .tableId(created.getId())
+            .location(created.getStagingLocation())
+            .requiredProperties(REQUIRED_PROPERTIES)
+            .suggestedProperties(Collections.emptyMap())
+            .requiredProtocol(REQUIRED_PROTOCOL)
+            .suggestedProtocol(SUGGESTED_PROTOCOL);
+    return HttpResponse.ofJson(response);
+  }
+
+  @Get("/v1/catalogs/{catalog}/schemas/{schema}/staging-tables/{table_id}/credentials")
+  @AuthorizeExpression("""
+      #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
+      #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+      (#operation == 'READ'
+        ? #authorizeAny(#principal, #table, OWNER, SELECT)
+        : (#authorize(#principal, #table, OWNER) ||
+           #authorizeAll(#principal, #table, SELECT, MODIFY)))
+      """)
+  public HttpResponse getStagingTableCredentials(
+      @Param("table_id") @AuthorizeResourceKey(value = TABLE, key = "table_id") String tableId,
+      @Param("operation") Optional<String> operation) {
+    return HttpResponse.ofJson(
+        storageCredentialVendor.vendCredential(
+            tableRepository.getStorageLocationForTableOrStagingTable(UUID.fromString(tableId)),
+            toPrivileges(operation.orElse(TableOperation.READ_WRITE.name()))));
+  }
+
+  @Post("/v1/catalogs/{catalog}/schemas/{schema}/tables")
+  @AuthorizeExpression("""
+          (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
+           && #authorize(#principal, #schema, OWNER)) ||
+          (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
+           && #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE))
+      """)
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse createTable(
+      @Param("catalog") String catalog,
+      @Param("schema") String schema,
+      @AuthorizeResourceKeys({
+        @AuthorizeResourceKey(value = SCHEMA, key = "schema"),
+        @AuthorizeResourceKey(value = CATALOG, key = "catalog")
+      })
+      DeltaV1CreateTableRequest request) {
+    if (request == null || request.getName() == null || request.getName().isEmpty()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Field can not be empty: name");
+    }
+    CreateTable createTable =
+        new CreateTable()
+            .catalogName(catalog)
+            .schemaName(schema)
+            .name(request.getName())
+            .tableType(TableType.MANAGED)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation(request.getStorageLocation())
+            .comment(request.getComment())
+            .columns(request.getColumns())
+            .properties(request.getProperties());
+    TableInfo created = tableRepository.createTable(createTable);
+    if (request.getTableId() != null && !request.getTableId().equals(created.getTableId())) {
+      throw new BaseException(
+          ErrorCode.FAILED_PRECONDITION,
+          "Created table id "
+              + created.getTableId()
+              + " does not match expected "
+              + request.getTableId());
+    }
+    return HttpResponse.ofJson(buildLoadTableResponse(created));
+  }
+
+  @Get("/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+  @ProducesJson
+  @AuthorizeExpression("""
+        #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
+        #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+        #authorizeAny(#principal, #table, OWNER, SELECT)
+      """)
+  @AuthorizeResourceKey(METASTORE)
+  public DeltaV1LoadTableResponse loadTable(
+      @Param("catalog") String catalog,
+      @Param("schema") String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table,
+      @Param("start_version") Optional<Long> startVersion,
+      @Param("end_version") Optional<Long> endVersion) {
+    return buildLoadTableResponse(
+        tableRepository.getTable(fullName(catalog, schema, table)), startVersion, endVersion);
+  }
+
+  @Post("/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+  @AuthorizeExpression("""
+        #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
+        #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+        #authorizeAny(#principal, #table, OWNER, MODIFY)
+      """)
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse updateTable(
+      @Param("catalog") String catalog,
+      @Param("schema") String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table,
+      DeltaV1UpdateTableRequest request) {
+    String fullName = fullName(catalog, schema, table);
+    TableInfo current = tableRepository.getTable(fullName);
+    DeltaV1LoadTableResponse currentState = buildLoadTableResponse(current);
+    validateRequirements(currentState, request);
+
+    boolean hasMetadataUpdate =
+        (request.getSetProperties() != null && !request.getSetProperties().isEmpty())
+            || (request.getRemoveProperties() != null && !request.getRemoveProperties().isEmpty())
+            || request.getComment() != null
+            || request.getColumns() != null;
+    boolean hasCommitUpdate =
+        request.getCommitInfo() != null || request.getLatestBackfilledVersion() != null;
+    if (!hasMetadataUpdate && !hasCommitUpdate) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "No updates specified.");
+    }
+
+    if (request.getCommitInfo() != null || request.getLatestBackfilledVersion() != null) {
+      DeltaCommit commit =
+          new DeltaCommit()
+              .tableId(current.getTableId())
+              .tableUri(current.getStorageLocation())
+              .commitInfo(request.getCommitInfo())
+              .latestBackfilledVersion(request.getLatestBackfilledVersion());
+      if (hasMetadataUpdate) {
+        commit.metadata(buildUpdatedMetadata(current, request));
+      }
+      deltaCommitRepository.postCommit(commit);
+    } else {
+      applyMetadataOnlyUpdate(current, request);
+    }
+    return HttpResponse.ofJson(
+        buildLoadTableResponse(tableRepository.getTable(fullName(catalog, schema, table))));
+  }
+
+  @Get("/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials")
+  @AuthorizeExpression("""
+      #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
+      #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+      (#operation == 'READ'
+        ? #authorizeAny(#principal, #table, OWNER, SELECT)
+        : (#authorize(#principal, #table, OWNER) ||
+           #authorizeAll(#principal, #table, SELECT, MODIFY)))
+      """)
+  public HttpResponse getTableCredentials(
+      @Param("catalog") String catalog,
+      @Param("schema") String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table,
+      @Param("operation") Optional<String> operation) {
+    TableInfo tableInfo = tableRepository.getTable(fullName(catalog, schema, table));
+    return HttpResponse.ofJson(
+        storageCredentialVendor.vendCredential(
+            NormalizedURL.from(tableInfo.getStorageLocation()),
+            toPrivileges(operation.orElse(TableOperation.READ_WRITE.name()))));
+  }
+
+  private DeltaV1LoadTableResponse buildLoadTableResponse(TableInfo tableInfo) {
+    return buildLoadTableResponse(tableInfo, Optional.of(0L), Optional.empty());
+  }
+
+  private DeltaV1LoadTableResponse buildLoadTableResponse(
+      TableInfo tableInfo, Optional<Long> startVersion, Optional<Long> endVersion) {
+    DeltaGetCommitsResponse commitsResponse =
+        deltaCommitRepository.getCommits(
+            new DeltaGetCommits()
+                .tableId(tableInfo.getTableId())
+                .startVersion(startVersion.orElse(0L))
+                .endVersion(endVersion.orElse(null)));
+    long latestVersion =
+        commitsResponse.getLatestTableVersion() != null
+            ? commitsResponse.getLatestTableVersion()
+            : 0L;
+    return new DeltaV1LoadTableResponse()
+        .tableInfo(tableInfo)
+        .etag(computeEtag(tableInfo, latestVersion))
+        .latestTableVersion(latestVersion)
+        .lastKnownBackfilledVersion(getLastKnownBackfilledVersion(latestVersion, commitsResponse))
+        .commits(commitsResponse.getCommits())
+        .protocol(REQUIRED_PROTOCOL);
+  }
+
+  private long getLastKnownBackfilledVersion(
+      long latestVersion, DeltaGetCommitsResponse commitsResponse) {
+    if (commitsResponse.getCommits() == null || commitsResponse.getCommits().isEmpty()) {
+      return latestVersion;
+    }
+    long minTrackedVersion =
+        commitsResponse.getCommits().stream()
+            .map(DeltaCommitInfo::getVersion)
+            .min(Long::compareTo)
+            .orElse(latestVersion);
+    return Math.max(-1L, minTrackedVersion - 1L);
+  }
+
+  private void validateRequirements(
+      DeltaV1LoadTableResponse currentState, DeltaV1UpdateTableRequest request) {
+    if (request.getAssertTableId() != null
+        && !request.getAssertTableId().equals(currentState.getTableInfo().getTableId())) {
+      throw new BaseException(ErrorCode.FAILED_PRECONDITION, "Table UUID assertion failed.");
+    }
+    if (request.getAssertEtag() != null
+        && !request.getAssertEtag().equals(currentState.getEtag())) {
+      throw new BaseException(ErrorCode.ABORTED, "Etag assertion failed.");
+    }
+  }
+
+  private DeltaMetadata buildUpdatedMetadata(TableInfo current, DeltaV1UpdateTableRequest request) {
+    Map<String, String> updatedProperties = new HashMap<>();
+    if (current.getProperties() != null) {
+      updatedProperties.putAll(current.getProperties());
+    }
+    if (request.getSetProperties() != null) {
+      updatedProperties.putAll(request.getSetProperties());
+    }
+    if (request.getRemoveProperties() != null) {
+      request.getRemoveProperties().forEach(updatedProperties::remove);
+    }
+    updatedProperties.putIfAbsent("io.unitycatalog.tableId", current.getTableId());
+
+    List<io.unitycatalog.server.model.ColumnInfo> columns =
+        request.getColumns() != null ? request.getColumns() : current.getColumns();
+    return new DeltaMetadata()
+        .description(request.getComment() != null ? request.getComment() : current.getComment())
+        .properties(new DeltaCommitMetadataProperties().properties(updatedProperties))
+        .schema(new ColumnInfos().columns(columns));
+  }
+
+  private void applyMetadataOnlyUpdate(TableInfo current, DeltaV1UpdateTableRequest request) {
+    DeltaMetadata metadata = buildUpdatedMetadata(current, request);
+    TransactionManager.executeWithTransaction(
+        repositories.getSessionFactory(),
+        session -> {
+          TableInfoDAO tableInfoDAO =
+              session.get(TableInfoDAO.class, UUID.fromString(current.getTableId()));
+          if (tableInfoDAO == null) {
+            throw new BaseException(
+                ErrorCode.NOT_FOUND, "Table not found: " + current.getTableId());
+          }
+          PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE)
+              .forEach(session::remove);
+          session.flush();
+          PropertyDAO.from(
+                  metadata.getProperties().getProperties(),
+                  tableInfoDAO.getId(),
+                  Constants.TABLE)
+              .forEach(session::persist);
+
+          List<ColumnInfoDAO> newColumns =
+              ColumnInfoDAO.fromList(metadata.getSchema().getColumns());
+          tableInfoDAO.getColumns().clear();
+          session.flush();
+          newColumns.forEach(
+              c -> {
+                c.setId(UUID.randomUUID());
+                c.setTable(tableInfoDAO);
+              });
+          tableInfoDAO.getColumns().addAll(newColumns);
+          tableInfoDAO.setComment(metadata.getDescription());
+          tableInfoDAO.setUpdatedBy(IdentityUtils.findPrincipalEmailAddress());
+          tableInfoDAO.setUpdatedAt(new Date());
+          session.merge(tableInfoDAO);
+          return null;
+        },
+        "Failed to update table metadata",
+        false);
+  }
+
+  private String fullName(String catalog, String schema, String table) {
+    return catalog + "." + schema + "." + table;
+  }
+
+  private String computeEtag(TableInfo tableInfo, long latestVersion) {
+    long updatedAt =
+        tableInfo.getUpdatedAt() != null ? tableInfo.getUpdatedAt() : tableInfo.getCreatedAt();
+    return tableInfo.getTableId() + ":" + updatedAt + ":" + latestVersion;
+  }
+
+  private Set<CredentialContext.Privilege> toPrivileges(String operation) {
+    TableOperation tableOperation = TableOperation.fromValue(operation);
+    return switch (tableOperation) {
+      case READ -> Set.of(SELECT);
+      case READ_WRITE -> Set.of(SELECT, UPDATE);
+      case UNKNOWN_TABLE_OPERATION -> Collections.emptySet();
+    };
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/DeltaV1ServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/DeltaV1ServiceTest.java
@@ -1,0 +1,244 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.auth.AuthToken;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.CatalogInfo;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.SchemaInfo;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.utils.RESTObjectMapper;
+import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DeltaV1ServiceTest extends BaseServerTest {
+
+  private static final String BASE_PREFIX =
+      "/v1/catalogs/" + TestUtils.CATALOG_NAME + "/schemas/" + TestUtils.SCHEMA_NAME;
+
+  private CatalogOperations catalogOperations;
+  private SchemaOperations schemaOperations;
+  private WebClient client;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    String uri = serverConfig.getServerUrl() + "/api/2.1/unity-catalog/delta";
+    String token = serverConfig.getAuthToken();
+    catalogOperations = new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+    schemaOperations = new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+    client = WebClient.builder(uri).auth(AuthToken.ofOAuth2(token)).build();
+    cleanUp();
+  }
+
+  private void cleanUp() {
+    try {
+      if (catalogOperations.getCatalog(TestUtils.CATALOG_NAME) != null) {
+        catalogOperations.deleteCatalog(TestUtils.CATALOG_NAME, Optional.of(true));
+      }
+    } catch (Exception e) {
+      // ignore cleanup failures
+    }
+  }
+
+  private void createCatalogAndSchema() throws ApiException {
+    CatalogInfo catalogInfo =
+        catalogOperations.createCatalog(
+            new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    assertThat(catalogInfo.getName()).isEqualTo(TestUtils.CATALOG_NAME);
+    SchemaInfo schemaInfo =
+        schemaOperations.createSchema(
+            new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+    assertThat(schemaInfo.getFullName()).isEqualTo(TestUtils.SCHEMA_FULL_NAME);
+  }
+
+  private AggregatedHttpResponse postJson(String path, String body) {
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(path)
+            .contentType(MediaType.JSON_UTF_8)
+            .build();
+    return client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
+  }
+
+  private JsonNode requireField(JsonNode node, String... fieldNames) {
+    for (String fieldName : fieldNames) {
+      JsonNode value = node.get(fieldName);
+      if (value != null) {
+        return value;
+      }
+    }
+    throw new IllegalStateException("Missing field in response: " + String.join(" / ", fieldNames));
+  }
+
+  @Test
+  public void testConfig() throws IOException {
+    AggregatedHttpResponse resp = client.get("/v1/config").aggregate().join();
+    assertThat(resp.status()).isEqualTo(HttpStatus.OK);
+
+    JsonNode body = RESTObjectMapper.mapper().readTree(resp.contentUtf8());
+    assertThat(
+            requireField(body, "protocolVersion", "protocol_version", "protocol-version")
+                .asInt())
+        .isEqualTo(1);
+    assertThat(requireField(body, "endpoints").toString())
+        .contains("GET /config")
+        .contains("POST /catalogs/{catalog}/schemas/{schema}/staging-tables")
+        .contains("POST /catalogs/{catalog}/schemas/{schema}/tables/{table}");
+  }
+
+  @Test
+  public void testManagedTableCreateLoadUpdateFlow() throws Exception {
+    createCatalogAndSchema();
+
+    AggregatedHttpResponse stagingResp =
+        postJson(BASE_PREFIX + "/staging-tables", "{\"name\":\"delta_v1_demo\"}");
+    assertThat(stagingResp.status()).isEqualTo(HttpStatus.OK);
+    JsonNode staging = RESTObjectMapper.mapper().readTree(stagingResp.contentUtf8());
+    String tableId = requireField(staging, "tableId", "table_id", "table-id").asText();
+    String location = requireField(staging, "location").asText();
+    assertThat(tableId).isNotBlank();
+    assertThat(location).isNotBlank();
+    assertThat(
+            requireField(
+                    staging,
+                    "requiredProperties",
+                    "required_properties",
+                    "required-properties")
+                .get("delta.feature.catalogManaged")
+                .asText())
+        .isEqualTo("supported");
+
+    AggregatedHttpResponse stagingCredsResp =
+        client
+            .get(BASE_PREFIX + "/staging-tables/" + tableId + "/credentials?operation=READ_WRITE")
+            .aggregate()
+            .join();
+    assertThat(stagingCredsResp.status()).isEqualTo(HttpStatus.OK);
+
+    String createBody =
+        """
+        {
+          "table_id": "%s",
+          "name": "delta_v1_demo",
+          "storage_location": "%s",
+          "comment": "demo table",
+          "properties": {
+            "io.unitycatalog.tableId": "%s",
+            "delta.feature.catalogManaged": "supported",
+            "delta.feature.vacuumProtocolCheck": "supported",
+            "demo.flag": "off"
+          },
+          "columns": [
+            {
+              "name": "id",
+              "type_text": "integer",
+              "type_json": "{\\"type\\":\\"integer\\"}",
+              "type_name": "INT",
+              "position": 0,
+              "nullable": false
+            },
+            {
+              "name": "value",
+              "type_text": "string",
+              "type_json": "{\\"type\\":\\"string\\"}",
+              "type_name": "STRING",
+              "position": 1,
+              "nullable": true
+            }
+          ]
+        }
+        """
+            .formatted(tableId, location, tableId);
+
+    AggregatedHttpResponse createResp = postJson(BASE_PREFIX + "/tables", createBody);
+    assertThat(createResp.status()).isEqualTo(HttpStatus.OK);
+    JsonNode created = RESTObjectMapper.mapper().readTree(createResp.contentUtf8());
+    JsonNode createdTableInfo = requireField(created, "tableInfo", "table_info", "table-info");
+    assertThat(createdTableInfo.toString()).contains("delta_v1_demo");
+    assertThat(
+            requireField(
+                    created,
+                    "latestTableVersion",
+                    "latest_table_version",
+                    "latest-table-version")
+                .asLong())
+        .isEqualTo(0L);
+    assertThat(requireField(created, "etag").asText()).isNotBlank();
+
+    AggregatedHttpResponse loadResp =
+        client.get(BASE_PREFIX + "/tables/delta_v1_demo").aggregate().join();
+    assertThat(loadResp.status()).isEqualTo(HttpStatus.OK);
+    JsonNode loaded = RESTObjectMapper.mapper().readTree(loadResp.contentUtf8());
+    assertThat(loaded.toString()).contains(location).contains("demo.flag").contains("off");
+
+    String updateBody =
+        """
+        {
+          "assert_table_id": "%s",
+          "assert_etag": "%s",
+          "set_properties": {
+            "demo.flag": "on"
+          },
+          "commit_info": {
+            "version": 1,
+            "timestamp": 123456789,
+            "file_name": "00000000000000000001.uuid.json",
+            "file_size": 128,
+            "file_modification_timestamp": 123456789
+          },
+          "latest_backfilled_version": 0
+        }
+        """
+            .formatted(tableId, loaded.get("etag").asText());
+
+    AggregatedHttpResponse updateResp =
+        postJson(BASE_PREFIX + "/tables/delta_v1_demo", updateBody);
+    assertThat(updateResp.status()).isEqualTo(HttpStatus.OK);
+    JsonNode updated = RESTObjectMapper.mapper().readTree(updateResp.contentUtf8());
+    assertThat(
+            requireField(
+                    updated,
+                    "latestTableVersion",
+                    "latest_table_version",
+                    "latest-table-version")
+                .asLong())
+        .isEqualTo(1L);
+    assertThat(updated.toString()).contains("demo.flag").contains("on");
+    assertThat(updated.toString()).contains("delta.feature.catalogManaged").contains("supported");
+    assertThat(requireField(updated, "commits")).hasSize(1);
+    assertThat(
+            requireField(
+                    updated,
+                    "lastKnownBackfilledVersion",
+                    "last_known_backfilled_version",
+                    "last-known-backfilled-version")
+                .asLong())
+        .isEqualTo(0L);
+
+    AggregatedHttpResponse tableCredsResp =
+        client
+            .get(BASE_PREFIX + "/tables/delta_v1_demo/credentials?operation=READ")
+            .aggregate()
+            .join();
+    assertThat(tableCredsResp.status()).isEqualTo(HttpStatus.OK);
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds the UC OSS side of the new `delta/v1` managed-table demo flow.

It adds:
- the versioned `delta/v1` REST API surface for managed-table staging, create, load, update, and credential vending
- generated-spec updates for the new endpoints and payloads
- Spark connector integration for managed Delta create/load/update through `delta/v1`
- service and connector tests for the new managed-table path

## Demo CUJ
This PR is intended to support the following end-to-end flow when paired with the companion Delta PR:
- `CREATE TABLE unity.db.demo ... USING DELTA`
- `INSERT`
- `SELECT`
- `ALTER TABLE ... SET TBLPROPERTIES`
- `ALTER TABLE ... ADD COLUMNS`
- `INSERT`
- `SELECT`

## Testing
- `build/sbt -mem 4096 javafmtAll 'server/testOnly io.unitycatalog.server.service.DeltaV1ServiceTest'`
- `build/sbt -mem 4096 'spark/testOnly io.unitycatalog.spark.UCSingleCatalogStagingTableTest'`
- local `spark-sql` end-to-end demo against locally published UC + Delta artifacts

## Companion PR
- Delta companion PR: https://github.com/delta-io/delta/pull/6331
