### PR TITLE
Implement Delta REST Catalog loadTable endpoint

### DIFF
--- a/api/delta-docs/Models/DeltaCommit.md
+++ b/api/delta-docs/Models/DeltaCommit.md
@@ -4,10 +4,10 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **version** | **Long** | Commit version | [default to null] |
-| **timestamp** | **Long** | In-commit timestamp | [default to null] |
+| **timestamp** | **Long** | In-commit timestamp, in epoch milliseconds | [default to null] |
 | **file-name** | **String** | UUID-based commit file name | [default to null] |
 | **file-size** | **Long** | Commit file size in bytes | [default to null] |
-| **file-modification-timestamp** | **Long** | File modification timestamp | [default to null] |
+| **file-modification-timestamp** | **Long** | File modification timestamp, in epoch milliseconds | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1307,7 +1307,7 @@ components:
         timestamp:
           type: integer
           format: int64
-          description: In-commit timestamp
+          description: In-commit timestamp, in epoch milliseconds
         file-name:
           type: string
           description: UUID-based commit file name
@@ -1318,7 +1318,7 @@ components:
         file-modification-timestamp:
           type: integer
           format: int64
-          description: File modification timestamp
+          description: File modification timestamp, in epoch milliseconds
       required:
         - version
         - timestamp

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -101,32 +101,57 @@ public class DeltaCommitRepository {
   }
 
   /**
-   * Retrieves all commits for a table in descending order by version up to NUM_COMMITS_PER_BATCH.
+   * Result of querying unbackfilled commits for a table.
+   *
+   * @param commits unbackfilled commits (descending version order, newest first)
+   * @param latestTableVersion the latest commit version (0 if no commits)
+   * @param oldestVersion the oldest commit version in the DB (used for pagination base)
    */
-  private List<DeltaCommitDAO> getAllCommitDAOsDesc(UUID tableId) {
-    return TransactionManager.executeWithTransaction(
-        sessionFactory,
-        session -> {
-          TableInfoDAO tableInfoDAO = session.get(TableInfoDAO.class, tableId);
-          if (tableInfoDAO == null) {
-            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableId);
-          }
-          validateTable(tableInfoDAO);
+  record CommitQueryResult(
+      List<DeltaCommitDAO> commits, long latestTableVersion, long oldestVersion) {}
 
-          Query<DeltaCommitDAO> query =
-              session.createQuery(
-                  "FROM DeltaCommitDAO WHERE tableId = :tableId ORDER BY commitVersion DESC",
-                  DeltaCommitDAO.class);
-          query.setParameter("tableId", tableId);
-          query.setMaxResults(NUM_COMMITS_PER_BATCH);
-          return query.list();
-        },
-        "Failed to get latest commits",
-        /* readOnly= */ true,
-        // Use REPEATABLE_READ isolation to ensure consistent snapshot and prevent version numbers
-        // from appearing to go backwards during concurrent writes. This is critical for get
-        // commits that expect monotonic version progression after posting a commit.
-        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
+  /**
+   * Query unbackfilled commits for a table within an existing session. Returns commits in
+   * descending version order (newest first) and the latest table version.
+   *
+   * <p>Handles empty tables (returns version 0) and fully backfilled tables (returns empty list
+   * with correct version).
+   */
+  CommitQueryResult getUnbackfilledCommits(Session session, UUID tableId) {
+    Query<DeltaCommitDAO> query =
+        session.createQuery(
+            "FROM DeltaCommitDAO WHERE tableId = :tableId ORDER BY commitVersion DESC",
+            DeltaCommitDAO.class);
+    query.setParameter("tableId", tableId);
+    query.setMaxResults(NUM_COMMITS_PER_BATCH);
+    List<DeltaCommitDAO> allDesc = query.list();
+
+    if (allDesc.isEmpty()) {
+      return new CommitQueryResult(List.of(), 0L, 0L);
+    }
+
+    int commitCount = allDesc.size();
+    if (commitCount > MAX_NUM_COMMITS_PER_TABLE) {
+      LOGGER.error(
+          "Table {} has {} commits, exceeds limit {}.",
+          tableId,
+          commitCount,
+          MAX_NUM_COMMITS_PER_TABLE);
+    }
+
+    DeltaCommitDAO newestCommit = allDesc.get(0);
+    long latestVersion = newestCommit.getCommitVersion();
+    long oldestVersion = allDesc.get(allDesc.size() - 1).getCommitVersion();
+    if (newestCommit.isBackfilledLatestCommit()) {
+      return new CommitQueryResult(List.of(), latestVersion, oldestVersion);
+    }
+
+    // Only the latest backfilled version is kept in the DB as a
+    // marker (isBackfilledLatestCommit=true). All other backfilled
+    // commits are deleted. Filter out this single marker.
+    List<DeltaCommitDAO> unbackfilled =
+        allDesc.stream().filter(c -> !c.isBackfilledLatestCommit()).toList();
+    return new CommitQueryResult(unbackfilled, latestVersion, oldestVersion);
   }
 
   /**
@@ -163,56 +188,38 @@ public class DeltaCommitRepository {
         endVersion.filter(x -> x < startVersion).isEmpty(),
         "end_version must be >=start_version if set");
 
-    List<DeltaCommitDAO> allCommitDAOsDesc = getAllCommitDAOsDesc(tableId);
-    int commitCount = allCommitDAOsDesc.size();
-    if (commitCount > MAX_NUM_COMMITS_PER_TABLE) {
-      // This should never occur. But this is recoverable and not fatal.
-      LOGGER.error(
-          "Table {} has {} commits, which exceeds the limit of {}.",
-          tableId,
-          commitCount,
-          MAX_NUM_COMMITS_PER_TABLE);
-    }
-    if (commitCount == 0) {
-      // Table is validated as a managed Delta table. UC is the source of truth for
-      // managed tables, so a newly created table with no commits is at version 0.
-      return new DeltaGetCommitsResponse().latestTableVersion(0L);
-    }
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          // Validate table exists and is managed Delta
+          TableInfoDAO tableInfoDAO = session.get(TableInfoDAO.class, tableId);
+          if (tableInfoDAO == null) {
+            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableId);
+          }
+          validateTable(tableInfoDAO);
 
-    // In case there's only one commit in database, firstCommitDAO and lastCommitDAO will be the
-    // same object.
-    DeltaCommitDAO firstCommitDAO = allCommitDAOsDesc.get(allCommitDAOsDesc.size() - 1);
-    DeltaCommitDAO lastCommitDAO = allCommitDAOsDesc.get(0);
-    assert firstCommitDAO.getCommitVersion() <= lastCommitDAO.getCommitVersion();
-    if (lastCommitDAO.isBackfilledLatestCommit()) {
-      // The last commit is already backfilled. Just return an empty list. No need to return any
-      // actual commits.
-      return new DeltaGetCommitsResponse().latestTableVersion(lastCommitDAO.getCommitVersion());
-    }
+          CommitQueryResult result = getUnbackfilledCommits(session, tableId);
 
-    // The last version to return if endVersion is not set. It's limited by pagination limit.
-    // In normal cases the pagination limitation should not happen at all since the limit is the
-    // same limit that a table can have as many unbackfilled commits as possible. But it is
-    // implemented this way just in case.
-    long paginatedEndVersionInclusive =
-        Math.max(startVersion, firstCommitDAO.getCommitVersion()) + MAX_NUM_COMMITS_PER_TABLE - 1;
-    // The actual last version to return
-    long effectiveEndVersionInclusive =
-        Math.min(endVersion.orElse(Long.MAX_VALUE), paginatedEndVersionInclusive);
+          // Apply version range filter + pagination
+          long paginatedEnd =
+              Math.max(startVersion, result.oldestVersion()) + MAX_NUM_COMMITS_PER_TABLE - 1;
+          long effectiveEnd = Math.min(endVersion.orElse(Long.MAX_VALUE), paginatedEnd);
 
-    // Filter result and return
-    List<DeltaCommitInfo> commits =
-        allCommitDAOsDesc.stream()
-            .filter(
-                c ->
-                    !c.isBackfilledLatestCommit()
-                        && c.getCommitVersion() >= startVersion
-                        && c.getCommitVersion() <= effectiveEndVersionInclusive)
-            .map(DeltaCommitDAO::toCommitInfo)
-            .collect(Collectors.toList());
-    return new DeltaGetCommitsResponse()
-        .commits(commits)
-        .latestTableVersion(lastCommitDAO.getCommitVersion());
+          List<DeltaCommitInfo> commits =
+              result.commits().stream()
+                  .filter(
+                      c ->
+                          c.getCommitVersion() >= startVersion
+                              && c.getCommitVersion() <= effectiveEnd)
+                  .map(DeltaCommitDAO::toCommitInfo)
+                  .collect(Collectors.toList());
+          return new DeltaGetCommitsResponse()
+              .commits(commits)
+              .latestTableVersion(result.latestTableVersion());
+        },
+        "Failed to get commits",
+        /* readOnly= */ true,
+        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -1,5 +1,7 @@
 package io.unitycatalog.server.persist;
 
+import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
+
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfos;
@@ -219,7 +221,7 @@ public class DeltaCommitRepository {
         },
         "Failed to get commits",
         /* readOnly= */ true,
-        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
+        Optional.of(TRANSACTION_REPEATABLE_READ));
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -1,5 +1,7 @@
 package io.unitycatalog.server.persist;
 
+import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
+
 import io.unitycatalog.server.delta.model.DeltaCommit;
 import io.unitycatalog.server.delta.model.LoadTableResponse;
 import io.unitycatalog.server.delta.model.StructType;
@@ -214,7 +216,7 @@ public class TableRepository {
         },
         "Failed to load table",
         /* readOnly = */ true,
-        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
+        Optional.of(TRANSACTION_REPEATABLE_READ));
   }
 
   private TableMetadata buildTableMetadata(

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -221,9 +221,11 @@ public class TableRepository {
       Session session, TableInfoDAO dao, String catalog, String schema, String table) {
     TableMetadata metadata = new TableMetadata();
     Long updatedAt = dao.getUpdatedAt() != null ? dao.getUpdatedAt().getTime() : null;
-    // When updatedAt is null (shouldn't happen for a persisted table but defensively handled),
-    // the etag becomes "etag-null" which is a stable distinct value for that edge case.
-    metadata.setEtag("etag-" + updatedAt);
+    // Normal case: etag keyed on the table's last update time. If updatedAt is missing
+    // (shouldn't happen for a persisted table, but defensively handled), fall back to the
+    // table UUID so the etag stays unique per table rather than collapsing to "etag-null"
+    // across rows.
+    metadata.setEtag(updatedAt != null ? "etag-" + updatedAt : "etag-" + dao.getId());
     metadata.setDataSourceFormat(toDeltaFormat(dao.getDataSourceFormat()));
     metadata.setTableType(toDeltaTableType(dao.getType()));
     metadata.setTableUuid(dao.getId());
@@ -281,14 +283,18 @@ public class TableRepository {
             .toList();
     for (int i = 0; i < partitionInfos.size(); i++) {
       if (partitionInfos.get(i).getPartitionIndex() != i) {
+        // Non-contiguous indices mean the persisted partition spec is corrupt. Emit an empty
+        // partition list rather than a possibly-partial one the client can't reconcile.
         LOGGER.warn(
-            "Table {}.{}.{} has invalid partition indices, expected {} but got {}",
+            "Table {}.{}.{} has invalid partition indices, expected {} but got {}; "
+                + "emitting empty partition columns",
             catalog,
             schema,
             table,
             i,
             partitionInfos.get(i).getPartitionIndex());
-        break;
+        metadata.setPartitionColumns(List.of());
+        return;
       }
     }
     metadata.setPartitionColumns(partitionInfos.stream().map(ColumnInfo::getName).toList());

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -1,5 +1,11 @@
 package io.unitycatalog.server.persist;
 
+import io.unitycatalog.server.delta.model.DeltaCommit;
+import io.unitycatalog.server.delta.model.LoadTableResponse;
+import io.unitycatalog.server.delta.model.StructType;
+import io.unitycatalog.server.delta.model.TableMetadata;
+import io.unitycatalog.server.delta.model.UniformMetadata;
+import io.unitycatalog.server.delta.model.UniformMetadataIceberg;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
@@ -8,6 +14,7 @@ import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
@@ -17,18 +24,21 @@ import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.persist.utils.RepositoryUtils;
 import io.unitycatalog.server.persist.utils.TransactionManager;
+import io.unitycatalog.server.utils.ColumnUtils;
 import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.TableProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -161,6 +171,189 @@ public class TableRepository {
         /* readOnly = */ true);
   }
 
+  /**
+   * Load a table for the Delta REST Catalog API in a single REPEATABLE_READ transaction.
+   *
+   * <p>Returns a {@link LoadTableResponse} containing:
+   *
+   * <ul>
+   *   <li>Table metadata (format, type, location, columns, partition columns, properties)
+   *   <li>Unbackfilled commits (managed Delta tables only; empty for external tables)
+   *   <li>Uniform metadata (Iceberg location/version if present)
+   * </ul>
+   *
+   * <p>Column parsing is best-effort: corrupt typeJson data yields an empty schema rather than
+   * failing the entire response.
+   */
+  public LoadTableResponse loadTableForDelta(String catalog, String schema, String table) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          TableInfoDAO dao = findTable(session, catalog, schema, table);
+          if (dao == null) {
+            throw new BaseException(
+                ErrorCode.TABLE_NOT_FOUND,
+                "Table not found: " + catalog + "." + schema + "." + table);
+          }
+
+          TableMetadata metadata = buildTableMetadata(session, dao, catalog, schema, table);
+
+          LoadTableResponse response = new LoadTableResponse();
+          response.setMetadata(metadata);
+
+          // Commits (managed Delta tables only)
+          if (TableType.MANAGED.toString().equals(dao.getType())
+              && DataSourceFormat.DELTA.toString().equals(dao.getDataSourceFormat())) {
+            populateCommitsForDelta(
+                response, repositories.getDeltaCommitRepository(), session, dao.getId());
+          }
+
+          populateUniformMetadata(response, dao);
+
+          return response;
+        },
+        "Failed to load table",
+        /* readOnly = */ true,
+        Optional.of(java.sql.Connection.TRANSACTION_REPEATABLE_READ));
+  }
+
+  private TableMetadata buildTableMetadata(
+      Session session, TableInfoDAO dao, String catalog, String schema, String table) {
+    TableMetadata metadata = new TableMetadata();
+    Long updatedAt = dao.getUpdatedAt() != null ? dao.getUpdatedAt().getTime() : null;
+    // When updatedAt is null (shouldn't happen for a persisted table but defensively handled),
+    // the etag becomes "etag-null" which is a stable distinct value for that edge case.
+    metadata.setEtag("etag-" + updatedAt);
+    metadata.setDataSourceFormat(toDeltaFormat(dao.getDataSourceFormat()));
+    metadata.setTableType(toDeltaTableType(dao.getType()));
+    metadata.setTableUuid(dao.getId());
+    metadata.setLocation(NormalizedURL.normalize(dao.getUrl()));
+    metadata.setCreatedTime(dao.getCreatedAt() != null ? dao.getCreatedAt().getTime() : null);
+    metadata.setUpdatedTime(updatedAt);
+    metadata.setSecurableType(io.unitycatalog.server.delta.model.SecurableType.TABLE);
+
+    // Columns -- best-effort; corrupt data should not fail the entire response
+    StructType emptySchema = new StructType().fields(List.of());
+    List<ColumnInfo> cols = List.of();
+    try {
+      cols = ColumnInfoDAO.toList(dao.getColumns());
+      if (cols != null && !cols.isEmpty()) {
+        metadata.setColumns(
+            new StructType().fields(cols.stream().map(ColumnUtils::toStructField).toList()));
+      } else {
+        metadata.setColumns(emptySchema);
+      }
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to parse columns for table {}.{}.{}, returning empty schema",
+          catalog,
+          schema,
+          table,
+          e);
+      metadata.setColumns(emptySchema);
+    }
+
+    populatePartitionColumns(metadata, cols, catalog, schema, table);
+
+    List<PropertyDAO> propDAOs =
+        PropertyRepository.findProperties(session, dao.getId(), Constants.TABLE);
+    Map<String, String> props = PropertyDAO.toMap(propDAOs);
+    metadata.setProperties(props);
+
+    // last-commit-version and last-commit-timestamp track only metadata-changing commits
+    // (delta.lastUpdateVersion / delta.lastCommitTimestamp) and are written by the commit path.
+    // They are distinct from CommitQueryResult.latestTableVersion, which advances on every
+    // commit including data-only ones. Reading from table properties preserves that distinction.
+    parseLongProperty(props, TableProperties.LAST_UPDATE_VERSION)
+        .ifPresent(metadata::setLastCommitVersion);
+    parseLongProperty(props, TableProperties.LAST_COMMIT_TIMESTAMP)
+        .ifPresent(metadata::setLastCommitTimestampMs);
+
+    return metadata;
+  }
+
+  private static void populatePartitionColumns(
+      TableMetadata metadata, List<ColumnInfo> cols, String catalog, String schema, String table) {
+    List<ColumnInfo> partitionInfos =
+        cols.stream()
+            .filter(c -> c.getPartitionIndex() != null)
+            .sorted(Comparator.comparingInt(ColumnInfo::getPartitionIndex))
+            .toList();
+    for (int i = 0; i < partitionInfos.size(); i++) {
+      if (partitionInfos.get(i).getPartitionIndex() != i) {
+        LOGGER.warn(
+            "Table {}.{}.{} has invalid partition indices, expected {} but got {}",
+            catalog,
+            schema,
+            table,
+            i,
+            partitionInfos.get(i).getPartitionIndex());
+        break;
+      }
+    }
+    metadata.setPartitionColumns(partitionInfos.stream().map(ColumnInfo::getName).toList());
+  }
+
+  private static Optional<Long> parseLongProperty(Map<String, String> props, String key) {
+    String value = props.get(key);
+    if (value == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(Long.parseLong(value));
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Invalid long value for property {}: {}", key, value);
+      return Optional.empty();
+    }
+  }
+
+  /** Populate unbackfilled commits from DeltaCommitRepository into the response. */
+  private static void populateCommitsForDelta(
+      LoadTableResponse response, DeltaCommitRepository commitRepo, Session session, UUID tableId) {
+    DeltaCommitRepository.CommitQueryResult result =
+        commitRepo.getUnbackfilledCommits(session, tableId);
+    response.setLatestTableVersion(result.latestTableVersion());
+
+    List<DeltaCommit> commits =
+        result.commits().stream()
+            .map(
+                c ->
+                    new DeltaCommit()
+                        .version(c.getCommitVersion())
+                        .timestamp(c.getCommitTimestamp().getTime())
+                        .fileName(c.getCommitFilename())
+                        .fileSize(c.getCommitFilesize())
+                        .fileModificationTimestamp(
+                            c.getCommitFileModificationTimestamp().getTime()))
+            .toList();
+    response.setCommits(commits);
+  }
+
+  private static void populateUniformMetadata(LoadTableResponse response, TableInfoDAO dao) {
+    String uniformLocation = dao.getUniformIcebergMetadataLocation();
+    if (uniformLocation == null) {
+      return;
+    }
+    UniformMetadataIceberg iceberg = new UniformMetadataIceberg().metadataLocation(uniformLocation);
+    if (dao.getUniformIcebergConvertedDeltaVersion() != null) {
+      iceberg.convertedDeltaVersion(dao.getUniformIcebergConvertedDeltaVersion());
+    }
+    if (dao.getUniformIcebergConvertedDeltaTimestamp() != null) {
+      iceberg.convertedDeltaTimestamp(dao.getUniformIcebergConvertedDeltaTimestamp().getTime());
+    }
+    response.setUniform(new UniformMetadata().iceberg(iceberg));
+  }
+
+  // Delta model enum converters (avoid FQ names for types that
+  // conflict with io.unitycatalog.server.model.*)
+  private static io.unitycatalog.server.delta.model.DataSourceFormat toDeltaFormat(String value) {
+    return io.unitycatalog.server.delta.model.DataSourceFormat.fromValue(value);
+  }
+
+  private static io.unitycatalog.server.delta.model.TableType toDeltaTableType(String value) {
+    return io.unitycatalog.server.delta.model.TableType.fromValue(value);
+  }
+
   public String getTableUniformMetadataLocation(
       Session session, String catalogName, String schemaName, String tableName) {
     TableInfoDAO dao = findTable(session, catalogName, schemaName, tableName);
@@ -180,7 +373,7 @@ public class TableRepository {
     List<ColumnInfo> columnInfos =
         createTable.getColumns().stream()
             .map(c -> c.typeText(c.getTypeText().toLowerCase(Locale.ROOT)))
-            .collect(Collectors.toList());
+            .toList();
     Long createTime = System.currentTimeMillis();
     String fullName = getTableFullName(createTable);
     LOGGER.debug("Creating table: {}", fullName);

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -2,6 +2,8 @@ package io.unitycatalog.server.service.delta;
 
 import static io.unitycatalog.server.model.SecurableType.CATALOG;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+import static io.unitycatalog.server.model.SecurableType.TABLE;
 
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
@@ -11,11 +13,13 @@ import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.delta.model.CatalogConfig;
+import io.unitycatalog.server.delta.model.LoadTableResponse;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.DeltaRestExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.CatalogRepository;
 import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.service.AuthorizedService;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import java.util.List;
@@ -45,6 +49,7 @@ public class DeltaRestCatalogService extends AuthorizedService {
           "GET /v1/temporary-path-credentials");
 
   private final CatalogRepository catalogRepository;
+  private final TableRepository tableRepository;
 
   public DeltaRestCatalogService(
       UnityCatalogAuthorizer authorizer,
@@ -52,6 +57,7 @@ public class DeltaRestCatalogService extends AuthorizedService {
       StorageCredentialVendor storageCredentialVendor) {
     super(authorizer, repositories);
     this.catalogRepository = repositories.getCatalogRepository();
+    this.tableRepository = repositories.getTableRepository();
   }
 
   // ==================== Configuration API ====================
@@ -77,5 +83,26 @@ public class DeltaRestCatalogService extends AuthorizedService {
 
     // For now, we only have 1.0 as the first protocol version. Input protocolVersions is ignored.
     return new CatalogConfig().endpoints(ENDPOINTS).protocolVersion("1.0");
+  }
+
+  // ==================== Load Table API ====================
+
+  @Get("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+  @ProducesJson
+  @AuthorizeExpression(
+      """
+      #authorize(#principal, #metastore, OWNER) ||
+      #authorize(#principal, #catalog, OWNER) ||
+      (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
+      (#authorize(#principal, #schema, USE_SCHEMA) &&
+          #authorize(#principal, #catalog, USE_CATALOG) &&
+          #authorizeAny(#principal, #table, OWNER, SELECT, MODIFY))
+      """)
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse loadTable(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table) {
+    return tableRepository.loadTableForDelta(catalog, schema, table);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -1,5 +1,15 @@
 package io.unitycatalog.server.utils;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.delta.model.ArrayType;
+import io.unitycatalog.server.delta.model.DeltaType;
+import io.unitycatalog.server.delta.model.MapType;
+import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.serde.DeltaTypeModule;
+import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.ColumnTypeName;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import java.util.HashMap;
@@ -63,5 +73,80 @@ public class ColumnUtils {
             columnInfoDAO.getName(),
             columnInfoDAO.isNullable(),
             getPrecisionAndScale(columnInfoDAO)));
+  }
+
+  // ObjectMapper for reading/writing Spark's camelCase typeJson.
+  // Getter mixins override the generated kebab-case @JsonProperty
+  // so both ser and deser use camelCase.
+  private static final ObjectMapper TYPE_MAPPER = createTypeMapper();
+
+  private static ObjectMapper createTypeMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new DeltaTypeModule());
+    mapper.addMixIn(ArrayType.class, CamelCaseArrayMixin.class);
+    mapper.addMixIn(MapType.class, CamelCaseMapMixin.class);
+    return mapper;
+  }
+
+  abstract static class CamelCaseArrayMixin {
+    @JsonProperty("elementType")
+    abstract DeltaType getElementType();
+
+    @JsonSetter("elementType")
+    abstract void setElementType(DeltaType v);
+
+    @JsonProperty("containsNull")
+    abstract Boolean getContainsNull();
+
+    @JsonSetter("containsNull")
+    abstract void setContainsNull(Boolean v);
+  }
+
+  abstract static class CamelCaseMapMixin {
+    @JsonProperty("keyType")
+    abstract DeltaType getKeyType();
+
+    @JsonSetter("keyType")
+    abstract void setKeyType(DeltaType v);
+
+    @JsonProperty("valueType")
+    abstract DeltaType getValueType();
+
+    @JsonSetter("valueType")
+    abstract void setValueType(DeltaType v);
+
+    @JsonProperty("valueContainsNull")
+    abstract Boolean getValueContainsNull();
+
+    @JsonSetter("valueContainsNull")
+    abstract void setValueContainsNull(Boolean v);
+  }
+
+  /**
+   * Convert a UC ColumnInfo to a Delta REST API StructField by parsing typeJson directly. The
+   * typeJson is in Spark's StructField format and contains the complete field definition (name,
+   * type, nullable, metadata). Only partitionIndex comes from ColumnInfo, not typeJson.
+   */
+  public static StructField toStructField(ColumnInfo column) {
+    String typeJson = column.getTypeJson();
+    if (typeJson == null || typeJson.isEmpty()) {
+      throw new IllegalStateException("Column " + column.getName() + " has null/empty typeJson");
+    }
+    try {
+      return TYPE_MAPPER.readValue(typeJson, StructField.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          "Failed to parse typeJson for column " + column.getName() + ": " + typeJson, e);
+    }
+  }
+
+  /** Serialize a Delta StructField to Spark's camelCase typeJson format for UC database storage. */
+  public static String toTypeJson(StructField field) {
+    try {
+      return TYPE_MAPPER.writeValueAsString(field);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          "Failed to serialize typeJson for field " + field.getName(), e);
+    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/TableProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/TableProperties.java
@@ -3,4 +3,10 @@ package io.unitycatalog.server.utils;
 public class TableProperties {
   /** Key for identifying Unity Catalog table ID in Delta commits. */
   public static final String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
+
+  /** Last metadata-changing commit version (delta.lastUpdateVersion). */
+  public static final String LAST_UPDATE_VERSION = "delta.lastUpdateVersion";
+
+  /** Timestamp of the last metadata-changing commit (delta.lastCommitTimestamp). */
+  public static final String LAST_COMMIT_TIMESTAMP = "delta.lastCommitTimestamp";
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -50,6 +50,14 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
     TablesApi regular2TablesApi = new TablesApi(TestUtils.createApiClient(regular2Config));
     SchemasApi regular2SchemasApi = new SchemasApi(TestUtils.createApiClient(regular2Config));
 
+    // Delta REST API clients for loadTable tests
+    io.unitycatalog.client.delta.api.TablesApi adminDeltaApi =
+        new io.unitycatalog.client.delta.api.TablesApi(adminApiClient);
+    io.unitycatalog.client.delta.api.TablesApi regular1DeltaApi =
+        new io.unitycatalog.client.delta.api.TablesApi(TestUtils.createApiClient(regular1Config));
+    io.unitycatalog.client.delta.api.TablesApi regular2DeltaApi =
+        new io.unitycatalog.client.delta.api.TablesApi(TestUtils.createApiClient(regular2Config));
+
     // Grant USE CATALOG and USE SCHEMA to principal-1
     grantPermissions(PRINCIPAL_1, SecurableType.CATALOG, "cat_pr1", Privileges.USE_CATALOG);
     grantPermissions(PRINCIPAL_1, SecurableType.SCHEMA, "cat_pr1.sch_pr1", Privileges.USE_SCHEMA);
@@ -133,6 +141,16 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
     // get, table (regular-2) -> use schema, use catalog, select [table] -> allowed
     TableInfo tableInfoRegular2 = getTable(regular2TablesApi, "cat_pr1.sch_pr1.tbl_pr1");
     assertThat(tableInfoRegular2).isNotNull();
+
+    // Delta loadTable follows the same authz as getTable
+    // loadTable (admin) -> metastore admin -> allowed
+    assertThat(adminDeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1")).isNotNull();
+
+    // loadTable (regular-1) -> use catalog, use schema, but no SELECT -> denied
+    assertPermissionDenied(() -> regular1DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1"));
+
+    // loadTable (regular-2) -> use schema, use catalog, select -> allowed
+    assertThat(regular2DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1")).isNotNull();
 
     // grant CREATE SCHEMA to regular-2
     grantPermissions(

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
@@ -41,6 +41,11 @@ import org.hibernate.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * End-to-end tests for the Delta REST Catalog loadTable endpoint. Consolidated into a single test
+ * with sections so the BaseServerTest setUp/tearDown (server start + DB reset per test) runs once
+ * for all scenarios. Each section creates its own uniquely-named table so they don't collide.
+ */
 public class SdkLoadTableTest extends BaseServerTest {
 
   private CatalogOperations catalogOps;
@@ -81,307 +86,324 @@ public class SdkLoadTableTest extends BaseServerTest {
   }
 
   @Test
-  public void testLoadTable() throws Exception {
-    // --- External table: verify metadata and columns ---
-    tableOps.createTable(
-        new CreateTable()
-            .name(TestUtils.TABLE_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.EXTERNAL)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .storageLocation("file:///tmp/uc_test/delta_table")
-            .columns(
-                List.of(
-                    new ColumnInfo()
-                        .name("id")
-                        .typeName(ColumnTypeName.LONG)
-                        .typeText("bigint")
-                        .typeJson(
-                            "{\"name\":\"id\",\"type\":\"long\","
-                                + "\"nullable\":false,\"metadata\":{}}")
-                        .position(0)
-                        .nullable(false),
-                    new ColumnInfo()
-                        .name("name")
-                        .typeName(ColumnTypeName.STRING)
-                        .typeText("string")
-                        .typeJson(
-                            "{\"name\":\"name\",\"type\":\"string\","
-                                + "\"nullable\":true,\"metadata\":{}}")
-                        .position(1)
-                        .nullable(true))));
+  public void testLoadTableEndpoints() throws Exception {
+    // -------- External DELTA table: typed columns, no commits --------
+    {
+      String tableName = "tbl_external";
+      tableOps.createTable(
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .tableType(TableType.EXTERNAL)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .storageLocation("file:///tmp/uc_test/" + tableName)
+              .columns(
+                  List.of(
+                      new ColumnInfo()
+                          .name("id")
+                          .typeName(ColumnTypeName.LONG)
+                          .typeText("bigint")
+                          .typeJson(
+                              "{\"name\":\"id\",\"type\":\"long\","
+                                  + "\"nullable\":false,\"metadata\":{}}")
+                          .position(0)
+                          .nullable(false),
+                      new ColumnInfo()
+                          .name("name")
+                          .typeName(ColumnTypeName.STRING)
+                          .typeText("string")
+                          .typeJson(
+                              "{\"name\":\"name\",\"type\":\"string\","
+                                  + "\"nullable\":true,\"metadata\":{}}")
+                          .position(1)
+                          .nullable(true))));
 
-    LoadTableResponse response =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    TableMetadata metadata = response.getMetadata();
+      LoadTableResponse response = loadTable(tableName);
+      TableMetadata metadata = response.getMetadata();
 
-    assertThat(metadata.getTableUuid()).isNotNull();
-    assertThat(metadata.getDataSourceFormat().getValue()).isEqualTo("DELTA");
-    assertThat(metadata.getTableType().getValue()).isEqualTo("EXTERNAL");
-    assertThat(metadata.getLocation()).isNotNull();
-    assertThat(metadata.getCreatedTime()).isNotNull();
-    assertThat(metadata.getUpdatedTime()).isNotNull();
-    assertThat(metadata.getEtag()).isNotNull();
-    assertThat(metadata.getProperties()).isNotNull();
+      assertThat(metadata.getTableUuid()).isNotNull();
+      assertThat(metadata.getDataSourceFormat().getValue()).isEqualTo("DELTA");
+      assertThat(metadata.getTableType().getValue()).isEqualTo("EXTERNAL");
+      assertThat(metadata.getLocation()).isNotNull();
+      assertThat(metadata.getCreatedTime()).isNotNull();
+      assertThat(metadata.getUpdatedTime()).isNotNull();
+      assertThat(metadata.getEtag()).isNotNull();
+      assertThat(metadata.getProperties()).isNotNull();
 
-    List<StructField> fields = metadata.getColumns().getFields();
-    assertThat(fields).hasSize(2);
-    assertThat(fields.get(0).getName()).isEqualTo("id");
-    assertThat(fields.get(0).getType()).isInstanceOf(PrimitiveType.class);
-    assertThat(fields.get(0).getType().getType()).isEqualTo("long");
-    assertThat(fields.get(0).getNullable()).isFalse();
-    assertThat(fields.get(1).getName()).isEqualTo("name");
-    assertThat(fields.get(1).getType()).isInstanceOf(PrimitiveType.class);
-    assertThat(fields.get(1).getType().getType()).isEqualTo("string");
-    assertThat(fields.get(1).getNullable()).isTrue();
+      List<StructField> fields = metadata.getColumns().getFields();
+      assertThat(fields).hasSize(2);
+      assertThat(fields.get(0).getName()).isEqualTo("id");
+      assertThat(fields.get(0).getType()).isInstanceOf(PrimitiveType.class);
+      assertThat(fields.get(0).getType().getType()).isEqualTo("long");
+      assertThat(fields.get(0).getNullable()).isFalse();
+      assertThat(fields.get(1).getName()).isEqualTo("name");
+      assertThat(fields.get(1).getType()).isInstanceOf(PrimitiveType.class);
+      assertThat(fields.get(1).getType().getType()).isEqualTo("string");
+      assertThat(fields.get(1).getNullable()).isTrue();
 
-    // External table: no commits
-    assertThat(response.getCommits()).isNullOrEmpty();
-    assertThat(response.getLatestTableVersion()).isNull();
+      // External table: no commits
+      assertThat(response.getCommits()).isNullOrEmpty();
+      assertThat(response.getLatestTableVersion()).isNull();
+    }
 
-    // --- Managed table: commit flow ---
-    tableOps.deleteTable(
-        TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + TestUtils.TABLE_NAME);
-    TableInfo tableInfo =
-        BaseTableCRUDTestEnv.createTestingTable(
-            TestUtils.TABLE_NAME, TableType.MANAGED, Optional.empty(), tableOps);
-    String tableId = tableInfo.getTableId();
-    String tableUri = tableInfo.getStorageLocation();
+    // -------- Managed DELTA table: commit + backfill flow --------
+    {
+      String tableName = "tbl_commits";
+      TableInfo tableInfo =
+          BaseTableCRUDTestEnv.createTestingTable(
+              tableName, TableType.MANAGED, Optional.empty(), tableOps);
+      String tableId = tableInfo.getTableId();
+      String tableUri = tableInfo.getStorageLocation();
 
-    // Load before any commits: version 0, empty list
-    LoadTableResponse r1 =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(r1.getCommits()).isEmpty();
-    assertThat(r1.getLatestTableVersion()).isEqualTo(0L);
+      // Load before any commits: version 0, empty list
+      LoadTableResponse r1 = loadTable(tableName);
+      assertThat(r1.getCommits()).isEmpty();
+      assertThat(r1.getLatestTableVersion()).isEqualTo(0L);
 
-    // Commit v1, load: 1 commit
-    commitsApi.commit(
-        new DeltaCommit()
-            .tableId(tableId)
-            .tableUri(tableUri)
-            .commitInfo(
-                new DeltaCommitInfo()
-                    .version(1L)
-                    .fileName("00000001.json")
-                    .fileSize(1024L)
-                    .timestamp(1700000001L)
-                    .fileModificationTimestamp(1700000001L)));
-    LoadTableResponse r2 =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(r2.getCommits()).hasSize(1);
-    assertThat(r2.getCommits().get(0).getVersion()).isEqualTo(1);
-    assertThat(r2.getLatestTableVersion()).isEqualTo(1L);
+      // Commit v1, load: 1 commit
+      commitsApi.commit(
+          new DeltaCommit()
+              .tableId(tableId)
+              .tableUri(tableUri)
+              .commitInfo(
+                  new DeltaCommitInfo()
+                      .version(1L)
+                      .fileName("00000001.json")
+                      .fileSize(1024L)
+                      .timestamp(1700000001L)
+                      .fileModificationTimestamp(1700000001L)));
+      LoadTableResponse r2 = loadTable(tableName);
+      assertThat(r2.getCommits()).hasSize(1);
+      assertThat(r2.getCommits().get(0).getVersion()).isEqualTo(1);
+      assertThat(r2.getLatestTableVersion()).isEqualTo(1L);
 
-    // Commit v2, load: 2 commits in descending order
-    commitsApi.commit(
-        new DeltaCommit()
-            .tableId(tableId)
-            .tableUri(tableUri)
-            .commitInfo(
-                new DeltaCommitInfo()
-                    .version(2L)
-                    .fileName("00000002.json")
-                    .fileSize(2048L)
-                    .timestamp(1700000002L)
-                    .fileModificationTimestamp(1700000002L)));
-    LoadTableResponse r3 =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(r3.getCommits()).hasSize(2);
-    assertThat(r3.getCommits().get(0).getVersion()).isEqualTo(2);
-    assertThat(r3.getCommits().get(1).getVersion()).isEqualTo(1);
-    assertThat(r3.getLatestTableVersion()).isEqualTo(2L);
+      // Commit v2, load: 2 commits in descending order
+      commitsApi.commit(
+          new DeltaCommit()
+              .tableId(tableId)
+              .tableUri(tableUri)
+              .commitInfo(
+                  new DeltaCommitInfo()
+                      .version(2L)
+                      .fileName("00000002.json")
+                      .fileSize(2048L)
+                      .timestamp(1700000002L)
+                      .fileModificationTimestamp(1700000002L)));
+      LoadTableResponse r3 = loadTable(tableName);
+      assertThat(r3.getCommits()).hasSize(2);
+      assertThat(r3.getCommits().get(0).getVersion()).isEqualTo(2);
+      assertThat(r3.getCommits().get(1).getVersion()).isEqualTo(1);
+      assertThat(r3.getLatestTableVersion()).isEqualTo(2L);
 
-    // Backfill v1, load: v1 removed, only v2 remains
-    commitsApi.commit(
-        new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(1L));
-    LoadTableResponse r4 =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(r4.getCommits()).hasSize(1);
-    assertThat(r4.getCommits().get(0).getVersion()).isEqualTo(2);
-    assertThat(r4.getLatestTableVersion()).isEqualTo(2L);
+      // Backfill v1, load: v1 removed, only v2 remains
+      commitsApi.commit(
+          new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(1L));
+      LoadTableResponse r4 = loadTable(tableName);
+      assertThat(r4.getCommits()).hasSize(1);
+      assertThat(r4.getCommits().get(0).getVersion()).isEqualTo(2);
+      assertThat(r4.getLatestTableVersion()).isEqualTo(2L);
 
-    // Backfill v2, load: all backfilled, empty commits
-    commitsApi.commit(
-        new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(2L));
-    LoadTableResponse r5 =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(r5.getCommits()).isEmpty();
-    assertThat(r5.getLatestTableVersion()).isEqualTo(2L);
+      // Backfill v2, load: all backfilled, empty commits
+      commitsApi.commit(
+          new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(2L));
+      LoadTableResponse r5 = loadTable(tableName);
+      assertThat(r5.getCommits()).isEmpty();
+      assertThat(r5.getLatestTableVersion()).isEqualTo(2L);
+    }
+
+    // -------- Not-found: 404 with "Table not found" --------
+    {
+      ApiException ex = assertThrows(ApiException.class, () -> loadTable("nonexistent"));
+      assertThat(ex.getMessage()).contains("Table not found");
+      assertThat(ex.getCode()).isEqualTo(404);
+    }
+
+    // -------- Full metadata: partition columns + property-derived fields + uniform Iceberg
+    // --------
+    {
+      String tableName = "tbl_full";
+      tableOps.createTable(
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .tableType(TableType.MANAGED)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .properties(
+                  Map.of(
+                      "delta.lastUpdateVersion", "42",
+                      "delta.lastCommitTimestamp", "1700000000000",
+                      "user.custom", "value"))
+              .columns(
+                  List.of(
+                      new ColumnInfo()
+                          .name("id")
+                          .typeName(ColumnTypeName.LONG)
+                          .typeText("bigint")
+                          .typeJson(
+                              "{\"name\":\"id\",\"type\":\"long\","
+                                  + "\"nullable\":false,\"metadata\":{}}")
+                          .position(0)
+                          .partitionIndex(0)
+                          .nullable(false),
+                      new ColumnInfo()
+                          .name("region")
+                          .typeName(ColumnTypeName.STRING)
+                          .typeText("string")
+                          .typeJson(
+                              "{\"name\":\"region\",\"type\":\"string\","
+                                  + "\"nullable\":true,\"metadata\":{}}")
+                          .position(1)
+                          .partitionIndex(1)
+                          .nullable(true),
+                      new ColumnInfo()
+                          .name("amount")
+                          .typeName(ColumnTypeName.DECIMAL)
+                          .typeText("decimal(10,2)")
+                          .typeJson(
+                              "{\"name\":\"amount\",\"type\":\"decimal(10,2)\","
+                                  + "\"nullable\":true,\"metadata\":{}}")
+                          .position(2)
+                          .nullable(true))));
+
+      TableInfo tableInfo =
+          tableOps.getTable(TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + tableName);
+      String icebergLocation = "file:///tmp/uc_test/iceberg/v5.metadata.json";
+      long icebergVersion = 5L;
+      long icebergTimestampMs = 1700000100000L;
+      updateUniformMetadata(
+          UUID.fromString(tableInfo.getTableId()),
+          icebergLocation,
+          icebergVersion,
+          new Date(icebergTimestampMs));
+
+      LoadTableResponse response = loadTable(tableName);
+      TableMetadata metadata = response.getMetadata();
+
+      // Partition columns come back in partitionIndex order.
+      assertThat(metadata.getPartitionColumns()).containsExactly("id", "region");
+
+      // Property-derived fields resolved from delta.lastUpdateVersion / delta.lastCommitTimestamp.
+      assertThat(metadata.getLastCommitVersion()).isEqualTo(42L);
+      assertThat(metadata.getLastCommitTimestampMs()).isEqualTo(1700000000000L);
+      assertThat(metadata.getProperties()).containsEntry("user.custom", "value");
+
+      // Uniform Iceberg metadata is populated from the DAO fields.
+      assertThat(response.getUniform()).isNotNull();
+      UniformMetadataIceberg iceberg = response.getUniform().getIceberg();
+      assertThat(iceberg).isNotNull();
+      assertThat(iceberg.getMetadataLocation()).isEqualTo(icebergLocation);
+      assertThat(iceberg.getConvertedDeltaVersion()).isEqualTo(icebergVersion);
+      assertThat(iceberg.getConvertedDeltaTimestamp()).isEqualTo(icebergTimestampMs);
+    }
+
+    // -------- Non-contiguous partition indices: empty partitionColumns --------
+    // Corrupt partition spec (indices 0 and 2, missing 1). loadTable succeeds, logs a warning,
+    // and returns an empty list rather than a possibly-partial one the client can't reconcile.
+    {
+      String tableName = "tbl_bad_parts";
+      tableOps.createTable(
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .tableType(TableType.MANAGED)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .columns(
+                  List.of(
+                      new ColumnInfo()
+                          .name("id")
+                          .typeName(ColumnTypeName.LONG)
+                          .typeText("bigint")
+                          .typeJson(
+                              "{\"name\":\"id\",\"type\":\"long\","
+                                  + "\"nullable\":false,\"metadata\":{}}")
+                          .position(0)
+                          .partitionIndex(0)
+                          .nullable(false),
+                      new ColumnInfo()
+                          .name("filler")
+                          .typeName(ColumnTypeName.STRING)
+                          .typeText("string")
+                          .typeJson(
+                              "{\"name\":\"filler\",\"type\":\"string\","
+                                  + "\"nullable\":true,\"metadata\":{}}")
+                          .position(1)
+                          .nullable(true),
+                      new ColumnInfo()
+                          .name("region")
+                          .typeName(ColumnTypeName.STRING)
+                          .typeText("string")
+                          .typeJson(
+                              "{\"name\":\"region\",\"type\":\"string\","
+                                  + "\"nullable\":true,\"metadata\":{}}")
+                          .position(2)
+                          // Partition indices: 0 on "id" and 2 on "region" -- missing index 1.
+                          .partitionIndex(2)
+                          .nullable(true))));
+
+      assertThat(loadTable(tableName).getMetadata().getPartitionColumns()).isEmpty();
+    }
+
+    // -------- Malformed long property: field absent rather than 5xx --------
+    {
+      String tableName = "tbl_bad_prop";
+      tableOps.createTable(
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .tableType(TableType.MANAGED)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .properties(Map.of("delta.lastUpdateVersion", "not-a-number"))
+              .columns(
+                  List.of(
+                      new ColumnInfo()
+                          .name("id")
+                          .typeName(ColumnTypeName.LONG)
+                          .typeText("bigint")
+                          .typeJson(
+                              "{\"name\":\"id\",\"type\":\"long\","
+                                  + "\"nullable\":false,\"metadata\":{}}")
+                          .position(0)
+                          .nullable(false))));
+
+      LoadTableResponse response = loadTable(tableName);
+      assertThat(response.getMetadata()).isNotNull();
+      assertThat(response.getMetadata().getLastCommitVersion()).isNull();
+    }
+
+    // -------- Corrupt typeJson: empty schema rather than 5xx --------
+    {
+      String tableName = "tbl_corrupt_json";
+      tableOps.createTable(
+          new CreateTable()
+              .name(tableName)
+              .catalogName(TestUtils.CATALOG_NAME)
+              .schemaName(TestUtils.SCHEMA_NAME)
+              .tableType(TableType.MANAGED)
+              .dataSourceFormat(DataSourceFormat.DELTA)
+              .columns(
+                  List.of(
+                      new ColumnInfo()
+                          .name("id")
+                          .typeName(ColumnTypeName.LONG)
+                          .typeText("bigint")
+                          // Malformed typeJson -- loadTable should swallow the parse error and
+                          // return an empty schema rather than 5xx'ing.
+                          .typeJson("not json at all")
+                          .position(0)
+                          .nullable(false))));
+
+      LoadTableResponse response = loadTable(tableName);
+      assertThat(response.getMetadata()).isNotNull();
+      assertThat(response.getMetadata().getColumns().getFields()).isEmpty();
+    }
   }
 
-  @Test
-  public void testLoadTableNotFound() {
-    ApiException ex =
-        assertThrows(
-            ApiException.class,
-            () ->
-                deltaTablesApi.loadTable(
-                    TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "nonexistent"));
-    assertThat(ex.getMessage()).contains("Table not found");
-    assertThat(ex.getCode()).isEqualTo(404);
-  }
-
-  /**
-   * Exercises the partition-column, property-derived version/timestamp, and uniform Iceberg
-   * metadata paths of loadTable on a MANAGED Delta table (the primary target of loadTable).
-   */
-  @Test
-  public void testLoadTableFullMetadata() throws Exception {
-    // Build a MANAGED Delta table with 2 partition columns and table properties including
-    // delta.lastUpdateVersion / delta.lastCommitTimestamp. storageLocation is filled in by
-    // SdkTableOperations from the staging flow.
-    tableOps.createTable(
-        new CreateTable()
-            .name(TestUtils.TABLE_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.MANAGED)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .properties(
-                Map.of(
-                    "delta.lastUpdateVersion", "42",
-                    "delta.lastCommitTimestamp", "1700000000000",
-                    "user.custom", "value"))
-            .columns(
-                List.of(
-                    new ColumnInfo()
-                        .name("id")
-                        .typeName(ColumnTypeName.LONG)
-                        .typeText("bigint")
-                        .typeJson(
-                            "{\"name\":\"id\",\"type\":\"long\","
-                                + "\"nullable\":false,\"metadata\":{}}")
-                        .position(0)
-                        .partitionIndex(0)
-                        .nullable(false),
-                    new ColumnInfo()
-                        .name("region")
-                        .typeName(ColumnTypeName.STRING)
-                        .typeText("string")
-                        .typeJson(
-                            "{\"name\":\"region\",\"type\":\"string\","
-                                + "\"nullable\":true,\"metadata\":{}}")
-                        .position(1)
-                        .partitionIndex(1)
-                        .nullable(true),
-                    new ColumnInfo()
-                        .name("amount")
-                        .typeName(ColumnTypeName.DECIMAL)
-                        .typeText("decimal(10,2)")
-                        .typeJson(
-                            "{\"name\":\"amount\",\"type\":\"decimal(10,2)\","
-                                + "\"nullable\":true,\"metadata\":{}}")
-                        .position(2)
-                        .nullable(true))));
-
-    // Uniform Iceberg metadata is not exposed through CreateTable, so set it directly on the DAO.
-    TableInfo tableInfo =
-        tableOps.getTable(
-            TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + TestUtils.TABLE_NAME);
-    String icebergLocation = "file:///tmp/uc_test/iceberg/v5.metadata.json";
-    long icebergVersion = 5L;
-    long icebergTimestampMs = 1700000100000L;
-    updateUniformMetadata(
-        UUID.fromString(tableInfo.getTableId()),
-        icebergLocation,
-        icebergVersion,
-        new Date(icebergTimestampMs));
-
-    LoadTableResponse response =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    TableMetadata metadata = response.getMetadata();
-
-    // Partition columns come back in partitionIndex order and match the two columns set above.
-    assertThat(metadata.getPartitionColumns()).containsExactly("id", "region");
-
-    // Property-derived fields resolved from delta.lastUpdateVersion / delta.lastCommitTimestamp.
-    assertThat(metadata.getLastCommitVersion()).isEqualTo(42L);
-    assertThat(metadata.getLastCommitTimestampMs()).isEqualTo(1700000000000L);
-    assertThat(metadata.getProperties()).containsEntry("user.custom", "value");
-
-    // Uniform Iceberg metadata is populated from the DAO fields.
-    assertThat(response.getUniform()).isNotNull();
-    UniformMetadataIceberg iceberg = response.getUniform().getIceberg();
-    assertThat(iceberg).isNotNull();
-    assertThat(iceberg.getMetadataLocation()).isEqualTo(icebergLocation);
-    assertThat(iceberg.getConvertedDeltaVersion()).isEqualTo(icebergVersion);
-    assertThat(iceberg.getConvertedDeltaTimestamp()).isEqualTo(icebergTimestampMs);
-  }
-
-  /**
-   * Verifies that a malformed long value in a property (e.g., delta.lastUpdateVersion="abc") is
-   * handled gracefully: loadTable still succeeds, and the affected field is absent from the
-   * response (the catch branch in parseLongProperty logs a warning and returns empty).
-   */
-  @Test
-  public void testLoadTableMalformedLongProperty() throws Exception {
-    tableOps.createTable(
-        new CreateTable()
-            .name(TestUtils.TABLE_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.MANAGED)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .properties(Map.of("delta.lastUpdateVersion", "not-a-number"))
-            .columns(
-                List.of(
-                    new ColumnInfo()
-                        .name("id")
-                        .typeName(ColumnTypeName.LONG)
-                        .typeText("bigint")
-                        .typeJson(
-                            "{\"name\":\"id\",\"type\":\"long\","
-                                + "\"nullable\":false,\"metadata\":{}}")
-                        .position(0)
-                        .nullable(false))));
-
-    LoadTableResponse response =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    // Response still succeeds, but lastCommitVersion is absent because the property was malformed.
-    assertThat(response.getMetadata()).isNotNull();
-    assertThat(response.getMetadata().getLastCommitVersion()).isNull();
-  }
-
-  /**
-   * Verifies that a corrupt typeJson on a stored column is handled gracefully: loadTable still
-   * succeeds, returning an empty schema rather than throwing (the catch branch in
-   * buildTableMetadata logs a warning and substitutes an empty StructType).
-   */
-  @Test
-  public void testLoadTableCorruptColumnTypeJson() throws Exception {
-    tableOps.createTable(
-        new CreateTable()
-            .name(TestUtils.TABLE_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.MANAGED)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .columns(
-                List.of(
-                    new ColumnInfo()
-                        .name("id")
-                        .typeName(ColumnTypeName.LONG)
-                        .typeText("bigint")
-                        // Malformed typeJson -- not valid JSON. loadTable should swallow the parse
-                        // error and return an empty schema rather than 5xx'ing.
-                        .typeJson("not json at all")
-                        .position(0)
-                        .nullable(false))));
-
-    LoadTableResponse response =
-        deltaTablesApi.loadTable(
-            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
-    assertThat(response.getMetadata()).isNotNull();
-    assertThat(response.getMetadata().getColumns().getFields()).isEmpty();
+  private LoadTableResponse loadTable(String tableName) throws ApiException {
+    return deltaTablesApi.loadTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, tableName);
   }
 
   private void updateUniformMetadata(

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
@@ -1,0 +1,399 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.DeltaCommitsApi;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.PrimitiveType;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.TableMetadata;
+import io.unitycatalog.client.delta.model.UniformMetadataIceberg;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.DeltaCommit;
+import io.unitycatalog.client.model.DeltaCommitInfo;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.BaseTableCRUDTestEnv;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SdkLoadTableTest extends BaseServerTest {
+
+  private CatalogOperations catalogOps;
+  private SchemaOperations schemaOps;
+  private TableOperations tableOps;
+  private DeltaCommitsApi commitsApi;
+  private TablesApi deltaTablesApi;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    var apiClient = TestUtils.createApiClient(serverConfig);
+    catalogOps = new SdkCatalogOperations(apiClient);
+    schemaOps = new SdkSchemaOperations(apiClient);
+    tableOps = new SdkTableOperations(apiClient);
+    commitsApi = new DeltaCommitsApi(apiClient);
+    deltaTablesApi = new TablesApi(apiClient);
+    cleanUp();
+    createCatalogAndSchema();
+  }
+
+  private void cleanUp() {
+    try {
+      catalogOps.deleteCatalog(TestUtils.CATALOG_NAME, Optional.of(true));
+    } catch (Exception e) {
+      // Ignore
+    }
+  }
+
+  private void createCatalogAndSchema() {
+    try {
+      catalogOps.createCatalog(new CreateCatalog().name(TestUtils.CATALOG_NAME).comment("test"));
+      schemaOps.createSchema(
+          new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testLoadTable() throws Exception {
+    // --- External table: verify metadata and columns ---
+    tableOps.createTable(
+        new CreateTable()
+            .name(TestUtils.TABLE_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation("file:///tmp/uc_test/delta_table")
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("id")
+                        .typeName(ColumnTypeName.LONG)
+                        .typeText("bigint")
+                        .typeJson(
+                            "{\"name\":\"id\",\"type\":\"long\","
+                                + "\"nullable\":false,\"metadata\":{}}")
+                        .position(0)
+                        .nullable(false),
+                    new ColumnInfo()
+                        .name("name")
+                        .typeName(ColumnTypeName.STRING)
+                        .typeText("string")
+                        .typeJson(
+                            "{\"name\":\"name\",\"type\":\"string\","
+                                + "\"nullable\":true,\"metadata\":{}}")
+                        .position(1)
+                        .nullable(true))));
+
+    LoadTableResponse response =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    TableMetadata metadata = response.getMetadata();
+
+    assertThat(metadata.getTableUuid()).isNotNull();
+    assertThat(metadata.getDataSourceFormat().getValue()).isEqualTo("DELTA");
+    assertThat(metadata.getTableType().getValue()).isEqualTo("EXTERNAL");
+    assertThat(metadata.getLocation()).isNotNull();
+    assertThat(metadata.getCreatedTime()).isNotNull();
+    assertThat(metadata.getUpdatedTime()).isNotNull();
+    assertThat(metadata.getEtag()).isNotNull();
+    assertThat(metadata.getProperties()).isNotNull();
+
+    List<StructField> fields = metadata.getColumns().getFields();
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0).getName()).isEqualTo("id");
+    assertThat(fields.get(0).getType()).isInstanceOf(PrimitiveType.class);
+    assertThat(fields.get(0).getType().getType()).isEqualTo("long");
+    assertThat(fields.get(0).getNullable()).isFalse();
+    assertThat(fields.get(1).getName()).isEqualTo("name");
+    assertThat(fields.get(1).getType()).isInstanceOf(PrimitiveType.class);
+    assertThat(fields.get(1).getType().getType()).isEqualTo("string");
+    assertThat(fields.get(1).getNullable()).isTrue();
+
+    // External table: no commits
+    assertThat(response.getCommits()).isNullOrEmpty();
+    assertThat(response.getLatestTableVersion()).isNull();
+
+    // --- Managed table: commit flow ---
+    tableOps.deleteTable(
+        TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + TestUtils.TABLE_NAME);
+    TableInfo tableInfo =
+        BaseTableCRUDTestEnv.createTestingTable(
+            TestUtils.TABLE_NAME, TableType.MANAGED, Optional.empty(), tableOps);
+    String tableId = tableInfo.getTableId();
+    String tableUri = tableInfo.getStorageLocation();
+
+    // Load before any commits: version 0, empty list
+    LoadTableResponse r1 =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(r1.getCommits()).isEmpty();
+    assertThat(r1.getLatestTableVersion()).isEqualTo(0L);
+
+    // Commit v1, load: 1 commit
+    commitsApi.commit(
+        new DeltaCommit()
+            .tableId(tableId)
+            .tableUri(tableUri)
+            .commitInfo(
+                new DeltaCommitInfo()
+                    .version(1L)
+                    .fileName("00000001.json")
+                    .fileSize(1024L)
+                    .timestamp(1700000001L)
+                    .fileModificationTimestamp(1700000001L)));
+    LoadTableResponse r2 =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(r2.getCommits()).hasSize(1);
+    assertThat(r2.getCommits().get(0).getVersion()).isEqualTo(1);
+    assertThat(r2.getLatestTableVersion()).isEqualTo(1L);
+
+    // Commit v2, load: 2 commits in descending order
+    commitsApi.commit(
+        new DeltaCommit()
+            .tableId(tableId)
+            .tableUri(tableUri)
+            .commitInfo(
+                new DeltaCommitInfo()
+                    .version(2L)
+                    .fileName("00000002.json")
+                    .fileSize(2048L)
+                    .timestamp(1700000002L)
+                    .fileModificationTimestamp(1700000002L)));
+    LoadTableResponse r3 =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(r3.getCommits()).hasSize(2);
+    assertThat(r3.getCommits().get(0).getVersion()).isEqualTo(2);
+    assertThat(r3.getCommits().get(1).getVersion()).isEqualTo(1);
+    assertThat(r3.getLatestTableVersion()).isEqualTo(2L);
+
+    // Backfill v1, load: v1 removed, only v2 remains
+    commitsApi.commit(
+        new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(1L));
+    LoadTableResponse r4 =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(r4.getCommits()).hasSize(1);
+    assertThat(r4.getCommits().get(0).getVersion()).isEqualTo(2);
+    assertThat(r4.getLatestTableVersion()).isEqualTo(2L);
+
+    // Backfill v2, load: all backfilled, empty commits
+    commitsApi.commit(
+        new DeltaCommit().tableId(tableId).tableUri(tableUri).latestBackfilledVersion(2L));
+    LoadTableResponse r5 =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(r5.getCommits()).isEmpty();
+    assertThat(r5.getLatestTableVersion()).isEqualTo(2L);
+  }
+
+  @Test
+  public void testLoadTableNotFound() {
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                deltaTablesApi.loadTable(
+                    TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "nonexistent"));
+    assertThat(ex.getMessage()).contains("Table not found");
+    assertThat(ex.getCode()).isEqualTo(404);
+  }
+
+  /**
+   * Exercises the partition-column, property-derived version/timestamp, and uniform Iceberg
+   * metadata paths of loadTable on a MANAGED Delta table (the primary target of loadTable).
+   */
+  @Test
+  public void testLoadTableFullMetadata() throws Exception {
+    // Build a MANAGED Delta table with 2 partition columns and table properties including
+    // delta.lastUpdateVersion / delta.lastCommitTimestamp. storageLocation is filled in by
+    // SdkTableOperations from the staging flow.
+    tableOps.createTable(
+        new CreateTable()
+            .name(TestUtils.TABLE_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.MANAGED)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .properties(
+                Map.of(
+                    "delta.lastUpdateVersion", "42",
+                    "delta.lastCommitTimestamp", "1700000000000",
+                    "user.custom", "value"))
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("id")
+                        .typeName(ColumnTypeName.LONG)
+                        .typeText("bigint")
+                        .typeJson(
+                            "{\"name\":\"id\",\"type\":\"long\","
+                                + "\"nullable\":false,\"metadata\":{}}")
+                        .position(0)
+                        .partitionIndex(0)
+                        .nullable(false),
+                    new ColumnInfo()
+                        .name("region")
+                        .typeName(ColumnTypeName.STRING)
+                        .typeText("string")
+                        .typeJson(
+                            "{\"name\":\"region\",\"type\":\"string\","
+                                + "\"nullable\":true,\"metadata\":{}}")
+                        .position(1)
+                        .partitionIndex(1)
+                        .nullable(true),
+                    new ColumnInfo()
+                        .name("amount")
+                        .typeName(ColumnTypeName.DECIMAL)
+                        .typeText("decimal(10,2)")
+                        .typeJson(
+                            "{\"name\":\"amount\",\"type\":\"decimal(10,2)\","
+                                + "\"nullable\":true,\"metadata\":{}}")
+                        .position(2)
+                        .nullable(true))));
+
+    // Uniform Iceberg metadata is not exposed through CreateTable, so set it directly on the DAO.
+    TableInfo tableInfo =
+        tableOps.getTable(
+            TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + TestUtils.TABLE_NAME);
+    String icebergLocation = "file:///tmp/uc_test/iceberg/v5.metadata.json";
+    long icebergVersion = 5L;
+    long icebergTimestampMs = 1700000100000L;
+    updateUniformMetadata(
+        UUID.fromString(tableInfo.getTableId()),
+        icebergLocation,
+        icebergVersion,
+        new Date(icebergTimestampMs));
+
+    LoadTableResponse response =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    TableMetadata metadata = response.getMetadata();
+
+    // Partition columns come back in partitionIndex order and match the two columns set above.
+    assertThat(metadata.getPartitionColumns()).containsExactly("id", "region");
+
+    // Property-derived fields resolved from delta.lastUpdateVersion / delta.lastCommitTimestamp.
+    assertThat(metadata.getLastCommitVersion()).isEqualTo(42L);
+    assertThat(metadata.getLastCommitTimestampMs()).isEqualTo(1700000000000L);
+    assertThat(metadata.getProperties()).containsEntry("user.custom", "value");
+
+    // Uniform Iceberg metadata is populated from the DAO fields.
+    assertThat(response.getUniform()).isNotNull();
+    UniformMetadataIceberg iceberg = response.getUniform().getIceberg();
+    assertThat(iceberg).isNotNull();
+    assertThat(iceberg.getMetadataLocation()).isEqualTo(icebergLocation);
+    assertThat(iceberg.getConvertedDeltaVersion()).isEqualTo(icebergVersion);
+    assertThat(iceberg.getConvertedDeltaTimestamp()).isEqualTo(icebergTimestampMs);
+  }
+
+  /**
+   * Verifies that a malformed long value in a property (e.g., delta.lastUpdateVersion="abc") is
+   * handled gracefully: loadTable still succeeds, and the affected field is absent from the
+   * response (the catch branch in parseLongProperty logs a warning and returns empty).
+   */
+  @Test
+  public void testLoadTableMalformedLongProperty() throws Exception {
+    tableOps.createTable(
+        new CreateTable()
+            .name(TestUtils.TABLE_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.MANAGED)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .properties(Map.of("delta.lastUpdateVersion", "not-a-number"))
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("id")
+                        .typeName(ColumnTypeName.LONG)
+                        .typeText("bigint")
+                        .typeJson(
+                            "{\"name\":\"id\",\"type\":\"long\","
+                                + "\"nullable\":false,\"metadata\":{}}")
+                        .position(0)
+                        .nullable(false))));
+
+    LoadTableResponse response =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    // Response still succeeds, but lastCommitVersion is absent because the property was malformed.
+    assertThat(response.getMetadata()).isNotNull();
+    assertThat(response.getMetadata().getLastCommitVersion()).isNull();
+  }
+
+  /**
+   * Verifies that a corrupt typeJson on a stored column is handled gracefully: loadTable still
+   * succeeds, returning an empty schema rather than throwing (the catch branch in
+   * buildTableMetadata logs a warning and substitutes an empty StructType).
+   */
+  @Test
+  public void testLoadTableCorruptColumnTypeJson() throws Exception {
+    tableOps.createTable(
+        new CreateTable()
+            .name(TestUtils.TABLE_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.MANAGED)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("id")
+                        .typeName(ColumnTypeName.LONG)
+                        .typeText("bigint")
+                        // Malformed typeJson -- not valid JSON. loadTable should swallow the parse
+                        // error and return an empty schema rather than 5xx'ing.
+                        .typeJson("not json at all")
+                        .position(0)
+                        .nullable(false))));
+
+    LoadTableResponse response =
+        deltaTablesApi.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(response.getMetadata()).isNotNull();
+    assertThat(response.getMetadata().getColumns().getFields()).isEmpty();
+  }
+
+  private void updateUniformMetadata(
+      UUID tableId, String metadataLocation, long convertedVersion, Date convertedTimestamp) {
+    var sessionFactory = hibernateConfigurator.getSessionFactory();
+    try (Session session = sessionFactory.openSession()) {
+      Transaction tx = session.beginTransaction();
+      TableInfoDAO dao = session.get(TableInfoDAO.class, tableId);
+      dao.setUniformIcebergMetadataLocation(metadataLocation);
+      dao.setUniformIcebergConvertedDeltaVersion(convertedVersion);
+      dao.setUniformIcebergConvertedDeltaTimestamp(convertedTimestamp);
+      tx.commit();
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -1,0 +1,220 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.delta.model.ArrayType;
+import io.unitycatalog.server.delta.model.DecimalType;
+import io.unitycatalog.server.delta.model.MapType;
+import io.unitycatalog.server.delta.model.PrimitiveType;
+import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructType;
+import io.unitycatalog.server.model.ColumnInfo;
+import org.junit.jupiter.api.Test;
+
+/** Tests for ColumnUtils.toStructField parsing typeJson into typed Delta StructField. */
+public class ColumnUtilsTest {
+
+  private static ColumnInfo col(String name, String typeJson) {
+    return new ColumnInfo().name(name).typeJson(typeJson);
+  }
+
+  // ---------- Primitives ----------
+
+  @Test
+  public void testPrimitive() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col("id", "{\"name\":\"id\",\"type\":\"long\",\"nullable\":false,\"metadata\":{}}"));
+    assertThat(f.getName()).isEqualTo("id");
+    assertThat(f.getNullable()).isFalse();
+    assertThat(f.getType()).isInstanceOf(PrimitiveType.class);
+    assertThat(f.getType().getType()).isEqualTo("long");
+    assertThat(f.getMetadata()).isEmpty();
+  }
+
+  @Test
+  public void testDecimal() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "price",
+                "{\"name\":\"price\",\"type\":\"decimal(10,2)\","
+                    + "\"nullable\":true,\"metadata\":{}}"));
+    assertThat(f.getType()).isInstanceOf(DecimalType.class);
+    DecimalType dt = (DecimalType) f.getType();
+    assertThat(dt.getPrecision()).isEqualTo(10);
+    assertThat(dt.getScale()).isEqualTo(2);
+  }
+
+  // ---------- Complex types with Spark camelCase ----------
+
+  @Test
+  public void testArrayCamelCase() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "tags",
+                "{\"name\":\"tags\",\"type\":{\"type\":\"array\","
+                    + "\"elementType\":\"string\",\"containsNull\":true},"
+                    + "\"nullable\":true,\"metadata\":{}}"));
+    assertThat(f.getType()).isInstanceOf(ArrayType.class);
+    ArrayType at = (ArrayType) f.getType();
+    assertThat(at.getElementType()).isInstanceOf(PrimitiveType.class);
+    assertThat(at.getElementType().getType()).isEqualTo("string");
+    assertThat(at.getContainsNull()).isTrue();
+  }
+
+  @Test
+  public void testMapCamelCase() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "scores",
+                "{\"name\":\"scores\",\"type\":{\"type\":\"map\","
+                    + "\"keyType\":\"string\",\"valueType\":\"double\","
+                    + "\"valueContainsNull\":false},"
+                    + "\"nullable\":true,\"metadata\":{}}"));
+    assertThat(f.getType()).isInstanceOf(MapType.class);
+    MapType mt = (MapType) f.getType();
+    assertThat(mt.getKeyType().getType()).isEqualTo("string");
+    assertThat(mt.getValueType().getType()).isEqualTo("double");
+    assertThat(mt.getValueContainsNull()).isFalse();
+  }
+
+  @Test
+  public void testStructCamelCase() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "addr",
+                "{\"name\":\"addr\",\"type\":{\"type\":\"struct\","
+                    + "\"fields\":[{\"name\":\"zip\",\"type\":\"integer\","
+                    + "\"nullable\":false,\"metadata\":{}}]},"
+                    + "\"nullable\":true,\"metadata\":{}}"));
+    assertThat(f.getType()).isInstanceOf(StructType.class);
+    StructType st = (StructType) f.getType();
+    assertThat(st.getFields()).hasSize(1);
+    assertThat(st.getFields().get(0).getName()).isEqualTo("zip");
+    assertThat(st.getFields().get(0).getType().getType()).isEqualTo("integer");
+  }
+
+  // ---------- Nested complex ----------
+
+  @Test
+  public void testNestedMapArrayStructCamelCase() {
+    // map<string, array<struct<v:double>>>
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "data",
+                "{\"name\":\"data\",\"type\":{\"type\":\"map\","
+                    + "\"keyType\":\"string\","
+                    + "\"valueType\":{\"type\":\"array\","
+                    + "\"elementType\":{\"type\":\"struct\","
+                    + "\"fields\":[{\"name\":\"v\",\"type\":\"double\","
+                    + "\"nullable\":false,\"metadata\":{}}]},"
+                    + "\"containsNull\":true},"
+                    + "\"valueContainsNull\":true},"
+                    + "\"nullable\":true,\"metadata\":{}}"));
+    MapType mt = (MapType) f.getType();
+    ArrayType at = (ArrayType) mt.getValueType();
+    StructType st = (StructType) at.getElementType();
+    assertThat(st.getFields().get(0).getType().getType()).isEqualTo("double");
+  }
+
+  // ---------- Metadata ----------
+
+  @Test
+  public void testMetadataPreserved() {
+    StructField f =
+        ColumnUtils.toStructField(
+            col(
+                "id",
+                "{\"name\":\"id\",\"type\":\"long\",\"nullable\":false,"
+                    + "\"metadata\":{\"delta.columnMapping.id\":1,"
+                    + "\"comment\":\"primary key\"}}"));
+    assertThat(f.getMetadata()).containsEntry("comment", "primary key");
+    assertThat(f.getMetadata()).containsEntry("delta.columnMapping.id", 1);
+  }
+
+  // ---------- Roundtrip (read camelCase -> write camelCase) ----------
+
+  @Test
+  public void testRoundtripPrimitive() {
+    String typeJson = "{\"name\":\"id\",\"type\":\"long\"," + "\"nullable\":false,\"metadata\":{}}";
+    StructField f = ColumnUtils.toStructField(col("id", typeJson));
+    String written = ColumnUtils.toTypeJson(f);
+    assertThat(written).contains("\"type\":\"long\"");
+    assertThat(written).contains("\"name\":\"id\"");
+  }
+
+  @Test
+  public void testRoundtripArray() {
+    String typeJson =
+        "{\"name\":\"tags\",\"type\":{\"type\":\"array\","
+            + "\"elementType\":\"string\",\"containsNull\":true},"
+            + "\"nullable\":true,\"metadata\":{}}";
+    StructField f = ColumnUtils.toStructField(col("tags", typeJson));
+    String written = ColumnUtils.toTypeJson(f);
+    // Must serialize back to camelCase, not kebab-case
+    assertThat(written).contains("\"elementType\"");
+    assertThat(written).contains("\"containsNull\"");
+    assertThat(written).doesNotContain("\"element-type\"");
+    assertThat(written).doesNotContain("\"contains-null\"");
+  }
+
+  @Test
+  public void testRoundtripMap() {
+    String typeJson =
+        "{\"name\":\"m\",\"type\":{\"type\":\"map\","
+            + "\"keyType\":\"string\",\"valueType\":\"double\","
+            + "\"valueContainsNull\":false},"
+            + "\"nullable\":true,\"metadata\":{}}";
+    StructField f = ColumnUtils.toStructField(col("m", typeJson));
+    String written = ColumnUtils.toTypeJson(f);
+    assertThat(written).contains("\"keyType\"");
+    assertThat(written).contains("\"valueType\"");
+    assertThat(written).contains("\"valueContainsNull\"");
+    assertThat(written).doesNotContain("\"key-type\"");
+  }
+
+  @Test
+  public void testRoundtripNestedPreservesStructure() {
+    String typeJson =
+        "{\"name\":\"data\",\"type\":{\"type\":\"map\","
+            + "\"keyType\":\"string\","
+            + "\"valueType\":{\"type\":\"array\","
+            + "\"elementType\":{\"type\":\"struct\","
+            + "\"fields\":[{\"name\":\"v\",\"type\":\"double\","
+            + "\"nullable\":false,\"metadata\":{}}]},"
+            + "\"containsNull\":true},"
+            + "\"valueContainsNull\":true},"
+            + "\"nullable\":true,\"metadata\":{}}";
+    StructField f = ColumnUtils.toStructField(col("data", typeJson));
+    String written = ColumnUtils.toTypeJson(f);
+    // Re-read and verify structure
+    StructField f2 = ColumnUtils.toStructField(col("data", written));
+    MapType mt = (MapType) f2.getType();
+    ArrayType at = (ArrayType) mt.getValueType();
+    StructType st = (StructType) at.getElementType();
+    assertThat(st.getFields().get(0).getName()).isEqualTo("v");
+    assertThat(st.getFields().get(0).getType().getType()).isEqualTo("double");
+  }
+
+  // ---------- Error handling ----------
+
+  @Test
+  public void testNullTypeJson() {
+    assertThatThrownBy(() -> ColumnUtils.toStructField(col("bad", null)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("null/empty typeJson");
+  }
+
+  @Test
+  public void testMalformedTypeJson() {
+    assertThatThrownBy(() -> ColumnUtils.toStructField(col("bad", "not json")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to parse");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -5,9 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.model.ErrorResponse;
 import io.unitycatalog.client.delta.model.ErrorType;
+import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
@@ -63,17 +66,13 @@ public class TestUtils {
   public static final String COMMON_ENTITY_NAME = "zz_uc_common_entity_name";
 
   public static ApiClient createApiClient(ServerConfig serverConfig) {
-    ApiClient apiClient = new ApiClient();
     URI uri = URI.create(serverConfig.getServerUrl());
-    int port = uri.getPort();
-    apiClient.setHost(uri.getHost());
-    apiClient.setPort(port);
-    apiClient.setScheme(uri.getScheme());
-    if (serverConfig.getAuthToken() != null && !serverConfig.getAuthToken().isEmpty()) {
-      apiClient.setRequestInterceptor(
-          request -> request.header("Authorization", "Bearer " + serverConfig.getAuthToken()));
-    }
-    return apiClient;
+    String token = serverConfig.getAuthToken() != null ? serverConfig.getAuthToken() : "";
+    return ApiClientBuilder.create()
+        .uri(uri)
+        .tokenProvider(TokenProvider.create(Map.of("type", "static", "token", token)))
+        .retryPolicy(JitterDelayRetryPolicy.builder().maxAttempts(1).build())
+        .build();
   }
 
   public static void assertApiException(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1488/files) to review incremental changes.
- [**stack/drc_loadtable**](https://github.com/unitycatalog/unitycatalog/pull/1488) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1488/files)]
  - [stack/drc_get_param](https://github.com/unitycatalog/unitycatalog/pull/1499) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1499/files/8b968878117e49caf205eae1584bbb964908677d..fe561fea278407099e68aa1778d05e2bb25c518c)]
    - [stack/drc_cred](https://github.com/unitycatalog/unitycatalog/pull/1500) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1500/files/fe561fea278407099e68aa1778d05e2bb25c518c..82449580bc53760649fe486a2b48437b577f2567)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Implement Delta REST Catalog loadTable endpoint

Adds GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} returning LoadTableResponse with metadata, typed columns, properties, partition columns, commits, and uniform metadata in a single REPEATABLE_READ transaction.

- TableRepository.loadTableForDelta assembles the full response from DAO. Columns parsed from typeJson via ColumnUtils with Jackson mixins for Spark camelCase support. Commits via refactored DeltaCommitRepository.getUnbackfilledCommits (reused by existing getCommits). last-commit-version from table properties, not commit list.
- Fix ApiClientBuilder DeltaTypeModule registration (getObjectMapper returns a copy). TestUtils.createApiClient now uses ApiClientBuilder.
- Tests: SdkLoadTableTest (external + managed commit/backfill flow), ColumnUtilsTest, access control in SdkTableAccessControlCRUDTest.
