### PR TITLE
Add DeltaRestClientProvider and deltaRestApi.enabled runtime flag

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
@@ -1,0 +1,36 @@
+package io.unitycatalog.client.delta;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+
+/**
+ * Interface for catalog implementations that can provide a Delta REST Catalog
+ * {@link TablesApi} client. This enables a single shared client instance owned
+ * by the catalog (UCProxy) to be reused by all consumers -- AbstractDeltaCatalog,
+ * UCCommitCoordinatorClient, and the Kernel v2 connector -- instead of each
+ * creating their own HTTP client to the same UC server.
+ *
+ * <p>Implementations should return the same cached {@link TablesApi} instance
+ * on every call. The caller must not close or modify the returned client.
+ *
+ * <p>This interface lives in {@code unitycatalog-client} so that both the UC Spark
+ * connector (which implements it) and Delta Spark (which consumes it) can depend on it
+ * without a circular dependency.
+ */
+public interface DeltaRestClientProvider {
+
+  /**
+   * Returns the shared Delta REST Catalog {@link TablesApi} client, or {@code null}
+   * when the Delta REST Catalog integration is disabled for this catalog (see
+   * the {@code deltaRestApi.enabled} option). Callers must null-check.
+   * The returned instance is owned by the catalog and must not be closed by the caller.
+   */
+  TablesApi getDeltaTablesApi();
+
+  /**
+   * Returns the base {@link io.unitycatalog.client.ApiClient} for legacy UC API access,
+   * or {@code null} when the implementation does not expose its client. Returned as
+   * {@link Object} so that callers in modules that do not depend on the generated
+   * client package can receive it opaquely and cast when they need it.
+   */
+  default Object getApiClient() { return null; }
+}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,6 +17,9 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
 
+  public static final String DELTA_REST_API_ENABLED = "deltaRestApi.enabled";
+  public static final boolean DEFAULT_DELTA_REST_API_ENABLED = false;
+
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {
     String value = props.get(property);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -2,6 +2,8 @@ package io.unitycatalog.spark
 
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.{TablesApi => DeltaTablesApi}
 import io.unitycatalog.client.model.{TableInfo, _}
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
@@ -34,12 +36,14 @@ import scala.language.existentials
 class UCSingleCatalog
   extends StagingTableCatalog
   with SupportsNamespaces
+  with DeltaRestClientProvider
   with Logging {
 
   private[this] var uri: URI = null
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = false
+  private[this] var deltaRestApiEnabled: Boolean = false
   private[this] var apiClient: ApiClient = null;
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
@@ -61,13 +65,17 @@ class UCSingleCatalog
     val serverSidePlanningEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED,
       OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
+    deltaRestApiEnabled = OptionsUtil.getBoolean(options,
+      OptionsUtil.DELTA_REST_API_ENABLED,
+      OptionsUtil.DEFAULT_DELTA_REST_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     tablesApi = new TablesApi(apiClient)
     val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi)
+      serverSidePlanningEnabled, deltaRestApiEnabled,
+      apiClient, tablesApi, temporaryCredentialsApi)
     proxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
@@ -87,6 +95,13 @@ class UCSingleCatalog
   }
 
   override def name(): String = delegate.name()
+
+  override def getDeltaTablesApi(): DeltaTablesApi = delegate match {
+    case provider: DeltaRestClientProvider => provider.getDeltaTablesApi()
+    case _ => null
+  }
+
+  override def getApiClient(): Object = apiClient
 
   override def listTables(namespace: Array[String]): Array[Identifier] = delegate.listTables(namespace)
 
@@ -546,11 +561,22 @@ private class UCProxy(
     renewCredEnabled: Boolean,
     credScopedFsEnabled: Boolean,
     serverSidePlanningEnabled: Boolean,
+    deltaRestApiEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi,
-    temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
+    temporaryCredentialsApi: TemporaryCredentialsApi)
+  extends TableCatalog
+  with SupportsNamespaces
+  with DeltaRestClientProvider
+  with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
+  private[this] lazy val deltaTablesApi: DeltaTablesApi = new DeltaTablesApi(apiClient)
+
+  override def getDeltaTablesApi(): DeltaTablesApi =
+    if (deltaRestApiEnabled) deltaTablesApi else null
+
+  override def getApiClient(): Object = apiClient
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
@@ -1,0 +1,97 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.spark.utils.OptionsUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DeltaRestClientProvider} as exposed through the public {@link
+ * TableCatalog#initialize} surface of {@link UCSingleCatalog}.
+ *
+ * <p>{@code LOAD_DELTA_CATALOG} is set to {@code false} so the internal delegate is {@code UCProxy}
+ * (the only class that implements the provider in UC today). No reflection on private state; the
+ * provider contract is the observable surface.
+ */
+public class DeltaRestClientProviderTest {
+
+  private static final String CATALOG = "test_catalog";
+  // Port 0 is fine: initialize() only constructs the client; no HTTP call fires here.
+  private static final String URI = "http://localhost:0";
+  private static final String TOKEN = "dummy-token";
+
+  @BeforeEach
+  public void setUp() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  private static UCSingleCatalog catalogWithFlag(Boolean flagValue) {
+    Map<String, String> opts = new HashMap<>();
+    opts.put(OptionsUtil.URI, URI);
+    opts.put(OptionsUtil.TOKEN, TOKEN);
+    if (flagValue != null) {
+      opts.put(OptionsUtil.DELTA_REST_API_ENABLED, flagValue.toString());
+    }
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize(CATALOG, new CaseInsensitiveStringMap(opts));
+    return catalog;
+  }
+
+  @Test
+  public void flagEnabled_catalogOwnsCachedDeltaTablesApi() {
+    // Flag on: the catalog returns a single cached TablesApi. The assignment to
+    // DeltaRestClientProvider is a compile-time check that UCSingleCatalog
+    // implements the interface (consumers cast to the interface to reach the
+    // client). The isSameAs assertion locks in the lazy-val caching invariant;
+    // if someone changes it to build per-call, this test fails.
+    UCSingleCatalog catalog = catalogWithFlag(true);
+    DeltaRestClientProvider provider = catalog;
+    TablesApi first = provider.getDeltaTablesApi();
+    assertThat(first).isNotNull();
+    assertThat(provider.getDeltaTablesApi()).isSameAs(first);
+  }
+
+  @Test
+  public void eachCatalogOwnsItsOwnDeltaTablesApi() {
+    // Two independently initialized catalogs produce distinct TablesApi
+    // instances. Guards against an accidental singleton / global-state
+    // regression that would cause clients for different UC catalogs to share
+    // one HTTP client.
+    UCSingleCatalog a = catalogWithFlag(true);
+    UCSingleCatalog b = catalogWithFlag(true);
+    assertThat(a.getDeltaTablesApi()).isNotSameAs(b.getDeltaTablesApi());
+  }
+
+  @Test
+  public void flagDisabled_deltaRestCatalogIsUnavailable() {
+    // Default (absent option) and explicit false both disable DRC. The
+    // observable contract is that the provider returns no client, so consumers
+    // route through the legacy UC API path. Removing the flag gate in UCProxy
+    // would cause this test to fail.
+    assertThat(catalogWithFlag(null).getDeltaTablesApi()).isNull();
+    assertThat(catalogWithFlag(false).getDeltaTablesApi()).isNull();
+  }
+
+  @Test
+  public void getApiClient_returnsApiClient_regardlessOfFlag() {
+    // getApiClient is not flag-gated: legacy UC API consumers still need the
+    // underlying client when DRC is disabled. Accidentally gating getApiClient
+    // on the flag would break the non-DRC path; this test catches that.
+    assertThat(catalogWithFlag(false).getApiClient()).isInstanceOf(ApiClient.class);
+    assertThat(catalogWithFlag(true).getApiClient()).isInstanceOf(ApiClient.class);
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1508/files) to review incremental changes.
- [**stack/drc-provider**](https://github.com/unitycatalog/unitycatalog/pull/1508) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1508/files)]

---------
Adds the `deltaRestApi.enabled` per-catalog option (default `false`)
and a Java interface `DeltaRestClientProvider` in
`io.unitycatalog.client.delta`. Delta Spark (future PR in
`delta-io/delta`) casts the UC catalog to this interface to get the
Delta REST Catalog (DRC) HTTP client when the flag is on.

`UCSingleCatalog` and its internal `UCProxy` both implement the
interface. `UCProxy` owns the DRC `TablesApi` as a `lazy val` and is
the single flag gate: when `deltaRestApi.enabled=false`,
`getDeltaTablesApi()` returns `null` and the `lazy val` is never
initialized. `UCSingleCatalog.getDeltaTablesApi()` pattern-matches on
its delegate and forwards to any delegate that implements the
provider; otherwise returns `null`.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds the `deltaRestApi.enabled` per-catalog option (default `false`) and a Java interface `DeltaRestClientProvider` in `io.unitycatalog.client.delta`. Delta Spark (future PR in `delta-io/delta`) casts the UC catalog to this interface to get the Delta REST Catalog (DRC) HTTP client when the flag is on.

Two types are involved:

- `ApiClient` — UC's HTTP client. Holds the server URL, auth token, and connection pool.
- `DeltaTablesApi` = `io.unitycatalog.client.delta.api.TablesApi`. Generated from the DRC OpenAPI spec. Uses an `ApiClient` under the hood to call DRC endpoints (`getTable`, `commitTable`, ...). This is **not** the legacy `io.unitycatalog.client.api.TablesApi`.

The interface:

```java
public interface DeltaRestClientProvider {
  DeltaTablesApi getDeltaTablesApi();   // non-null iff deltaRestApi.enabled=true
  Object getApiClient();                // always non-null once the catalog is initialized
}
```

**What the null means, and who handles it**

`getDeltaTablesApi()` returns `null` when DRC is disabled. The caller (Delta Spark) null-checks and falls back to the legacy UC API, which it builds from the `ApiClient`:

```java
DeltaRestClientProvider provider = (DeltaRestClientProvider) catalog;
DeltaTablesApi drc = provider.getDeltaTablesApi();
if (drc != null) {
  drc.getTable(catalogName, schemaName, tableName);               // DRC path
} else {
  ApiClient api = (ApiClient) provider.getApiClient();
  new io.unitycatalog.client.api.TablesApi(api)                    // legacy path
      .getTable(fullName, false, false);
}
```

`getApiClient()` is exposed so Delta Spark can also build other legacy API wrappers (`SchemasApi`, `TemporaryCredentialsApi`, ...) when needed, regardless of the DRC flag.

**Implementations**

`UCProxy` owns the `DeltaTablesApi` and gates construction on the flag:

```scala
private[this] lazy val deltaTablesApi: DeltaTablesApi = new DeltaTablesApi(apiClient)

override def getDeltaTablesApi(): DeltaTablesApi =
  if (deltaRestApiEnabled) deltaTablesApi else null

override def getApiClient(): Object = apiClient
```

When `deltaRestApiEnabled=false`, the `lazy val` never initializes, so no `DeltaTablesApi` is constructed.

`UCSingleCatalog` is the catalog class Spark registers. It holds `delegate: TableCatalog`, which is either `UCProxy` directly (when Delta is not on the classpath) or `DeltaCatalog` wrapping `UCProxy`. `getDeltaTablesApi()` asks the delegate; `getApiClient()` returns its own `apiClient` field:

```scala
override def getDeltaTablesApi(): DeltaTablesApi = delegate match {
  case provider: DeltaRestClientProvider => provider.getDeltaTablesApi()
  case _ => null
}

override def getApiClient(): Object = apiClient
```

Today `DeltaCatalog` does not implement `DeltaRestClientProvider`, so in the production config (Delta on classpath) the `case _ => null` branch fires. A follow-up PR in `delta-io/delta` will make `DeltaCatalog` implement the interface and forward to its inner delegate (which is `UCProxy`). After that lands, the full chain `UCSingleCatalog → DeltaCatalog → UCProxy` implements the interface and the call reaches `UCProxy`.

**Architecture**

```
UCSingleCatalog : DeltaRestClientProvider
   └── delegate ──┬── UCProxy : DeltaRestClientProvider
                  │     └── lazy deltaTablesApi     ← flag gate here
                  │
                  └── DeltaCatalog   (future PR in delta-io/delta will make
                       └── delegateCatalog = UCProxy    DeltaCatalog implement the
                             └── lazy deltaTablesApi    interface and forward to UCProxy)
```

**Example conf usage**

```
spark.sql.catalog.unity=io.unitycatalog.spark.UCSingleCatalog
spark.sql.catalog.unity.uri=http://localhost:8080
spark.sql.catalog.unity.token=<token>
spark.sql.catalog.unity.deltaRestApi.enabled=true
```

**What this PR changes**

- Adds `DELTA_REST_API_ENABLED` + `DEFAULT_DELTA_REST_API_ENABLED` constants to `OptionsUtil.java`.
- `UCSingleCatalog.initialize()` reads the flag into a private field.
- Adds `DeltaRestClientProvider.java` at `clients/java/src/main/java/io/unitycatalog/client/delta/`.
- `UCSingleCatalog` and `UCProxy` implement the interface.
- `UCProxy` constructor gains `deltaRestApiEnabled: Boolean`; `UCSingleCatalog.initialize()` passes the value in.
- Adds `DeltaRestClientProviderTest` — 4 unit tests driving the contract through `TableCatalog.initialize`.

Signed-off-by: Timothy Wang <timothy.art@gmail.com>

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
