### PR TITLE
Add cross-channel authz probes to guard parameter-swap attacks

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
@@ -14,7 +14,9 @@ import io.unitycatalog.client.model.UpdateCatalog;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +106,34 @@ public class SdkCatalogAccessControlCRUDTest extends SdkAccessControlBaseCRUDTes
 
     // get catalog (principal-1) -> denied
     assertPermissionDenied(() -> principal1CatalogsApi.getCatalog("admincatalog1"));
+
+    // Cross-channel probe: the same GET with a JSON body that tries to override the path
+    // parameter. Authorization must still resolve from the URL; the body must not move the
+    // request into an unauthorized bypass path.
+    HttpResponse<String> rawWithBody =
+        TestUtils.sendRawGet(
+            principal1Config,
+            "/api/2.1/unity-catalog/catalogs/admincatalog1",
+            Optional.of("{\"name\":\"different\"}"));
+    assertThat(rawWithBody.statusCode())
+        .as("body on a URL-param GET must not bypass URL-driven authz")
+        .isEqualTo(403);
+
+    // Cross-channel probe 2: attacker omits the URL path segment entirely and moves the name
+    // into the body. This routes to listCatalogs (a different endpoint with per-user filtering),
+    // NOT getCatalog. The body's "name" field is not routed through authz, and the response must
+    // not leak admincatalog1 to principal-1 who lacks access.
+    HttpResponse<String> rawWithBodyNoPath =
+        TestUtils.sendRawGet(
+            principal1Config,
+            "/api/2.1/unity-catalog/catalogs",
+            Optional.of("{\"name\":\"admincatalog1\"}"));
+    assertThat(rawWithBodyNoPath.statusCode())
+        .as("listCatalogs must return 200 for a principal that can see at least their own catalog")
+        .isEqualTo(200);
+    assertThat(rawWithBodyNoPath.body())
+        .as("listCatalogs response must not leak catalogs the caller cannot see")
+        .doesNotContain("admincatalog1");
 
     // get catalog (regular-1) -> USE CATALOG -> allowed
     CatalogInfo getCatalog1AsRegular1 = regular1CatalogsApi.getCatalog("catalog1");

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
@@ -21,6 +21,7 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +111,52 @@ public class SdkCatalogAccessControlCRUDTest extends SdkAccessControlBaseCRUDTes
 
     // get catalog (principal-1) -> denied
     assertPermissionDenied(() -> principal1CatalogsApi.getCatalog("admincatalog1"));
+
+    // Cross-channel probe 1: the same GET, but with a JSON body that tries to override the `name`
+    // path parameter. getCatalog's authorization key is the URL path segment, so the body must not
+    // change which catalog is authorized; the request stays denied (403) exactly as it did with no
+    // body.
+    HttpResponse<String> rawWithBody =
+        TestUtils.sendRawGet(
+            principal1Config,
+            "/api/2.1/unity-catalog/catalogs/admincatalog1",
+            Optional.of("{\"name\":\"different\"}"));
+    assertThat(rawWithBody.statusCode())
+        .as("body on a URL-param GET must not bypass URL-driven authz")
+        .isEqualTo(403);
+
+    // Cross-channel probe 2: attacker omits the URL path segment entirely and moves the name
+    // into the body. This routes to listCatalogs (a different endpoint with per-user filtering),
+    // NOT getCatalog. The body's "name" field is not routed through authz, and the response must
+    // not leak admincatalog1 to principal-1 who lacks access.
+    HttpResponse<String> rawWithBodyNoPath =
+        TestUtils.sendRawGet(
+            principal1Config,
+            "/api/2.1/unity-catalog/catalogs",
+            Optional.of("{\"name\":\"admincatalog1\"}"));
+    assertThat(rawWithBodyNoPath.statusCode())
+        .as("listCatalogs must return 200 for a principal that can see at least their own catalog")
+        .isEqualTo(200);
+    assertThat(rawWithBodyNoPath.body())
+        .as("listCatalogs response must not leak catalogs the caller cannot see")
+        .doesNotContain("admincatalog1");
+
+    // Cross-channel probe 3 (write path via PATCH): updateCatalog's authorization key is the URL
+    // path segment, not the body. A request body must not flip a path-based denial into a
+    // successful mutation. principal-1 does not own admincatalog1, so the PATCH must be denied
+    // regardless of the body it carries, and the catalog must be left unmodified.
+    HttpResponse<String> rawPatch =
+        TestUtils.sendRaw(
+            principal1Config,
+            "PATCH",
+            "/api/2.1/unity-catalog/catalogs/admincatalog1",
+            Optional.of("{\"comment\":\"hijacked\",\"new_name\":\"hijacked\"}"));
+    assertThat(rawPatch.statusCode())
+        .as("mutation on a non-owned catalog must be denied regardless of request body")
+        .isEqualTo(403);
+    assertThat(adminCatalogsApi.getCatalog("admincatalog1").getComment())
+        .as("a denied PATCH must not have modified the catalog")
+        .isEqualTo("(created from scratch)");
 
     // get catalog (regular-1) -> USE CATALOG -> allowed
     CatalogInfo getCatalog1AsRegular1 = regular1CatalogsApi.getCatalog("catalog1");

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
@@ -23,7 +23,9 @@ import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -187,6 +189,29 @@ public class SdkDeltaCommitsAccessControlCRUDTest extends SdkAccessControlBaseCR
 
     // No-access user attempts to get commits should fail with 403 Forbidden
     assertPermissionDenied(() -> getCommits(noAccessUserCommitsApi));
+
+    // Cross-channel probe: the same GET with PAYLOAD-source fields moved to URL query params
+    // and no body. Regression guard for the PAYLOAD-on-body-less-GET class of bug: if someone
+    // makes a future change that either (a) fixes the decorator to fail-closed (-> 403) or
+    // (b) keeps the decorator as-is but adds query-param binding for DeltaGetCommits (-> would
+    // leak), the assertions below keep the "no data leak" invariant. Either 400 (binding) or
+    // 403 (authz) is acceptable; a 2xx with commit data is not.
+    HttpResponse<String> rawByQuery =
+        TestUtils.sendRawGet(
+            noAccessUserConfig,
+            "/api/2.1/unity-catalog/delta/preview/commits"
+                + "?tableId="
+                + tableInfo.getTableId()
+                + "&tableUri="
+                + tableInfo.getStorageLocation()
+                + "&startVersion=0",
+            Optional.empty());
+    assertThat(rawByQuery.statusCode())
+        .as("attacker must not receive commits via URL-query-only GET")
+        .isBetween(400, 499);
+    assertThat(rawByQuery.body())
+        .as("response must not contain commit data for an unauthorized caller")
+        .doesNotContain("\"commits\"");
 
     // read user can get commits
     DeltaGetCommitsResponse commits = getCommits(readUserCommitsApi);

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
@@ -29,9 +29,11 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -199,6 +201,53 @@ public class SdkDeltaCommitsAccessControlCRUDTest extends SdkAccessControlBaseCR
 
     // No-access user attempts to get commits should fail with 403 Forbidden
     assertPermissionDenied(() -> getCommits(noAccessUserCommitsApi));
+
+    // Cross-channel probe: the same GET but with the request-body fields moved to URL query params
+    // and no body -- the body-less-GET case that motivated the decorator's fail-closed design.
+    // Today Armeria's Jackson converter rejects the body-less GET during POJO binding (400) before
+    // authz runs, so the relocated query params are never honored. Whatever happens to that path,
+    // the invariant this locks in is that an unauthorized caller never receives commit data: any
+    // 4xx is acceptable, a 2xx carrying commits is not.
+    HttpResponse<String> rawByQuery =
+        TestUtils.sendRawGet(
+            noAccessUserConfig,
+            "/api/2.1/unity-catalog/delta/preview/commits"
+                + "?tableId="
+                + tableInfo.getTableId()
+                + "&tableUri="
+                + tableInfo.getStorageLocation()
+                + "&startVersion=0",
+            Optional.empty());
+    assertThat(rawByQuery.statusCode())
+        .as("attacker must not receive commits via URL-query-only GET")
+        .isBetween(400, 499);
+    assertThat(rawByQuery.body())
+        .as("response must not contain commit data for an unauthorized caller")
+        .doesNotContain("\"commits\"");
+
+    // Cross-channel probe (write path via POST): postCommit's authorization key `table_id` is a
+    // PAYLOAD (request-body) field, authorized by the deferred gate converter on the bound body
+    // *before* the handler runs. An attacker moves `table_id` to a URL query param (which the
+    // PAYLOAD locator does not read) and omits it from the body, hoping authz is skipped. It must
+    // not be: with no `table_id` in the body the gate resolves a null table and denies before the
+    // handler runs, so no commit is ever applied. Today that denial surfaces as a 500 rather than
+    // a clean 403 -- ungraceful, but still fail-closed -- so the invariant we lock in is only "the
+    // request is rejected (never a 2xx)". The `commits.size() == 1` assertion below corroborates
+    // that no write occurred.
+    String bodyWithoutTableId =
+        "{\"table_uri\":\""
+            + tableInfo.getStorageLocation()
+            + "\",\"commit_info\":{\"version\":99,\"file_name\":\"probe\",\"file_size\":1,"
+            + "\"timestamp\":1700000000,\"file_modification_timestamp\":1700000000}}";
+    HttpResponse<String> rawPost =
+        TestUtils.sendRaw(
+            noAccessUserConfig,
+            "POST",
+            "/api/2.1/unity-catalog/delta/preview/commits?table_id=" + tableInfo.getTableId(),
+            Optional.of(bodyWithoutTableId));
+    assertThat(rawPost.statusCode())
+        .as("PAYLOAD-source authz must reject (never apply) a commit whose key is off the body")
+        .isGreaterThanOrEqualTo(400);
 
     // read user can get commits
     DeltaGetCommitsResponse commits = getCommits(readUserCommitsApi);

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/delta/DeltaConfigAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/delta/DeltaConfigAccessControlTest.java
@@ -12,6 +12,8 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.sdk.access.SdkAccessControlBaseCRUDTest;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +42,24 @@ public class DeltaConfigAccessControlTest extends SdkAccessControlBaseCRUDTest {
     assertThatThrownBy(() -> regularApi.getConfig(TestUtils.CATALOG_NAME, "1.0"))
         .isInstanceOf(ApiException.class)
         .satisfies(e -> assertThat(((ApiException) e).getCode()).isEqualTo(403));
+
+    // Cross-channel probe: the attacker omits the `catalog` query parameter and moves the field
+    // into a JSON body instead. The body must not be treated as a fallback source for a
+    // query-param-driven authz decision. Today the request fails with 404 (Armeria rejects the
+    // missing required query param before authz runs); if a future framework change routes the
+    // request past Armeria's value resolver, authz would see #catalog=null and must still deny
+    // with 403. Any 4xx plus an empty config body is the security invariant we guard.
+    HttpResponse<String> rawWithBodyNoQuery =
+        TestUtils.sendRawGet(
+            regularConfig,
+            "/api/2.1/unity-catalog/delta/v1/config",
+            Optional.of("{\"catalog\":\"" + TestUtils.CATALOG_NAME + "\"}"));
+    assertThat(rawWithBodyNoQuery.statusCode())
+        .as("body must not act as a fallback source for a query-param-driven authz decision")
+        .isBetween(400, 499);
+    assertThat(rawWithBodyNoQuery.body())
+        .as("response must not leak the catalog config to an unauthorized caller")
+        .doesNotContain("\"endpoints\"");
 
     // Authorized: user with USE_CATALOG returns 200
     ServerConfig principalConfig = createTestUserServerConfig(PRINCIPAL_1);

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/delta/DeltaConfigAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/delta/DeltaConfigAccessControlTest.java
@@ -12,6 +12,8 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.sdk.access.SdkAccessControlBaseCRUDTest;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +44,24 @@ public class DeltaConfigAccessControlTest extends SdkAccessControlBaseCRUDTest {
     assertThatThrownBy(() -> regularApi.getConfig(TestUtils.CATALOG_NAME, "1.0"))
         .isInstanceOf(ApiException.class)
         .satisfies(e -> assertThat(((ApiException) e).getCode()).isEqualTo(403));
+
+    // Cross-channel probe: the attacker omits the `catalog` query parameter and moves the field
+    // into a JSON body instead. The body must not be treated as a fallback source for a
+    // query-param-driven authz decision. Today the request fails with 404 (Armeria rejects the
+    // missing required query param before authz runs); if a future framework change routes the
+    // request past Armeria's value resolver, authz would see #catalog=null and must still deny
+    // with 403. Any 4xx plus an empty config body is the security invariant we guard.
+    HttpResponse<String> rawWithBodyNoQuery =
+        TestUtils.sendRawGet(
+            regularConfig,
+            "/api/2.1/unity-catalog/delta/v1/config",
+            Optional.of("{\"catalog\":\"" + TestUtils.CATALOG_NAME + "\"}"));
+    assertThat(rawWithBodyNoQuery.statusCode())
+        .as("body must not act as a fallback source for a query-param-driven authz decision")
+        .isBetween(400, 499);
+    assertThat(rawWithBodyNoQuery.body())
+        .as("response must not leak the catalog config to an unauthorized caller")
+        .doesNotContain("\"endpoints\"");
 
     // Authorized: user with USE_CATALOG returns 200
     ServerConfig principalConfig = createTestUserServerConfig(PRINCIPAL_1);

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -11,8 +11,12 @@ import io.unitycatalog.client.delta.model.ErrorType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.function.Executable;
 
 public class TestUtils {
@@ -109,5 +113,26 @@ public class TestUtils {
 
   public static void assertPermissionDenied(Executable executable) {
     assertApiException(executable, ErrorCode.PERMISSION_DENIED, "PERMISSION_DENIED");
+  }
+
+  /**
+   * Raw HTTP GET, bypassing the generated SDK, for cross-channel authorization probes. Pass {@link
+   * Optional#empty()} for a body-less GET; otherwise the GET is sent with that body and {@code
+   * Content-Type: application/json}.
+   */
+  public static HttpResponse<String> sendRawGet(
+      ServerConfig config, String path, Optional<String> jsonBody) throws Exception {
+    HttpRequest.Builder b =
+        HttpRequest.newBuilder()
+            .uri(URI.create(config.getServerUrl() + path))
+            .header("Authorization", "Bearer " + config.getAuthToken());
+    if (jsonBody.isPresent()) {
+      b =
+          b.header("Content-Type", "application/json")
+              .method("GET", HttpRequest.BodyPublishers.ofString(jsonBody.get()));
+    } else {
+      b = b.GET();
+    }
+    return HttpClient.newHttpClient().send(b.build(), HttpResponse.BodyHandlers.ofString());
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -310,7 +310,7 @@ public class TestUtils {
    */
   public static HttpResponse<String> sendRawEmptyPost(ServerConfig config, String path)
       throws Exception {
-    return sendRawPost(config, path, HttpRequest.BodyPublishers.noBody(), null);
+    return sendRawRequest(config, "POST", path, HttpRequest.BodyPublishers.noBody(), null);
   }
 
   /**
@@ -320,7 +320,8 @@ public class TestUtils {
    */
   public static HttpResponse<String> sendRawJsonPost(
       ServerConfig config, String path, String body, String contentType) throws Exception {
-    return sendRawPost(config, path, HttpRequest.BodyPublishers.ofString(body), contentType);
+    return sendRawRequest(
+        config, "POST", path, HttpRequest.BodyPublishers.ofString(body), contentType);
   }
 
   /**
@@ -337,7 +338,7 @@ public class TestUtils {
             new BufferSequencePublisher(
                 ByteBuffer.wrap(Arrays.copyOfRange(bytes, 0, mid)),
                 ByteBuffer.wrap(Arrays.copyOfRange(bytes, mid, bytes.length))));
-    return sendRawPost(config, path, twoChunks, contentType);
+    return sendRawRequest(config, "POST", path, twoChunks, contentType);
   }
 
   /**
@@ -377,11 +378,22 @@ public class TestUtils {
     }
   }
 
-  private static HttpResponse<String> sendRawPost(
-      ServerConfig config, String path, HttpRequest.BodyPublisher body, String contentType)
+  /**
+   * Core raw-HTTP sender shared by every raw test helper below: builds a request to {@code
+   * config.getServerUrl() + path} with the given method and body, attaching the bearer token when
+   * one is configured and {@code Content-Type} when non-null, and sending on a fresh client.
+   */
+  private static HttpResponse<String> sendRawRequest(
+      ServerConfig config,
+      String method,
+      String path,
+      HttpRequest.BodyPublisher body,
+      String contentType)
       throws Exception {
     HttpRequest.Builder reqBuilder =
-        HttpRequest.newBuilder().uri(URI.create(config.getServerUrl() + path)).POST(body);
+        HttpRequest.newBuilder()
+            .uri(URI.create(config.getServerUrl() + path))
+            .method(method, body);
     if (contentType != null) {
       reqBuilder.header("Content-Type", contentType);
     }
@@ -390,5 +402,28 @@ public class TestUtils {
     }
     return HttpClient.newHttpClient()
         .send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  /**
+   * Raw HTTP request with an explicit method and optional JSON body, bypassing the generated SDK,
+   * for cross-channel authorization probes. Pass {@link Optional#empty()} for a body-less request;
+   * otherwise the body is sent with {@code Content-Type: application/json}. The {@code path} may
+   * include a query string. Used to place a parameter on the "wrong" channel (URL path, URL query,
+   * or request body) relative to where the endpoint's authorization decorator reads it.
+   */
+  public static HttpResponse<String> sendRaw(
+      ServerConfig config, String method, String path, Optional<String> jsonBody) throws Exception {
+    HttpRequest.BodyPublisher body =
+        jsonBody
+            .map(HttpRequest.BodyPublishers::ofString)
+            .orElseGet(HttpRequest.BodyPublishers::noBody);
+    return sendRawRequest(
+        config, method, path, body, jsonBody.isPresent() ? "application/json" : null);
+  }
+
+  /** Convenience wrapper over {@link #sendRaw} for GET probes. */
+  public static HttpResponse<String> sendRawGet(
+      ServerConfig config, String path, Optional<String> jsonBody) throws Exception {
+    return sendRaw(config, "GET", path, jsonBody);
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Add cross-channel authz probes to guard parameter-swap attacks

`UnityAccessDecorator` picks a locator source (URL path, URL query, or request body) per `@Param`. Moving a parameter to the "wrong" channel must not skip authz; the latent danger is a PAYLOAD-source key on a body-less method, safe today only because Armeria blocks body-less GETs that need POJO binding.

These probes extend existing denial tests with raw `HttpClient` calls that retry the denied operation through the wrong channel, asserting no data leak and no unauthorized mutation, across read (GET) and write (PATCH/POST) paths and all three sources:

- `SdkCatalogAccessControlCRUDTest` (path): body-override GET still 403; no-path GET routes to `listCatalogs` and must not leak `admincatalog1`; `updateCatalog` PATCH on a non-owned catalog stays 403 and leaves it unmodified.
- `DeltaConfigAccessControlTest` (query): `getConfig` with `catalog` moved to the body is rejected without the config (404 today, before authz runs).
- `SdkDeltaCommitsAccessControlCRUDTest` (body): body-less `getCommits` with fields on the query is rejected without commit data (400); `postCommit` with `table_id` moved to the query never applies a commit (500 today -- fail-closed but ungraceful).

Shared `TestUtils.sendRaw(config, method, path, Optional<String> jsonBody)` handles the raw HTTP (`sendRawGet` delegates to it), consolidating the former POST-only helper. No production code changes, no new test files.