### PR TITLE
Add deltaRestApi.enabled runtime flag to UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,6 +17,9 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
 
+  public static final String DELTA_REST_API_ENABLED = "deltaRestApi.enabled";
+  public static final boolean DEFAULT_DELTA_REST_API_ENABLED = false;
+
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {
     String value = props.get(property);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -40,6 +40,7 @@ class UCSingleCatalog
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = false
+  private[this] var deltaRestApiEnabled: Boolean = false
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
@@ -61,6 +62,9 @@ class UCSingleCatalog
     val serverSidePlanningEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED,
       OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
+    deltaRestApiEnabled = OptionsUtil.getBoolean(options,
+      OptionsUtil.DELTA_REST_API_ENABLED,
+      OptionsUtil.DEFAULT_DELTA_REST_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogDeltaRestApiFlagTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogDeltaRestApiFlagTest.java
@@ -1,0 +1,73 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that UCSingleCatalog reads the deltaRestApi.enabled option into its internal
+ * deltaRestApiEnabled field. The flag is foundation for the Delta REST Catalog integration; no code
+ * branches on it yet.
+ */
+public class UCSingleCatalogDeltaRestApiFlagTest {
+
+  private static final Map<String, String> BASE_OPTIONS =
+      Map.of("uri", "http://localhost:0", "token", "dummy-token");
+
+  @BeforeEach
+  public void disableDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void restoreDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  @Test
+  public void testFlagDefaultsToFalseWhenUnset() {
+    UCSingleCatalog catalog = initializedCatalog(BASE_OPTIONS);
+    assertThat(readFlag(catalog)).isFalse();
+  }
+
+  @Test
+  public void testFlagReadsTrueWhenExplicitlyTrue() {
+    Map<String, String> options = withFlag(BASE_OPTIONS, "true");
+    UCSingleCatalog catalog = initializedCatalog(options);
+    assertThat(readFlag(catalog)).isTrue();
+  }
+
+  @Test
+  public void testFlagReadsFalseWhenExplicitlyFalse() {
+    Map<String, String> options = withFlag(BASE_OPTIONS, "false");
+    UCSingleCatalog catalog = initializedCatalog(options);
+    assertThat(readFlag(catalog)).isFalse();
+  }
+
+  private static UCSingleCatalog initializedCatalog(Map<String, String> options) {
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize("unity", new CaseInsensitiveStringMap(options));
+    return catalog;
+  }
+
+  private static Map<String, String> withFlag(Map<String, String> base, String value) {
+    java.util.HashMap<String, String> merged = new java.util.HashMap<>(base);
+    merged.put("deltaRestApi.enabled", value);
+    return merged;
+  }
+
+  private static boolean readFlag(UCSingleCatalog catalog) {
+    try {
+      Field f = UCSingleCatalog.class.getDeclaredField("deltaRestApiEnabled");
+      f.setAccessible(true);
+      return (Boolean) f.get(catalog);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Introduces a per-catalog flag `spark.sql.catalog.<cat>.deltaRestApi.enabled` (default `false`) read in `UCSingleCatalog.initialize()` via `OptionsUtil`. This is pure scaffolding — no code branches on the flag yet. Later stacks wire it to route traffic through the Delta REST Catalog (DRC) API.

Per TD's guidance, the flag is OSS-only and not registered in `DeltaSQLConf.scala`.

**User impact:** none. Setting the flag has no behavioral effect in this PR.

**Testing:** added `UCSingleCatalogDeltaRestApiFlagTest` — 3 cases (unset / true / false). `sbt spark/testOnly *UCSingleCatalogDeltaRestApiFlagTest` passes.