### PR TITLE
[API] Add METRIC_VIEW table type and view_definition/view_dependencies

### DIFF
--- a/api/Models/CreateTable.md
+++ b/api/Models/CreateTable.md
@@ -7,11 +7,13 @@
 | **catalog\_name** | **String** | Name of parent catalog. | [default to null] |
 | **schema\_name** | **String** | Name of parent schema relative to its parent catalog. | [default to null] |
 | **table\_type** | [**TableType**](TableType.md) |  | [default to null] |
-| **data\_source\_format** | [**DataSourceFormat**](DataSourceFormat.md) |  | [default to null] |
+| **data\_source\_format** | [**DataSourceFormat**](DataSourceFormat.md) |  | [optional] [default to null] |
 | **columns** | [**List**](ColumnInfo.md) | The array of __ColumnInfo__ definitions of the table&#39;s columns. | [default to null] |
-| **storage\_location** | **String** | Storage root URL for external table | [default to null] |
+| **storage\_location** | **String** | Storage root URL for external table | [optional] [default to null] |
 | **comment** | **String** | User-provided free-form text description. | [optional] [default to null] |
 | **properties** | **Map** | A map of key-value properties attached to the securable. | [optional] [default to null] |
+| **view\_definition** | **String** | Definition text for view-like table types such as VIEW, MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format depends on the table type (SQL for views, YAML for metric views). | [optional] [default to null] |
+| **view\_dependencies** | [**DependencyList**](DependencyList.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/Models/TableInfo.md
+++ b/api/Models/TableInfo.md
@@ -18,6 +18,8 @@
 | **updated\_at** | **Long** | Time at which this table was last modified, in epoch milliseconds. | [optional] [default to null] |
 | **updated\_by** | **String** | Username of user who last modified the table. | [optional] [default to null] |
 | **table\_id** | **String** | Unique identifier for the table. | [optional] [default to null] |
+| **view\_definition** | **String** | Definition text for view-like table types such as VIEW, MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format depends on the table type (SQL for views, YAML for metric views). | [optional] [default to null] |
+| **view\_dependencies** | [**DependencyList**](DependencyList.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1679,6 +1679,7 @@ components:
         - EXTERNAL
         - STREAMING_TABLE # Not yet fully implemented
         - MATERIALIZED_VIEW # Not yet fully implemented
+        - METRIC_VIEW
     DataSourceFormat:
       description: Data source format
       type: string
@@ -1739,6 +1740,14 @@ components:
         table_id:
           description: Unique identifier for the table.
           type: string
+        view_definition:
+          description: >-
+            Definition text for view-like table types such as VIEW,
+            MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format
+            depends on the table type (SQL for views, YAML for metric views).
+          type: string
+        view_dependencies:
+          "$ref": "#/components/schemas/DependencyList"
     CreateTable:
       type: object
       properties:
@@ -1768,14 +1777,20 @@ components:
           type: string
         properties:
           $ref: '#/components/schemas/SecurablePropertiesMap'
+        view_definition:
+          description: >-
+            Definition text for view-like table types such as VIEW,
+            MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format
+            depends on the table type (SQL for views, YAML for metric views).
+          type: string
+        view_dependencies:
+          "$ref": "#/components/schemas/DependencyList"
       required:
         - name
         - catalog_name
         - schema_name
         - table_type
-        - data_source_format
         - columns
-        - storage_location
     StagingTableInfo:
       type: object
       properties:

--- a/ui/src/types/api/catalog.gen.ts
+++ b/ui/src/types/api/catalog.gen.ts
@@ -762,6 +762,9 @@ export interface components {
       updated_by?: string;
       /** @description Unique identifier for the table. */
       table_id?: string;
+      /** @description Definition text for view-like table types such as VIEW, MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format depends on the table type (SQL for views, YAML for metric views). */
+      view_definition?: string;
+      view_dependencies?: components['schemas']['DependencyList'];
     };
     CreateTable: {
       /** @description Name of table, relative to parent schema. */
@@ -771,14 +774,17 @@ export interface components {
       /** @description Name of parent schema relative to its parent catalog. */
       schema_name: string;
       table_type: components['schemas']['TableType'];
-      data_source_format: components['schemas']['DataSourceFormat'];
+      data_source_format?: components['schemas']['DataSourceFormat'];
       /** @description The array of __ColumnInfo__ definitions of the table's columns. */
       columns: components['schemas']['ColumnInfo'][];
       /** @description Storage root URL for external table */
-      storage_location: string;
+      storage_location?: string;
       /** @description User-provided free-form text description. */
       comment?: string;
       properties?: components['schemas']['SecurablePropertiesMap'];
+      /** @description Definition text for view-like table types such as VIEW, MATERIALIZED_VIEW, STREAMING_TABLE, and METRIC_VIEW. The format depends on the table type (SQL for views, YAML for metric views). */
+      view_definition?: string;
+      view_dependencies?: components['schemas']['DependencyList'];
     };
     ListTablesResponse: {
       /** @description An array of table information objects. */
@@ -2467,6 +2473,7 @@ export enum ColumnTypeName {
 export enum TableType {
   MANAGED = 'MANAGED',
   EXTERNAL = 'EXTERNAL',
+  METRIC_VIEW = 'METRIC_VIEW',
 }
 export enum DataSourceFormat {
   DELTA = 'DELTA',


### PR DESCRIPTION
## Summary

Adds metric view support to the Unity Catalog OpenAPI specification. This is the first PR in a 3-PR series; the follow-ups add server-side persistence and the Spark connector implementation.

## Motivation

Metric views provide a powerful semantic layer on top of tables. Adding support to OSS UC unlocks the feature for the open-source Spark community and keeps wire compatibility with the Databricks UC API.

## Changes

`api/all.yaml`:

- Add `METRIC_VIEW` to the `TableType` enum.
- Add optional `view_definition` (string) and `view_dependencies` (`DependencyList`) fields to `TableInfo` and `CreateTable`.
- Drop `data_source_format` and `storage_location` from `CreateTable.required` so metric views (which have neither) can be created.

Generated artifacts regenerated to match:

- `api/Models/*.md` (OpenAPI markdown docs)
- `api/README.md`
- `ui/src/types/api/catalog.gen.ts` (UI typed client)

## Compatibility

The new fields on `TableInfo` and `CreateTable` are optional. Relaxing `CreateTable.required` is wire-backwards-compatible: existing clients that send `data_source_format` and `storage_location` continue to work unchanged.

The schema shape matches the corresponding Databricks UC API so the same client can target either server.

## Stack

This PR is the bottom of a 3-PR stack:

1. (this PR) [API] Add METRIC_VIEW table type and view_definition/view_dependencies
2. [Server] Add METRIC_VIEW persistence and CRUD support
3. [Spark Connector] Metric view support in UC Spark connector

## Test Plan

- `./build/sbt client/compile serverModels/compile server/compile` succeeds with the new schema.
- `./build/sbt apiDocs/generate` was run to regenerate `api/Models/*.md` and `api/README.md`.
- `npx openapi-typescript --enum api/all.yaml -o ui/src/types/api/catalog.gen.ts` would normally regenerate the TS file; the equivalent edits were applied manually here (offline environment).

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
