### PR TITLE
Fix SCIM HTTP status and add default stack-trace-off test

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
@@ -21,7 +21,8 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
     // SCIM has its own error format, handle before normalization
     if (cause instanceof Scim2RuntimeException) {
       ScimException scimException = (ScimException) cause.getCause();
-      return HttpResponse.ofJson(HttpStatus.INTERNAL_SERVER_ERROR, scimException.getScimError());
+      HttpStatus httpStatus = HttpStatus.valueOf(scimException.getScimError().getStatus());
+      return HttpResponse.ofJson(httpStatus, scimException.getScimError());
     }
     return super.handleException(ctx, req, cause);
   }

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -184,7 +184,7 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     // Second create triggers Scim2RuntimeException wrapping ResourceConflictException
     AggregatedHttpResponse second =
         client.execute(headers, HttpData.ofUtf8(userJson)).aggregate().join();
-    assertThat(second.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(second.status()).isEqualTo(HttpStatus.CONFLICT);
 
     // Verify the SCIM error response is a valid JSON object (not double-serialized)
     // with the expected SCIM error fields

--- a/server/src/test/java/io/unitycatalog/server/service/ErrorResponseTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/ErrorResponseTest.java
@@ -1,0 +1,59 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.auth.AuthToken;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.utils.ServerProperties.Property;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that verify the error response format, particularly that stack traces are excluded by
+ * default.
+ */
+public class ErrorResponseTest extends BaseServerTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private WebClient client;
+
+  @Override
+  protected void setUpProperties() {
+    serverProperties = new Properties();
+    serverProperties.setProperty(Property.SERVER_ENV.getKey(), "test");
+    // Do NOT set INCLUDE_STACK_TRACE_IN_ERROR -- it defaults to false
+    serverProperties.setProperty(Property.MANAGED_TABLE_ENABLED.getKey(), "true");
+    tableStorageRoot = getManagedStorageCloudPath(testDirectoryRoot);
+    serverProperties.setProperty(Property.TABLE_STORAGE_ROOT.getKey(), tableStorageRoot);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    String uri = serverConfig.getServerUrl() + "/api/2.1/unity-catalog";
+    String token = serverConfig.getAuthToken();
+    client = WebClient.builder(uri).auth(AuthToken.ofOAuth2(token)).build();
+  }
+
+  @Test
+  public void testErrorResponseOmitsStackTraceByDefault() throws Exception {
+    // Trigger a NOT_FOUND error
+    AggregatedHttpResponse resp = client.get("/catalogs/nonexistent").aggregate().join();
+    assertThat(resp.status()).isEqualTo(HttpStatus.NOT_FOUND);
+
+    JsonNode json = MAPPER.readTree(resp.contentUtf8());
+    assertThat(json.has("error_code")).isTrue();
+    assertThat(json.get("error_code").asText()).isEqualTo("NOT_FOUND");
+    assertThat(json.has("message")).isTrue();
+    assertThat(json.has("stack_trace"))
+        .as("stack_trace should be absent when include-stacktrace-in-error is false (default)")
+        .isFalse();
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Fix SCIM HTTP status and add default stack-trace-off test

Follow-up to #1473 addressing review feedback:
- SCIM error responses now return the correct HTTP status from the SCIM payload (e.g., 409 Conflict for duplicate user) instead of always returning 500
- Added test verifying that `stack_trace` is omitted from error responses by default
