### PR TITLE
HttpRetryHandler to expose the last received error response

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/internal/HttpRetryHandler.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/internal/HttpRetryHandler.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Set;
 
 /** Retry handler that retries on common recoverable HTTP errors and network exceptions. */
@@ -37,15 +35,17 @@ class HttpRetryHandler {
       HttpClient delegate, HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
       throws IOException, InterruptedException {
     IOException lastException = null;
-    Instant startTime = clock.now();
+    HttpResponse<T> lastResponse = null;
 
     for (int attempt = 1; attempt <= retryPolicy.maxAttempts(); attempt++) {
-      HttpResponse<T> response;
+      // Reset per attempt so the post-loop branch only sees the final attempt's state.
+      lastException = null;
+      lastResponse = null;
       boolean shouldRetry = true;
       try {
-        response = delegate.send(request, responseBodyHandler);
-        if (!isRetryable(response.statusCode())) {
-          return response;
+        lastResponse = delegate.send(request, responseBodyHandler);
+        if (!isRetryable(lastResponse.statusCode())) {
+          return lastResponse;
         }
       } catch (IOException e) {
         lastException = e;
@@ -64,15 +64,19 @@ class HttpRetryHandler {
       }
     }
 
+    // Return the last retryable response if available, so the caller sees the original error
+    // (e.g., 429) instead of a generic IOException.
+    if (lastResponse != null) {
+      return lastResponse;
+    }
     if (lastException != null) {
       throw lastException;
-    } else {
-      long elapsedMs = Duration.between(startTime, clock.now()).toMillis();
-      throw new IOException(
-          String.format(
-              "Failed HTTP request after %s attempts with elapsed time %s ms",
-              retryPolicy.maxAttempts(), elapsedMs));
     }
+    // Unreachable when maxAttempts >= 1: every iteration either returns, sets lastResponse, or
+    // sets lastException. Only reachable with a misconfigured maxAttempts == 0.
+    throw new IllegalStateException(
+        "HttpRetryHandler reached unreachable state; maxAttempts must be >= 1, got "
+            + retryPolicy.maxAttempts());
   }
 
   private static boolean isRetryable(int statusCode) {

--- a/clients/java/src/test/java/io/unitycatalog/client/internal/HttpRetryHandlerTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/internal/HttpRetryHandlerTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.client.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -207,6 +208,108 @@ public class HttpRetryHandlerTest {
     assertThat(result.statusCode()).isEqualTo(200);
     // Retry delays: 50ms (after exception) + 100ms (after 503) = 150ms total.
     assertThat(clock.now()).isEqualTo(start.plus(Duration.ofMillis(150)));
+  }
+
+  @Test
+  public void testRetriesExhaustedOnRetryableStatusReturnsLastResponse()
+      throws IOException, InterruptedException {
+    // When every attempt returns a retryable status (e.g., 429), the handler should return the
+    // last response so the caller can see the original status code / body, not a synthetic
+    // IOException.
+    RetryPolicy retryPolicy =
+        JitterDelayRetryPolicy.builder()
+            .maxAttempts(3)
+            .initDelayMs(10L)
+            .delayMultiplier(1.0)
+            .delayJitterFactor(0.0)
+            .build();
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/rate-limited")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response429 = createMockResponse(429, "Rate limit body");
+    when(mockClient.send(
+            ArgumentMatchers.any(HttpRequest.class),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(response429);
+
+    HttpRetryHandler handler = new HttpRetryHandler(retryPolicy, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    verify(mockClient, times(3))
+        .send(
+            ArgumentMatchers.any(HttpRequest.class),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    assertThat(result.statusCode()).isEqualTo(429);
+    // Body from the original response survives the retry loop.
+    assertThat(result.body()).isEqualTo("Rate limit body");
+  }
+
+  @Test
+  public void testRetriesExhaustedOnRecoverableExceptionStillThrows() {
+    // Regression guard: when every attempt throws a recoverable IOException, the handler
+    // should still propagate the original exception (not swallow it into a response).
+    RetryPolicy retryPolicy =
+        JitterDelayRetryPolicy.builder()
+            .maxAttempts(2)
+            .initDelayMs(10L)
+            .delayMultiplier(1.0)
+            .delayJitterFactor(0.0)
+            .build();
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/flaky")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    java.net.SocketTimeoutException timeout = new java.net.SocketTimeoutException("timed out");
+    try {
+      when(mockClient.send(
+              ArgumentMatchers.any(HttpRequest.class),
+              ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+          .thenThrow(timeout);
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    HttpRetryHandler handler = new HttpRetryHandler(retryPolicy, clock);
+    assertThatThrownBy(() -> handler.call(mockClient, mockRequest, bodyHandler)).isSameAs(timeout);
+  }
+
+  @Test
+  public void testExceptionThenRetryableResponseReturnsResponse()
+      throws IOException, InterruptedException {
+    // The per-iteration reset of lastException / lastResponse is load-bearing: if attempts 1-2
+    // throw a recoverable exception and attempt 3 returns a retryable status, the final result
+    // should be the retryable response (not the stale exception).
+    RetryPolicy retryPolicy =
+        JitterDelayRetryPolicy.builder()
+            .maxAttempts(3)
+            .initDelayMs(10L)
+            .delayMultiplier(1.0)
+            .delayJitterFactor(0.0)
+            .build();
+
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpRequest mockRequest =
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/api/mixed")).build();
+    HttpResponse.BodyHandler<String> bodyHandler = HttpResponse.BodyHandlers.ofString();
+
+    HttpResponse<String> response429 = createMockResponse(429, "Too Many Requests");
+    when(mockClient.send(
+            ArgumentMatchers.any(HttpRequest.class),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new java.net.SocketTimeoutException("attempt 1"))
+        .thenThrow(new java.net.SocketTimeoutException("attempt 2"))
+        .thenReturn(response429);
+
+    HttpRetryHandler handler = new HttpRetryHandler(retryPolicy, clock);
+    HttpResponse<String> result = handler.call(mockClient, mockRequest, bodyHandler);
+
+    assertThat(result.statusCode()).isEqualTo(429);
+    assertThat(result.body()).isEqualTo("Too Many Requests");
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1489/files) to review incremental changes.
- [**stack/retry_client**](https://github.com/unitycatalog/unitycatalog/pull/1489) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1489/files)]
  - [stack/drc_loadtable](https://github.com/unitycatalog/unitycatalog/pull/1488) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1488/files/04030e1f52891fa083e19afbb552579178d081f9..b7b7fe0d20caa63e29b5d383df1949c9b5211ce0)]
    - [stack/drc_get_param](https://github.com/unitycatalog/unitycatalog/pull/1499) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1499/files/b7b7fe0d20caa63e29b5d383df1949c9b5211ce0..8e79c9230d55f9cc28da5f13e3670e4dc2179ebf)]
      - [stack/drc_cred](https://github.com/unitycatalog/unitycatalog/pull/1500) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1500/files/8e79c9230d55f9cc28da5f13e3670e4dc2179ebf..ef4d334a3ead02ffa6931aa024e7baa25776c776)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
## Description of changes

### Problem
When `HttpRetryHandler` exhausted all retries on a retryable HTTP status (e.g., `429 Too Many Requests` or `5xx`), it threw a synthetic `IOException("Failed HTTP request after N attempts with elapsed time M ms")`. This **masked the original HTTP response** — callers lost the status code, `Retry-After` header, and response body, making it impossible to distinguish rate-limiting from a generic network failure or apply their own backoff logic downstream.

### Change
When retries are exhausted on a retryable status, return the last `HttpResponse` directly so callers see the original status and body.

Network-level `IOException` exhaustion still propagates the original exception (unchanged), so callers that rely on catching `SocketTimeoutException` etc. are unaffected.

The unreachable fallback (only reachable with `maxAttempts == 0`, a misconfiguration) was tightened from a generic `IOException` to an `IllegalStateException` with a clearer message.

### Behavioral change (for API consumers)
Any SDK consumer catching `IOException` specifically to detect retry-exhaustion on a retryable status will now receive the 4xx/5xx `HttpResponse` object instead. No known callers rely on the old exception path.

### Tests
Added to `HttpRetryHandlerTest.java`:
- `testRetriesExhaustedOnRetryableStatusReturnsLastResponse` — all attempts return 429, asserts the 429 response (with body) is returned, not an IOException
- `testRetriesExhaustedOnRecoverableExceptionStillThrows` — regression guard for the IOException path
- `testExceptionThenRetryableResponseReturnsResponse` — exercises the per-iteration `lastException`/`lastResponse` reset when exception attempts precede a response attempt

All 7 tests (4 existing + 3 new) pass.
