### PR TITLE
Add DeltaRestClientProvider and deltaRestApi.enabled runtime flag

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaRestClientProvider.java
@@ -1,0 +1,47 @@
+package io.unitycatalog.client.delta;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.delta.api.TablesApi;
+import java.util.Optional;
+
+/**
+ * Interface for catalog implementations that can provide a Delta REST Catalog {@link TablesApi}
+ * client. This enables a single shared client instance owned by the catalog (UCProxy) to be reused
+ * by all consumers -- AbstractDeltaCatalog, UCCommitCoordinatorClient, and the Kernel v2 connector
+ * -- instead of each creating their own HTTP client to the same UC server.
+ *
+ * <p>Implementations should return the same cached {@link TablesApi} instance on every call. The
+ * caller must not close or modify the returned client.
+ *
+ * <p>This interface lives in {@code unitycatalog-client} so that both the UC Spark connector (which
+ * implements it) and Delta Spark (which consumes it) can depend on it without a circular
+ * dependency.
+ */
+public interface DeltaRestClientProvider {
+
+  /**
+   * Returns the shared Delta REST Catalog {@link TablesApi} client when the Delta REST Catalog
+   * integration is enabled for this catalog (see the {@code deltaRestApi.enabled} option), or
+   * {@link Optional#empty()} when it is disabled. The returned instance is owned by the catalog and
+   * must not be closed by the caller.
+   *
+   * <p>The current Delta Spark consumer builds its own {@link TablesApi} from {@link
+   * #getApiClient()} rather than reusing this cached instance; this method is intended for future
+   * consumers (commit coordinator, Kernel v2 connector) that want to share UC's cached client
+   * instead of constructing their own.
+   *
+   * @return the cached DRC {@link TablesApi} when DRC is enabled, otherwise {@link
+   *     Optional#empty()} — indicating the caller should fall back to the legacy UC API via {@link
+   *     #getApiClient()}.
+   */
+  Optional<TablesApi> getDeltaTablesApi();
+
+  /**
+   * Returns the base {@link ApiClient} for UC API access. Consumers use it to construct typed
+   * wrappers (legacy {@code TablesApi}, {@code DeltaCommitsApi}, DRC {@code TablesApi}, etc.)
+   * against UC's shared HTTP pool. This exists so consumers don't build a duplicate {@link
+   * ApiClient} from URL + token (as Delta did previously) and end up with two HTTP connection pools
+   * pointing at the same UC server. Implementations must return a non-null client.
+   */
+  ApiClient getApiClient();
+}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,6 +17,9 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
 
+  public static final String DELTA_REST_API_ENABLED = "deltaRestApi.enabled";
+  public static final boolean DEFAULT_DELTA_REST_API_ENABLED = false;
+
   public static boolean getBoolean(
       Map<String, String> props, String property, boolean defaultValue) {
     String value = props.get(property);

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -2,6 +2,8 @@ package io.unitycatalog.spark
 
 import io.unitycatalog.client.api.{SchemasApi, TablesApi, TemporaryCredentialsApi}
 import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.{TablesApi => DeltaTablesApi}
 import io.unitycatalog.client.model.{TableInfo, _}
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
@@ -22,7 +24,7 @@ import org.sparkproject.guava.base.Preconditions
 
 import java.net.URI
 import java.util
-import java.util.Locale
+import java.util.{Locale, Optional}
 import scala.collection.JavaConverters._
 import scala.collection.convert.ImplicitConversions._
 import scala.collection.mutable.ArrayBuffer
@@ -34,15 +36,18 @@ import scala.language.existentials
 class UCSingleCatalog
   extends StagingTableCatalog
   with SupportsNamespaces
+  with DeltaRestClientProvider
   with Logging {
 
   private[this] var uri: URI = null
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = false
-  private[this] var apiClient: ApiClient = null;
+  private[this] var deltaRestApiEnabled: Boolean = false
+  private[this] var apiClient: ApiClient = null
   private[this] var temporaryCredentialsApi: TemporaryCredentialsApi = null
   private[this] var tablesApi: TablesApi = null
+  private[this] var ucProxy: UCProxy = null
 
   @volatile private var delegate: TableCatalog = null
 
@@ -61,32 +66,43 @@ class UCSingleCatalog
     val serverSidePlanningEnabled = OptionsUtil.getBoolean(options,
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED,
       OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
+    deltaRestApiEnabled = OptionsUtil.getBoolean(options,
+      OptionsUtil.DELTA_REST_API_ENABLED,
+      OptionsUtil.DEFAULT_DELTA_REST_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
     temporaryCredentialsApi = new TemporaryCredentialsApi(apiClient)
     tablesApi = new TablesApi(apiClient)
-    val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi, temporaryCredentialsApi)
-    proxy.initialize(name, options)
+    ucProxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
+      serverSidePlanningEnabled, deltaRestApiEnabled,
+      apiClient, tablesApi, temporaryCredentialsApi)
+    ucProxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
         delegate = Class.forName("org.apache.spark.sql.delta.catalog.DeltaCatalog")
           .getDeclaredConstructor().newInstance().asInstanceOf[TableCatalog]
-        delegate.asInstanceOf[DelegatingCatalogExtension].setDelegateCatalog(proxy)
+        delegate.asInstanceOf[DelegatingCatalogExtension].setDelegateCatalog(ucProxy)
         delegate.initialize(name, options)
         UCSingleCatalog.DELTA_CATALOG_LOADED.set(true)
       } catch {
         case e: ClassNotFoundException =>
           logWarning("DeltaCatalog is not available in the classpath", e)
-          delegate = proxy
+          delegate = ucProxy
       }
     } else {
-      delegate = proxy
+      delegate = ucProxy
     }
   }
 
   override def name(): String = delegate.name()
+
+  // Forward directly to UCProxy, not through `delegate`. In production `delegate` is
+  // DeltaCatalog, which does not implement DeltaRestClientProvider — routing through
+  // it would always return empty even when the flag is on.
+  override def getDeltaTablesApi(): Optional[DeltaTablesApi] = ucProxy.getDeltaTablesApi()
+
+  override def getApiClient(): ApiClient = ucProxy.getApiClient()
 
   override def listTables(namespace: Array[String]): Array[Identifier] = delegate.listTables(namespace)
 
@@ -546,11 +562,27 @@ private class UCProxy(
     renewCredEnabled: Boolean,
     credScopedFsEnabled: Boolean,
     serverSidePlanningEnabled: Boolean,
+    deltaRestApiEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi,
-    temporaryCredentialsApi: TemporaryCredentialsApi) extends TableCatalog with SupportsNamespaces with Logging {
+    temporaryCredentialsApi: TemporaryCredentialsApi)
+  extends TableCatalog
+  with SupportsNamespaces
+  with DeltaRestClientProvider
+  with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
+  // Null when DRC is disabled; constructed once at UCProxy ctor when enabled.
+  // The flag decides construction directly; callers see this through the Optional
+  // wrapper in getDeltaTablesApi().
+  private[this] val deltaTablesApi: DeltaTablesApi =
+    if (deltaRestApiEnabled) new DeltaTablesApi(apiClient) else null
+
+  override def getDeltaTablesApi(): Optional[DeltaTablesApi] =
+    Optional.ofNullable(deltaTablesApi)
+
+  // Always exposes the underlying ApiClient so callers can build legacy API wrappers.
+  override def getApiClient(): ApiClient = apiClient
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaRestClientProviderTest.java
@@ -1,0 +1,98 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.spark.utils.OptionsUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DeltaRestClientProvider} as exposed through the public {@link
+ * TableCatalog#initialize} surface of {@link UCSingleCatalog}. {@code UCSingleCatalog} forwards
+ * provider calls directly to its internal {@code UCProxy} field, so the tests drive the catalog
+ * through public initialization and assert on the observable Optional return.
+ */
+public class DeltaRestClientProviderTest {
+
+  private static final String CATALOG = "test_catalog";
+  // Port 0 is fine: initialize() only constructs the client; no HTTP call fires here.
+  private static final String URI = "http://localhost:0";
+  private static final String TOKEN = "dummy-token";
+
+  @BeforeEach
+  public void setUp() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
+
+  private static UCSingleCatalog catalogWithFlag(Boolean flagValue) {
+    Map<String, String> opts = new HashMap<>();
+    opts.put(OptionsUtil.URI, URI);
+    opts.put(OptionsUtil.TOKEN, TOKEN);
+    if (flagValue != null) {
+      opts.put(OptionsUtil.DELTA_REST_API_ENABLED, flagValue.toString());
+    }
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    catalog.initialize(CATALOG, new CaseInsensitiveStringMap(opts));
+    return catalog;
+  }
+
+  @Test
+  public void flagEnabled_returnsDeltaTablesApi() {
+    // Flag on: the catalog returns a present Optional carrying a TablesApi. The assignment
+    // to DeltaRestClientProvider is a compile-time check that UCSingleCatalog implements
+    // the interface.
+    UCSingleCatalog catalog = catalogWithFlag(true);
+    DeltaRestClientProvider provider = catalog;
+    assertThat(provider.getDeltaTablesApi()).isPresent();
+  }
+
+  @Test
+  public void eachCatalogOwnsItsOwnDeltaTablesApi() {
+    // Two independently initialized catalogs have their own ApiClient and their own
+    // DRC TablesApi. Guards against an accidental singleton or shared static-state
+    // regression that would make different UC catalogs collide on one HTTP client.
+    UCSingleCatalog a = catalogWithFlag(true);
+    UCSingleCatalog b = catalogWithFlag(true);
+    assertThat(a.getDeltaTablesApi().get()).isNotSameAs(b.getDeltaTablesApi().get());
+    assertThat(a.getApiClient()).isNotSameAs(b.getApiClient());
+  }
+
+  @Test
+  public void flagDisabled_deltaRestCatalogIsUnavailable() {
+    // Default (absent option) and explicit false both disable DRC. The observable
+    // contract is an empty Optional — consumers fall through to the legacy UC API
+    // path via getApiClient(). Removing the flag gate in UCProxy would cause this
+    // test to fail.
+    assertThat(catalogWithFlag(null).getDeltaTablesApi()).isEmpty();
+    assertThat(catalogWithFlag(false).getDeltaTablesApi()).isEmpty();
+  }
+
+  @Test
+  public void getApiClient_returnsApiClient_regardlessOfFlag() {
+    // getApiClient is not flag-gated: legacy UC API consumers still need the
+    // underlying client when DRC is disabled. The isSameAs checks confirm the
+    // method returns the SAME cached instance on repeated calls — catches the
+    // "accidentally flag-gated, returns a fresh client each call" regression.
+    UCSingleCatalog off = catalogWithFlag(false);
+    ApiClient offClient = off.getApiClient();
+    assertThat(offClient).isNotNull();
+    assertThat(off.getApiClient()).isSameAs(offClient);
+
+    UCSingleCatalog on = catalogWithFlag(true);
+    ApiClient onClient = on.getApiClient();
+    assertThat(onClient).isNotNull();
+    assertThat(on.getApiClient()).isSameAs(onClient);
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds:

1. A per-catalog Spark option `deltaRestApi.enabled` (default `false`).
```
spark.sql.catalog.unity=io.unitycatalog.spark.UCSingleCatalog
spark.sql.catalog.unity.uri=http://localhost:8080
spark.sql.catalog.unity.token=<token>
spark.sql.catalog.unity.deltaRestApi.enabled=true
```
2. A Java interface `DeltaRestClientProvider` that Delta Spark uses to reach UC's HTTP client from a UC catalog plugin.

```java
public interface DeltaRestClientProvider {
  Optional<DeltaTablesApi> getDeltaTablesApi();   // present iff deltaRestApi.enabled=true
  ApiClient getApiClient();                       // always non-null once the catalog is initialized
}
```

`DeltaTablesApi` = `io.unitycatalog.client.delta.api.TablesApi` — the codegen client for DRC endpoints. Not the legacy `io.unitycatalog.client.api.TablesApi`. `ApiClient` is UC's base HTTP client.

Both `UCProxy` and `UCSingleCatalog` implement the interface — Delta reaches `UCProxy` via its own delegate chain, external callers (e.g. the future commit coordinator) reach `UCSingleCatalog` by catalog name.

**Architecture**

```
UCSingleCatalog : DeltaRestClientProvider              (the class Spark registers)
   │
   └── delegate = DeltaCatalog                         (when Delta is on the classpath,
         │                                              the production default;
         │                                              if not, delegate = UCProxy directly)
         │
         └── delegateCatalog = UCProxy : DeltaRestClientProvider
                                                        (set by UCSingleCatalog via
                                                         setDelegateCatalog at init)
               ├── deltaTablesApi   ← null when flag off, built at ctor when on;
               │                      wrapped in Optional by getDeltaTablesApi
               └── apiClient        ← returned by getApiClient unconditionally

Delta code pattern-matches its own delegate (= UCProxy) as DeltaRestClientProvider
and calls getApiClient() to build its own wrapper.
```
