### PR TITLE
When MAVEN_PROXY_URL is set, also use local as a repo

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -67,10 +67,11 @@ realpath () {
 }
 
 if [[ -n "$MAVEN_PROXY_URL" ]]; then
-  # If MAVEN_PROXY_URL is set, use it as the sole repository for all dependencies.
+  # If MAVEN_PROXY_URL is set, use it (and local) as the sole repository for all dependencies.
   SBT_REPOSITORIES_CONFIG=$(mktemp)
   cat > "$SBT_REPOSITORIES_CONFIG" <<EOF
 [repositories]
+  local
   maven-proxy: $MAVEN_PROXY_URL
   maven-proxy-ivy: $MAVEN_PROXY_URL, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
 EOF


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
When MAVEN_PROXY_URL is set, also use local as a repo. This is needed by `sbt publishLocal` when using maven proxy. Otherwise an error pops up:
```
[error] (server / publishLocal) Undefined resolver 'local'
```