### PR TITLE
Add DeltaRestClientProvider; wire UCSingleCatalog and UCProxy

### DIFF
--- a/.github/workflows/spark-tests-drc-enabled.yml
+++ b/.github/workflows/spark-tests-drc-enabled.yml
@@ -1,0 +1,38 @@
+name: Spark Tests (DRC enabled)
+
+# Runs the Spark connector test suite with the Delta REST Catalog flag
+# (spark.sql.catalog.<cat>.deltaRestApi.enabled) turned on. Future PRs will
+# plumb this env var through the test harness to toggle DRC routing in
+# integration tests. For now this job proves the flag-on path compiles and
+# existing tests stay green with the system property set.
+
+on:
+  push:
+    branches: [ "main", "branch-*" ]
+  pull_request:
+    branches: [ "main", "branch-*" ]
+
+permissions:
+  contents: read
+
+jobs:
+  spark-tests-drc-enabled:
+    runs-on: ubuntu-latest
+    name: Spark tests with deltaRestApi.enabled=true (Spark 4.0.0, Delta 4.1.0)
+
+    env:
+      DELTA_REST_API_ENABLED: "true"
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - name: Set up JDK 17
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Build and publish to local Maven
+      run: build/sbt -DsparkVersion=4.0.0 -DdeltaVersion=4.1.0 -J-Xmx2G clean package publishM2
+
+    - name: Run Spark connector tests with DRC flag
+      run: build/sbt -DsparkVersion=4.0.0 -DdeltaVersion=4.1.0 -DdeltaRestApiEnabled=true -J-Xmx2G spark/test

--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
@@ -1,0 +1,31 @@
+package io.unitycatalog.client.delta;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+
+/**
+ * Exposes the shared Delta REST Catalog (DRC) client resources owned by a UC
+ * connector catalog. Implementers are discovered via pattern match on Spark
+ * catalog instances (e.g. {@code UCSingleCatalog}, {@code UCProxy}).
+ *
+ * <p>When DRC is disabled for the owning catalog, {@link #getDeltaTablesApi()}
+ * returns {@code null}. Callers treat a non-null return as the single signal
+ * that DRC is enabled.
+ */
+public interface DeltaRestClientProvider {
+
+  /**
+   * Returns the cached DRC {@link TablesApi} bound to the shared
+   * {@code ApiClient}, or {@code null} when DRC is disabled for this catalog.
+   * Callers must not close the returned instance.
+   */
+  TablesApi getDeltaTablesApi();
+
+  /**
+   * Returns the shared base {@code ApiClient} for callers that need to build
+   * their own API wrappers (e.g. Delta's {@code UCDeltaClient}). Default
+   * implementation returns {@code null}; implementers override to expose it.
+   */
+  default Object getApiClient() {
+    return null;
+  }
+}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,6 +17,9 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
 
+  public static final String DELTA_REST_API_ENABLED = "deltaRestApi.enabled";
+  public static final boolean DEFAULT_DELTA_REST_API_ENABLED = false;
+
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {
     String value = props.get(property);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -2,6 +2,8 @@ package io.unitycatalog.spark
 
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.{TablesApi => DeltaTablesApi}
 import io.unitycatalog.client.model.{TableInfo, _}
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
@@ -34,6 +36,7 @@ import scala.language.existentials
 class UCSingleCatalog
   extends StagingTableCatalog
   with SupportsNamespaces
+  with DeltaRestClientProvider
   with Logging {
 
   private[this] var uri: URI = null
@@ -44,8 +47,14 @@ class UCSingleCatalog
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
+  private[this] var ucProxy: UCProxy = null
 
   @volatile private var delegate: TableCatalog = null
+
+  override def getDeltaTablesApi(): DeltaTablesApi =
+    if (ucProxy != null) ucProxy.getDeltaTablesApi() else null
+
+  override def getApiClient(): Object = apiClient
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     val urlStr = options.get(OptionsUtil.URI)
@@ -70,23 +79,24 @@ class UCSingleCatalog
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     tablesApi = new TablesApi(apiClient)
-    val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi)
-    proxy.initialize(name, options)
+    ucProxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
+      serverSidePlanningEnabled, deltaRestApiEnabled, apiClient, tablesApi,
+      temporaryCredentialsApi)
+    ucProxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
         delegate = Class.forName("org.apache.spark.sql.delta.catalog.DeltaCatalog")
           .getDeclaredConstructor().newInstance().asInstanceOf[TableCatalog]
-        delegate.asInstanceOf[DelegatingCatalogExtension].setDelegateCatalog(proxy)
+        delegate.asInstanceOf[DelegatingCatalogExtension].setDelegateCatalog(ucProxy)
         delegate.initialize(name, options)
         UCSingleCatalog.DELTA_CATALOG_LOADED.set(true)
       } catch {
         case e: ClassNotFoundException =>
           logWarning("DeltaCatalog is not available in the classpath", e)
-          delegate = proxy
+          delegate = ucProxy
       }
     } else {
-      delegate = proxy
+      delegate = ucProxy
     }
   }
 
@@ -550,11 +560,19 @@ private class UCProxy(
     renewCredEnabled: Boolean,
     credScopedFsEnabled: Boolean,
     serverSidePlanningEnabled: Boolean,
+    deltaRestApiEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi,
-    temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
+    temporaryCredentialsApi: TemporaryCredentialsApi)
+  extends TableCatalog with SupportsNamespaces with DeltaRestClientProvider with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
+  private[this] lazy val deltaTablesApi: DeltaTablesApi = new DeltaTablesApi(apiClient)
+
+  override def getDeltaTablesApi(): DeltaTablesApi =
+    if (deltaRestApiEnabled) deltaTablesApi else null
+
+  override def getApiClient(): Object = apiClient
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -40,6 +40,7 @@ class UCSingleCatalog
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = false
+  private[this] var deltaRestApiEnabled: Boolean = false
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
@@ -61,6 +62,9 @@ class UCSingleCatalog
     val serverSidePlanningEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED,
       OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
+    deltaRestApiEnabled = OptionsUtil.getBoolean(options,
+      OptionsUtil.DELTA_REST_API_ENABLED,
+      OptionsUtil.DEFAULT_DELTA_REST_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
@@ -1,0 +1,115 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.client.delta.api.TablesApi;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests DeltaRestClientProvider wiring in UCSingleCatalog and UCProxy: flag gate at UCProxy,
+ * UCSingleCatalog forwards via its ucProxy field (not through delegate), and both entry points
+ * return the same cached TablesApi instance.
+ *
+ * <p>Uses LOAD_DELTA_CATALOG=false to avoid needing a SparkSession. A non-provider mock delegate is
+ * injected via reflection to simulate the production case where delegate is DeltaCatalog.
+ */
+public class DeltaRestClientProviderTest {
+
+  private static final Map<String, String> BASE_OPTIONS =
+      Map.of("uri", "http://localhost:0", "token", "dummy-token");
+
+  @BeforeEach
+  public void disableDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void restoreDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  @Test
+  public void testFlagOnBothEntryPointsReturnSameInstance() {
+    UCSingleCatalog catalog = initializedCatalog(withFlag(BASE_OPTIONS, "true"));
+
+    TablesApi fromCatalog = ((DeltaRestClientProvider) catalog).getDeltaTablesApi();
+    TablesApi fromProxy = readUcProxy(catalog).getDeltaTablesApi();
+
+    assertThat(fromCatalog).isNotNull();
+    assertThat(fromProxy).isSameAs(fromCatalog);
+  }
+
+  @Test
+  public void testFlagOffReturnsNullFromBothEntryPoints() {
+    UCSingleCatalog catalog = initializedCatalog(withFlag(BASE_OPTIONS, "false"));
+
+    assertThat(((DeltaRestClientProvider) catalog).getDeltaTablesApi()).isNull();
+    assertThat(readUcProxy(catalog).getDeltaTablesApi()).isNull();
+  }
+
+  /**
+   * Simulates the production case where UCSingleCatalog.delegate is DeltaCatalog (which does not
+   * implement DeltaRestClientProvider). UCSingleCatalog must still resolve the TablesApi via its
+   * ucProxy field rather than through delegate.
+   */
+  @Test
+  public void testForwardsThroughUcProxyFieldNotDelegate() {
+    UCSingleCatalog catalog = initializedCatalog(withFlag(BASE_OPTIONS, "true"));
+    TableCatalog nonProviderDelegate = mock(TableCatalog.class);
+    setField(catalog, "delegate", nonProviderDelegate);
+
+    TablesApi fromCatalog = ((DeltaRestClientProvider) catalog).getDeltaTablesApi();
+
+    assertThat(fromCatalog).isNotNull();
+    assertThat(fromCatalog).isSameAs(readUcProxy(catalog).getDeltaTablesApi());
+  }
+
+  @Test
+  public void testDeltaTablesApiIsCached() {
+    UCSingleCatalog catalog = initializedCatalog(withFlag(BASE_OPTIONS, "true"));
+    DeltaRestClientProvider provider = (DeltaRestClientProvider) catalog;
+
+    assertThat(provider.getDeltaTablesApi()).isSameAs(provider.getDeltaTablesApi());
+  }
+
+  private static UCSingleCatalog initializedCatalog(Map<String, String> options) {
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize("unity", new CaseInsensitiveStringMap(options));
+    return catalog;
+  }
+
+  private static Map<String, String> withFlag(Map<String, String> base, String value) {
+    HashMap<String, String> merged = new HashMap<>(base);
+    merged.put("deltaRestApi.enabled", value);
+    return merged;
+  }
+
+  private static DeltaRestClientProvider readUcProxy(UCSingleCatalog catalog) {
+    try {
+      Field f = UCSingleCatalog.class.getDeclaredField("ucProxy");
+      f.setAccessible(true);
+      return (DeltaRestClientProvider) f.get(catalog);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void setField(UCSingleCatalog catalog, String name, Object value) {
+    try {
+      Field f = UCSingleCatalog.class.getDeclaredField(name);
+      f.setAccessible(true);
+      f.set(catalog, value);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogDeltaRestApiFlagTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogDeltaRestApiFlagTest.java
@@ -1,0 +1,73 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that UCSingleCatalog reads the deltaRestApi.enabled option into its internal
+ * deltaRestApiEnabled field. The flag is foundation for the Delta REST Catalog integration; no code
+ * branches on it yet.
+ */
+public class UCSingleCatalogDeltaRestApiFlagTest {
+
+  private static final Map<String, String> BASE_OPTIONS =
+      Map.of("uri", "http://localhost:0", "token", "dummy-token");
+
+  @BeforeEach
+  public void disableDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void restoreDeltaCatalogLoading() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  @Test
+  public void testFlagDefaultsToFalseWhenUnset() {
+    UCSingleCatalog catalog = initializedCatalog(BASE_OPTIONS);
+    assertThat(readFlag(catalog)).isFalse();
+  }
+
+  @Test
+  public void testFlagReadsTrueWhenExplicitlyTrue() {
+    Map<String, String> options = withFlag(BASE_OPTIONS, "true");
+    UCSingleCatalog catalog = initializedCatalog(options);
+    assertThat(readFlag(catalog)).isTrue();
+  }
+
+  @Test
+  public void testFlagReadsFalseWhenExplicitlyFalse() {
+    Map<String, String> options = withFlag(BASE_OPTIONS, "false");
+    UCSingleCatalog catalog = initializedCatalog(options);
+    assertThat(readFlag(catalog)).isFalse();
+  }
+
+  private static UCSingleCatalog initializedCatalog(Map<String, String> options) {
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize("unity", new CaseInsensitiveStringMap(options));
+    return catalog;
+  }
+
+  private static Map<String, String> withFlag(Map<String, String> base, String value) {
+    java.util.HashMap<String, String> merged = new java.util.HashMap<>(base);
+    merged.put("deltaRestApi.enabled", value);
+    return merged;
+  }
+
+  private static boolean readFlag(UCSingleCatalog catalog) {
+    try {
+      Field f = UCSingleCatalog.class.getDeclaredField("deltaRestApiEnabled");
+      f.setAccessible(true);
+      return (Boolean) f.get(catalog);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Introduces the `DeltaRestClientProvider` interface at `clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java` and wires it into both `UCSingleCatalog` and `UCProxy`.

- **`UCProxy`** is the single flag gate: takes `deltaRestApiEnabled` in its ctor, holds a lazy DRC `TablesApi`, and returns `null` from `getDeltaTablesApi()` when the flag is off.
- **`UCSingleCatalog`** implements the same interface and forwards via its new `ucProxy` field (not through `delegate`), so the call resolves whether `delegate` is `UCProxy` directly or a `DeltaCatalog` wrapper.

The interface lives in the UC client jar so both UC connector and Delta can depend on it without a circular dep. Delta's `UCDeltaClient` (delta-io/delta#6575) will wrap the `ApiClient` returned by `getApiClient()`.

**Why two implementers:**
- Delta-side callers (e.g. `AbstractDeltaCatalog.loadTable`) reach `UCProxy` via `this.delegate` (set by `setDelegateCatalog` at `UCSingleCatalog.scala:76`) and can cast directly.
- External callers (e.g. a future commit coordinator) reach `UCSingleCatalog` by catalog name.

A single implementer would force one of those callers through a brittle lookup.

**User impact:** none. The interface is wired but no consumer calls it yet; runtime behavior is unchanged regardless of the flag.

**Testing:** added `DeltaRestClientProviderTest` — 4 cases: flag on returns shared `TablesApi`, flag off returns `null` from both entry points, forwarding works when `delegate` is a non-provider mock (simulates Delta-loaded prod), `TablesApi` is cached across calls. `sbt spark/testOnly *DeltaRestClientProviderTest *UCSingleCatalogDeltaRestApiFlagTest` — 7/7 pass.