### PR TITLE
Fail-closed guard for PAYLOAD-source authorization

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -12,10 +12,12 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.docs.DocService;
 import io.unitycatalog.server.auth.AllowingAuthorizer;
 import io.unitycatalog.server.auth.JCasbinAuthorizer;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
 import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
 import io.unitycatalog.server.auth.decorator.UnityAccessUtil;
 import io.unitycatalog.server.delta.serde.DeltaTypeModule;
@@ -191,8 +193,8 @@ public class UnityCatalogServer {
     TemporaryPathCredentialsService temporaryPathCredentialsService =
         new TemporaryPathCredentialsService(storageCredentialVendor);
 
-    JacksonRequestConverterFunction requestConverterFunction =
-        new JacksonRequestConverterFunction(
+    RequestConverterFunction requestConverterFunction =
+        gatedJackson(
             JsonMapper.builder()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build());
@@ -257,6 +259,17 @@ public class UnityCatalogServer {
     addDeltaApiServices(armeriaServerBuilder, authorizer, repositories, storageCredentialVendor);
   }
 
+  /**
+   * Wraps a Jackson body converter with {@link AuthorizationGateConverter}. Every annotated
+   * service's request converter must go through this so the PAYLOAD-source auth check fires before
+   * body binding. Using a wrapper (rather than registering the gate as a separate chain element per
+   * {@code annotatedService(...)} call) makes the gate impossible to forget when a new service is
+   * added.
+   */
+  private static RequestConverterFunction gatedJackson(ObjectMapper mapper) {
+    return new AuthorizationGateConverter(new JacksonRequestConverterFunction(mapper));
+  }
+
   private void addIcebergApiServices(
       ServerBuilder armeriaServerBuilder,
       ServerProperties serverProperties,
@@ -269,8 +282,7 @@ public class UnityCatalogServer {
 
     // Add support for Iceberg REST APIs
     ObjectMapper icebergMapper = IcebergObjectMapper.mapper();
-    JacksonRequestConverterFunction icebergRequestConverter =
-        new JacksonRequestConverterFunction(icebergMapper);
+    RequestConverterFunction icebergRequestConverter = gatedJackson(icebergMapper);
     JacksonResponseConverterFunction icebergResponseConverter =
         new JacksonResponseConverterFunction(icebergMapper);
     MetadataService metadataService =
@@ -301,7 +313,7 @@ public class UnityCatalogServer {
     armeriaServerBuilder.annotatedService(
         BASE_PATH,
         deltaRestService,
-        new JacksonRequestConverterFunction(deltaMapper),
+        gatedJackson(deltaMapper),
         new JacksonResponseConverterFunction(deltaMapper));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -12,10 +12,12 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.docs.DocService;
 import io.unitycatalog.server.auth.AllowingAuthorizer;
 import io.unitycatalog.server.auth.JCasbinAuthorizer;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
 import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
 import io.unitycatalog.server.auth.decorator.UnityAccessUtil;
 import io.unitycatalog.server.exception.BaseException;
@@ -203,8 +205,8 @@ public class UnityCatalogServer {
     TemporaryPathCredentialsService temporaryPathCredentialsService =
         new TemporaryPathCredentialsService(storageCredentialVendor);
 
-    JacksonRequestConverterFunction requestConverterFunction =
-        new JacksonRequestConverterFunction(
+    RequestConverterFunction requestConverterFunction =
+        gatedJackson(
             JsonMapper.builder()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build());
@@ -270,6 +272,17 @@ public class UnityCatalogServer {
         armeriaServerBuilder, authorizer, repositories, serverProperties, storageCredentialVendor);
   }
 
+  /**
+   * Wraps a Jackson body converter with {@link AuthorizationGateConverter}. Every annotated
+   * service's request converter must go through this so the PAYLOAD-source auth check fires before
+   * body binding. Using a wrapper (rather than registering the gate as a separate chain element per
+   * {@code annotatedService(...)} call) makes the gate impossible to forget when a new service is
+   * added.
+   */
+  private static RequestConverterFunction gatedJackson(ObjectMapper mapper) {
+    return new AuthorizationGateConverter(new JacksonRequestConverterFunction(mapper));
+  }
+
   private void addIcebergApiServices(
       ServerBuilder armeriaServerBuilder,
       ServerProperties serverProperties,
@@ -282,8 +295,7 @@ public class UnityCatalogServer {
 
     // Add support for Iceberg REST APIs
     ObjectMapper icebergMapper = IcebergObjectMapper.mapper();
-    JacksonRequestConverterFunction icebergRequestConverter =
-        new JacksonRequestConverterFunction(icebergMapper);
+    RequestConverterFunction icebergRequestConverter = gatedJackson(icebergMapper);
     JacksonResponseConverterFunction icebergResponseConverter =
         new JacksonResponseConverterFunction(icebergMapper);
     MetadataService metadataService =
@@ -312,7 +324,7 @@ public class UnityCatalogServer {
     armeriaServerBuilder.annotatedService(
         BASE_PATH,
         deltaApiService,
-        new JacksonRequestConverterFunction(deltaMapper),
+        gatedJackson(deltaMapper),
         new JacksonResponseConverterFunction(deltaMapper));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
@@ -1,0 +1,49 @@
+package io.unitycatalog.server.auth.decorator;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import java.lang.reflect.ParameterizedType;
+import java.util.Objects;
+
+/**
+ * Fail-closed wrapper that enforces {@link UnityAccessDecorator}'s PAYLOAD-source authorization
+ * before delegating to an inner body converter (e.g. Jackson). The decorator sets {@link
+ * UnityAccessDecorator#AUTH_PENDING} on entry to the PAYLOAD path and clears it only after {@code
+ * checkAuthorization} succeeds; if the flag is still {@code true} when a parameter is being bound,
+ * {@code peekData}'s callback never fired (no body, non-JSON content-type, malformed JSON, trailing
+ * whitespace) and the request must be denied.
+ *
+ * <p>Wrapping Jackson (rather than sitting in front of it as a separate chain element) means
+ * services register a single converter and the gate is impossible to forget when a new annotated
+ * service is added.
+ *
+ * <p>Scope: gates only parameters bound via the converter chain. Endpoints with no body-bound
+ * parameter (pure {@code @Param}/path) don't trigger this converter, but those endpoints also don't
+ * use PAYLOAD locators, so the decorator never sets the flag and no gate is needed.
+ */
+public final class AuthorizationGateConverter implements RequestConverterFunction {
+
+  private final RequestConverterFunction delegate;
+
+  public AuthorizationGateConverter(RequestConverterFunction delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+  }
+
+  @Override
+  public Object convertRequest(
+      ServiceRequestContext ctx,
+      AggregatedHttpRequest request,
+      Class<?> expectedResultType,
+      ParameterizedType expectedParameterizedResultType)
+      throws Exception {
+    if (Boolean.TRUE.equals(ctx.attr(UnityAccessDecorator.AUTH_PENDING))) {
+      throw new BaseException(
+          ErrorCode.PERMISSION_DENIED, "Authorization could not be verified for this request");
+    }
+    return delegate.convertRequest(
+        ctx, request, expectedResultType, expectedParameterizedResultType);
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
@@ -11,10 +11,10 @@ import java.util.Objects;
 /**
  * Fail-closed wrapper that enforces {@link UnityAccessDecorator}'s PAYLOAD-source authorization
  * before delegating to an inner body converter (e.g. Jackson). The decorator sets {@link
- * UnityAccessDecorator#AUTH_PENDING} on entry to the PAYLOAD path and clears it only after {@code
- * checkAuthorization} succeeds; if the flag is still {@code true} when a parameter is being bound,
- * {@code peekData}'s callback never fired (no body, non-JSON content-type, malformed JSON, trailing
- * whitespace) and the request must be denied.
+ * UnityAccessDecorator#AUTH_PENDING} on entry to the PAYLOAD path and clears it only after the
+ * authorization evaluation succeeds; if the flag is still {@code true} when a parameter is being
+ * bound, {@code peekData}'s callback never fired (no body, non-JSON content-type, malformed JSON,
+ * trailing whitespace) and the request must be denied.
  *
  * <p>Wrapping Jackson (rather than sitting in front of it as a separate chain element) means
  * services register a single converter and the gate is impossible to forget when a new annotated
@@ -29,7 +29,7 @@ public final class AuthorizationGateConverter implements RequestConverterFunctio
   private final RequestConverterFunction delegate;
 
   public AuthorizationGateConverter(RequestConverterFunction delegate) {
-    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.delegate = Objects.requireNonNull(delegate);
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import io.netty.util.AttributeKey;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
@@ -57,11 +58,28 @@ import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.S
  * <p>3. {@code @AuthorizeKey} - This annotation is used to define request and payload parameters
  * for that are usually not resources but parameters of the operation. For example, table_type,
  * operation, etc.
+ *
+ * <p>For PAYLOAD-source locators (body-read), {@code peekData} only observes complete JSON chunks;
+ * anything else (no body, non-JSON content-type, malformed JSON, trailing whitespace) silently
+ * skips {@link #checkAuthorization}. The {@link #AUTH_PENDING} flag and {@link
+ * AuthorizationGateConverter} close that gap: the decorator marks the request auth-pending on
+ * entry to the PAYLOAD path, clears it only after authorization succeeds, and the gate converter
+ * denies any body-binding where the flag is still set.
  */
 public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnityAccessDecorator.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Per-request flag: {@code true} once the decorator enters the PAYLOAD path, flipped to
+   * {@code false} when {@link #checkAuthorization} completes inside the peekData callback. Read by
+   * {@link AuthorizationGateConverter} at body-binding time: if still {@code true}, authorization
+   * never ran (no body chunk arrived, content-type wasn't JSON, or JSON didn't complete) and the
+   * request must be denied.
+   */
+  public static final AttributeKey<Boolean> AUTH_PENDING =
+      AttributeKey.valueOf(UnityAccessDecorator.class, "AUTH_PENDING");
   private final KeyMapper keyMapper;
   private final UserRepository userRepository;
 
@@ -170,13 +188,19 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
           resourceKeys,
           nonResourceValues);
 
-      // Note that peekData only gets called for requests that actually have data (like PUT&POST)
+      // peekData's lambda only fires when a body chunk arrives AND processPeekData returns true
+      // (JSON content-type + chunk ending in '}'). Any other path (no body, non-JSON, malformed
+      // JSON, trailing whitespace) silently skips authorization. Mark the request auth-pending
+      // here and clear it only after checkAuthorization runs; AuthorizationGateConverter denies
+      // any body-binding attempt where this flag is still set.
+      ctx.setAttr(AUTH_PENDING, true);
 
       var peekReq = req.peekData(data -> {
         LOGGER.debug("Authorization peekData invoked.");
 
         if (peekDataHandler.processPeekData(data)) {
           checkAuthorization(principal, expression, resourceKeys, nonResourceValues);
+          ctx.setAttr(AUTH_PENDING, false);
         }
       });
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -62,11 +62,28 @@ import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.S
  * <p>3. {@code @AuthorizeKey} - Works like {@code @AuthorizeResourceKey} for source selection, but
  * for non-resource request values (operation mode, table type, flag, etc.) exposed directly as a
  * SpEL variable instead of being mapped to a resource identifier.
+ *
+ * <p>For PAYLOAD-source locators (body-read), {@code peekData} only observes complete JSON chunks;
+ * anything else (no body, non-JSON content-type, malformed JSON, trailing whitespace) silently
+ * skips {@link #checkAuthorization}. The {@link #AUTH_PENDING} flag and {@link
+ * AuthorizationGateConverter} close that gap: the decorator marks the request auth-pending on
+ * entry to the PAYLOAD path, clears it only after authorization succeeds, and the gate converter
+ * denies any body-binding where the flag is still set.
  */
 public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnityAccessDecorator.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Per-request flag: {@code true} once the decorator enters the PAYLOAD path, flipped to
+   * {@code false} when {@link #checkAuthorization} completes inside the peekData callback. Read by
+   * {@link AuthorizationGateConverter} at body-binding time: if still {@code true}, authorization
+   * never ran (no body chunk arrived, content-type wasn't JSON, or JSON didn't complete) and the
+   * request must be denied.
+   */
+  public static final AttributeKey<Boolean> AUTH_PENDING =
+      AttributeKey.valueOf(UnityAccessDecorator.class, "AUTH_PENDING");
   private final KeyMapper keyMapper;
   private final UserRepository userRepository;
 
@@ -177,15 +194,22 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
           resourceKeys,
           nonResourceValues);
 
-      // Note that peekData only gets called for requests that actually have data (like PUT&POST)
+      // peekData's lambda only fires when a body chunk arrives AND processPeekData returns true
+      // (JSON content-type + chunk ending in '}'). Any other path (no body, non-JSON, malformed
+      // JSON, trailing whitespace) silently skips authorization. Mark the request auth-pending
+      // here and clear it only after checkAuthorization runs; AuthorizationGateConverter denies
+      // any body-binding attempt where this flag is still set.
+      ctx.setAttr(AUTH_PENDING, true);
 
       req = req.peekData(data -> {
         // This code block is not called immediately. It is called later as part of delegate.serve()
         LOGGER.debug("Authorization peekData invoked.");
 
-        peekDataHandler.processPeekData(data);
-        Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
-        evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
+        if (peekDataHandler.processPeekData(data)) {
+          Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
+          evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
+          ctx.setAttr(AUTH_PENDING, false);
+        }
       });
     }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -65,7 +65,7 @@ import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.S
  *
  * <p>For PAYLOAD-source locators (body-read), {@code peekData} only observes complete JSON chunks;
  * anything else (no body, non-JSON content-type, malformed JSON, trailing whitespace) silently
- * skips {@link #checkAuthorization}. The {@link #AUTH_PENDING} flag and {@link
+ * skips the authorization evaluation. The {@link #AUTH_PENDING} flag and {@link
  * AuthorizationGateConverter} close that gap: the decorator marks the request auth-pending on
  * entry to the PAYLOAD path, clears it only after authorization succeeds, and the gate converter
  * denies any body-binding where the flag is still set.
@@ -77,7 +77,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   /**
    * Per-request flag: {@code true} once the decorator enters the PAYLOAD path, flipped to
-   * {@code false} when {@link #checkAuthorization} completes inside the peekData callback. Read by
+   * {@code false} when the authorization evaluation completes inside the peekData callback. Read by
    * {@link AuthorizationGateConverter} at body-binding time: if still {@code true}, authorization
    * never ran (no body chunk arrived, content-type wasn't JSON, or JSON didn't complete) and the
    * request must be denied.
@@ -197,8 +197,8 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
       // peekData's lambda only fires when a body chunk arrives AND processPeekData returns true
       // (JSON content-type + chunk ending in '}'). Any other path (no body, non-JSON, malformed
       // JSON, trailing whitespace) silently skips authorization. Mark the request auth-pending
-      // here and clear it only after checkAuthorization runs; AuthorizationGateConverter denies
-      // any body-binding attempt where this flag is still set.
+      // here and clear it only after the authorization evaluation runs; AuthorizationGateConverter
+      // denies any body-binding attempt where this flag is still set.
       ctx.setAttr(AUTH_PENDING, true);
 
       req = req.peekData(data -> {

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.sdk.access;
 
+import static io.unitycatalog.server.utils.TestUtils.assertHttpApiException;
 import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +13,7 @@ import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.client.model.SecurableType;
 import io.unitycatalog.client.model.UpdateCatalog;
 import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
@@ -196,5 +198,20 @@ public class SdkCatalogAccessControlCRUDTest extends SdkAccessControlBaseCRUDTes
             .name("catalog_with_location2")
             .storageRoot("file:///tmp/external_location/ext_table");
     assertPermissionDenied(() -> principal1CatalogsApi.createCatalog(catalogWithLoc2));
+  }
+
+  /**
+   * POST /catalogs has a PAYLOAD-source authorization locator (@AuthorizeResourceKey on the
+   * CreateCatalog body). A body-less request never triggers UnityAccessDecorator's peekData
+   * callback, so checkAuthorization is silently skipped. AuthorizationGateConverter catches this at
+   * body-binding time and denies the request before the handler sees it.
+   */
+  @Test
+  @SneakyThrows
+  public void bodylessPostDeniedByAuthorizationGate() {
+    assertHttpApiException(
+        TestUtils.sendRawEmptyPost(adminConfig, "/api/2.1/unity-catalog/catalogs"),
+        ErrorCode.PERMISSION_DENIED,
+        "Authorization could not be verified for this request");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -11,6 +11,9 @@ import io.unitycatalog.client.delta.model.ErrorType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.function.Executable;
@@ -109,5 +112,35 @@ public class TestUtils {
 
   public static void assertPermissionDenied(Executable executable) {
     assertApiException(executable, ErrorCode.PERMISSION_DENIED, "PERMISSION_DENIED");
+  }
+
+  /**
+   * Raw-HTTP counterpart to {@link #assertApiException}. Use when the generated SDK can't reach the
+   * failure mode (e.g. the SDK always serializes a body, so you can't exercise body-less
+   * authorization paths with it).
+   */
+  public static void assertHttpApiException(
+      HttpResponse<String> response, ErrorCode errorCode, String containsMessage) {
+    // Check the body first. When tests fail due to mismatching error, the body can tell us more.
+    assertThat(response.body()).contains(containsMessage).contains(errorCode.name());
+    assertThat(response.statusCode()).isEqualTo(errorCode.getHttpStatus().code());
+  }
+
+  /**
+   * Sends a body-less POST to the given path. The SDK always attaches a serialized body, so raw
+   * HTTP is the only way to reach the body-less code path (used to exercise {@link
+   * io.unitycatalog.server.auth.decorator.AuthorizationGateConverter}'s silent-skip denial).
+   */
+  public static HttpResponse<String> sendRawEmptyPost(ServerConfig config, String path)
+      throws Exception {
+    HttpRequest.Builder reqBuilder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(config.getServerUrl() + path))
+            .POST(HttpRequest.BodyPublishers.noBody());
+    if (config.getAuthToken() != null && !config.getAuthToken().isEmpty()) {
+      reqBuilder.header("Authorization", "Bearer " + config.getAuthToken());
+    }
+    return HttpClient.newHttpClient()
+        .send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -13,6 +13,9 @@ import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -127,5 +130,35 @@ public class TestUtils {
    */
   public static void assertPermissionDenied(Executable executable) {
     assertPermissionDenied(executable, "PERMISSION_DENIED");
+  }
+
+  /**
+   * Raw-HTTP counterpart to {@link #assertApiException}. Use when the generated SDK can't reach the
+   * failure mode (e.g. the SDK always serializes a body, so you can't exercise body-less
+   * authorization paths with it).
+   */
+  public static void assertHttpApiException(
+      HttpResponse<String> response, ErrorCode errorCode, String containsMessage) {
+    // Check the body first. When tests fail due to mismatching error, the body can tell us more.
+    assertThat(response.body()).contains(containsMessage).contains(errorCode.name());
+    assertThat(response.statusCode()).isEqualTo(errorCode.getHttpStatus().code());
+  }
+
+  /**
+   * Sends a body-less POST to the given path. The SDK always attaches a serialized body, so raw
+   * HTTP is the only way to reach the body-less code path (used to exercise {@link
+   * io.unitycatalog.server.auth.decorator.AuthorizationGateConverter}'s silent-skip denial).
+   */
+  public static HttpResponse<String> sendRawEmptyPost(ServerConfig config, String path)
+      throws Exception {
+    HttpRequest.Builder reqBuilder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(config.getServerUrl() + path))
+            .POST(HttpRequest.BodyPublishers.noBody());
+    if (config.getAuthToken() != null && !config.getAuthToken().isEmpty()) {
+      reqBuilder.header("Authorization", "Bearer " + config.getAuthToken());
+    }
+    return HttpClient.newHttpClient()
+        .send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1494/files) to review incremental changes.
- [**auth-block-empty-body**](https://github.com/unitycatalog/unitycatalog/pull/1494) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1494/files)] ← _this PR_
  - stack/armeria_builder
  - stack/auth-hardening-wip

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Fail-closed guard for PAYLOAD-source authorization

UnityAccessDecorator authorizes body-field (PAYLOAD) locators inside Armeria's `peekData` callback, which only fires for a request that delivers a complete JSON body. A body-less, non-JSON, or malformed request silently skips that authorization while the handler still runs. This is defense in depth: every current PAYLOAD endpoint also binds a required POJO body, so such requests already fail Jackson binding with a 400.

- Add a per-request `AUTH_PENDING` attribute, set on entry to the PAYLOAD path and cleared only after the authorization evaluation runs.
- Add `AuthorizationGateConverter`, which denies with `403 PERMISSION_DENIED` at body-binding time if `AUTH_PENDING` is still set.
- Wire the gate via `gatedJackson()` in `UnityCatalogServer`.

Follow-up: widening `peekData`'s payload-recognition heuristic (charset-qualified content types, trailing whitespace) is deferred so the gate cannot deny valid non-SDK requests; current SDK clients are unaffected.

Tested: `SdkCatalogAccessControlCRUDTest` asserts a body-less `POST /catalogs` returns 403 before the handler runs.
