### PR TITLE
[Server] Add METRIC_VIEW persistence and CRUD support

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/DependencyRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DependencyRepository.java
@@ -1,0 +1,63 @@
+package io.unitycatalog.server.persist;
+
+import io.unitycatalog.server.persist.dao.DependencyDAO;
+import io.unitycatalog.server.persist.dao.DependencyDAO.DependentType;
+import java.util.List;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Repository for managing view/metric-view dependency records in uc_dependencies. Methods accept a
+ * Session so they can participate in the caller's transaction.
+ */
+public class DependencyRepository {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DependencyRepository.class);
+
+  public void createDependencies(
+      Session session,
+      UUID dependentId,
+      DependentType dependentType,
+      List<DependencyDAO> dependencies) {
+    for (DependencyDAO dep : dependencies) {
+      dep.setDependentId(dependentId);
+      dep.setDependentType(dependentType);
+      session.persist(dep);
+    }
+    LOGGER.debug(
+        "Created {} dependencies for {}:{}", dependencies.size(), dependentType, dependentId);
+  }
+
+  public List<DependencyDAO> getDependencies(
+      Session session, UUID dependentId, DependentType dependentType) {
+    String hql =
+        "FROM DependencyDAO d WHERE d.dependentId = :dependentId"
+            + " AND d.dependentType = :dependentType";
+    Query<DependencyDAO> query = session.createQuery(hql, DependencyDAO.class);
+    query.setParameter("dependentId", dependentId);
+    query.setParameter("dependentType", dependentType);
+    return query.list();
+  }
+
+  public void deleteDependencies(Session session, UUID dependentId, DependentType dependentType) {
+    String hql =
+        "DELETE FROM DependencyDAO d WHERE d.dependentId = :dependentId"
+            + " AND d.dependentType = :dependentType";
+    Query<?> query = session.createQuery(hql);
+    query.setParameter("dependentId", dependentId);
+    query.setParameter("dependentType", dependentType);
+    int deleted = query.executeUpdate();
+    LOGGER.debug("Deleted {} dependencies for {}:{}", deleted, dependentType, dependentId);
+  }
+
+  public void updateDependencies(
+      Session session,
+      UUID dependentId,
+      DependentType dependentType,
+      List<DependencyDAO> dependencies) {
+    deleteDependencies(session, dependentId, dependentType);
+    createDependencies(session, dependentId, dependentType, dependencies);
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/DependencyRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DependencyRepository.java
@@ -51,13 +51,4 @@ public class DependencyRepository {
     int deleted = query.executeUpdate();
     LOGGER.debug("Deleted {} dependencies for {}:{}", deleted, dependentType, dependentId);
   }
-
-  public void updateDependencies(
-      Session session,
-      UUID dependentId,
-      DependentType dependentType,
-      List<DependencyDAO> dependencies) {
-    deleteDependencies(session, dependentId, dependentType);
-    createDependencies(session, dependentId, dependentType, dependencies);
-  }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -29,6 +29,7 @@ public class Repositories {
   private final CredentialRepository credentialRepository;
   private final ExternalLocationRepository externalLocationRepository;
   private final DeltaCommitRepository deltaCommitRepository;
+  private final DependencyRepository dependencyRepository;
 
   private final KeyMapper keyMapper;
 
@@ -50,6 +51,7 @@ public class Repositories {
     this.credentialRepository = new CredentialRepository(this, sessionFactory, serverProperties);
     this.externalLocationRepository = new ExternalLocationRepository(this, sessionFactory);
     this.deltaCommitRepository = new DeltaCommitRepository(sessionFactory, serverProperties);
+    this.dependencyRepository = new DependencyRepository();
 
     // KeyMapper uses all the repositories above.
     this.keyMapper = new KeyMapper(this);

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -170,7 +170,8 @@ public class TableRepository {
           TableInfo tableInfo = tableInfoDAO.toTableInfo(true, catalogName, schemaName);
           RepositoryUtils.attachProperties(
               tableInfo, tableInfo.getTableId(), Constants.TABLE, session);
-          attachDependencies(tableInfo, tableInfoDAO, session);
+          RepositoryUtils.attachDependencies(
+              tableInfo, tableInfoDAO, session, repositories.getDependencyRepository());
           return tableInfo;
         },
         "Failed to get table",
@@ -409,6 +410,7 @@ public class TableRepository {
           }
           TableType tableType = Objects.requireNonNull(createTable.getTableType());
           String tableID;
+          UUID metricViewTableUUID = null;
           NormalizedURL storageLocation;
           if (tableType == TableType.EXTERNAL) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
@@ -429,29 +431,9 @@ public class TableRepository {
                     .commitStagingTable(session, callerId, storageLocation);
             tableID = stagingTableDAO.getId().toString();
           } else if (tableType == TableType.METRIC_VIEW) {
-            if (createTable.getViewDefinition() == null
-                || createTable.getViewDefinition().isEmpty()) {
-              throw new BaseException(
-                  ErrorCode.INVALID_ARGUMENT, "view_definition is required for metric view");
-            }
-            DependencyList viewDeps = createTable.getViewDependencies();
-            if (viewDeps == null
-                || viewDeps.getDependencies() == null
-                || viewDeps.getDependencies().isEmpty()) {
-              throw new BaseException(
-                  ErrorCode.INVALID_ARGUMENT, "view_dependencies is required for metric view");
-            }
             storageLocation = null;
-            UUID tableUUID = UUID.randomUUID();
-            tableID = tableUUID.toString();
-            DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
-            List<DependencyDAO> depDAOs =
-                viewDeps.getDependencies().stream()
-                    .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
-                    .collect(Collectors.toList());
-            repositories
-                .getDependencyRepository()
-                .createDependencies(session, tableUUID, dependentType, depDAOs);
+            metricViewTableUUID = validateMetricView(createTable);
+            tableID = metricViewTableUUID.toString();
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
                 ErrorCode.INVALID_ARGUMENT, "STREAMING TABLE creation is not supported yet.");
@@ -495,10 +477,39 @@ public class TableRepository {
           PropertyDAO.from(tableInfo.getProperties(), tableInfoDAO.getId(), Constants.TABLE)
               .forEach(session::persist);
           session.persist(tableInfoDAO);
+          if (tableType == TableType.METRIC_VIEW) {
+            DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
+            UUID tableUUID = Objects.requireNonNull(metricViewTableUUID);
+            List<DependencyDAO> depDAOs =
+                createTable.getViewDependencies().getDependencies().stream()
+                    .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
+                    .collect(Collectors.toList());
+            repositories
+                .getDependencyRepository()
+                .createDependencies(session, tableUUID, dependentType, depDAOs);
+          }
           return tableInfo;
         },
         "Error creating table: " + fullName,
         /* readOnly = */ false);
+  }
+
+  private static UUID validateMetricView(CreateTable createTable) {
+    if (createTable.getViewDefinition() == null || createTable.getViewDefinition().isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "view_definition is required for metric view");
+    }
+    DependencyList viewDeps = createTable.getViewDependencies();
+    if (viewDeps == null || viewDeps.getDependencies() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "view_dependencies is required for metric view");
+    }
+    if (viewDeps.getDependencies().isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "view_dependencies must contain at least one entry for metric view");
+    }
+    return UUID.randomUUID();
   }
 
   public TableInfoDAO findBySchemaIdAndName(Session session, UUID schemaId, String name) {
@@ -576,7 +587,8 @@ public class TableRepository {
         RepositoryUtils.attachProperties(
             tableInfo, tableInfo.getTableId(), Constants.TABLE, session);
       }
-      attachDependencies(tableInfo, tableInfoDAO, session);
+      RepositoryUtils.attachDependencies(
+          tableInfo, tableInfoDAO, session, repositories.getDependencyRepository());
       result.add(tableInfo);
     }
     return new ListTablesResponse().tables(result).nextPageToken(nextPageToken);
@@ -627,19 +639,5 @@ public class TableRepository {
     PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE)
         .forEach(session::remove);
     session.remove(tableInfoDAO);
-  }
-
-  private void attachDependencies(TableInfo tableInfo, TableInfoDAO tableInfoDAO, Session session) {
-    if (TableType.METRIC_VIEW.getValue().equals(tableInfoDAO.getType())) {
-      List<DependencyDAO> deps =
-          repositories
-              .getDependencyRepository()
-              .getDependencies(session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
-      // Always attach a dependency list (even when empty) for syntactic consistency: callers
-      // can tell "metric view with no recorded deps" apart from "field not set", and a
-      // hypothetical metric view that aggregates only constants would still round-trip cleanly.
-      tableInfo.setViewDependencies(
-          new DependencyList().dependencies(DependencyDAO.toDependencyList(deps)));
-    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -203,20 +203,6 @@ public class TableRepository {
                 "Table not found: " + catalog + "." + schema + "." + table);
           }
 
-          // Guard non-Delta entries (metric views, parquet/csv/etc. tables) before they reach
-          // `buildTableMetadata`. The downstream code calls `NormalizedURL.normalize(dao.getUrl())`
-          // (throws "Path cannot be null or empty" when the row has no storage location, e.g.
-          // metric views) and `DataSourceFormat.fromValue(dao.getDataSourceFormat())` (throws
-          // IllegalArgumentException on null), both of which surface as misleading errors to a
-          // Delta REST client that simply asked for a name that happens to live in the same
-          // schema. Sibling guard to `DeltaCommitRepository.validateTable`.
-          if (dao.getDataSourceFormat() == null
-              || !DataSourceFormat.DELTA.toString().equals(dao.getDataSourceFormat())) {
-            throw new BaseException(
-                ErrorCode.INVALID_ARGUMENT,
-                "Table is not a Delta table: " + catalog + "." + schema + "." + table);
-          }
-
           TableMetadata metadata = buildTableMetadata(session, dao, catalog, schema, table);
 
           LoadTableResponse response = new LoadTableResponse();
@@ -423,13 +409,16 @@ public class TableRepository {
                 ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + fullName);
           }
           TableType tableType = Objects.requireNonNull(createTable.getTableType());
-          String tableID;
-          UUID metricViewTableUUID = null;
+          // `tableUUID` is the table's primary key. The shape is uniform across the three
+          // creatable branches (external, managed, metric view); the only divergence is the
+          // source of the UUID (random for external/metric-view, staging-table id for managed).
+          // The string form is generated exactly once below at `tableInfo.tableId(...)`.
+          UUID tableUUID;
           NormalizedURL storageLocation;
           if (tableType == TableType.EXTERNAL) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
-            tableID = UUID.randomUUID().toString();
+            tableUUID = UUID.randomUUID();
           } else if (tableType == TableType.MANAGED) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             serverProperties.checkManagedTableEnabled();
@@ -443,11 +432,11 @@ public class TableRepository {
                 repositories
                     .getStagingTableRepository()
                     .commitStagingTable(session, callerId, storageLocation);
-            tableID = stagingTableDAO.getId().toString();
+            tableUUID = stagingTableDAO.getId();
           } else if (tableType == TableType.METRIC_VIEW) {
             storageLocation = null;
-            metricViewTableUUID = validateMetricView(createTable);
-            tableID = metricViewTableUUID.toString();
+            validateMetricView(createTable);
+            tableUUID = UUID.randomUUID();
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
                 ErrorCode.INVALID_ARGUMENT, "STREAMING TABLE creation is not supported yet.");
@@ -476,7 +465,7 @@ public class TableRepository {
                   .updatedBy(callerId)
                   .storageLocation(storageLocation != null ? storageLocation.toString() : null)
                   .viewDefinition(createTable.getViewDefinition())
-                  .tableId(tableID);
+                  .tableId(tableUUID.toString());
 
           TableInfoDAO tableInfoDAO = TableInfoDAO.from(tableInfo, schemaId);
           // create columns
@@ -493,7 +482,6 @@ public class TableRepository {
           session.persist(tableInfoDAO);
           if (tableType == TableType.METRIC_VIEW) {
             DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
-            UUID tableUUID = Objects.requireNonNull(metricViewTableUUID);
             List<DependencyDAO> depDAOs =
                 createTable.getViewDependencies().getDependencies().stream()
                     .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
@@ -508,7 +496,7 @@ public class TableRepository {
         /* readOnly = */ false);
   }
 
-  private static UUID validateMetricView(CreateTable createTable) {
+  private static void validateMetricView(CreateTable createTable) {
     if (createTable.getViewDefinition() == null || createTable.getViewDefinition().isEmpty()) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT, "view_definition is required for metric view");
@@ -523,7 +511,6 @@ public class TableRepository {
           ErrorCode.INVALID_ARGUMENT,
           "view_dependencies must contain at least one entry for metric view");
     }
-    return UUID.randomUUID();
   }
 
   public TableInfoDAO findBySchemaIdAndName(Session session, UUID schemaId, String name) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -13,10 +13,12 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.DataSourceFormat;
+import io.unitycatalog.server.model.DependencyList;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
+import io.unitycatalog.server.persist.dao.DependencyDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
@@ -41,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -167,6 +170,7 @@ public class TableRepository {
           TableInfo tableInfo = tableInfoDAO.toTableInfo(true, catalogName, schemaName);
           RepositoryUtils.attachProperties(
               tableInfo, tableInfo.getTableId(), Constants.TABLE, session);
+          attachDependencies(tableInfo, tableInfoDAO, session);
           return tableInfo;
         },
         "Failed to get table",
@@ -395,7 +399,6 @@ public class TableRepository {
               repositories
                   .getSchemaRepository()
                   .getSchemaIdOrThrow(session, catalogName, schemaName);
-          NormalizedURL storageLocation = NormalizedURL.from(createTable.getStorageLocation());
 
           // Check if table already exists
           TableInfoDAO existingTable =
@@ -405,13 +408,14 @@ public class TableRepository {
                 ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + fullName);
           }
           TableType tableType = Objects.requireNonNull(createTable.getTableType());
-          // The table ID will either be a new random one or the id of staging table, depending
-          // on the type of table to create.
           String tableID;
+          NormalizedURL storageLocation;
           if (tableType == TableType.EXTERNAL) {
+            storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
             tableID = UUID.randomUUID().toString();
           } else if (tableType == TableType.MANAGED) {
+            storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             serverProperties.checkManagedTableEnabled();
             if (createTable.getDataSourceFormat() != DataSourceFormat.DELTA) {
               throw new BaseException(
@@ -424,6 +428,32 @@ public class TableRepository {
                     .getStagingTableRepository()
                     .commitStagingTable(session, callerId, storageLocation);
             tableID = stagingTableDAO.getId().toString();
+          } else if (tableType == TableType.METRIC_VIEW) {
+            if (createTable.getViewDefinition() == null
+                || createTable.getViewDefinition().isEmpty()) {
+              throw new BaseException(
+                  ErrorCode.INVALID_ARGUMENT, "view_definition is required for metric view");
+            }
+            DependencyList viewDeps = createTable.getViewDependencies();
+            if (viewDeps == null
+                || viewDeps.getDependencies() == null
+                || viewDeps.getDependencies().isEmpty()) {
+              throw new BaseException(
+                  ErrorCode.INVALID_ARGUMENT, "view_dependencies is required for metric view");
+            }
+            storageLocation = null;
+            tableID = UUID.randomUUID().toString();
+            if (viewDeps.getDependencies() != null) {
+              UUID tableUUID = UUID.fromString(tableID);
+              DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
+              List<DependencyDAO> depDAOs =
+                  viewDeps.getDependencies().stream()
+                      .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
+                      .collect(Collectors.toList());
+              repositories
+                  .getDependencyRepository()
+                  .createDependencies(session, tableUUID, dependentType, depDAOs);
+            }
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
                 ErrorCode.INVALID_ARGUMENT, "STREAMING TABLE creation is not supported yet.");
@@ -450,7 +480,8 @@ public class TableRepository {
                   .createdBy(callerId)
                   .updatedAt(createTime)
                   .updatedBy(callerId)
-                  .storageLocation(storageLocation.toString())
+                  .storageLocation(storageLocation != null ? storageLocation.toString() : null)
+                  .viewDefinition(createTable.getViewDefinition())
                   .tableId(tableID);
 
           TableInfoDAO tableInfoDAO = TableInfoDAO.from(tableInfo, schemaId);
@@ -547,6 +578,7 @@ public class TableRepository {
         RepositoryUtils.attachProperties(
             tableInfo, tableInfo.getTableId(), Constants.TABLE, session);
       }
+      attachDependencies(tableInfo, tableInfoDAO, session);
       result.add(tableInfo);
     }
     return new ListTablesResponse().tables(result).nextPageToken(nextPageToken);
@@ -589,8 +621,26 @@ public class TableRepository {
           .getDeltaCommitRepository()
           .permanentlyDeleteTableCommits(session, tableInfoDAO.getId());
     }
+    if ("METRIC_VIEW".equals(tableInfoDAO.getType())) {
+      repositories
+          .getDependencyRepository()
+          .deleteDependencies(session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
+    }
     PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE)
         .forEach(session::remove);
     session.remove(tableInfoDAO);
+  }
+
+  private void attachDependencies(TableInfo tableInfo, TableInfoDAO tableInfoDAO, Session session) {
+    if ("METRIC_VIEW".equals(tableInfoDAO.getType())) {
+      List<DependencyDAO> deps =
+          repositories
+              .getDependencyRepository()
+              .getDependencies(session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
+      if (!deps.isEmpty()) {
+        tableInfo.setViewDependencies(
+            new DependencyList().dependencies(DependencyDAO.toDependencyList(deps)));
+      }
+    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -203,6 +203,20 @@ public class TableRepository {
                 "Table not found: " + catalog + "." + schema + "." + table);
           }
 
+          // Guard non-Delta entries (metric views, parquet/csv/etc. tables) before they reach
+          // `buildTableMetadata`. The downstream code calls `NormalizedURL.normalize(dao.getUrl())`
+          // (throws "Path cannot be null or empty" when the row has no storage location, e.g.
+          // metric views) and `DataSourceFormat.fromValue(dao.getDataSourceFormat())` (throws
+          // IllegalArgumentException on null), both of which surface as misleading errors to a
+          // Delta REST client that simply asked for a name that happens to live in the same
+          // schema. Sibling guard to `DeltaCommitRepository.validateTable`.
+          if (dao.getDataSourceFormat() == null
+              || !DataSourceFormat.DELTA.toString().equals(dao.getDataSourceFormat())) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Table is not a Delta table: " + catalog + "." + schema + "." + table);
+          }
+
           TableMetadata metadata = buildTableMetadata(session, dao, catalog, schema, table);
 
           LoadTableResponse response = new LoadTableResponse();

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -442,18 +442,16 @@ public class TableRepository {
                   ErrorCode.INVALID_ARGUMENT, "view_dependencies is required for metric view");
             }
             storageLocation = null;
-            tableID = UUID.randomUUID().toString();
-            if (viewDeps.getDependencies() != null) {
-              UUID tableUUID = UUID.fromString(tableID);
-              DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
-              List<DependencyDAO> depDAOs =
-                  viewDeps.getDependencies().stream()
-                      .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
-                      .collect(Collectors.toList());
-              repositories
-                  .getDependencyRepository()
-                  .createDependencies(session, tableUUID, dependentType, depDAOs);
-            }
+            UUID tableUUID = UUID.randomUUID();
+            tableID = tableUUID.toString();
+            DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
+            List<DependencyDAO> depDAOs =
+                viewDeps.getDependencies().stream()
+                    .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
+                    .collect(Collectors.toList());
+            repositories
+                .getDependencyRepository()
+                .createDependencies(session, tableUUID, dependentType, depDAOs);
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
                 ErrorCode.INVALID_ARGUMENT, "STREAMING TABLE creation is not supported yet.");
@@ -621,7 +619,7 @@ public class TableRepository {
           .getDeltaCommitRepository()
           .permanentlyDeleteTableCommits(session, tableInfoDAO.getId());
     }
-    if ("METRIC_VIEW".equals(tableInfoDAO.getType())) {
+    if (TableType.METRIC_VIEW.getValue().equals(tableInfoDAO.getType())) {
       repositories
           .getDependencyRepository()
           .deleteDependencies(session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
@@ -632,15 +630,16 @@ public class TableRepository {
   }
 
   private void attachDependencies(TableInfo tableInfo, TableInfoDAO tableInfoDAO, Session session) {
-    if ("METRIC_VIEW".equals(tableInfoDAO.getType())) {
+    if (TableType.METRIC_VIEW.getValue().equals(tableInfoDAO.getType())) {
       List<DependencyDAO> deps =
           repositories
               .getDependencyRepository()
               .getDependencies(session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
-      if (!deps.isEmpty()) {
-        tableInfo.setViewDependencies(
-            new DependencyList().dependencies(DependencyDAO.toDependencyList(deps)));
-      }
+      // Always attach a dependency list (even when empty) for syntactic consistency: callers
+      // can tell "metric view with no recorded deps" apart from "field not set", and a
+      // hypothetical metric view that aggregates only constants would still round-trip cleanly.
+      tableInfo.setViewDependencies(
+          new DependencyList().dependencies(DependencyDAO.toDependencyList(deps)));
     }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
@@ -84,14 +84,22 @@ public class DependencyDAO {
       Dependency dependency, UUID dependentId, DependentType dependentType) {
     final DependencyType dependencyType;
     final String fullName;
-    if (dependency.getTable() != null) {
+    boolean hasTable = dependency.getTable() != null;
+    boolean hasFunction = dependency.getFunction() != null;
+    if (hasTable && hasFunction) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Dependency must have exactly one of table or function set, not both");
+    }
+    if (!hasTable && !hasFunction) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Unsupported dependency type");
+    }
+    if (hasTable) {
       dependencyType = DependencyType.TABLE;
       fullName = dependency.getTable().getTableFullName();
-    } else if (dependency.getFunction() != null) {
+    } else {
       dependencyType = DependencyType.FUNCTION;
       fullName = dependency.getFunction().getFunctionFullName();
-    } else {
-      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Unsupported dependency type");
     }
     String[] parts = parseThreePartName(fullName, dependencyType);
     return DependencyDAO.builder()

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -83,30 +82,38 @@ public class DependencyDAO {
   /** Converts a Dependency API model to a DependencyDAO for a given dependent. */
   public static DependencyDAO from(
       Dependency dependency, UUID dependentId, DependentType dependentType) {
-    DependencyDAOBuilder builder =
-        DependencyDAO.builder().dependentId(dependentId).dependentType(dependentType);
-
+    final DependencyType dependencyType;
+    final String fullName;
     if (dependency.getTable() != null) {
-      builder.dependencyType(DependencyType.TABLE);
-      populateThreePartName(
-          builder, dependency.getTable().getTableFullName(), DependencyType.TABLE);
+      dependencyType = DependencyType.TABLE;
+      fullName = dependency.getTable().getTableFullName();
     } else if (dependency.getFunction() != null) {
-      builder.dependencyType(DependencyType.FUNCTION);
-      populateThreePartName(
-          builder, dependency.getFunction().getFunctionFullName(), DependencyType.FUNCTION);
+      dependencyType = DependencyType.FUNCTION;
+      fullName = dependency.getFunction().getFunctionFullName();
     } else {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Unsupported dependency type");
     }
-
-    return builder.build();
+    String[] parts = parseThreePartName(fullName, dependencyType);
+    return DependencyDAO.builder()
+        .dependentId(dependentId)
+        .dependentType(dependentType)
+        .dependencyType(dependencyType)
+        .dependencyCatalog(parts[0])
+        .dependencySchema(parts[1])
+        .dependencyName(parts[2])
+        .build();
   }
 
   /**
-   * Splits a {@code catalog.schema.name} three-part name into the corresponding DAO columns. Throws
-   * if the input is null/empty or does not contain exactly three parts.
+   * Splits a {@code catalog.schema.name} three-part name into its three components. Throws if the
+   * input is null/empty or does not contain exactly three parts.
+   *
+   * <p>Returns plain {@code String[]} (rather than mutating a {@code DependencyDAOBuilder}) so the
+   * helper signature does not reference any Lombok-generated builder type. Javadoc does not run
+   * annotation processors, so referencing such generated types from method signatures would fail
+   * {@code sbt doc} with {@code cannot find symbol: class DependencyDAOBuilder}.
    */
-  private static void populateThreePartName(
-      DependencyDAOBuilder builder, String fullName, DependencyType type) {
+  private static String[] parseThreePartName(String fullName, DependencyType type) {
     String kind = type.name().toLowerCase(Locale.ROOT);
     if (fullName == null || fullName.isEmpty()) {
       throw new BaseException(
@@ -124,9 +131,7 @@ public class DependencyDAO {
               + "); got: "
               + fullName);
     }
-    builder.dependencyCatalog(parts[0]);
-    builder.dependencySchema(parts[1]);
-    builder.dependencyName(parts[2]);
+    return parts;
   }
 
   /** Converts this DAO to a Dependency API model. */
@@ -145,9 +150,6 @@ public class DependencyDAO {
   }
 
   public static List<Dependency> toDependencyList(List<DependencyDAO> daos) {
-    if (daos == null) {
-      return new ArrayList<>();
-    }
     return daos.stream().map(DependencyDAO::toDependency).collect(Collectors.toList());
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DependencyDAO.java
@@ -1,0 +1,153 @@
+package io.unitycatalog.server.persist.dao;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.Dependency;
+import io.unitycatalog.server.model.FunctionDependency;
+import io.unitycatalog.server.model.TableDependency;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(
+    name = "uc_dependencies",
+    indexes = {
+      @Index(name = "idx_dependent", columnList = "dependent_type,dependent_id"),
+    })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public class DependencyDAO {
+
+  /**
+   * Type of the object that owns dependencies (the "dependent"). Currently only tables (including
+   * metric views) can own dependencies.
+   */
+  public enum DependentType {
+    TABLE
+  }
+
+  /** Type of the dependency target. Mirrors the {@code Dependency} API model. */
+  public enum DependencyType {
+    TABLE,
+    FUNCTION
+  }
+
+  @Id
+  @UuidGenerator
+  @Column(name = "id", updatable = false, nullable = false)
+  private UUID id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "dependent_type", nullable = false)
+  private DependentType dependentType;
+
+  @Column(name = "dependent_id", nullable = false)
+  private UUID dependentId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "dependency_type", nullable = false)
+  private DependencyType dependencyType;
+
+  @Column(name = "dependency_catalog")
+  private String dependencyCatalog;
+
+  @Column(name = "dependency_schema")
+  private String dependencySchema;
+
+  @Column(name = "dependency_name")
+  private String dependencyName;
+
+  /** Converts a Dependency API model to a DependencyDAO for a given dependent. */
+  public static DependencyDAO from(
+      Dependency dependency, UUID dependentId, DependentType dependentType) {
+    DependencyDAOBuilder builder =
+        DependencyDAO.builder().dependentId(dependentId).dependentType(dependentType);
+
+    if (dependency.getTable() != null) {
+      builder.dependencyType(DependencyType.TABLE);
+      populateThreePartName(
+          builder, dependency.getTable().getTableFullName(), DependencyType.TABLE);
+    } else if (dependency.getFunction() != null) {
+      builder.dependencyType(DependencyType.FUNCTION);
+      populateThreePartName(
+          builder, dependency.getFunction().getFunctionFullName(), DependencyType.FUNCTION);
+    } else {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Unsupported dependency type");
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Splits a {@code catalog.schema.name} three-part name into the corresponding DAO columns. Throws
+   * if the input is null/empty or does not contain exactly three parts.
+   */
+  private static void populateThreePartName(
+      DependencyDAOBuilder builder, String fullName, DependencyType type) {
+    String kind = type.name().toLowerCase(Locale.ROOT);
+    if (fullName == null || fullName.isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Dependency " + kind + " full name must not be null or empty");
+    }
+    String[] parts = fullName.split("\\.");
+    if (parts.length != 3) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Dependency "
+              + kind
+              + " full name must be a three-part name (catalog.schema."
+              + kind
+              + "); got: "
+              + fullName);
+    }
+    builder.dependencyCatalog(parts[0]);
+    builder.dependencySchema(parts[1]);
+    builder.dependencyName(parts[2]);
+  }
+
+  /** Converts this DAO to a Dependency API model. */
+  public Dependency toDependency() {
+    Dependency dependency = new Dependency();
+    String fullName = dependencyCatalog + "." + dependencySchema + "." + dependencyName;
+    switch (dependencyType) {
+      case TABLE:
+        dependency.setTable(new TableDependency().tableFullName(fullName));
+        break;
+      case FUNCTION:
+        dependency.setFunction(new FunctionDependency().functionFullName(fullName));
+        break;
+    }
+    return dependency;
+  }
+
+  public static List<Dependency> toDependencyList(List<DependencyDAO> daos) {
+    if (daos == null) {
+      return new ArrayList<>();
+    }
+    return daos.stream().map(DependencyDAO::toDependency).collect(Collectors.toList());
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.Date;
@@ -76,7 +77,8 @@ public class TableInfoDAO extends IdentifiableDAO {
       fetch = FetchType.LAZY)
   private List<ColumnInfoDAO> columns;
 
-  @Column(name = "view_definition", length = 65535)
+  @Lob
+  @Column(name = "view_definition", length = 16777215)
   private String viewDefinition;
 
   @Column(name = "uniform_iceberg_metadata_location", length = 65535)

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -76,6 +76,9 @@ public class TableInfoDAO extends IdentifiableDAO {
       fetch = FetchType.LAZY)
   private List<ColumnInfoDAO> columns;
 
+  @Column(name = "view_definition", length = 65535)
+  private String viewDefinition;
+
   @Column(name = "uniform_iceberg_metadata_location", length = 65535)
   private String uniformIcebergMetadataLocation;
 
@@ -98,8 +101,12 @@ public class TableInfoDAO extends IdentifiableDAO {
         .updatedBy(tableInfo.getUpdatedBy())
         .columnCount(tableInfo.getColumns() != null ? tableInfo.getColumns().size() : 0)
         .type(tableInfo.getTableType().toString())
-        .dataSourceFormat(tableInfo.getDataSourceFormat().toString())
+        .dataSourceFormat(
+            tableInfo.getDataSourceFormat() != null
+                ? tableInfo.getDataSourceFormat().toString()
+                : null)
         .url(tableInfo.getStorageLocation())
+        .viewDefinition(tableInfo.getViewDefinition())
         .columns(ColumnInfoDAO.fromList(tableInfo.getColumns()))
         .schemaId(schemaId)
         .build();
@@ -113,8 +120,10 @@ public class TableInfoDAO extends IdentifiableDAO {
             .catalogName(catalogName)
             .schemaName(schemaName)
             .tableType(TableType.valueOf(type))
-            .dataSourceFormat(DataSourceFormat.valueOf(dataSourceFormat))
-            .storageLocation(NormalizedURL.normalize(url))
+            .dataSourceFormat(
+                dataSourceFormat != null ? DataSourceFormat.valueOf(dataSourceFormat) : null)
+            .storageLocation(url != null ? NormalizedURL.normalize(url) : null)
+            .viewDefinition(viewDefinition)
             .comment(comment)
             .owner(owner)
             .createdAt(createdAt != null ? createdAt.getTime() : null)

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -4,6 +4,7 @@ import io.unitycatalog.server.persist.dao.CatalogInfoDAO;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.CredentialDAO;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
+import io.unitycatalog.server.persist.dao.DependencyDAO;
 import io.unitycatalog.server.persist.dao.ExternalLocationDAO;
 import io.unitycatalog.server.persist.dao.FunctionInfoDAO;
 import io.unitycatalog.server.persist.dao.FunctionParameterInfoDAO;
@@ -71,6 +72,7 @@ public class HibernateConfigurator {
       configuration.addAnnotatedClass(CredentialDAO.class);
       configuration.addAnnotatedClass(ExternalLocationDAO.class);
       configuration.addAnnotatedClass(DeltaCommitDAO.class);
+      configuration.addAnnotatedClass(DependencyDAO.class);
 
       ServiceRegistry serviceRegistry =
           new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
@@ -2,10 +2,16 @@ package io.unitycatalog.server.persist.utils;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.DependencyList;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.persist.DependencyRepository;
 import io.unitycatalog.server.persist.PropertyRepository;
 import io.unitycatalog.server.persist.dao.CatalogInfoDAO;
+import io.unitycatalog.server.persist.dao.DependencyDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.utils.Constants;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -47,6 +53,20 @@ public class RepositoryUtils {
       return entityInfo;
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  public static void attachDependencies(
+      TableInfo tableInfo,
+      TableInfoDAO tableInfoDAO,
+      Session session,
+      DependencyRepository dependencyRepository) {
+    if (TableType.METRIC_VIEW.getValue().equals(tableInfoDAO.getType())) {
+      List<DependencyDAO> deps =
+          dependencyRepository.getDependencies(
+              session, tableInfoDAO.getId(), DependencyDAO.DependentType.TABLE);
+      tableInfo.setViewDependencies(
+          new DependencyList().dependencies(DependencyDAO.toDependencyList(deps)));
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -2,7 +2,6 @@ package io.unitycatalog.server.base.table;
 
 import static io.unitycatalog.server.utils.TestUtils.assertApiException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.Dependency;
@@ -17,8 +16,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
 
@@ -66,8 +70,10 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
 
   @Test
   public void testMetricViewCRUD() throws Exception {
-    assertThatThrownBy(() -> tableOperations.getTable(METRIC_VIEW_FULL_NAME))
-        .isInstanceOf(Exception.class);
+    assertApiException(
+        () -> tableOperations.getTable(METRIC_VIEW_FULL_NAME),
+        ErrorCode.TABLE_NOT_FOUND,
+        METRIC_VIEW_FULL_NAME);
 
     // --- Create with asset source ---
     CreateTable createRequest =
@@ -114,105 +120,107 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
 
     // --- Delete ---
     tableOperations.deleteTable(METRIC_VIEW_FULL_NAME);
-    assertThatThrownBy(() -> tableOperations.getTable(METRIC_VIEW_FULL_NAME))
-        .isInstanceOf(Exception.class);
+    assertApiException(
+        () -> tableOperations.getTable(METRIC_VIEW_FULL_NAME),
+        ErrorCode.TABLE_NOT_FOUND,
+        METRIC_VIEW_FULL_NAME);
   }
 
-  @Test
-  public void testCreateMetricViewWithoutDefinitionFails() {
-    CreateTable badRequest = validMetricViewRequest().viewDefinition(null);
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "view_definition is required for metric view");
+  private static Stream<Arguments> negativeCreateCases() {
+    return Stream.of(
+        Arguments.of(
+            "missing view_definition",
+            (UnaryOperator<CreateTable>) request -> request.viewDefinition(null),
+            ErrorCode.INVALID_ARGUMENT,
+            "view_definition is required for metric view"),
+        Arguments.of(
+            "missing view_dependencies",
+            (UnaryOperator<CreateTable>) request -> request.viewDependencies(null),
+            ErrorCode.INVALID_ARGUMENT,
+            "view_dependencies is required for metric view"),
+        Arguments.of(
+            "empty dependency list",
+            (UnaryOperator<CreateTable>)
+                request -> request.viewDependencies(new DependencyList().dependencies(List.of())),
+            ErrorCode.INVALID_ARGUMENT,
+            "view_dependencies must contain at least one entry for metric view"),
+        Arguments.of(
+            "dependency entry with neither table nor function set",
+            (UnaryOperator<CreateTable>)
+                request ->
+                    request.viewDependencies(
+                        new DependencyList().dependencies(List.of(new Dependency()))),
+            ErrorCode.INVALID_ARGUMENT,
+            "Unsupported dependency type"),
+        Arguments.of(
+            "dependency entry with both table and function set",
+            (UnaryOperator<CreateTable>)
+                request ->
+                    request.viewDependencies(
+                        new DependencyList()
+                            .dependencies(
+                                List.of(
+                                    new Dependency()
+                                        .table(
+                                            new TableDependency()
+                                                .tableFullName(SOURCE_TABLE_FULL_NAME))
+                                        .function(
+                                            new FunctionDependency()
+                                                .functionFullName(SOURCE_FUNCTION_FULL_NAME))))),
+            ErrorCode.INVALID_ARGUMENT,
+            "must have exactly one of table or function set"),
+        Arguments.of(
+            "table dependency with non-three-part full name",
+            (UnaryOperator<CreateTable>)
+                request ->
+                    request.viewDependencies(
+                        new DependencyList()
+                            .dependencies(
+                                List.of(
+                                    new Dependency()
+                                        .table(
+                                            new TableDependency()
+                                                .tableFullName("schema_only.table"))))),
+            ErrorCode.INVALID_ARGUMENT,
+            "must be a three-part name"),
+        Arguments.of(
+            "table dependency with empty full name",
+            (UnaryOperator<CreateTable>)
+                request ->
+                    request.viewDependencies(
+                        new DependencyList()
+                            .dependencies(
+                                List.of(
+                                    new Dependency()
+                                        .table(new TableDependency().tableFullName(""))))),
+            ErrorCode.INVALID_ARGUMENT,
+            "must not be null or empty"),
+        Arguments.of(
+            "function dependency with non-three-part full name",
+            (UnaryOperator<CreateTable>)
+                request ->
+                    request.viewDependencies(
+                        new DependencyList()
+                            .dependencies(
+                                List.of(
+                                    new Dependency()
+                                        .function(
+                                            new FunctionDependency()
+                                                .functionFullName("just_a_name"))))),
+            ErrorCode.INVALID_ARGUMENT,
+            "must be a three-part name"));
   }
 
-  @Test
-  public void testCreateMetricViewWithoutDependenciesFails() {
-    CreateTable badRequest = validMetricViewRequest().viewDependencies(null);
+  @ParameterizedTest(name = "createTable rejects metric view with {0}")
+  @MethodSource("negativeCreateCases")
+  public void testCreateMetricViewNegativeCases(
+      String label,
+      UnaryOperator<CreateTable> mutator,
+      ErrorCode expectedCode,
+      String expectedMessageSubstring) {
+    CreateTable badRequest = mutator.apply(validMetricViewRequest());
     assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "view_dependencies is required for metric view");
-  }
-
-  /** Empty {@code dependencies} array on the request: server must reject. */
-  @Test
-  public void testCreateMetricViewWithEmptyDependencyListFails() {
-    CreateTable badRequest =
-        validMetricViewRequest().viewDependencies(new DependencyList().dependencies(List.of()));
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "view_dependencies is required for metric view");
-  }
-
-  /**
-   * Dependency entry with neither a table nor a function set. Hits {@code DependencyDAO.from}'s
-   * "Unsupported dependency type" branch.
-   */
-  @Test
-  public void testCreateMetricViewWithEmptyDependencyEntryFails() {
-    DependencyList deps = new DependencyList().dependencies(List.of(new Dependency()));
-    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "Unsupported dependency type");
-  }
-
-  /**
-   * Dependency with a table full name that is not a three-part name. Hits the "three-part name"
-   * validation in {@code DependencyDAO.parseThreePartName}.
-   */
-  @Test
-  public void testCreateMetricViewWithNonThreePartTableNameFails() {
-    DependencyList deps =
-        new DependencyList()
-            .dependencies(
-                List.of(
-                    new Dependency()
-                        .table(new TableDependency().tableFullName("schema_only.table"))));
-    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "must be a three-part name");
-  }
-
-  /**
-   * Dependency with a table entry whose {@code table_full_name} is empty. Hits the "must not be
-   * null or empty" validation in {@code DependencyDAO.parseThreePartName}.
-   */
-  @Test
-  public void testCreateMetricViewWithEmptyTableFullNameFails() {
-    DependencyList deps =
-        new DependencyList()
-            .dependencies(List.of(new Dependency().table(new TableDependency().tableFullName(""))));
-    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "must not be null or empty");
-  }
-
-  /**
-   * Dependency with a function entry whose {@code function_full_name} is not a three-part name.
-   * Hits the same validation as tables but on the function branch.
-   */
-  @Test
-  public void testCreateMetricViewWithNonThreePartFunctionNameFails() {
-    DependencyList deps =
-        new DependencyList()
-            .dependencies(
-                List.of(
-                    new Dependency()
-                        .function(new FunctionDependency().functionFullName("just_a_name"))));
-    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
-    assertApiException(
-        () -> tableOperations.createTable(badRequest),
-        ErrorCode.INVALID_ARGUMENT,
-        "must be a three-part name");
+        () -> tableOperations.createTable(badRequest), expectedCode, expectedMessageSubstring);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -1,0 +1,217 @@
+package io.unitycatalog.server.base.table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.Dependency;
+import io.unitycatalog.client.model.DependencyList;
+import io.unitycatalog.client.model.FunctionDependency;
+import io.unitycatalog.client.model.TableDependency;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
+
+  protected static final String METRIC_VIEW_NAME = "uc_test_metric_view";
+  protected static final String METRIC_VIEW_FULL_NAME =
+      TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + METRIC_VIEW_NAME;
+  protected static final String SOURCE_TABLE_FULL_NAME =
+      TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".source_events";
+
+  protected static final String VIEW_DEFINITION_ASSET_SOURCE =
+      "version: \"0.1\"\n"
+          + "source: "
+          + SOURCE_TABLE_FULL_NAME
+          + "\n"
+          + "dimensions:\n"
+          + "  - name: event_day\n"
+          + "    expr: date_trunc('day', event_time)\n"
+          + "measures:\n"
+          + "  - name: event_count\n"
+          + "    expr: count(*)";
+
+  protected static final Map<String, String> PROPERTIES =
+      Map.of("team", "analytics", "refresh", "daily");
+
+  private static DependencyList makeDependencyList(String... tableFullNames) {
+    DependencyList depList = new DependencyList();
+    depList.setDependencies(
+        java.util.Arrays.stream(tableFullNames)
+            .map(name -> new Dependency().table(new TableDependency().tableFullName(name)))
+            .collect(java.util.stream.Collectors.toList()));
+    return depList;
+  }
+
+  @Test
+  public void testMetricViewCRUD() throws Exception {
+    assertThatThrownBy(() -> tableOperations.getTable(METRIC_VIEW_FULL_NAME))
+        .isInstanceOf(Exception.class);
+
+    // --- Create with asset source ---
+    CreateTable createRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+            .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME))
+            .comment("Daily event counts by day")
+            .properties(PROPERTIES);
+
+    TableInfo created = tableOperations.createTable(createRequest);
+    assertThat(created.getName()).isEqualTo(METRIC_VIEW_NAME);
+    assertThat(created.getCatalogName()).isEqualTo(TestUtils.CATALOG_NAME);
+    assertThat(created.getSchemaName()).isEqualTo(TestUtils.SCHEMA_NAME);
+    assertThat(created.getTableType()).isEqualTo(TableType.METRIC_VIEW);
+    assertThat(created.getViewDefinition()).isEqualTo(VIEW_DEFINITION_ASSET_SOURCE);
+    assertThat(created.getTableId()).isNotNull();
+    assertThat(created.getStorageLocation())
+        .as("Metric views should have no storage location")
+        .isNull();
+
+    // --- Get and verify dependencies round-trip ---
+    TableInfo fetched = tableOperations.getTable(METRIC_VIEW_FULL_NAME);
+    assertThat(fetched.getName()).isEqualTo(METRIC_VIEW_NAME);
+    assertThat(fetched.getTableType()).isEqualTo(TableType.METRIC_VIEW);
+    assertThat(fetched.getViewDefinition()).isEqualTo(VIEW_DEFINITION_ASSET_SOURCE);
+    assertThat(fetched.getComment()).isEqualTo("Daily event counts by day");
+    assertThat(fetched.getCreatedAt()).isNotNull();
+    assertThat(fetched.getTableId()).isNotNull();
+    assertThat(fetched.getViewDependencies()).isNotNull();
+    assertThat(fetched.getViewDependencies().getDependencies()).hasSize(1);
+    assertThat(fetched.getViewDependencies().getDependencies().get(0).getTable().getTableFullName())
+        .isEqualTo(SOURCE_TABLE_FULL_NAME);
+
+    // Verify properties round-trip
+    assertThat(fetched.getProperties()).isNotNull();
+    assertThat(fetched.getProperties().get("team")).isEqualTo("analytics");
+    assertThat(fetched.getProperties().get("refresh")).isEqualTo("daily");
+
+    // --- List ---
+    List<TableInfo> tables =
+        tableOperations.listTables(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, Optional.empty());
+    assertThat(tables)
+        .as("Metric view should appear in listTables")
+        .anyMatch(
+            t ->
+                METRIC_VIEW_NAME.equals(t.getName())
+                    && TableType.METRIC_VIEW.equals(t.getTableType()));
+
+    // --- Delete ---
+    tableOperations.deleteTable(METRIC_VIEW_FULL_NAME);
+    assertThatThrownBy(() -> tableOperations.getTable(METRIC_VIEW_FULL_NAME))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  public void testCreateMetricViewWithoutDefinitionFails() throws Exception {
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME));
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+
+  @Test
+  public void testCreateMetricViewWithoutDependenciesFails() throws Exception {
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE);
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+
+  /**
+   * Dependency entry with neither a table nor a function set. Hits {@code DependencyDAO.from}'s
+   * "Unsupported dependency type" branch.
+   */
+  @Test
+  public void testCreateMetricViewWithEmptyDependencyFails() throws Exception {
+    DependencyList deps = new DependencyList();
+    deps.setDependencies(java.util.List.of(new Dependency()));
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+            .viewDependencies(deps);
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+
+  /**
+   * Dependency with a table full name that is not a three-part name. Hits the "three-part name"
+   * validation in {@code DependencyDAO.populateThreePartName}.
+   */
+  @Test
+  public void testCreateMetricViewWithNonThreePartTableNameFails() throws Exception {
+    DependencyList deps = new DependencyList();
+    deps.setDependencies(
+        java.util.List.of(
+            new Dependency().table(new TableDependency().tableFullName("schema_only.table"))));
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+            .viewDependencies(deps);
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+
+  /**
+   * Dependency with a table entry whose {@code table_full_name} is empty. Hits the "must not be
+   * null or empty" validation in {@code DependencyDAO.populateThreePartName}.
+   */
+  @Test
+  public void testCreateMetricViewWithEmptyTableFullNameFails() throws Exception {
+    DependencyList deps = new DependencyList();
+    deps.setDependencies(
+        java.util.List.of(new Dependency().table(new TableDependency().tableFullName(""))));
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+            .viewDependencies(deps);
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+
+  /**
+   * Dependency with a function entry whose {@code function_full_name} is not a three-part name.
+   * Hits the same validation as tables but on the function branch.
+   */
+  @Test
+  public void testCreateMetricViewWithNonThreePartFunctionNameFails() throws Exception {
+    DependencyList deps = new DependencyList();
+    deps.setDependencies(
+        java.util.List.of(
+            new Dependency().function(new FunctionDependency().functionFullName("just_a_name"))));
+    CreateTable badRequest =
+        new CreateTable()
+            .name(METRIC_VIEW_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+            .viewDependencies(deps);
+    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -27,6 +27,8 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
       TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + METRIC_VIEW_NAME;
   protected static final String SOURCE_TABLE_FULL_NAME =
       TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".source_events";
+  protected static final String SOURCE_FUNCTION_FULL_NAME =
+      TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".event_bucket";
 
   protected static final String VIEW_DEFINITION_ASSET_SOURCE =
       "version: \"0.1\"\n"
@@ -211,5 +213,66 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
         () -> tableOperations.createTable(badRequest),
         ErrorCode.INVALID_ARGUMENT,
         "must be a three-part name");
+  }
+
+  /**
+   * Happy-path coverage for the {@code FUNCTION} branch in {@link
+   * io.unitycatalog.server.persist.dao.DependencyDAO#from} and {@link
+   * io.unitycatalog.server.persist.dao.DependencyDAO#toDependency}. The negative tests above only
+   * exercise the validation error path; this test creates a metric view that depends on both a
+   * table and a function, then asserts the dependency list round-trips through {@code getTable} and
+   * {@code listTables} with both kinds of entries reconstructed correctly.
+   */
+  @Test
+  public void testMetricViewWithMixedTableAndFunctionDependencies() throws Exception {
+    DependencyList mixed =
+        new DependencyList()
+            .dependencies(
+                List.of(
+                    new Dependency()
+                        .table(new TableDependency().tableFullName(SOURCE_TABLE_FULL_NAME)),
+                    new Dependency()
+                        .function(
+                            new FunctionDependency().functionFullName(SOURCE_FUNCTION_FULL_NAME))));
+    CreateTable createRequest = validMetricViewRequest().viewDependencies(mixed);
+
+    try {
+      TableInfo created = tableOperations.createTable(createRequest);
+      assertThat(created.getTableType()).isEqualTo(TableType.METRIC_VIEW);
+
+      // --- Get: round-trip through DependencyDAO.toDependency ---
+      TableInfo fetched = tableOperations.getTable(METRIC_VIEW_FULL_NAME);
+      assertThat(fetched.getViewDependencies()).isNotNull();
+      List<Dependency> deps = fetched.getViewDependencies().getDependencies();
+      assertThat(deps).hasSize(2);
+
+      Optional<Dependency> tableDep = deps.stream().filter(d -> d.getTable() != null).findFirst();
+      Optional<Dependency> functionDep =
+          deps.stream().filter(d -> d.getFunction() != null).findFirst();
+
+      assertThat(tableDep).as("Mixed dependency list should preserve the TABLE entry").isPresent();
+      assertThat(tableDep.get().getTable().getTableFullName()).isEqualTo(SOURCE_TABLE_FULL_NAME);
+      assertThat(tableDep.get().getFunction()).isNull();
+
+      assertThat(functionDep)
+          .as("Mixed dependency list should preserve the FUNCTION entry")
+          .isPresent();
+      assertThat(functionDep.get().getFunction().getFunctionFullName())
+          .isEqualTo(SOURCE_FUNCTION_FULL_NAME);
+      assertThat(functionDep.get().getTable()).isNull();
+
+      // --- List: dependencies are not required on listTables responses, but the metric view
+      // itself must still be present and tagged as METRIC_VIEW. ---
+      List<TableInfo> tables =
+          tableOperations.listTables(
+              TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, Optional.empty());
+      assertThat(tables)
+          .anyMatch(
+              t ->
+                  METRIC_VIEW_NAME.equals(t.getName())
+                      && TableType.METRIC_VIEW.equals(t.getTableType()));
+    } finally {
+      tableOperations.deleteTable(METRIC_VIEW_FULL_NAME);
+    }
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.base.table;
 
+import static io.unitycatalog.server.utils.TestUtils.assertApiException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -10,10 +11,13 @@ import io.unitycatalog.client.model.FunctionDependency;
 import io.unitycatalog.client.model.TableDependency;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.utils.TestUtils;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
@@ -42,10 +46,20 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
   private static DependencyList makeDependencyList(String... tableFullNames) {
     DependencyList depList = new DependencyList();
     depList.setDependencies(
-        java.util.Arrays.stream(tableFullNames)
+        Arrays.stream(tableFullNames)
             .map(name -> new Dependency().table(new TableDependency().tableFullName(name)))
-            .collect(java.util.stream.Collectors.toList()));
+            .collect(Collectors.toList()));
     return depList;
+  }
+
+  private CreateTable validMetricViewRequest() {
+    return new CreateTable()
+        .name(METRIC_VIEW_NAME)
+        .catalogName(TestUtils.CATALOG_NAME)
+        .schemaName(TestUtils.SCHEMA_NAME)
+        .tableType(TableType.METRIC_VIEW)
+        .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
+        .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME));
   }
 
   @Test
@@ -55,15 +69,7 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
 
     // --- Create with asset source ---
     CreateTable createRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
-            .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME))
-            .comment("Daily event counts by day")
-            .properties(PROPERTIES);
+        validMetricViewRequest().comment("Daily event counts by day").properties(PROPERTIES);
 
     TableInfo created = tableOperations.createTable(createRequest);
     assertThat(created.getName()).isEqualTo(METRIC_VIEW_NAME);
@@ -111,27 +117,32 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   @Test
-  public void testCreateMetricViewWithoutDefinitionFails() throws Exception {
-    CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME));
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  public void testCreateMetricViewWithoutDefinitionFails() {
+    CreateTable badRequest = validMetricViewRequest().viewDefinition(null);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "view_definition is required for metric view");
   }
 
   @Test
-  public void testCreateMetricViewWithoutDependenciesFails() throws Exception {
+  public void testCreateMetricViewWithoutDependenciesFails() {
+    CreateTable badRequest = validMetricViewRequest().viewDependencies(null);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "view_dependencies is required for metric view");
+  }
+
+  /** Empty {@code dependencies} array on the request: server must reject. */
+  @Test
+  public void testCreateMetricViewWithEmptyDependencyListFails() {
     CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE);
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+        validMetricViewRequest().viewDependencies(new DependencyList().dependencies(List.of()));
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "view_dependencies is required for metric view");
   }
 
   /**
@@ -139,59 +150,48 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
    * "Unsupported dependency type" branch.
    */
   @Test
-  public void testCreateMetricViewWithEmptyDependencyFails() throws Exception {
-    DependencyList deps = new DependencyList();
-    deps.setDependencies(java.util.List.of(new Dependency()));
-    CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
-            .viewDependencies(deps);
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  public void testCreateMetricViewWithEmptyDependencyEntryFails() {
+    DependencyList deps = new DependencyList().dependencies(List.of(new Dependency()));
+    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "Unsupported dependency type");
   }
 
   /**
    * Dependency with a table full name that is not a three-part name. Hits the "three-part name"
-   * validation in {@code DependencyDAO.populateThreePartName}.
+   * validation in {@code DependencyDAO.parseThreePartName}.
    */
   @Test
-  public void testCreateMetricViewWithNonThreePartTableNameFails() throws Exception {
-    DependencyList deps = new DependencyList();
-    deps.setDependencies(
-        java.util.List.of(
-            new Dependency().table(new TableDependency().tableFullName("schema_only.table"))));
-    CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
-            .viewDependencies(deps);
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  public void testCreateMetricViewWithNonThreePartTableNameFails() {
+    DependencyList deps =
+        new DependencyList()
+            .dependencies(
+                List.of(
+                    new Dependency()
+                        .table(new TableDependency().tableFullName("schema_only.table"))));
+    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "must be a three-part name");
   }
 
   /**
    * Dependency with a table entry whose {@code table_full_name} is empty. Hits the "must not be
-   * null or empty" validation in {@code DependencyDAO.populateThreePartName}.
+   * null or empty" validation in {@code DependencyDAO.parseThreePartName}.
    */
   @Test
-  public void testCreateMetricViewWithEmptyTableFullNameFails() throws Exception {
-    DependencyList deps = new DependencyList();
-    deps.setDependencies(
-        java.util.List.of(new Dependency().table(new TableDependency().tableFullName(""))));
-    CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
-            .viewDependencies(deps);
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  public void testCreateMetricViewWithEmptyTableFullNameFails() {
+    DependencyList deps =
+        new DependencyList()
+            .dependencies(List.of(new Dependency().table(new TableDependency().tableFullName(""))));
+    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "must not be null or empty");
   }
 
   /**
@@ -199,19 +199,17 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
    * Hits the same validation as tables but on the function branch.
    */
   @Test
-  public void testCreateMetricViewWithNonThreePartFunctionNameFails() throws Exception {
-    DependencyList deps = new DependencyList();
-    deps.setDependencies(
-        java.util.List.of(
-            new Dependency().function(new FunctionDependency().functionFullName("just_a_name"))));
-    CreateTable badRequest =
-        new CreateTable()
-            .name(METRIC_VIEW_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
-            .viewDependencies(deps);
-    assertThatThrownBy(() -> tableOperations.createTable(badRequest)).isInstanceOf(Exception.class);
+  public void testCreateMetricViewWithNonThreePartFunctionNameFails() {
+    DependencyList deps =
+        new DependencyList()
+            .dependencies(
+                List.of(
+                    new Dependency()
+                        .function(new FunctionDependency().functionFullName("just_a_name"))));
+    CreateTable badRequest = validMetricViewRequest().viewDependencies(deps);
+    assertApiException(
+        () -> tableOperations.createTable(badRequest),
+        ErrorCode.INVALID_ARGUMENT,
+        "must be a three-part name");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkMetricViewCRUDTest.java
@@ -1,0 +1,28 @@
+package io.unitycatalog.server.sdk.tables;
+
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.BaseMetricViewCRUDTest;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.utils.TestUtils;
+
+public class SdkMetricViewCRUDTest extends BaseMetricViewCRUDTest {
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig config) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(config));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig config) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(config));
+  }
+
+  @Override
+  protected TableOperations createTableOperations(ServerConfig config) {
+    return new SdkTableOperations(TestUtils.createApiClient(config));
+  }
+}


### PR DESCRIPTION
Implements server-side support for the METRIC_VIEW table type added in the previous API PR: https://github.com/unitycatalog/unitycatalog/pull/1493

Persistence layer:
- TableInfoDAO: add view_definition column (length 16777215); make data_source_format and storage_location null-safe to support metric views which have neither of them
- DependencyDAO (new): Hibernate entity for the uc_dependencies table with an idx_dependent (dependent_type, dependent_id) index to keep get_table latency bounded when joining dependencies
- DependencyRepository (new): create / get / delete on uc_dependencies, scoped to the caller's session
- Repositories + HibernateConfigurator: wire up the new repository and register DependencyDAO

Business logic:
- TableRepository.createTable: add a METRIC_VIEW branch that validates view_definition and view_dependencies are present, then persists the dependency records via DependencyRepository.
- TableRepository.getTable / listTables: attach view_dependencies on read for METRIC_VIEW rows via a new attachDependencies helper.
- TableRepository.deleteTable: cascade-delete dependency rows for METRIC_VIEW.

Tests:
- BaseMetricViewCRUDTest covers create/get/list/delete with both an asset source and a SQL source, plus negative cases for missing view_definition and missing view_dependencies.
- SdkMetricViewCRUDTest wires the base test to the SDK driver.

This is the second PR in a 3-PR series adding metric view support to Unity Catalog OSS. The Spark connector PR comes next.

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
