### PR TITLE
Add DeltaRestClientProvider and wire UCSingleCatalog + UCProxy

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
@@ -1,0 +1,36 @@
+package io.unitycatalog.client.delta;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+
+/**
+ * Interface for catalog implementations that can provide a Delta REST Catalog
+ * {@link TablesApi} client. This enables a single shared client instance owned
+ * by the catalog (UCProxy) to be reused by all consumers -- AbstractDeltaCatalog,
+ * UCCommitCoordinatorClient, and the Kernel v2 connector -- instead of each
+ * creating their own HTTP client to the same UC server.
+ *
+ * <p>Implementations should return the same cached {@link TablesApi} instance
+ * on every call. The caller must not close or modify the returned client.
+ *
+ * <p>This interface lives in {@code unitycatalog-client} so that both the UC Spark
+ * connector (which implements it) and Delta Spark (which consumes it) can depend on it
+ * without a circular dependency.
+ */
+public interface DeltaRestClientProvider {
+
+  /**
+   * Returns the shared Delta REST Catalog {@link TablesApi} client, or {@code null}
+   * when the Delta REST Catalog integration is disabled for this catalog (see
+   * the {@code deltaRestApi.enabled} option). Callers must null-check.
+   * The returned instance is owned by the catalog and must not be closed by the caller.
+   */
+  TablesApi getDeltaTablesApi();
+
+  /**
+   * Returns the base {@link io.unitycatalog.client.ApiClient} for legacy UC API access,
+   * or {@code null} when the implementation does not expose its client. Returned as
+   * {@link Object} so that callers in modules that do not depend on the generated
+   * client package can receive it opaquely and cast when they need it.
+   */
+  default Object getApiClient() { return null; }
+}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,6 +17,9 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
 
+  public static final String DELTA_REST_API_ENABLED = "deltaRestApi.enabled";
+  public static final boolean DEFAULT_DELTA_REST_API_ENABLED = false;
+
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {
     String value = props.get(property);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -2,6 +2,8 @@ package io.unitycatalog.spark
 
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.{TablesApi => DeltaTablesApi}
 import io.unitycatalog.client.model.{TableInfo, _}
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
@@ -34,6 +36,7 @@ import scala.language.existentials
 class UCSingleCatalog
   extends StagingTableCatalog
   with SupportsNamespaces
+  with DeltaRestClientProvider
   with Logging {
 
   private[this] var uri: URI = null
@@ -71,7 +74,8 @@ class UCSingleCatalog
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     tablesApi = new TablesApi(apiClient)
     val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi)
+      serverSidePlanningEnabled, deltaRestApiEnabled,
+      apiClient, tablesApi, temporaryCredentialsApi)
     proxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
@@ -91,6 +95,13 @@ class UCSingleCatalog
   }
 
   override def name(): String = delegate.name()
+
+  override def getDeltaTablesApi(): DeltaTablesApi = delegate match {
+    case provider: DeltaRestClientProvider => provider.getDeltaTablesApi()
+    case _ => null
+  }
+
+  override def getApiClient(): Object = apiClient
 
   override def listTables(namespace: Array[String]): Array[Identifier] = delegate.listTables(namespace)
 
@@ -550,11 +561,22 @@ private class UCProxy(
     renewCredEnabled: Boolean,
     credScopedFsEnabled: Boolean,
     serverSidePlanningEnabled: Boolean,
+    deltaRestApiEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi,
-    temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
+    temporaryCredentialsApi: TemporaryCredentialsApi)
+  extends TableCatalog
+  with SupportsNamespaces
+  with DeltaRestClientProvider
+  with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
+  private[this] lazy val deltaTablesApi: DeltaTablesApi = new DeltaTablesApi(apiClient)
+
+  override def getDeltaTablesApi(): DeltaTablesApi =
+    if (deltaRestApiEnabled) deltaTablesApi else null
+
+  override def getApiClient(): Object = apiClient
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -40,6 +40,7 @@ class UCSingleCatalog
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = false
+  private[this] var deltaRestApiEnabled: Boolean = false
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
@@ -61,6 +62,9 @@ class UCSingleCatalog
     val serverSidePlanningEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED,
       OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
+    deltaRestApiEnabled = OptionsUtil.getBoolean(options,
+      OptionsUtil.DELTA_REST_API_ENABLED,
+      OptionsUtil.DEFAULT_DELTA_REST_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
@@ -1,0 +1,97 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.spark.utils.OptionsUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DeltaRestClientProvider} as exposed through the public {@link
+ * TableCatalog#initialize} surface of {@link UCSingleCatalog}.
+ *
+ * <p>{@code LOAD_DELTA_CATALOG} is set to {@code false} so the internal delegate is {@code UCProxy}
+ * (the only class that implements the provider in UC today). No reflection on private state; the
+ * provider contract is the observable surface.
+ */
+public class DeltaRestClientProviderTest {
+
+  private static final String CATALOG = "test_catalog";
+  // Port 0 is fine: initialize() only constructs the client; no HTTP call fires here.
+  private static final String URI = "http://localhost:0";
+  private static final String TOKEN = "dummy-token";
+
+  @BeforeEach
+  public void setUp() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  private static UCSingleCatalog catalogWithFlag(Boolean flagValue) {
+    Map<String, String> opts = new HashMap<>();
+    opts.put(OptionsUtil.URI, URI);
+    opts.put(OptionsUtil.TOKEN, TOKEN);
+    if (flagValue != null) {
+      opts.put(OptionsUtil.DELTA_REST_API_ENABLED, flagValue.toString());
+    }
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize(CATALOG, new CaseInsensitiveStringMap(opts));
+    return catalog;
+  }
+
+  @Test
+  public void flagEnabled_catalogOwnsCachedDeltaTablesApi() {
+    // Flag on: the catalog returns a single cached TablesApi. The assignment to
+    // DeltaRestClientProvider is a compile-time check that UCSingleCatalog
+    // implements the interface (consumers cast to the interface to reach the
+    // client). The isSameAs assertion locks in the lazy-val caching invariant;
+    // if someone changes it to build per-call, this test fails.
+    UCSingleCatalog catalog = catalogWithFlag(true);
+    DeltaRestClientProvider provider = catalog;
+    TablesApi first = provider.getDeltaTablesApi();
+    assertThat(first).isNotNull();
+    assertThat(provider.getDeltaTablesApi()).isSameAs(first);
+  }
+
+  @Test
+  public void eachCatalogOwnsItsOwnDeltaTablesApi() {
+    // Two independently initialized catalogs produce distinct TablesApi
+    // instances. Guards against an accidental singleton / global-state
+    // regression that would cause clients for different UC catalogs to share
+    // one HTTP client.
+    UCSingleCatalog a = catalogWithFlag(true);
+    UCSingleCatalog b = catalogWithFlag(true);
+    assertThat(a.getDeltaTablesApi()).isNotSameAs(b.getDeltaTablesApi());
+  }
+
+  @Test
+  public void flagDisabled_deltaRestCatalogIsUnavailable() {
+    // Default (absent option) and explicit false both disable DRC. The
+    // observable contract is that the provider returns no client, so consumers
+    // route through the legacy UC API path. Removing the flag gate in UCProxy
+    // would cause this test to fail.
+    assertThat(catalogWithFlag(null).getDeltaTablesApi()).isNull();
+    assertThat(catalogWithFlag(false).getDeltaTablesApi()).isNull();
+  }
+
+  @Test
+  public void getApiClient_returnsApiClient_regardlessOfFlag() {
+    // getApiClient is not flag-gated: legacy UC API consumers still need the
+    // underlying client when DRC is disabled. Accidentally gating getApiClient
+    // on the flag would break the non-DRC path; this test catches that.
+    assertThat(catalogWithFlag(false).getApiClient()).isInstanceOf(ApiClient.class);
+    assertThat(catalogWithFlag(true).getApiClient()).isInstanceOf(ApiClient.class);
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1507/files/12ba6545d815cec62eb5e6fad7ea44745b1e0c77..b4ad28c8b81d6868f42df80f36000a3ae3221d5c) to review incremental changes.
- [stack/drc-flag-constants](https://github.com/unitycatalog/unitycatalog/pull/1506) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1506/files)]
  - [**stack/drc-provider-wiring**](https://github.com/unitycatalog/unitycatalog/pull/1507) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1507/files/12ba6545d815cec62eb5e6fad7ea44745b1e0c77..b4ad28c8b81d6868f42df80f36000a3ae3221d5c)]

---------

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds the `DeltaRestClientProvider` contract so the UC Spark connector can expose its DRC HTTP client to Delta Spark without Delta having to reach into private UC catalog internals. No existing behavior changes when the flag is off (the default). When the flag is on, the DRC `TablesApi` client becomes reachable via `UCSingleCatalog` (and directly on `UCProxy`) through the new interface.

`UCSingleCatalog` and its internal `UCProxy` both implement the new interface. `UCProxy` is the single flag gate: when `deltaRestApi.enabled=false` (default), `UCProxy.getDeltaTablesApi()` returns `null` and the DRC client is not constructed. `UCSingleCatalog.getDeltaTablesApi()` pattern-matches on its delegate and forwards to any delegate that implements the provider contract; otherwise returns `null`.

The flag key (`deltaRestApi.enabled`) and the read in `UCSingleCatalog.initialize()` are defined in the previous PR of this stack. This PR threads the value into the `UCProxy` constructor and adds the provider interface + getters + tests.

**Example conf usage**

```
spark.sql.catalog.unity=io.unitycatalog.spark.UCSingleCatalog
spark.sql.catalog.unity.uri=http://localhost:8080
spark.sql.catalog.unity.token=<token>
spark.sql.catalog.unity.deltaRestApi.enabled=true
```

**Example usage in UC**

`UCSingleCatalog.initialize()` passes the flag value into the `UCProxy` constructor:

```scala
val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled,
  credScopedFsEnabled, serverSidePlanningEnabled, deltaRestApiEnabled,
  apiClient, tablesApi, temporaryCredentialsApi)
```

`UCProxy` then gates DRC-client construction on the flag:

```scala
private[this] lazy val deltaTablesApi: DeltaTablesApi =
  new DeltaTablesApi(apiClient)

override def getDeltaTablesApi(): DeltaTablesApi =
  if (deltaRestApiEnabled) deltaTablesApi else null
```

**Example usage in Delta**

Delta Spark obtains the DRC client by casting the UC catalog to `DeltaRestClientProvider`:

```java
DeltaRestClientProvider provider = (DeltaRestClientProvider) catalog;
TablesApi drcClient = provider.getDeltaTablesApi();
if (drcClient != null) {
  // DRC path: route table operations through the new REST endpoints.
} else {
  // Legacy path: use provider.getApiClient() and the existing UC TablesApi.
}
```

`getDeltaTablesApi()` returns non-null iff `deltaRestApi.enabled=true` on the UC catalog conf; `getApiClient()` returns the underlying UC `ApiClient` unconditionally so legacy consumers always have a client.
