### PR TITLE
New endpoint for Delta: createTable

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
@@ -52,6 +52,28 @@ public final class AuthorizeExpressions {
       """;
 
   /**
+   * Authorization policy for creating a table (UC REST {@code POST /tables} and Delta REST Catalog
+   * {@code createTable}). Catalog {@code USE_CATALOG}/{@code OWNER} plus either schema
+   * {@code OWNER} or schema {@code USE_SCHEMA}+{@code CREATE_TABLE}. For EXTERNAL tables, the
+   * caller additionally needs {@code OWNER}/{@code CREATE_EXTERNAL_TABLE} on the external location
+   * (if one resolves) and the storage path must not overlap a data securable.
+   *
+   * <p>The {@code #table_type} SpEL variable comes from {@code @AuthorizeKey(key = "table-type")};
+   * kebab-case payload keys surface with hyphens mapped to underscores (see {@link
+   * io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator#getVariableName}).
+   */
+  public static final String CREATE_TABLE =
+      """
+      #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+      (#authorize(#principal, #schema, OWNER) ||
+        #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE)) &&
+      (#table_type != 'EXTERNAL' ||
+        (#no_overlap_with_data_securable &&
+          (#external_location == null ||
+           #authorizeAny(#principal, #external_location, OWNER, CREATE_EXTERNAL_TABLE))))
+      """;
+
+  /**
    * Authorization policy for vending table credentials. Admin-above-the-table privileges on
    * their own are not sufficient; the caller must have an explicit table-level privilege
    * matching the requested operation. {@code READ} needs OWNER or SELECT; {@code READ_WRITE}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocator.java
@@ -43,14 +43,20 @@ public class AuthorizeKeyLocator {
   /**
    * Extracts the variable name from a key. For resources, returns their securable type as variable
    * name. e.g. "external_location" For other keys, returns the key name in annotated parameters or
-   * the last segment of the payload parameter. e.g. "config.operation" returns "operation"
+   * the last segment of the payload parameter. e.g. "config.operation" returns "operation".
+   *
+   * <p>Hyphens in the key are mapped to underscores so kebab-case payload fields (such as Delta
+   * REST Catalog's {@code table-type}) form valid SpEL identifiers like {@code #table_type}. The
+   * payload lookup still uses the original key verbatim; this transformation affects only the SpEL
+   * variable name.
    */
   public String getVariableName() {
     if (type.isPresent()) {
       return type.get().getValue();
     }
     int lastDot = key.lastIndexOf('.');
-    return lastDot >= 0 ? key.substring(lastDot + 1) : key;
+    String name = lastDot >= 0 ? key.substring(lastDot + 1) : key;
+    return name.replace('-', '_');
   }
 
   public static AuthorizeKeyLocator from(AuthorizeResourceKey key, Parameter parameter) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -29,6 +29,7 @@ import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.persist.utils.RepositoryUtils;
 import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
 import io.unitycatalog.server.utils.ColumnUtils;
 import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.IdentityUtils;
@@ -249,7 +250,6 @@ public class TableRepository {
                 ErrorCode.TABLE_NOT_FOUND,
                 "Table not found: " + catalog + "." + schema + "." + table);
           }
-
           // Guard non-Delta entries (metric views, parquet/csv/etc. tables) before they reach
           // `buildTableMetadata`. The downstream code calls `NormalizedURL.normalize(dao.getUrl())`
           // (throws "Path cannot be null or empty" when the row has no storage location, e.g.
@@ -263,26 +263,35 @@ public class TableRepository {
                 ErrorCode.INVALID_ARGUMENT,
                 "Table is not a Delta table: " + catalog + "." + schema + "." + table);
           }
-
-          TableMetadata metadata = buildTableMetadata(session, dao, catalog, schema, table);
-
-          LoadTableResponse response = new LoadTableResponse();
-          response.setMetadata(metadata);
-
-          // Commits (managed Delta tables only)
-          if (TableType.MANAGED.toString().equals(dao.getType())
-              && DataSourceFormat.DELTA.toString().equals(dao.getDataSourceFormat())) {
-            populateCommitsForDelta(
-                response, repositories.getDeltaCommitRepository(), session, dao.getId());
-          }
-
-          populateUniformMetadata(response, dao);
-
-          return response;
+          return buildLoadTableResponse(session, dao, catalog, schema, table);
         },
         "Failed to load table",
         /* readOnly = */ true,
         Optional.of(TRANSACTION_REPEATABLE_READ));
+  }
+
+  /**
+   * Build a {@link LoadTableResponse} from an already-loaded {@link TableInfoDAO}. Used by both
+   * {@link #loadTableForDelta} and {@link #createTableForDelta} so the post-load DAO → response
+   * assembly stays in one place.
+   */
+  private LoadTableResponse buildLoadTableResponse(
+      Session session, TableInfoDAO dao, String catalog, String schema, String table) {
+    TableMetadata metadata = buildTableMetadata(session, dao, catalog, schema, table);
+
+    LoadTableResponse response = new LoadTableResponse();
+    response.setMetadata(metadata);
+
+    // Commits (managed Delta tables only)
+    if (TableType.MANAGED.toString().equals(dao.getType())
+        && DataSourceFormat.DELTA.toString().equals(dao.getDataSourceFormat())) {
+      populateCommitsForDelta(
+          response, repositories.getDeltaCommitRepository(), session, dao.getId());
+    }
+
+    populateUniformMetadata(response, dao);
+
+    return response;
   }
 
   private TableMetadata buildTableMetadata(
@@ -442,6 +451,33 @@ public class TableRepository {
   }
 
   public TableInfo createTable(CreateTable createTable) {
+    return createTableImpl(createTable, (session, dao, tableInfo) -> tableInfo);
+  }
+
+  /**
+   * Create a table and return the Delta REST Catalog {@link LoadTableResponse} in a single
+   * transaction. The DAO persisted during create is the same one used to build the response, so
+   * there's no second lookup or risk of a reader observing an intermediate state.
+   */
+  public LoadTableResponse createTableForDelta(CreateTable createTable) {
+    return createTableImpl(
+        createTable,
+        (session, dao, tableInfo) ->
+            buildLoadTableResponse(
+                session,
+                dao,
+                createTable.getCatalogName(),
+                createTable.getSchemaName(),
+                createTable.getName()));
+  }
+
+  /**
+   * Shared implementation for the two {@code create} entry points. Validates the name, opens a
+   * write transaction, persists the new table (row, columns, properties), then hands the persisted
+   * DAO + built TableInfo to {@code mapper} which picks the return shape each caller needs. Keeps
+   * the create path as a single operation rather than a chain of private helpers.
+   */
+  private <T> T createTableImpl(CreateTable createTable, CreateResultMapper<T> mapper) {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
     List<ColumnInfo> columnInfos =
@@ -494,6 +530,13 @@ public class TableRepository {
                     .getStagingTableRepository()
                     .commitStagingTable(session, callerId, storageLocation);
             tableUUID = stagingTableDAO.getId();
+            // MANAGED tables (created via either UC REST or DRC) must carry UC_TABLE_ID in their
+            // properties, matching the staging UUID. UC has the staging UUID as the source of
+            // truth; a request with a missing or mismatched UC_TABLE_ID gets rejected here
+            // instead of producing an internally-inconsistent UC table that subsequent commits
+            // would fail on.
+            UcManagedDeltaContract.validateTableIdProperty(
+                createTable.getProperties(), tableUUID.toString());
           } else if (tableType == TableType.METRIC_VIEW) {
             storageLocation = null;
             validateMetricView(createTable);
@@ -551,10 +594,15 @@ public class TableRepository {
                 .getDependencyRepository()
                 .createDependencies(session, tableUUID, dependentType, depDAOs);
           }
-          return tableInfo;
+          return mapper.apply(session, tableInfoDAO, tableInfo);
         },
         "Error creating table: " + fullName,
         /* readOnly = */ false);
+  }
+
+  @FunctionalInterface
+  private interface CreateResultMapper<T> {
+    T apply(Session session, TableInfoDAO dao, TableInfo tableInfo);
   }
 
   private static void validateMetricView(CreateTable createTable) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -530,8 +530,8 @@ public class TableRepository {
                     .getStagingTableRepository()
                     .commitStagingTable(session, callerId, storageLocation);
             tableUUID = stagingTableDAO.getId();
-            // MANAGED tables (created via either UC REST or DRC) must carry UC_TABLE_ID in their
-            // properties, matching the staging UUID. UC has the staging UUID as the source of
+            // MANAGED tables (created via either UC REST or Delta REST) must carry UC_TABLE_ID in
+            // their properties, matching the staging UUID. UC has the staging UUID as the source of
             // truth; a request with a missing or mismatched UC_TABLE_ID gets rejected here
             // instead of producing an internally-inconsistent UC table that subsequent commits
             // would fail on.

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -77,15 +77,7 @@ public class TableService extends AuthorizedService {
    * @return HTTP response containing the created TableInfo
    */
   @Post("")
-  @AuthorizeExpression("""
-      #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
-      (#authorize(#principal, #schema, OWNER) ||
-        #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE)) &&
-      (#table_type != 'EXTERNAL' ||
-        (#no_overlap_with_data_securable &&
-          (#external_location == null ||
-           #authorizeAny(#principal, #external_location, OWNER, CREATE_EXTERNAL_TABLE))))
-      """)
+  @AuthorizeExpression(AuthorizeExpressions.CREATE_TABLE)
   public HttpResponse createTable(
       @AuthorizeResourceKeys({
         @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
@@ -92,5 +92,26 @@ public final class DeltaConsts {
         "delta.rowTracking.materializedRowIdColumnName";
     public static final String ROW_TRACKING_MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME =
         "delta.rowTracking.materializedRowCommitVersionColumnName";
+
+    /**
+     * Clustering columns, written as a JSON-encoded list of column paths (each path itself a list
+     * of segment names, so nested columns stay as arrays rather than collapsing to dotted strings).
+     * Mirrors the {@code delta.clustering} domain-metadata entry.
+     */
+    public static final String CLUSTERING_COLUMNS = "delta.clusteringColumns";
+
+    /**
+     * Row-tracking high water mark, mirroring the {@code delta.rowTracking.rowIdHighWaterMark} from
+     * the {@code delta.rowTracking} domain-metadata entry.
+     */
+    public static final String ROW_TRACKING_ROW_ID_HIGH_WATER_MARK =
+        "delta.rowTracking.rowIdHighWaterMark";
+
+    /**
+     * Prefix for per-feature properties written by the engine for every feature declared in the
+     * protocol. Projection is {@code delta.feature.<name> = supported}; the suffix is the feature
+     * name as it appears in {@code protocol.reader-features} / {@code protocol.writer-features}.
+     */
+    public static final String FEATURE_PREFIX = "delta.feature.";
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -1,0 +1,100 @@
+package io.unitycatalog.server.service.delta;
+
+import io.unitycatalog.server.delta.model.CreateTableRequest;
+import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.CreateTable;
+import io.unitycatalog.server.model.DataSourceFormat;
+import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.utils.ColumnUtils;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a Delta REST Catalog {@link CreateTableRequest} (with typed Delta columns and kebab-case
+ * field names) into the UC {@link CreateTable} (with UC {@link ColumnInfo}s and
+ * partition-index-per-column). The server holds path params for catalog and schema; the rest comes
+ * from the request body.
+ *
+ * <p>Required-field checks (name, location, columns, protocol, table-type, data-source-format) and
+ * the DELTA-only format rule apply to all tables. Domain-metadata vs feature consistency and the
+ * full UC catalog-managed contract ({@link UcManagedDeltaContract}) apply only to MANAGED tables;
+ * for EXTERNAL tables UC mirrors what the client wrote with the Delta log as the source of truth.
+ */
+public final class DeltaCreateTableMapper {
+
+  private DeltaCreateTableMapper() {}
+
+  public static CreateTable toCreateTable(String catalog, String schema, CreateTableRequest req) {
+    if (req == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Request body is required.");
+    }
+    if (req.getName() == null || req.getName().isBlank()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table name is required.");
+    }
+    if (req.getLocation() == null || req.getLocation().isBlank()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table location is required.");
+    }
+    if (req.getColumns() == null || req.getColumns().getFields() == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table columns are required.");
+    }
+
+    TableType tableType = toUCTableType(req.getTableType());
+    if (req.getProtocol() == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "protocol is required.");
+    }
+
+    // MANAGED-only: full UC catalog-managed contract (protocol versions + features + reader-subset
+    // + domain-metadata consistency + properties). EXTERNAL tables get a pass: UC mirrors what the
+    // client wrote; the Delta log is the source of truth.
+    if (tableType == TableType.MANAGED) {
+      UcManagedDeltaContract.validate(
+          req.getProtocol(), req.getDomainMetadata(), req.getProperties());
+    }
+
+    List<ColumnInfo> columns = new ArrayList<>();
+    List<StructField> fields = req.getColumns().getFields();
+    for (int i = 0; i < fields.size(); i++) {
+      columns.add(ColumnUtils.toColumnInfo(fields.get(i), i));
+    }
+    ColumnUtils.applyPartitionColumns(columns, req.getPartitionColumns());
+
+    return new CreateTable()
+        .name(req.getName())
+        .catalogName(catalog)
+        .schemaName(schema)
+        .tableType(tableType)
+        .dataSourceFormat(toUCDataSourceFormat(req.getDataSourceFormat()))
+        .columns(columns)
+        .comment(req.getComment())
+        .storageLocation(req.getLocation())
+        .properties(
+            DeltaPropertyMapper.mergeDerivedWithClient(
+                req.getProtocol(), req.getDomainMetadata(), req.getProperties()));
+  }
+
+  private static TableType toUCTableType(io.unitycatalog.server.delta.model.TableType type) {
+    if (type == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "table-type is required.");
+    }
+    return switch (type) {
+      case MANAGED -> TableType.MANAGED;
+      case EXTERNAL -> TableType.EXTERNAL;
+    };
+  }
+
+  private static DataSourceFormat toUCDataSourceFormat(
+      io.unitycatalog.server.delta.model.DataSourceFormat format) {
+    if (format == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "data-source-format is required.");
+    }
+    // Only DELTA is accepted.
+    if (format == io.unitycatalog.server.delta.model.DataSourceFormat.DELTA) {
+      return DataSourceFormat.DELTA;
+    }
+    throw new BaseException(
+        ErrorCode.INVALID_ARGUMENT, "Unsupported data-source-format: " + format.getValue());
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -19,9 +19,11 @@ import java.util.List;
  * from the request body.
  *
  * <p>Required-field checks (name, location, columns, protocol, table-type, data-source-format) and
- * the DELTA-only format rule apply to all tables. Domain-metadata vs feature consistency and the
- * full UC catalog-managed contract ({@link UcManagedDeltaContract}) apply only to MANAGED tables;
- * for EXTERNAL tables UC mirrors what the client wrote with the Delta log as the source of truth.
+ * the DELTA-only format rule apply to all tables. The full UC catalog-managed contract ({@link
+ * UcManagedDeltaContract}) applies only to MANAGED tables; EXTERNAL tables skip contract validation
+ * but still go through the same {@link DeltaPropertyMapper} projection, so derived
+ * {@code delta.feature.*} and {@code delta.clusteringColumns} entries override any client-supplied
+ * values under those keys.
  */
 public final class DeltaCreateTableMapper {
 
@@ -73,7 +75,7 @@ public final class DeltaCreateTableMapper {
         .comment(req.getComment())
         .storageLocation(req.getLocation())
         .properties(
-            DeltaPropertyMapper.mergeDerivedWithClient(
+            DeltaPropertyMapper.buildStoredProperties(
                 req.getProtocol(), req.getDomainMetadata(), req.getProperties()));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -37,7 +37,9 @@ public final class DeltaCreateTableMapper {
     if (req.getLocation() == null || req.getLocation().isBlank()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table location is required.");
     }
-    if (req.getColumns() == null || req.getColumns().getFields() == null) {
+    if (req.getColumns() == null
+        || req.getColumns().getFields() == null
+        || req.getColumns().getFields().isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table columns are required.");
     }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
@@ -1,0 +1,115 @@
+package io.unitycatalog.server.service.delta;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.server.delta.model.DeltaProtocol;
+import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.server.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps Delta REST Catalog {@code protocol} and {@code domain-metadata} blocks onto UC table
+ * properties. Designed to be shared by create, update, and commit endpoints: the mapping rules are
+ * specified by the Delta spec and don't vary by endpoint (only create is wired up today; update and
+ * commit are on follow-ups).
+ *
+ * <p>Every feature in {@code protocol.reader-features} and {@code protocol.writer-features} yields
+ * {@code delta.feature.<name> = supported}. Reader-writer features (which appear in both lists)
+ * collapse to a single entry via map dedup.
+ *
+ * <p>Domain-metadata entries yield their Delta-documented table-property projections:
+ *
+ * <ul>
+ *   <li>The {@code delta.clustering} domain-metadata entry's {@code clusteringColumns} field
+ *       projects to the {@code delta.clusteringColumns} table property as a JSON-encoded list of
+ *       column paths. Paths are arrays of segment names so nested columns survive as arrays rather
+ *       than collapsing into dotted strings.
+ *   <li>The {@code delta.rowTracking} domain-metadata entry's {@code rowIdHighWaterMark} field
+ *       projects to the {@code delta.rowTracking.rowIdHighWaterMark} table property.
+ * </ul>
+ *
+ * <p>Consistency rules (e.g. domain-metadata entry implies its writer feature) live in {@link
+ * UcManagedDeltaContract}, not here.
+ */
+public final class DeltaPropertyMapper {
+
+  private DeltaPropertyMapper() {}
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  /** Value emitted under {@code delta.feature.<name>} for each declared feature. */
+  private static final String FEATURE_SUPPORTED = "supported";
+
+  /**
+   * Returns the stored UC property map formed by merging protocol-derived, domain-metadata-derived,
+   * and client-supplied entries. Client-supplied entries take precedence so callers can pin
+   * engine-managed values (e.g. row-tracking materialized column names) or override a derived value
+   * if needed.
+   */
+  public static Map<String, String> mergeDerivedWithClient(
+      DeltaProtocol protocol,
+      DomainMetadataUpdates domainMetadata,
+      Map<String, String> clientProperties) {
+    Map<String, String> merged = new HashMap<>();
+    deriveFromProtocol(merged, protocol);
+    deriveFromDomainMetadata(merged, domainMetadata);
+    if (clientProperties != null) {
+      merged.putAll(clientProperties);
+    }
+    return merged;
+  }
+
+  /**
+   * Adds the {@code delta.feature.*} properties implied by a protocol block into {@code props}
+   * in-place. Iterates both reader- and writer-features; reader-writer features (which appear in
+   * both lists) collapse to a single entry via map dedup. The mapper does not assume the protocol
+   * has been validated -- if a reader-feature is missing from writer-features (a Delta-spec
+   * violation that {@link UcManagedDeltaContract#validate} catches), this method still emits an
+   * entry for it.
+   */
+  public static void deriveFromProtocol(Map<String, String> props, DeltaProtocol protocol) {
+    if (protocol == null) return;
+    addFeatureProperties(props, protocol.getReaderFeatures());
+    addFeatureProperties(props, protocol.getWriterFeatures());
+  }
+
+  /** Adds the table properties implied by a domain-metadata block into {@code props} in-place. */
+  public static void deriveFromDomainMetadata(
+      Map<String, String> props, DomainMetadataUpdates domainMetadata) {
+    if (domainMetadata == null) return;
+    ClusteringDomainMetadata clustering = domainMetadata.getDeltaClustering();
+    if (clustering != null && clustering.getClusteringColumns() != null) {
+      // Use a proper JSON encoder rather than string-joining so nested column paths don't
+      // collapse into dotted strings.
+      props.put(TableProperties.CLUSTERING_COLUMNS, toJson(clustering.getClusteringColumns()));
+    }
+    RowTrackingDomainMetadata rowTracking = domainMetadata.getDeltaRowTracking();
+    if (rowTracking != null && rowTracking.getRowIdHighWaterMark() != null) {
+      props.put(
+          TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK,
+          String.valueOf(rowTracking.getRowIdHighWaterMark()));
+    }
+  }
+
+  private static void addFeatureProperties(Map<String, String> props, List<String> features) {
+    if (features == null) return;
+    for (String feature : features) {
+      props.put(TableProperties.FEATURE_PREFIX + feature, FEATURE_SUPPORTED);
+    }
+  }
+
+  private static String toJson(Object value) {
+    try {
+      return JSON.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new BaseException(
+          ErrorCode.INTERNAL, "Failed to encode domain-metadata as JSON: " + e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
@@ -47,21 +47,24 @@ public final class DeltaPropertyMapper {
   private static final String FEATURE_SUPPORTED = "supported";
 
   /**
-   * Returns the stored UC property map formed by merging protocol-derived, domain-metadata-derived,
-   * and client-supplied entries. Client-supplied entries take precedence so callers can pin
-   * engine-managed values (e.g. row-tracking materialized column names) or override a derived value
-   * if needed.
+   * Returns the stored UC property map formed by layering client-supplied entries first, then
+   * overlaying protocol- and domain-metadata-derived entries on top. The structured {@code
+   * protocol} and {@code domain-metadata} blocks are the canonical source for the keys this method
+   * derives ({@code delta.feature.*}, {@code delta.clusteringColumns}, {@code
+   * delta.rowTracking.rowIdHighWaterMark}); a stray client property under those names cannot
+   * silently override the projection. Client-only properties (e.g. {@code
+   * delta.rowTracking.materializedRowIdColumnName}) flow through untouched.
    */
   public static Map<String, String> mergeDerivedWithClient(
       DeltaProtocol protocol,
       DomainMetadataUpdates domainMetadata,
       Map<String, String> clientProperties) {
     Map<String, String> merged = new HashMap<>();
-    deriveFromProtocol(merged, protocol);
-    deriveFromDomainMetadata(merged, domainMetadata);
     if (clientProperties != null) {
       merged.putAll(clientProperties);
     }
+    deriveFromProtocol(merged, protocol);
+    deriveFromDomainMetadata(merged, domainMetadata);
     return merged;
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
@@ -47,15 +47,15 @@ public final class DeltaPropertyMapper {
   private static final String FEATURE_SUPPORTED = "supported";
 
   /**
-   * Returns the stored UC property map formed by layering client-supplied entries first, then
-   * overlaying protocol- and domain-metadata-derived entries on top. The structured {@code
-   * protocol} and {@code domain-metadata} blocks are the canonical source for the keys this method
-   * derives ({@code delta.feature.*}, {@code delta.clusteringColumns}, {@code
+   * Builds the stored UC property map by layering client-supplied entries first, then overlaying
+   * protocol- and domain-metadata-derived entries on top. The structured {@code protocol} and
+   * {@code domain-metadata} blocks are the canonical source for the keys this method derives
+   * ({@code delta.feature.*}, {@code delta.clusteringColumns}, {@code
    * delta.rowTracking.rowIdHighWaterMark}); a stray client property under those names cannot
    * silently override the projection. Client-only properties (e.g. {@code
    * delta.rowTracking.materializedRowIdColumnName}) flow through untouched.
    */
-  public static Map<String, String> mergeDerivedWithClient(
+  public static Map<String, String> buildStoredProperties(
       DeltaProtocol protocol,
       DomainMetadataUpdates domainMetadata,
       Map<String, String> clientProperties) {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.service.delta;
 
 import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.TABLE;
@@ -17,6 +18,7 @@ import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.delta.model.CatalogConfig;
 import io.unitycatalog.server.delta.model.CreateStagingTableRequest;
+import io.unitycatalog.server.delta.model.CreateTableRequest;
 import io.unitycatalog.server.delta.model.CredentialOperation;
 import io.unitycatalog.server.delta.model.CredentialsResponse;
 import io.unitycatalog.server.delta.model.LoadTableResponse;
@@ -25,6 +27,7 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.DeltaRestExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.CreateStagingTable;
+import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.StagingTableInfo;
 import io.unitycatalog.server.model.TemporaryCredentials;
 import io.unitycatalog.server.persist.CatalogRepository;
@@ -158,6 +161,28 @@ public class DeltaRestCatalogService extends AuthorizedService {
             stagingLocation,
             Set.of(CredentialContext.Privilege.SELECT, CredentialContext.Privilege.UPDATE));
     return DeltaStagingTableMapper.toStagingTableResponse(staging, credentials);
+  }
+
+  // ==================== Create Table API ====================
+
+  /**
+   * Create a Delta table. Both MANAGED and EXTERNAL are supported (at feature parity with the UC
+   * {@code TableService.createTable}). For MANAGED, the caller must have previously called {@code
+   * POST /staging-tables}, written the initial Delta commit at the returned staging location, and
+   * passes that same location back here. For EXTERNAL, the caller supplies any storage location
+   * they have rights on.
+   */
+  @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables")
+  @ProducesJson
+  @AuthorizeExpression(AuthorizeExpressions.CREATE_TABLE)
+  public LoadTableResponse createTable(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "location")
+          @AuthorizeKey(key = "table-type")
+          CreateTableRequest request) {
+    CreateTable createTable = DeltaCreateTableMapper.toCreateTable(catalog, schema, request);
+    return tableRepository.createTableForDelta(createTable);
   }
 
   // ==================== Table Credentials API ====================

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -172,6 +172,15 @@ public class DeltaRestCatalogService extends AuthorizedService {
    * POST /staging-tables}, written the initial Delta commit at the returned staging location, and
    * passes that same location back here. For EXTERNAL, the caller supplies any storage location
    * they have rights on.
+   *
+   * <p>OWNER is the createTable-caller in both branches, matching UC REST {@code
+   * TableService.createTable}. EXTERNAL wires it via the {@code
+   * initializeHierarchicalAuthorization} call below. MANAGED reuses the staging-table UUID's auth
+   * row (already wired by {@code createStagingTable} under the staging-creator); {@code
+   * commitStagingTable} additionally enforces {@code callerId == staging.createdBy}, so a
+   * different principal cannot finalize someone else's staging — the staging-creator and the
+   * createTable-caller are always the same identity. The cross-principal rejection is pinned by
+   * {@code SdkStagingTableAccessControlTest#testManagedTableCreationByDifferentUserShouldFail}.
    */
   @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables")
   @ProducesJson

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -23,6 +23,7 @@ import io.unitycatalog.server.delta.model.CredentialOperation;
 import io.unitycatalog.server.delta.model.CredentialsResponse;
 import io.unitycatalog.server.delta.model.LoadTableResponse;
 import io.unitycatalog.server.delta.model.StagingTableResponse;
+import io.unitycatalog.server.delta.model.TableType;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.DeltaRestExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
@@ -182,7 +183,16 @@ public class DeltaRestCatalogService extends AuthorizedService {
           @AuthorizeKey(key = "table-type")
           CreateTableRequest request) {
     CreateTable createTable = DeltaCreateTableMapper.toCreateTable(catalog, schema, request);
-    return tableRepository.createTableForDelta(createTable);
+    LoadTableResponse response = tableRepository.createTableForDelta(createTable);
+    // Wire the new table into the auth hierarchy under its schema (mirrors
+    // TableService.createTable). MANAGED tables reuse the staging-table UUID, whose auth row
+    // was already created in createStagingTable, so re-init is unnecessary there.
+    if (request.getTableType() == TableType.EXTERNAL) {
+      initializeHierarchicalAuthorization(
+          response.getMetadata().getTableUuid().toString(),
+          schemaRepository.getSchemaIdOrThrow(catalog, schema).toString());
+    }
+    return response;
   }
 
   // ==================== Table Credentials API ====================

--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.service.delta;
 
+import io.unitycatalog.server.delta.model.DeltaProtocol;
+import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableFeatureKind;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
@@ -7,6 +11,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * The UC catalog-managed Delta table contract: protocol versions, table features, and table
@@ -84,6 +90,184 @@ public final class UcManagedDeltaContract {
     props.put(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_ID_COLUMN_NAME, null);
     props.put(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME, null);
     return Collections.unmodifiableMap(props);
+  }
+
+  /**
+   * Validates that the supplied protocol, domain-metadata, and properties satisfy the contract:
+   *
+   * <ul>
+   *   <li>the protocol's reader-features are a subset of its writer-features (Delta-spec rule);
+   *   <li>protocol versions meet the required minimums;
+   *   <li>every required feature is present in the appropriate wire list;
+   *   <li>every declared domain-metadata entry is backed by the matching writer feature;
+   *   <li>every fixed-value required property equals the expected value;
+   *   <li>the UC table-id property is set;
+   *   <li>the engine-generated required properties are present with non-null values.
+   * </ul>
+   *
+   * <p>Apply only when the table is UC catalog-managed (i.e. MANAGED). EXTERNAL tables don't go
+   * through staging and don't carry this contract.
+   *
+   * <p>Designed to be called from {@link DeltaCreateTableMapper}, future update / commit mappers,
+   * and anywhere else that needs to assert "this state is a valid UC-managed Delta table state."
+   */
+  public static void validate(
+      DeltaProtocol protocol,
+      DomainMetadataUpdates domainMetadata,
+      Map<String, String> properties) {
+    Objects.requireNonNull(protocol, "protocol");
+    validateReaderFeatureSubset(protocol);
+    validateRequiredVersions(protocol);
+    validateRequiredFeatures(protocol);
+    validateDomainMetadataAgainstProtocol(protocol, domainMetadata);
+    validateRequiredProperties(properties != null ? properties : Map.of());
+  }
+
+  /**
+   * Pins the Delta-spec invariant that every entry in {@code reader-features} must also be in
+   * {@code writer-features}. Reader-writer features appear in both lists; writer-only features
+   * appear only in writer-features; there is no reader-only feature. A request that places a
+   * feature in {@code reader-features} but not {@code writer-features} would yield a stored
+   * protocol no Delta writer can honor.
+   */
+  private static void validateReaderFeatureSubset(DeltaProtocol protocol) {
+    List<String> readerFeatures = protocol.getReaderFeatures();
+    if (readerFeatures == null || readerFeatures.isEmpty()) return;
+    Set<String> writerFeatures =
+        protocol.getWriterFeatures() != null ? Set.copyOf(protocol.getWriterFeatures()) : Set.of();
+    for (String rf : readerFeatures) {
+      if (!writerFeatures.contains(rf)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "Feature '"
+                + rf
+                + "' is in reader-features but not writer-features. Per the Delta protocol, every"
+                + " reader-feature must also be a writer-feature.");
+      }
+    }
+  }
+
+  /**
+   * Cross-check the client's claim against UC's own state: {@code properties[UC_TABLE_ID]} must
+   * equal the UC-allocated UUID for the table being created or updated. The {@code expectedTableId}
+   * is the source of truth -- the staging table's UUID at create time, the existing table's UUID at
+   * update time. {@link #validate} only checks presence; this method checks identity.
+   */
+  public static void validateTableIdProperty(
+      Map<String, String> properties, String expectedTableId) {
+    Objects.requireNonNull(expectedTableId, "expectedTableId");
+    String actual = properties != null ? properties.get(TableProperties.UC_TABLE_ID) : null;
+    if (!expectedTableId.equals(actual)) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "Property %s (%s) does not match the table id (%s).",
+              TableProperties.UC_TABLE_ID, actual, expectedTableId));
+    }
+  }
+
+  private static void validateRequiredVersions(DeltaProtocol protocol) {
+    Integer minReader = protocol.getMinReaderVersion();
+    if (minReader == null || minReader < REQUIRED_MIN_READER_VERSION) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "MANAGED table minReaderVersion must be at least "
+              + REQUIRED_MIN_READER_VERSION
+              + " (got "
+              + minReader
+              + ").");
+    }
+    Integer minWriter = protocol.getMinWriterVersion();
+    if (minWriter == null || minWriter < REQUIRED_MIN_WRITER_VERSION) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "MANAGED table minWriterVersion must be at least "
+              + REQUIRED_MIN_WRITER_VERSION
+              + " (got "
+              + minWriter
+              + ").");
+    }
+  }
+
+  private static void validateRequiredFeatures(DeltaProtocol protocol) {
+    Set<String> readerFeatures =
+        Set.copyOf(protocol.getReaderFeatures() != null ? protocol.getReaderFeatures() : List.of());
+    Set<String> writerFeatures =
+        Set.copyOf(protocol.getWriterFeatures() != null ? protocol.getWriterFeatures() : List.of());
+    for (String required : REQUIRED_READER_FEATURES) {
+      if (!readerFeatures.contains(required)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "MANAGED table missing required reader-feature '" + required + "'.");
+      }
+    }
+    for (String required : REQUIRED_WRITER_FEATURES) {
+      if (!writerFeatures.contains(required)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "MANAGED table missing required writer-feature '" + required + "'.");
+      }
+    }
+  }
+
+  /**
+   * Validates that each declared domain-metadata entry is backed by the matching writer feature in
+   * the protocol. A {@code delta.clustering} entry requires the {@code clustering} feature; a
+   * {@code delta.rowTracking} entry requires the {@code rowTracking} feature. Null domain-metadata
+   * is permitted; null protocol is treated as "no writer features declared" so any non-null
+   * domain-metadata fails.
+   */
+  private static void validateDomainMetadataAgainstProtocol(
+      DeltaProtocol protocol, DomainMetadataUpdates domainMetadata) {
+    if (domainMetadata == null) return;
+    List<String> writerFeatures =
+        protocol.getWriterFeatures() != null ? protocol.getWriterFeatures() : List.of();
+    if (domainMetadata.getDeltaClustering() != null
+        && !writerFeatures.contains(TableFeature.CLUSTERING.specName())) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "domain-metadata.delta.clustering requires the '"
+              + TableFeature.CLUSTERING.specName()
+              + "' writer feature.");
+    }
+    if (domainMetadata.getDeltaRowTracking() != null
+        && !writerFeatures.contains(TableFeature.ROW_TRACKING.specName())) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "domain-metadata.delta.rowTracking requires the '"
+              + TableFeature.ROW_TRACKING.specName()
+              + "' writer feature.");
+    }
+  }
+
+  private static void validateRequiredProperties(Map<String, String> properties) {
+    for (Map.Entry<String, String> entry : REQUIRED_FIXED_PROPERTIES.entrySet()) {
+      String actual = properties.get(entry.getKey());
+      if (!entry.getValue().equals(actual)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "MANAGED table required property '"
+                + entry.getKey()
+                + "' must be '"
+                + entry.getValue()
+                + "' (got '"
+                + actual
+                + "').");
+      }
+    }
+    String tableId = properties.get(TableProperties.UC_TABLE_ID);
+    if (tableId == null || tableId.isBlank()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "MANAGED table required property '" + TableProperties.UC_TABLE_ID + "' is missing.");
+    }
+    for (String key : ENGINE_GENERATED_PROPERTY_KEYS) {
+      if (properties.get(key) == null) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "MANAGED table required property '" + key + "' must be set by the engine.");
+      }
+    }
   }
 
   /** Spec names of the {@link TableFeatureKind#READER_WRITER} subset, in declaration order. */

--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -7,11 +7,11 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableFeatureKind;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.utils.ValidationUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -115,7 +115,7 @@ public final class UcManagedDeltaContract {
       DeltaProtocol protocol,
       DomainMetadataUpdates domainMetadata,
       Map<String, String> properties) {
-    Objects.requireNonNull(protocol, "protocol");
+    ValidationUtils.checkNotNull(protocol, "protocol is required.");
     validateReaderFeatureSubset(protocol);
     validateRequiredVersions(protocol);
     validateRequiredFeatures(protocol);
@@ -155,7 +155,7 @@ public final class UcManagedDeltaContract {
    */
   public static void validateTableIdProperty(
       Map<String, String> properties, String expectedTableId) {
-    Objects.requireNonNull(expectedTableId, "expectedTableId");
+    ValidationUtils.checkNotNull(expectedTableId, "expectedTableId is required.");
     String actual = properties != null ? properties.get(TableProperties.UC_TABLE_ID) : null;
     if (!expectedTableId.equals(actual)) {
       throw new BaseException(

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -5,16 +5,23 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.delta.model.ArrayType;
+import io.unitycatalog.server.delta.model.DecimalType;
 import io.unitycatalog.server.delta.model.DeltaType;
 import io.unitycatalog.server.delta.model.MapType;
 import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructType;
 import io.unitycatalog.server.delta.serde.DeltaTypeModule;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.ColumnTypeName;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ColumnUtils {
 
@@ -147,6 +154,159 @@ public class ColumnUtils {
     } catch (JsonProcessingException e) {
       throw new IllegalStateException(
           "Failed to serialize typeJson for field " + field.getName(), e);
+    }
+  }
+
+  /**
+   * Convert a Delta REST Catalog {@link StructField} into a UC {@link ColumnInfo}, mirroring
+   * {@code UCSingleCatalog.createTable}'s per-column projection so DRC-created tables render
+   * identically to Spark-created ones.
+   *
+   * <p>Fields populated (matching UCSingleCatalog exactly):
+   * <ul>
+   *   <li>{@code name}, {@code nullable}, {@code position}
+   *   <li>{@code comment} -- only when present in {@code metadata.comment} (UCSingleCatalog
+   *       skips the setter when {@code field.getComment().isEmpty}); when absent the field is
+   *       left at its default {@code null}, which produces the same wire shape
+   *   <li>{@code typeJson} -- {@code field.dataType.json}, the Spark-format column spec
+   *   <li>{@code typeName} -- {@code convertDataTypeToTypeName(field.dataType)}
+   *   <li>{@code typeText} -- {@code field.dataType.catalogString}
+   * </ul>
+   *
+   * <p>Fields intentionally not populated (matching UCSingleCatalog):
+   * {@code typePrecision}, {@code typeScale}, {@code typeIntervalType}, {@code partitionIndex}
+   * ({@code partitionIndex} is stamped separately by {@link #applyPartitionColumns}).
+   */
+  public static ColumnInfo toColumnInfo(StructField field, int position) {
+    DeltaType type = field.getType();
+    ColumnInfo column =
+        new ColumnInfo()
+            .name(field.getName())
+            .nullable(Boolean.TRUE.equals(field.getNullable()))
+            .position(position)
+            .typeJson(toTypeJson(field))
+            .typeName(resolveColumnTypeName(type))
+            .typeText(toCatalogString(type));
+    String comment = extractComment(field);
+    if (comment != null) {
+      column.comment(comment);
+    }
+    return column;
+  }
+
+  /**
+   * Render a {@link DeltaType} as a Spark-style catalog string -- the same format produced by
+   * {@code org.apache.spark.sql.types.DataType#catalogString}. Primitives go through the shared
+   * {@link #typeNameVsTypeText} override map (so {@code long}→{@code bigint}, {@code
+   * integer}→{@code int}, etc.); decimals include precision/scale; array/map/struct recurse.
+   *
+   * @throws BaseException with {@code INVALID_ARGUMENT} if {@code type} (or any nested element /
+   *     key / value / field type) is an unsupported Delta primitive -- this method delegates the
+   *     primitive lookup to {@link #resolveColumnTypeName}, which throws on unknown names.
+   */
+  public static String toCatalogString(DeltaType type) {
+    if (type instanceof DecimalType d) {
+      return "decimal" + getPrecisionAndScale(d.getPrecision(), d.getScale());
+    }
+    if (type instanceof ArrayType a) {
+      return "array<" + toCatalogString(a.getElementType()) + ">";
+    }
+    if (type instanceof MapType m) {
+      return "map<" + toCatalogString(m.getKeyType()) + "," + toCatalogString(m.getValueType())
+          + ">";
+    }
+    if (type instanceof StructType s) {
+      List<StructField> fields = s.getFields() != null ? s.getFields() : List.of();
+      StringBuilder sb = new StringBuilder("struct<");
+      for (int i = 0; i < fields.size(); i++) {
+        if (i > 0) sb.append(",");
+        StructField f = fields.get(i);
+        sb.append(f.getName()).append(":").append(toCatalogString(f.getType()));
+      }
+      return sb.append(">").toString();
+    }
+    return getTypeText(resolveColumnTypeName(type));
+  }
+
+  private static String extractComment(StructField field) {
+    Map<String, Object> metadata = field.getMetadata();
+    if (metadata == null) return null;
+    Object comment = metadata.get("comment");
+    return comment instanceof String s ? s : null;
+  }
+
+  private static ColumnTypeName resolveColumnTypeName(DeltaType type) {
+    if (type instanceof ArrayType) return ColumnTypeName.ARRAY;
+    if (type instanceof DecimalType) return ColumnTypeName.DECIMAL;
+    if (type instanceof MapType) return ColumnTypeName.MAP;
+    if (type instanceof StructType) return ColumnTypeName.STRUCT;
+    // PrimitiveType: the discriminator string IS the primitive name. The accepted set is the
+    // closed list of Delta-protocol primitives -- Kernel's BasePrimitiveType registry. Reject
+    // with INVALID_ARGUMENT for anything else; the server-side ColumnTypeName enum has no
+    // UNKNOWN_DEFAULT_OPEN_API sentinel (OpenAPI generator adds it only for clients).
+    //
+    // Not handled, and why:
+    //   - INTERVAL: not a Delta primitive.
+    //   - NULL ("void" in Spark JSON): UCSingleCatalog has a NullType branch because it runs
+    //     upstream of Delta's NullType-drop -- a user's CREATE TABLE can carry NullType and UC
+    //     stores it before Delta strips it on write (SchemaUtils.dropNullTypeColumns). DRC runs
+    //     downstream: Spark-Delta clients have already dropped NullType before sending, and
+    //     Kernel rejects "void" on read (DataTypeJsonSerDe.voidTypeEncountered). No conforming
+    //     Delta wire payload contains it.
+    //   - CHAR / UDT: Spark's Delta writer normalizes CHAR/VARCHAR to STRING (via
+    //     CharVarcharUtils) and unwraps UDTs to their underlying sqlType before persisting, so
+    //     DRC clients never send "char(n)" or {"type":"udt",...}.
+    //   - TABLE_TYPE: UC-internal (foreign tables); doesn't flow over the Delta wire.
+    String primitive = type.getType();
+    return switch (primitive) {
+      case "boolean" -> ColumnTypeName.BOOLEAN;
+      case "byte" -> ColumnTypeName.BYTE;
+      case "short" -> ColumnTypeName.SHORT;
+      case "integer" -> ColumnTypeName.INT;
+      case "long" -> ColumnTypeName.LONG;
+      case "float" -> ColumnTypeName.FLOAT;
+      case "double" -> ColumnTypeName.DOUBLE;
+      case "date" -> ColumnTypeName.DATE;
+      case "timestamp" -> ColumnTypeName.TIMESTAMP;
+      case "timestamp_ntz" -> ColumnTypeName.TIMESTAMP_NTZ;
+      case "string" -> ColumnTypeName.STRING;
+      case "binary" -> ColumnTypeName.BINARY;
+      case "variant" -> ColumnTypeName.VARIANT;
+      default ->
+          throw new BaseException(
+              ErrorCode.INVALID_ARGUMENT, "Unsupported Delta primitive type: " + primitive);
+    };
+  }
+
+  /**
+   * Stamp each {@link ColumnInfo} whose name appears in {@code partitionColumns} with its
+   * partition index (the position within {@code partitionColumns}). Throws {@code INVALID_ARGUMENT}
+   * at the first partition-column name that does not match any column in {@code columns}.
+   *
+   * <p>The input {@code columns} list is mutated in place. Designed to be shared between the
+   * Delta REST Catalog create and update/commit paths -- both take a kebab-case {@code
+   * partition-columns} list of names from the wire and project it onto UC's
+   * partition-index-per-column representation (only create is wired up today).
+   *
+   * <p>Runs in {@code O(|columns| + |partitionColumns|)}: builds a name → ColumnInfo lookup once,
+   * then walks {@code partitionColumns} stamping indices and rejecting unknown names inline.
+   */
+  public static void applyPartitionColumns(
+      List<ColumnInfo> columns, List<String> partitionColumns) {
+    if (partitionColumns == null || partitionColumns.isEmpty()) {
+      return;
+    }
+    Map<String, ColumnInfo> columnsByName =
+        columns.stream().collect(Collectors.toMap(ColumnInfo::getName, Function.identity()));
+    for (int i = 0; i < partitionColumns.size(); i++) {
+      String partName = partitionColumns.get(i);
+      ColumnInfo match = columnsByName.get(partName);
+      if (match == null) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "partition-columns references unknown column: " + partName);
+      }
+      match.setPartitionIndex(i);
     }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -159,7 +159,7 @@ public class ColumnUtils {
 
   /**
    * Convert a Delta REST Catalog {@link StructField} into a UC {@link ColumnInfo}, mirroring
-   * {@code UCSingleCatalog.createTable}'s per-column projection so DRC-created tables render
+   * {@code UCSingleCatalog.createTable}'s per-column projection so Delta-created tables render
    * identically to Spark-created ones.
    *
    * <p>Fields populated (matching UCSingleCatalog exactly):
@@ -249,13 +249,13 @@ public class ColumnUtils {
     //   - INTERVAL: not a Delta primitive.
     //   - NULL ("void" in Spark JSON): UCSingleCatalog has a NullType branch because it runs
     //     upstream of Delta's NullType-drop -- a user's CREATE TABLE can carry NullType and UC
-    //     stores it before Delta strips it on write (SchemaUtils.dropNullTypeColumns). DRC runs
+    //     stores it before Delta strips it on write (SchemaUtils.dropNullTypeColumns). Delta runs
     //     downstream: Spark-Delta clients have already dropped NullType before sending, and
     //     Kernel rejects "void" on read (DataTypeJsonSerDe.voidTypeEncountered). No conforming
     //     Delta wire payload contains it.
     //   - CHAR / UDT: Spark's Delta writer normalizes CHAR/VARCHAR to STRING (via
     //     CharVarcharUtils) and unwraps UDTs to their underlying sqlType before persisting, so
-    //     DRC clients never send "char(n)" or {"type":"udt",...}.
+    //     Delta clients never send "char(n)" or {"type":"udt",...}.
     //   - TABLE_TYPE: UC-internal (foreign tables); doesn't flow over the Delta wire.
     String primitive = type.getType();
     return switch (primitive) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ValidationUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ValidationUtils.java
@@ -58,4 +58,22 @@ public class ValidationUtils {
           ErrorCode.INVALID_ARGUMENT, String.format(messageTemplate, messageArgs));
     }
   }
+
+  /**
+   * Checks that {@code value} is non-null. If null, throws a BaseException with INVALID_ARGUMENT
+   * error code and the specified message. Returns the (non-null) value, mirroring Guava's {@code
+   * Preconditions.checkNotNull}, so callers can write {@code Foo f = checkNotNull(...)} with the
+   * null-check inline.
+   *
+   * @param value the value to check
+   * @param message the exception message to use if {@code value} is null
+   * @return {@code value}, guaranteed non-null
+   * @throws BaseException with INVALID_ARGUMENT if {@code value} is null
+   */
+  public static <T> T checkNotNull(T value, String message) {
+    if (value == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, message);
+    }
+    return value;
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocatorTest.java
@@ -1,0 +1,70 @@
+package io.unitycatalog.server.auth.decorator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.server.model.SecurableType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizeKeyLocatorTest {
+
+  @Test
+  public void resourceKeyVariableNameUsesSecurableType() {
+    AuthorizeKeyLocator l =
+        AuthorizeKeyLocator.builder()
+            .source(AuthorizeKeyLocator.Source.PAYLOAD)
+            .type(Optional.of(SecurableType.EXTERNAL_LOCATION))
+            .key("location")
+            .build();
+    // For resource keys, the SpEL variable is always the securable's type name regardless of the
+    // payload lookup key. This lets DRC's kebab-case payload field "location" surface as the same
+    // #external_location variable that the snake_case "storage_location" key uses.
+    assertThat(l.getVariableName()).isEqualTo("external_location");
+  }
+
+  @Test
+  public void plainKeyVariableNameStripsPathPrefix() {
+    AuthorizeKeyLocator l =
+        AuthorizeKeyLocator.builder()
+            .source(AuthorizeKeyLocator.Source.PAYLOAD)
+            .type(Optional.empty())
+            .key("config.operation")
+            .build();
+    assertThat(l.getVariableName()).isEqualTo("operation");
+  }
+
+  @Test
+  public void plainKeyVariableNameMapsHyphensToUnderscores() {
+    // Kebab-case keys (DRC payload shape) must surface as valid SpEL identifiers — hyphens in the
+    // last path segment map to underscores. The payload lookup itself still uses the original key.
+    AuthorizeKeyLocator hyphen =
+        AuthorizeKeyLocator.builder()
+            .source(AuthorizeKeyLocator.Source.PAYLOAD)
+            .type(Optional.empty())
+            .key("table-type")
+            .build();
+    assertThat(hyphen.getVariableName()).isEqualTo("table_type");
+    assertThat(hyphen.getKey()).isEqualTo("table-type");
+
+    // Hyphens in nested path segments survive the prefix-strip + transform combo.
+    AuthorizeKeyLocator nested =
+        AuthorizeKeyLocator.builder()
+            .source(AuthorizeKeyLocator.Source.PAYLOAD)
+            .type(Optional.empty())
+            .key("outer.inner-field")
+            .build();
+    assertThat(nested.getVariableName()).isEqualTo("inner_field");
+  }
+
+  @Test
+  public void plainSnakeCaseKeyIsUnchanged() {
+    AuthorizeKeyLocator l =
+        AuthorizeKeyLocator.builder()
+            .source(AuthorizeKeyLocator.Source.PAYLOAD)
+            .type(Optional.empty())
+            .key("table_type")
+            .build();
+    // Existing snake_case keys keep their behavior — the hyphen→underscore transform is a no-op.
+    assertThat(l.getVariableName()).isEqualTo("table_type");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/decorator/AuthorizeKeyLocatorTest.java
@@ -17,7 +17,7 @@ public class AuthorizeKeyLocatorTest {
             .key("location")
             .build();
     // For resource keys, the SpEL variable is always the securable's type name regardless of the
-    // payload lookup key. This lets DRC's kebab-case payload field "location" surface as the same
+    // payload lookup key. This lets Delta's kebab-case payload field "location" surface as the same
     // #external_location variable that the snake_case "storage_location" key uses.
     assertThat(l.getVariableName()).isEqualTo("external_location");
   }
@@ -35,8 +35,9 @@ public class AuthorizeKeyLocatorTest {
 
   @Test
   public void plainKeyVariableNameMapsHyphensToUnderscores() {
-    // Kebab-case keys (DRC payload shape) must surface as valid SpEL identifiers — hyphens in the
-    // last path segment map to underscores. The payload lookup itself still uses the original key.
+    // Kebab-case keys (Delta payload shape) must surface as valid SpEL identifiers — hyphens in
+    // the last path segment map to underscores. The payload lookup itself still uses the original
+    // key.
     AuthorizeKeyLocator hyphen =
         AuthorizeKeyLocator.builder()
             .source(AuthorizeKeyLocator.Source.PAYLOAD)

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
@@ -22,8 +22,11 @@ import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,13 +93,15 @@ public class SdkDeltaCommitsAccessControlCRUDTest extends SdkAccessControlBaseCR
     StagingTableInfo stagingTableInfo = adminTablesApi.createStagingTable(createStagingTable);
 
     // Then, create the managed table using the staging location
+    Map<String, String> properties = new HashMap<>(TestUtils.PROPERTIES);
+    properties.put(TableProperties.UC_TABLE_ID, stagingTableInfo.getId());
     CreateTable createTable =
         new CreateTable()
             .name(TestUtils.TABLE_NAME)
             .catalogName(TestUtils.CATALOG_NAME)
             .schemaName(TestUtils.SCHEMA_NAME)
             .columns(COLUMNS)
-            .properties(TestUtils.PROPERTIES)
+            .properties(properties)
             .comment(TestUtils.COMMENT)
             .storageLocation(stagingTableInfo.getStagingLocation())
             .tableType(TableType.MANAGED)

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
@@ -21,8 +21,10 @@ import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.persist.model.Privileges;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -194,6 +196,7 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
             .tableType(TableType.MANAGED)
             .dataSourceFormat(DataSourceFormat.DELTA)
             .storageLocation(stagingTableInfo.getStagingLocation())
+            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId()))
             .comment("Table created by different user - should fail");
 
     // This by user B should fail with PERMISSION_DENIED and a message identifying the check.

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -7,8 +7,14 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.SchemasApi;
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CreateTableRequest;
 import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.PrimitiveType;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.DataSourceFormat;
@@ -19,6 +25,8 @@ import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -216,6 +224,47 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
             .dataSourceFormat(DataSourceFormat.DELTA);
     TableInfo tableRg2Info = regular2TablesApi.createTable(createTableRg2);
     assertThat(tableRg2Info).isNotNull();
+
+    // Delta createTable for an EXTERNAL table must wire the new table into the auth
+    // hierarchy (mirrors TableService.createTable). regular-1 has only USE_CATALOG, USE_SCHEMA,
+    // CREATE_TABLE -- under GET_TABLE the only OR-branch this user can satisfy is the
+    // table-OWNER one, which only holds if initializeBasicAuthorization granted it. The
+    // subsequent loadTable proves the wiring. (MANAGED skips re-init: its UUID was already
+    // wired at createStagingTable time.)
+    String deltaExternalName = "tbl_delta_authz";
+    String deltaExternalLocation = "/tmp/" + deltaExternalName + "_" + UUID.randomUUID();
+    LoadTableResponse deltaCreated =
+        regular1DeltaApi.createTable(
+            "cat_pr1",
+            "sch_pr1",
+            new CreateTableRequest()
+                .name(deltaExternalName)
+                .location(deltaExternalLocation)
+                .tableType(io.unitycatalog.client.delta.model.TableType.EXTERNAL)
+                .dataSourceFormat(io.unitycatalog.client.delta.model.DataSourceFormat.DELTA)
+                .columns(
+                    new StructType()
+                        .type("struct")
+                        .fields(
+                            List.of(
+                                new StructField()
+                                    .name("id")
+                                    .type(new PrimitiveType().type("long"))
+                                    .nullable(false)
+                                    .metadata(Map.of()))))
+                .protocol(
+                    new DeltaProtocol()
+                        .minReaderVersion(3)
+                        .minWriterVersion(7)
+                        .readerFeatures(List.of("deletionVectors"))
+                        .writerFeatures(List.of("deletionVectors")))
+                .properties(Map.of("delta.enableDeletionVectors", "true")));
+    assertThat(
+            regular1DeltaApi
+                .loadTable("cat_pr1", "sch_pr1", deltaExternalName)
+                .getMetadata()
+                .getTableUuid())
+        .isEqualTo(deltaCreated.getMetadata().getTableUuid());
 
     // delete table (regular-1) -> -- -> denied
     assertPermissionDenied(() -> regular1TablesApi.deleteTable("cat_pr1.sch_rg2.tab_rg2"));

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -288,8 +288,6 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
   private static Map<String, String> fullManagedProperties(String tableId) {
     Map<String, String> props = new java.util.HashMap<>();
     props.put(TableProperties.CHECKPOINT_POLICY, "v2");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, tableId);

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -1,0 +1,350 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
+import io.unitycatalog.client.delta.model.CreateTableRequest;
+import io.unitycatalog.client.delta.model.DataSourceFormat;
+import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.client.delta.model.ErrorType;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.PrimitiveType;
+import io.unitycatalog.client.delta.model.StagingTableResponse;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructType;
+import io.unitycatalog.client.delta.model.TableType;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.server.base.BaseCRUDTestWithMockCredentials;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the Delta REST Catalog {@code POST /v1/.../tables} endpoint. Consolidated
+ * into one test with sections so the server start + mock-cloud setup runs once. Covers both MANAGED
+ * (staging-finalize) and EXTERNAL flows plus the protocol / domain-metadata validation rules.
+ */
+public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
+
+  private TablesApi deltaTablesApi;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig serverConfig) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    deltaTablesApi = new TablesApi(TestUtils.createApiClient(serverConfig));
+    createS3Catalog();
+  }
+
+  @Test
+  public void testCreateTableEndpoint() throws ApiException {
+    // -------- MANAGED happy path: staging -> createTable -> LoadTableResponse --------
+    String tableName = "tbl_happy";
+    StagingTableResponse staging =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name(tableName));
+
+    LoadTableResponse resp =
+        deltaTablesApi.createTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            managedTableRequest(tableName, staging));
+
+    assertThat(resp.getMetadata()).isNotNull();
+    assertThat(resp.getMetadata().getTableType()).isEqualTo(TableType.MANAGED);
+    // Finalized table inherits the staging location and the UUID allocated at staging time.
+    assertThat(resp.getMetadata().getLocation()).isEqualTo(staging.getLocation());
+    assertThat(resp.getMetadata().getTableUuid()).isEqualTo(staging.getTableId());
+    assertThat(resp.getMetadata().getColumns().getFields())
+        .extracting(StructField::getName)
+        .containsExactly("id", "amount");
+    // Every feature in the request's protocol is mirrored as delta.feature.* = supported in the
+    // stored table properties (both reader- and writer-side features collapse to one key per
+    // feature name). Client-supplied properties from the request are preserved alongside.
+    assertThat(resp.getMetadata().getProperties())
+        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.DELETION_VECTORS.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.IN_COMMIT_TIMESTAMP.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.V2_CHECKPOINT.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.VACUUM_PROTOCOL_CHECK.specName()), "supported")
+        .containsEntry("delta.enableDeletionVectors", "true");
+
+    // -------- EXTERNAL happy path at a fresh (unregistered) storage path --------
+    String externalName = "tbl_external";
+    String externalLocation = "s3://test-bucket0/external-path/tbl_external";
+    LoadTableResponse extResp =
+        deltaTablesApi.createTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            externalTableRequest(externalName, externalLocation));
+    assertThat(extResp.getMetadata().getTableType()).isEqualTo(TableType.EXTERNAL);
+    assertThat(extResp.getMetadata().getLocation()).isEqualTo(externalLocation);
+
+    // -------- ICEBERG rejected --------
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_iceberg", "s3://test-bucket0/unused")
+                    .dataSourceFormat(DataSourceFormat.ICEBERG)),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "Unsupported data-source-format");
+
+    // -------- name missing --------
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest(null, "s3://test-bucket0/unused")),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "Table name is required");
+
+    // -------- protocol missing --------
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_no_protocol", "s3://test-bucket0/unused").protocol(null)),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "protocol is required");
+
+    // -------- MANAGED without catalogManaged writer feature rejected --------
+    StagingTableResponse stagingNoCm =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_no_cm"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_no_cm", stagingNoCm)
+                    .protocol(
+                        new DeltaProtocol()
+                            .minReaderVersion(3)
+                            .minWriterVersion(7)
+                            .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
+                            // catalogManaged intentionally omitted.
+                            .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        TableFeature.CATALOG_MANAGED.specName());
+
+    // -------- domain-metadata without matching feature rejected --------
+    StagingTableResponse stagingDm =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_bad_domain"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_bad_domain", stagingDm)
+                    .domainMetadata(
+                        new DomainMetadataUpdates()
+                            .deltaClustering(
+                                new ClusteringDomainMetadata()
+                                    .clusteringColumns(List.of(List.of("id")))))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "'clustering' writer feature");
+
+    // -------- partition-columns referencing unknown column --------
+    StagingTableResponse stagingForBadPart =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_bad_part"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_bad_part", stagingForBadPart)
+                    .partitionColumns(List.of("nope"))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "partition-columns references unknown column: nope");
+
+    // -------- UC_TABLE_ID property doesn't match the staging UUID --------
+    // Pins the cross-check at the repository layer: the staging-allocated UUID is the source of
+    // truth, and a request claiming a different UUID gets rejected. Without this, a buggy or
+    // malicious client could persist an internally-inconsistent UC table (UUID-A persisted, but
+    // properties[UC_TABLE_ID]=UUID-B) which downstream commits would only catch much later.
+    StagingTableResponse stagingForWrongId =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_wrong_id"));
+    java.util.Map<String, String> wrongIdProps =
+        new java.util.HashMap<>(
+            fullManagedProperties("00000000-0000-0000-0000-000000000000")); // not the staging UUID
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_wrong_id", stagingForWrongId).properties(wrongIdProps)),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        TableProperties.UC_TABLE_ID);
+
+    // -------- partition-columns happy case --------
+    StagingTableResponse stagingPart =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_part"));
+    LoadTableResponse partResp =
+        deltaTablesApi.createTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            managedTableRequest("tbl_part", stagingPart).partitionColumns(List.of("id")));
+    assertThat(partResp.getMetadata().getPartitionColumns()).containsExactly("id");
+  }
+
+  /** Creates a catalog + schema whose staging tables resolve under s3://test-bucket0/. */
+  @SneakyThrows
+  private void createS3Catalog() {
+    catalogOperations.createCatalog(
+        new CreateCatalog()
+            .name(TestUtils.CATALOG_NAME2)
+            .storageRoot("s3://test-bucket0/catalogs/drc"));
+    schemaOperations.createSchema(
+        new CreateSchema().name(TestUtils.SCHEMA_NAME2).catalogName(TestUtils.CATALOG_NAME2));
+  }
+
+  /** Canonical (id long, amount double) columns shared across requests. */
+  private static StructType simpleSchema() {
+    return new StructType()
+        .type("struct")
+        .fields(
+            List.of(
+                new StructField()
+                    .name("id")
+                    .type(new PrimitiveType().type("long"))
+                    .nullable(false)
+                    .metadata(Map.of()),
+                new StructField()
+                    .name("amount")
+                    .type(new PrimitiveType().type("double"))
+                    .nullable(true)
+                    .metadata(Map.of())));
+  }
+
+  /** Full UC catalog-managed protocol: every required feature in the right list. */
+  private static DeltaProtocol managedProtocol() {
+    return new DeltaProtocol()
+        .minReaderVersion(3)
+        .minWriterVersion(7)
+        .readerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+        .writerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.IN_COMMIT_TIMESTAMP.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName()));
+  }
+
+  /**
+   * Properties that satisfy the UC-managed contract (the staging response advertises these). The
+   * engine-generated values can be any non-null placeholder; UC just checks presence.
+   */
+  private static Map<String, String> fullManagedProperties(String tableId) {
+    Map<String, String> props = new java.util.HashMap<>();
+    props.put(TableProperties.CHECKPOINT_POLICY, "v2");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
+    props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
+    props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
+    props.put(TableProperties.UC_TABLE_ID, tableId);
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
+    return props;
+  }
+
+  /** Build a canonical MANAGED Delta table request bound to a freshly-allocated staging table. */
+  private static CreateTableRequest managedTableRequest(String name, StagingTableResponse staging) {
+    return new CreateTableRequest()
+        .name(name)
+        .location(staging.getLocation())
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(simpleSchema())
+        .protocol(managedProtocol())
+        .properties(fullManagedProperties(staging.getTableId().toString()));
+  }
+
+  /**
+   * Build a MANAGED request not tied to a staging response -- for tests that exercise pre-contract
+   * failure paths (missing required field, wrong format) where the staging UUID never gets read.
+   */
+  private static CreateTableRequest managedTableRequest(String name, String location) {
+    return new CreateTableRequest()
+        .name(name)
+        .location(location)
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(simpleSchema())
+        .protocol(managedProtocol())
+        .properties(fullManagedProperties("00000000-0000-0000-0000-000000000000"));
+  }
+
+  /** Build an EXTERNAL Delta table request at an arbitrary storage path. */
+  private static CreateTableRequest externalTableRequest(String name, String location) {
+    return new CreateTableRequest()
+        .name(name)
+        .location(location)
+        .tableType(TableType.EXTERNAL)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(simpleSchema())
+        // EXTERNAL tables don't require catalogManaged; use a minimal modern Delta protocol.
+        .protocol(
+            new DeltaProtocol()
+                .minReaderVersion(3)
+                .minWriterVersion(7)
+                .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
+                .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
+        .properties(Map.of("delta.enableDeletionVectors", "true"));
+  }
+
+  /** {@code delta.feature.<name>} for the stored UC property assertions. */
+  private static String featureKey(String feature) {
+    return TableProperties.FEATURE_PREFIX + feature;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -13,6 +13,7 @@ import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.ErrorType;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 import io.unitycatalog.client.delta.model.PrimitiveType;
+import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StructField;
 import io.unitycatalog.client.delta.model.StructType;
@@ -88,12 +89,20 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     // Every feature in the request's protocol is mirrored as delta.feature.* = supported in the
     // stored table properties (both reader- and writer-side features collapse to one key per
     // feature name). Client-supplied properties from the request are preserved alongside.
+    //
+    // The catalogManaged and clusteringColumns entries also pin the server-derived-wins
+    // precedence end-to-end. The request's client properties include
+    // "delta.feature.catalogManaged" = "client-override" and "delta.clusteringColumns" =
+    // "[[\"wrong\"]]"; the assertions below verify the protocol-derived "supported" and the
+    // domainMetadata-derived JSON encoding of clusteringColumns=[["id"]] override them.
     assertThat(resp.getMetadata().getProperties())
         .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.CLUSTERING.specName()), "supported")
         .containsEntry(featureKey(TableFeature.DELETION_VECTORS.specName()), "supported")
         .containsEntry(featureKey(TableFeature.IN_COMMIT_TIMESTAMP.specName()), "supported")
         .containsEntry(featureKey(TableFeature.V2_CHECKPOINT.specName()), "supported")
         .containsEntry(featureKey(TableFeature.VACUUM_PROTOCOL_CHECK.specName()), "supported")
+        .containsEntry(TableProperties.CLUSTERING_COLUMNS, "[[\"id\"]]")
         .containsEntry("delta.enableDeletionVectors", "true");
 
     // -------- EXTERNAL happy path at a fresh (unregistered) storage path --------
@@ -174,11 +183,10 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                 managedTableRequest("tbl_bad_domain", stagingDm)
                     .domainMetadata(
                         new DomainMetadataUpdates()
-                            .deltaClustering(
-                                new ClusteringDomainMetadata()
-                                    .clusteringColumns(List.of(List.of("id")))))),
+                            .deltaRowTracking(
+                                new RowTrackingDomainMetadata().rowIdHighWaterMark(100L)))),
         ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
-        "'clustering' writer feature");
+        "'rowTracking' writer feature");
 
     // -------- partition-columns referencing unknown column --------
     StagingTableResponse stagingForBadPart =
@@ -261,7 +269,11 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                     .metadata(Map.of())));
   }
 
-  /** Full UC catalog-managed protocol: every required feature in the right list. */
+  /**
+   * Full UC catalog-managed protocol: every required feature in the right list, plus CLUSTERING in
+   * writerFeatures so the canonical request can carry a {@code deltaClustering} domain-metadata
+   * block (see {@link #managedTableRequest(String, StagingTableResponse)}).
+   */
   private static DeltaProtocol managedProtocol() {
     return new DeltaProtocol()
         .minReaderVersion(3)
@@ -275,6 +287,7 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
         .writerFeatures(
             List.of(
                 TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.CLUSTERING.specName(),
                 TableFeature.DELETION_VECTORS.specName(),
                 TableFeature.IN_COMMIT_TIMESTAMP.specName(),
                 TableFeature.V2_CHECKPOINT.specName(),
@@ -293,6 +306,18 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     props.put(TableProperties.UC_TABLE_ID, tableId);
     props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
     props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
+    // User-specified properties under server-derived keys are overridden by the structured
+    // protocol/domain-metadata blocks. End-to-end override is pinned by the assertions on
+    // featureKey(CATALOG_MANAGED) and CLUSTERING_COLUMNS in testCreateTableEndpoint.
+    //   - delta.feature.catalogManaged: protocol-derived (CATALOG_MANAGED is in writerFeatures);
+    //     "client-override" loses to the derived "supported".
+    //   - delta.clusteringColumns: domain-metadata-derived (managedTableRequest carries a
+    //     deltaClustering block with clusteringColumns=[["id"]]); "[[\"wrong\"]]" loses to the
+    //     derived JSON encoding of the structured block.
+    props.put(
+        TableProperties.FEATURE_PREFIX + TableFeature.CATALOG_MANAGED.specName(),
+        "client-override");
+    props.put(TableProperties.CLUSTERING_COLUMNS, "[[\"wrong\"]]");
     return props;
   }
 
@@ -305,6 +330,10 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
         .dataSourceFormat(DataSourceFormat.DELTA)
         .columns(simpleSchema())
         .protocol(managedProtocol())
+        .domainMetadata(
+            new DomainMetadataUpdates()
+                .deltaClustering(
+                    new ClusteringDomainMetadata().clusteringColumns(List.of(List.of("id")))))
         .properties(fullManagedProperties(staging.getTableId().toString()));
   }
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/managedlocation/SdkManagedLocationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/managedlocation/SdkManagedLocationTest.java
@@ -31,8 +31,10 @@ import io.unitycatalog.server.sdk.models.SdkModelOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.sdk.volume.SdkVolumeOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.TestUtils;
+import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -111,7 +113,8 @@ public class SdkManagedLocationTest extends BaseManagedLocationTest {
             .name(TABLE_NAME)
             .dataSourceFormat(DataSourceFormat.DELTA)
             .tableType(TableType.MANAGED)
-            .storageLocation(stagingTableInfo.getStagingLocation()));
+            .storageLocation(stagingTableInfo.getStagingLocation())
+            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId())));
     tablesApi.deleteTable(TABLE_FULL_NAME);
 
     VolumeInfo externalVolumeInfo = volumeOperations.createVolume(createExternalVolume);

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -23,9 +23,11 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.Session;
@@ -170,6 +172,7 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             .tableType(TableType.MANAGED)
             .dataSourceFormat(DataSourceFormat.DELTA)
             .storageLocation(stagingTableInfo.getStagingLocation())
+            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId()))
             .comment("Table created from staging location");
 
     TableInfo tableInfo = localTablesApi.createTable(createTableRequest);
@@ -246,7 +249,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             .columns(columns)
             .tableType(TableType.MANAGED)
             .dataSourceFormat(DataSourceFormat.DELTA)
-            .storageLocation(fakeStagingLocation);
+            .storageLocation(fakeStagingLocation)
+            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId()));
 
     // This should fail with NOT_FOUND
     assertThatExceptionOfType(ApiException.class)
@@ -305,7 +309,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             .columns(columns)
             .tableType(TableType.MANAGED)
             .dataSourceFormat(DataSourceFormat.DELTA)
-            .storageLocation(stagingTableInfo.getStagingLocation());
+            .storageLocation(stagingTableInfo.getStagingLocation())
+            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId()));
     TableInfo tableInfo = localTablesApi.createTable(createTableRequest);
     assertThat(tableInfo).isNotNull();
     assertThat(tableInfo.getStorageLocation()).isEqualTo(stagingTableInfo.getStagingLocation());

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableOperations.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableOperations.java
@@ -9,7 +9,10 @@ import io.unitycatalog.client.model.StagingTableInfo;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,6 +35,16 @@ public class SdkTableOperations implements TableOperations {
               .name(createTableRequest.getName());
       StagingTableInfo stagingTableInfo = tablesApi.createStagingTable(createStagingTableRequest);
       createTableRequest.setStorageLocation(stagingTableInfo.getStagingLocation());
+      // MANAGED Delta tables must carry the staging UUID in properties[UC_TABLE_ID]; the server
+      // cross-checks this against the staging table's actual UUID to catch buggy/malicious
+      // clients claiming the wrong table id. The test helper injects it so individual test
+      // fixtures don't have to thread the staging UUID through manually.
+      Map<String, String> props =
+          createTableRequest.getProperties() != null
+              ? new HashMap<>(createTableRequest.getProperties())
+              : new HashMap<>();
+      props.put(TableProperties.UC_TABLE_ID, stagingTableInfo.getId());
+      createTableRequest.setProperties(props);
     }
     return tablesApi.createTable(createTableRequest);
   }

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -1,0 +1,157 @@
+package io.unitycatalog.server.service.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.delta.model.CreateTableRequest;
+import io.unitycatalog.server.delta.model.DataSourceFormat;
+import io.unitycatalog.server.delta.model.DeltaProtocol;
+import io.unitycatalog.server.delta.model.PrimitiveType;
+import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructType;
+import io.unitycatalog.server.delta.model.TableType;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.model.CreateTable;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mapper-boundary unit tests for {@link DeltaCreateTableMapper}. The validation rules and the
+ * property projections themselves are owned by {@link UcManagedDeltaContract} and {@link
+ * DeltaPropertyMapper}, and are tested in their respective test files. This file only pins the
+ * orchestration the mapper itself adds: end-to-end request → CreateTable shape, the MANAGED-only
+ * contract gate, and the DELTA-only format gate.
+ */
+public class DeltaCreateTableMapperTest {
+
+  @Test
+  public void happyPathManagedBuildsCreateTable() {
+    CreateTable created = DeltaCreateTableMapper.toCreateTable("cat", "sch", baseManagedRequest());
+
+    assertThat(created.getName()).isEqualTo("tbl");
+    assertThat(created.getCatalogName()).isEqualTo("cat");
+    assertThat(created.getSchemaName()).isEqualTo("sch");
+    assertThat(created.getTableType()).isEqualTo(io.unitycatalog.server.model.TableType.MANAGED);
+    assertThat(created.getDataSourceFormat())
+        .isEqualTo(io.unitycatalog.server.model.DataSourceFormat.DELTA);
+    assertThat(created.getStorageLocation()).isEqualTo("s3://b/p");
+    assertThat(created.getColumns()).hasSize(1);
+    assertThat(created.getColumns().get(0).getName()).isEqualTo("id");
+    // Confirms the DeltaPropertyMapper merge ran end-to-end: a derived feature property and a
+    // client-supplied property both land in the merged map.
+    assertThat(created.getProperties())
+        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported")
+        .containsEntry(TableProperties.UC_TABLE_ID, "uuid-x");
+  }
+
+  @Test
+  public void externalTableSkipsUcManagedContract() {
+    // Pins the MANAGED-only gate: an EXTERNAL request that would fail UcManagedDeltaContract
+    // (missing catalogManaged, empty properties) succeeds because the gate routes around it.
+    CreateTableRequest req =
+        baseExternalRequest()
+            .protocol(
+                new DeltaProtocol()
+                    .minReaderVersion(3)
+                    .minWriterVersion(7)
+                    .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
+                    .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
+            .properties(Map.of());
+
+    CreateTable created = DeltaCreateTableMapper.toCreateTable("cat", "sch", req);
+    assertThat(created.getTableType()).isEqualTo(io.unitycatalog.server.model.TableType.EXTERNAL);
+  }
+
+  @Test
+  public void unsupportedDataSourceFormatRejected() {
+    // Use EXTERNAL so the contract gate doesn't fire first; the format gate is what's under test.
+    CreateTableRequest req = baseExternalRequest().dataSourceFormat(DataSourceFormat.ICEBERG);
+    assertThatThrownBy(() -> DeltaCreateTableMapper.toCreateTable("cat", "sch", req))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("Unsupported data-source-format");
+  }
+
+  // --- fixtures ---
+
+  /** A canonical fully-compliant MANAGED createTable request. */
+  private static CreateTableRequest baseManagedRequest() {
+    return new CreateTableRequest()
+        .name("tbl")
+        .location("s3://b/p")
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(simpleColumns())
+        .protocol(managedProtocol())
+        .properties(fullManagedProperties("uuid-x"));
+  }
+
+  /** A minimal EXTERNAL createTable request (UC mirrors whatever the client sends). */
+  private static CreateTableRequest baseExternalRequest() {
+    return new CreateTableRequest()
+        .name("tbl")
+        .location("s3://b/p")
+        .tableType(TableType.EXTERNAL)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(simpleColumns())
+        .protocol(
+            new DeltaProtocol()
+                .minReaderVersion(3)
+                .minWriterVersion(7)
+                .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
+                .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
+        .properties(Map.of());
+  }
+
+  private static StructType simpleColumns() {
+    return new StructType()
+        .type("struct")
+        .fields(
+            List.of(
+                new StructField()
+                    .name("id")
+                    .type(new PrimitiveType().type("long"))
+                    .nullable(false)
+                    .metadata(Map.of())));
+  }
+
+  private static DeltaProtocol managedProtocol() {
+    return new DeltaProtocol()
+        .minReaderVersion(3)
+        .minWriterVersion(7)
+        .readerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+        .writerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName(),
+                TableFeature.IN_COMMIT_TIMESTAMP.specName()));
+  }
+
+  private static Map<String, String> fullManagedProperties(String tableId) {
+    Map<String, String> props = new HashMap<>();
+    props.put(TableProperties.CHECKPOINT_POLICY, "v2");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
+    props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
+    props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
+    props.put(TableProperties.UC_TABLE_ID, tableId);
+    // Engine-generated values: any non-null placeholder satisfies the contract.
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
+    return props;
+  }
+
+  private static String featureKey(String feature) {
+    return TableProperties.FEATURE_PREFIX + feature;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -140,8 +140,6 @@ public class DeltaCreateTableMapperTest {
   private static Map<String, String> fullManagedProperties(String tableId) {
     Map<String, String> props = new HashMap<>();
     props.put(TableProperties.CHECKPOINT_POLICY, "v2");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, tableId);

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -1,0 +1,163 @@
+package io.unitycatalog.server.service.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.server.delta.model.DeltaProtocol;
+import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.server.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DeltaPropertyMapper}. This class is shared by create, update, and commit
+ * endpoints, so its wire-format projections and consistency rules are pinned here directly rather
+ * than only indirectly through one endpoint's integration tests.
+ */
+public class DeltaPropertyMapperTest {
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  // ---------- deriveFromProtocol ----------
+
+  @Test
+  public void deriveFromProtocolProducesFeaturePropertiesFromWriterFeatures() {
+    // Per the Delta spec, every reader-feature must also be a writer-feature, so the writer
+    // list is the superset. The mapper iterates writer-features only and that's sufficient to
+    // emit a delta.feature.<name> entry for every spec-defined feature.
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            .readerFeatures(
+                List.of(
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName()))
+            .writerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.IN_COMMIT_TIMESTAMP.specName()));
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromProtocol(props, protocol);
+    assertThat(props)
+        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.DELETION_VECTORS.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.V2_CHECKPOINT.specName()), "supported")
+        .containsEntry(featureKey(TableFeature.IN_COMMIT_TIMESTAMP.specName()), "supported");
+  }
+
+  @Test
+  public void deriveFromProtocolNullIsNoop() {
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromProtocol(props, null);
+    assertThat(props).isEmpty();
+  }
+
+  @Test
+  public void deriveFromProtocolEmptyFeatureListsIsNoop() {
+    DeltaProtocol protocol = new DeltaProtocol().minReaderVersion(3).minWriterVersion(7);
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromProtocol(props, protocol);
+    assertThat(props).isEmpty();
+  }
+
+  // ---------- deriveFromDomainMetadata ----------
+
+  @Test
+  public void deriveFromDomainMetadataClusteringEncodesAsJsonArrayOfPaths() throws Exception {
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaClustering(
+                new ClusteringDomainMetadata()
+                    .clusteringColumns(List.of(List.of("id"), List.of("address", "city"))));
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromDomainMetadata(props, dm);
+    String json = props.get(TableProperties.CLUSTERING_COLUMNS);
+    JsonNode parsed = JSON.readTree(json);
+    // Nested paths stay as arrays -- don't collapse into dotted strings.
+    assertThat(parsed.isArray()).isTrue();
+    assertThat(parsed.size()).isEqualTo(2);
+    assertThat(parsed.get(0).get(0).asText()).isEqualTo("id");
+    assertThat(parsed.get(1).get(0).asText()).isEqualTo("address");
+    assertThat(parsed.get(1).get(1).asText()).isEqualTo("city");
+  }
+
+  @Test
+  public void deriveFromDomainMetadataRowTrackingEncodesHighWaterMark() {
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(42L));
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromDomainMetadata(props, dm);
+    assertThat(props).containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "42");
+  }
+
+  @Test
+  public void deriveFromDomainMetadataNullIsNoop() {
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromDomainMetadata(props, null);
+    assertThat(props).isEmpty();
+  }
+
+  @Test
+  public void deriveFromDomainMetadataOmitsUnsetEntries() {
+    // A DomainMetadataUpdates with neither clustering nor row-tracking fields set yields no
+    // properties. Pins the "only write properties for entries the client actually provided"
+    // contract for the shared derive API.
+    Map<String, String> props = new HashMap<>();
+    DeltaPropertyMapper.deriveFromDomainMetadata(props, new DomainMetadataUpdates());
+    assertThat(props).isEmpty();
+  }
+
+  // ---------- mergeDerivedWithClient ----------
+
+  @Test
+  public void mergeClientPropertiesWinOnConflict() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            .writerFeatures(List.of(TableFeature.CATALOG_MANAGED.specName()));
+    Map<String, String> client =
+        Map.of(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
+    Map<String, String> merged = DeltaPropertyMapper.mergeDerivedWithClient(protocol, null, client);
+    // Client value wins -- callers can pin engine-managed values or override defaults.
+    assertThat(merged)
+        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
+  }
+
+  @Test
+  public void mergeTolerantOfAllNulls() {
+    assertThat(DeltaPropertyMapper.mergeDerivedWithClient(null, null, null)).isEmpty();
+  }
+
+  @Test
+  public void mergeCombinesProtocolDomainMetadataAndClient() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            .writerFeatures(List.of(TableFeature.ROW_TRACKING.specName()));
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(100L));
+    Map<String, String> client = Map.of("custom.key", "custom.value");
+    Map<String, String> merged = DeltaPropertyMapper.mergeDerivedWithClient(protocol, dm, client);
+    assertThat(merged)
+        .containsEntry(featureKey(TableFeature.ROW_TRACKING.specName()), "supported")
+        .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "100")
+        .containsEntry("custom.key", "custom.value");
+  }
+
+  private static String featureKey(String feature) {
+    return TableProperties.FEATURE_PREFIX + feature;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -120,7 +120,7 @@ public class DeltaPropertyMapperTest {
   // ---------- mergeDerivedWithClient ----------
 
   @Test
-  public void mergeClientPropertiesWinOnConflict() {
+  public void mergeDerivedPropertiesWinOnConflict() {
     DeltaProtocol protocol =
         new DeltaProtocol()
             .minReaderVersion(3)
@@ -129,9 +129,10 @@ public class DeltaPropertyMapperTest {
     Map<String, String> client =
         Map.of(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
     Map<String, String> merged = DeltaPropertyMapper.mergeDerivedWithClient(protocol, null, client);
-    // Client value wins -- callers can pin engine-managed values or override defaults.
+    // Server-derived projection of the structured protocol block wins over a stray client entry
+    // under the same key, so the structured block remains the single source of truth.
     assertThat(merged)
-        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
+        .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -117,7 +117,7 @@ public class DeltaPropertyMapperTest {
     assertThat(props).isEmpty();
   }
 
-  // ---------- mergeDerivedWithClient ----------
+  // ---------- buildStoredProperties ----------
 
   @Test
   public void mergeDerivedPropertiesWinOnConflict() {
@@ -128,7 +128,7 @@ public class DeltaPropertyMapperTest {
             .writerFeatures(List.of(TableFeature.CATALOG_MANAGED.specName()));
     Map<String, String> client =
         Map.of(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
-    Map<String, String> merged = DeltaPropertyMapper.mergeDerivedWithClient(protocol, null, client);
+    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(protocol, null, client);
     // Server-derived projection of the structured protocol block wins over a stray client entry
     // under the same key, so the structured block remains the single source of truth.
     assertThat(merged)
@@ -137,7 +137,7 @@ public class DeltaPropertyMapperTest {
 
   @Test
   public void mergeTolerantOfAllNulls() {
-    assertThat(DeltaPropertyMapper.mergeDerivedWithClient(null, null, null)).isEmpty();
+    assertThat(DeltaPropertyMapper.buildStoredProperties(null, null, null)).isEmpty();
   }
 
   @Test
@@ -151,7 +151,7 @@ public class DeltaPropertyMapperTest {
         new DomainMetadataUpdates()
             .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(100L));
     Map<String, String> client = Map.of("custom.key", "custom.value");
-    Map<String, String> merged = DeltaPropertyMapper.mergeDerivedWithClient(protocol, dm, client);
+    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(protocol, dm, client);
     assertThat(merged)
         .containsEntry(featureKey(TableFeature.ROW_TRACKING.specName()), "supported")
         .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "100")

--- a/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
@@ -329,8 +329,6 @@ public class UcManagedDeltaContractTest {
   private static Map<String, String> fullProperties() {
     Map<String, String> props = new HashMap<>();
     props.put(TableProperties.CHECKPOINT_POLICY, "v2");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
-    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, UUID.randomUUID().toString());

--- a/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
@@ -1,0 +1,341 @@
+package io.unitycatalog.server.service.delta;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.server.delta.model.DeltaProtocol;
+import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.server.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.server.delta.model.StagingTableResponse;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.model.StagingTableInfo;
+import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UcManagedDeltaContract#validate} -- the contract that {@link
+ * DeltaStagingTableMapper} advertises and future create / update / commit endpoints check against.
+ * Tests are organized as: closed-loop happy path, then per-arm negative cases.
+ */
+public class UcManagedDeltaContractTest {
+
+  /**
+   * Closed loop: take the contract advertised by {@link DeltaStagingTableMapper} verbatim (echoed
+   * back as the createTable request would carry it), fill in non-null values for the
+   * engine-generated entries, and assert {@link UcManagedDeltaContract#validate} accepts. Pins that
+   * the producer (staging mapper) and consumer (contract validator) agree on what "satisfies the
+   * contract" means.
+   */
+  @Test
+  public void validateAcceptsTheAdvertisedContractRoundTrip() {
+    StagingTableResponse staging =
+        DeltaStagingTableMapper.toStagingTableResponse(sampleStagingInfo(), emptyCredentials());
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(staging.getRequiredProtocol().getMinReaderVersion())
+            .minWriterVersion(staging.getRequiredProtocol().getMinWriterVersion())
+            .readerFeatures(staging.getRequiredProtocol().getReaderFeatures())
+            .writerFeatures(staging.getRequiredProtocol().getWriterFeatures());
+    Map<String, String> properties = new HashMap<>();
+    staging
+        .getRequiredProperties()
+        .forEach((k, v) -> properties.put(k, v != null ? v : "engine-supplied"));
+    assertThatCode(() -> UcManagedDeltaContract.validate(protocol, null, properties))
+        .doesNotThrowAnyException();
+  }
+
+  // ---------- reader-features subset of writer-features ----------
+
+  @Test
+  public void validateRejectsReaderFeatureNotInWriterFeatures() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            .readerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+            // V2_CHECKPOINT is in reader-features but missing from writer-features.
+            .writerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.IN_COMMIT_TIMESTAMP.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()));
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(protocol, null, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableFeature.V2_CHECKPOINT.specName())
+        .hasMessageContaining("reader-features but not writer-features");
+  }
+
+  // ---------- versions ----------
+
+  @Test
+  public void validateRejectsBelowMinReaderVersion() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(2)
+            .minWriterVersion(7)
+            .readerFeatures(fullProtocol().getReaderFeatures())
+            .writerFeatures(fullProtocol().getWriterFeatures());
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(protocol, null, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("minReaderVersion must be at least 3");
+  }
+
+  @Test
+  public void validateRejectsBelowMinWriterVersion() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(6)
+            .readerFeatures(fullProtocol().getReaderFeatures())
+            .writerFeatures(fullProtocol().getWriterFeatures());
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(protocol, null, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("minWriterVersion must be at least 7");
+  }
+
+  // ---------- features ----------
+
+  @Test
+  public void validateRejectsMissingRequiredWriterFeature() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            .readerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+            // IN_COMMIT_TIMESTAMP intentionally missing.
+            .writerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()));
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(protocol, null, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(
+            "missing required writer-feature '"
+                + TableFeature.IN_COMMIT_TIMESTAMP.specName()
+                + "'");
+  }
+
+  @Test
+  public void validateRejectsMissingRequiredReaderFeature() {
+    DeltaProtocol protocol =
+        new DeltaProtocol()
+            .minReaderVersion(3)
+            .minWriterVersion(7)
+            // CATALOG_MANAGED intentionally missing from reader-features (it's a reader-writer
+            // feature, must appear in BOTH lists).
+            .readerFeatures(
+                List.of(
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+            .writerFeatures(
+                List.of(
+                    TableFeature.CATALOG_MANAGED.specName(),
+                    TableFeature.DELETION_VECTORS.specName(),
+                    TableFeature.IN_COMMIT_TIMESTAMP.specName(),
+                    TableFeature.V2_CHECKPOINT.specName(),
+                    TableFeature.VACUUM_PROTOCOL_CHECK.specName()));
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(protocol, null, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(
+            "missing required reader-feature '" + TableFeature.CATALOG_MANAGED.specName() + "'");
+  }
+
+  // ---------- domain-metadata vs feature consistency ----------
+
+  @Test
+  public void validateRejectsClusteringDomainMetadataWithoutClusteringFeature() {
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaClustering(
+                new ClusteringDomainMetadata().clusteringColumns(List.of(List.of("id"))));
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), dm, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("'" + TableFeature.CLUSTERING.specName() + "' writer feature");
+  }
+
+  @Test
+  public void validateRejectsRowTrackingDomainMetadataWithoutRowTrackingFeature() {
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(0L));
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), dm, fullProperties()))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("'" + TableFeature.ROW_TRACKING.specName() + "' writer feature");
+  }
+
+  @Test
+  public void validateAcceptsDomainMetadataWithMatchingFeatures() {
+    DeltaProtocol protocol =
+        fullProtocolWithExtraWriterFeatures(
+            TableFeature.CLUSTERING.specName(), TableFeature.ROW_TRACKING.specName());
+    DomainMetadataUpdates dm =
+        new DomainMetadataUpdates()
+            .deltaClustering(
+                new ClusteringDomainMetadata().clusteringColumns(List.of(List.of("id"))))
+            .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(7L));
+    assertThatCode(() -> UcManagedDeltaContract.validate(protocol, dm, fullProperties()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void validateAcceptsNullDomainMetadata() {
+    assertThatCode(() -> UcManagedDeltaContract.validate(fullProtocol(), null, fullProperties()))
+        .doesNotThrowAnyException();
+  }
+
+  // ---------- properties ----------
+
+  @Test
+  public void validateRejectsRequiredPropertyWithWrongValue() {
+    Map<String, String> props = fullProperties();
+    props.put(TableProperties.CHECKPOINT_POLICY, "v1"); // contract says v2
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), null, props))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.CHECKPOINT_POLICY)
+        .hasMessageContaining("'v2'")
+        .hasMessageContaining("'v1'");
+  }
+
+  @Test
+  public void validateRejectsMissingUcTableId() {
+    Map<String, String> props = fullProperties();
+    props.remove(TableProperties.UC_TABLE_ID);
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), null, props))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.UC_TABLE_ID);
+  }
+
+  @Test
+  public void validateRejectsBlankUcTableId() {
+    Map<String, String> props = fullProperties();
+    props.put(TableProperties.UC_TABLE_ID, "   ");
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), null, props))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.UC_TABLE_ID);
+  }
+
+  @Test
+  public void validateRejectsNullEngineGeneratedProperty() {
+    // The staging response delivers IN_COMMIT_TIMESTAMP_ENABLEMENT_* with null values; the client
+    // must compute and substitute. Echoing the null back is a contract violation.
+    Map<String, String> props = fullProperties();
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, null);
+    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), null, props))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
+  }
+
+  // ---------- validateTableIdProperty ----------
+
+  @Test
+  public void validateTableIdAcceptsMatching() {
+    String id = UUID.randomUUID().toString();
+    Map<String, String> props = Map.of(TableProperties.UC_TABLE_ID, id);
+    assertThatCode(() -> UcManagedDeltaContract.validateTableIdProperty(props, id))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void validateTableIdRejectsMismatch() {
+    String expected = UUID.randomUUID().toString();
+    String wrong = UUID.randomUUID().toString();
+    Map<String, String> props = Map.of(TableProperties.UC_TABLE_ID, wrong);
+    assertThatThrownBy(() -> UcManagedDeltaContract.validateTableIdProperty(props, expected))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.UC_TABLE_ID)
+        .hasMessageContaining(wrong)
+        .hasMessageContaining(expected);
+  }
+
+  @Test
+  public void validateTableIdRejectsMissingProperty() {
+    String expected = UUID.randomUUID().toString();
+    assertThatThrownBy(() -> UcManagedDeltaContract.validateTableIdProperty(Map.of(), expected))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.UC_TABLE_ID);
+  }
+
+  @Test
+  public void validateTableIdRejectsNullPropertiesMap() {
+    String expected = UUID.randomUUID().toString();
+    assertThatThrownBy(() -> UcManagedDeltaContract.validateTableIdProperty(null, expected))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining(TableProperties.UC_TABLE_ID);
+  }
+
+  // --- fixtures ---
+
+  private static StagingTableInfo sampleStagingInfo() {
+    return new StagingTableInfo()
+        .id(UUID.randomUUID().toString())
+        .stagingLocation("s3://bucket/staging/" + UUID.randomUUID())
+        .name("tbl")
+        .catalogName("cat")
+        .schemaName("sch");
+  }
+
+  private static TemporaryCredentials emptyCredentials() {
+    return new TemporaryCredentials();
+  }
+
+  private static DeltaProtocol fullProtocol() {
+    return new DeltaProtocol()
+        .minReaderVersion(3)
+        .minWriterVersion(7)
+        .readerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName()))
+        .writerFeatures(
+            List.of(
+                TableFeature.CATALOG_MANAGED.specName(),
+                TableFeature.DELETION_VECTORS.specName(),
+                TableFeature.IN_COMMIT_TIMESTAMP.specName(),
+                TableFeature.V2_CHECKPOINT.specName(),
+                TableFeature.VACUUM_PROTOCOL_CHECK.specName()));
+  }
+
+  /** Full UC-managed protocol plus extra writer-only features (e.g. clustering, rowTracking). */
+  private static DeltaProtocol fullProtocolWithExtraWriterFeatures(String... extraWriterFeatures) {
+    DeltaProtocol p = fullProtocol();
+    java.util.ArrayList<String> writers = new java.util.ArrayList<>(p.getWriterFeatures());
+    for (String f : extraWriterFeatures) writers.add(f);
+    return p.writerFeatures(writers);
+  }
+
+  private static Map<String, String> fullProperties() {
+    Map<String, String> props = new HashMap<>();
+    props.put(TableProperties.CHECKPOINT_POLICY, "v2");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_JSON, "false");
+    props.put(TableProperties.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true");
+    props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
+    props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
+    props.put(TableProperties.UC_TABLE_ID, UUID.randomUUID().toString());
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
+    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
+    return props;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -9,7 +9,12 @@ import io.unitycatalog.server.delta.model.MapType;
 import io.unitycatalog.server.delta.model.PrimitiveType;
 import io.unitycatalog.server.delta.model.StructField;
 import io.unitycatalog.server.delta.model.StructType;
+import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.ColumnTypeName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /** Tests for ColumnUtils.toStructField parsing typeJson into typed Delta StructField. */
@@ -140,47 +145,13 @@ public class ColumnUtilsTest {
 
   // ---------- Roundtrip (read camelCase -> write camelCase) ----------
 
+  /**
+   * One nested round-trip covers all three composite shapes (map, array, struct) plus a primitive
+   * leaf, the camelCase-not-kebab-case ser format, and structure preservation. Splitting per shape
+   * tests the same property four times.
+   */
   @Test
-  public void testRoundtripPrimitive() {
-    String typeJson = "{\"name\":\"id\",\"type\":\"long\"," + "\"nullable\":false,\"metadata\":{}}";
-    StructField f = ColumnUtils.toStructField(col("id", typeJson));
-    String written = ColumnUtils.toTypeJson(f);
-    assertThat(written).contains("\"type\":\"long\"");
-    assertThat(written).contains("\"name\":\"id\"");
-  }
-
-  @Test
-  public void testRoundtripArray() {
-    String typeJson =
-        "{\"name\":\"tags\",\"type\":{\"type\":\"array\","
-            + "\"elementType\":\"string\",\"containsNull\":true},"
-            + "\"nullable\":true,\"metadata\":{}}";
-    StructField f = ColumnUtils.toStructField(col("tags", typeJson));
-    String written = ColumnUtils.toTypeJson(f);
-    // Must serialize back to camelCase, not kebab-case
-    assertThat(written).contains("\"elementType\"");
-    assertThat(written).contains("\"containsNull\"");
-    assertThat(written).doesNotContain("\"element-type\"");
-    assertThat(written).doesNotContain("\"contains-null\"");
-  }
-
-  @Test
-  public void testRoundtripMap() {
-    String typeJson =
-        "{\"name\":\"m\",\"type\":{\"type\":\"map\","
-            + "\"keyType\":\"string\",\"valueType\":\"double\","
-            + "\"valueContainsNull\":false},"
-            + "\"nullable\":true,\"metadata\":{}}";
-    StructField f = ColumnUtils.toStructField(col("m", typeJson));
-    String written = ColumnUtils.toTypeJson(f);
-    assertThat(written).contains("\"keyType\"");
-    assertThat(written).contains("\"valueType\"");
-    assertThat(written).contains("\"valueContainsNull\"");
-    assertThat(written).doesNotContain("\"key-type\"");
-  }
-
-  @Test
-  public void testRoundtripNestedPreservesStructure() {
+  public void testRoundtripNestedPreservesCamelCaseAndStructure() {
     String typeJson =
         "{\"name\":\"data\",\"type\":{\"type\":\"map\","
             + "\"keyType\":\"string\","
@@ -193,7 +164,17 @@ public class ColumnUtilsTest {
             + "\"nullable\":true,\"metadata\":{}}";
     StructField f = ColumnUtils.toStructField(col("data", typeJson));
     String written = ColumnUtils.toTypeJson(f);
-    // Re-read and verify structure
+    // Wire format is camelCase, not kebab-case.
+    assertThat(written)
+        .contains("\"keyType\"")
+        .contains("\"valueType\"")
+        .contains("\"valueContainsNull\"")
+        .contains("\"elementType\"")
+        .contains("\"containsNull\"")
+        .doesNotContain("\"key-type\"")
+        .doesNotContain("\"element-type\"")
+        .doesNotContain("\"contains-null\"");
+    // Re-read and verify structure end-to-end.
     StructField f2 = ColumnUtils.toStructField(col("data", written));
     MapType mt = (MapType) f2.getType();
     ArrayType at = (ArrayType) mt.getValueType();
@@ -216,5 +197,209 @@ public class ColumnUtilsTest {
     assertThatThrownBy(() -> ColumnUtils.toStructField(col("bad", "not json")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Failed to parse");
+  }
+
+  // ---------- toColumnInfo (DRC StructField -> UC ColumnInfo) ----------
+
+  @Test
+  public void testToColumnInfoPrimitive() {
+    StructField field =
+        new StructField()
+            .name("id")
+            .type(new PrimitiveType().type("long"))
+            .nullable(false)
+            .metadata(Map.of());
+    ColumnInfo info = ColumnUtils.toColumnInfo(field, 0);
+    assertThat(info.getName()).isEqualTo("id");
+    assertThat(info.getNullable()).isFalse();
+    assertThat(info.getPosition()).isEqualTo(0);
+    assertThat(info.getTypeName()).isEqualTo(ColumnTypeName.LONG);
+    // LONG -> "bigint" via the SQL-style alias map.
+    assertThat(info.getTypeText()).isEqualTo("bigint");
+    assertThat(info.getTypeJson()).contains("\"type\":\"long\"");
+  }
+
+  @Test
+  public void testToColumnInfoDecimalPreservesPrecisionAndScale() {
+    StructField field =
+        new StructField()
+            .name("amount")
+            .type(new DecimalType().precision(10).scale(2))
+            .nullable(true)
+            .metadata(Map.of());
+    ColumnInfo info = ColumnUtils.toColumnInfo(field, 1);
+    assertThat(info.getTypeName()).isEqualTo(ColumnTypeName.DECIMAL);
+    // Precision/scale must reach typeText so DESCRIBE TABLE renders the right SQL type.
+    assertThat(info.getTypeText()).isEqualTo("decimal(10,2)");
+  }
+
+  @Test
+  public void testToColumnInfoComplex() {
+    StructField arr =
+        new StructField()
+            .name("tags")
+            .type(new ArrayType().type("array").elementType(new PrimitiveType().type("string")))
+            .nullable(true)
+            .metadata(Map.of());
+    ColumnInfo arrInfo = ColumnUtils.toColumnInfo(arr, 0);
+    assertThat(arrInfo.getTypeName()).isEqualTo(ColumnTypeName.ARRAY);
+    // typeText is the Spark catalogString-equivalent, recursively parameterized.
+    assertThat(arrInfo.getTypeText()).isEqualTo("array<string>");
+
+    StructField map =
+        new StructField()
+            .name("attrs")
+            .type(
+                new MapType()
+                    .type("map")
+                    .keyType(new PrimitiveType().type("string"))
+                    .valueType(new PrimitiveType().type("double")))
+            .nullable(true)
+            .metadata(Map.of());
+    ColumnInfo mapInfo = ColumnUtils.toColumnInfo(map, 0);
+    assertThat(mapInfo.getTypeName()).isEqualTo(ColumnTypeName.MAP);
+    assertThat(mapInfo.getTypeText()).isEqualTo("map<string,double>");
+
+    StructField struct =
+        new StructField()
+            .name("nested")
+            .type(
+                new StructType()
+                    .type("struct")
+                    .fields(
+                        List.of(
+                            new StructField()
+                                .name("zip")
+                                .type(new PrimitiveType().type("integer"))
+                                .nullable(false)
+                                .metadata(Map.of()),
+                            new StructField()
+                                .name("city")
+                                .type(new PrimitiveType().type("string"))
+                                .nullable(true)
+                                .metadata(Map.of()))))
+            .nullable(true)
+            .metadata(Map.of());
+    ColumnInfo structInfo = ColumnUtils.toColumnInfo(struct, 0);
+    assertThat(structInfo.getTypeName()).isEqualTo(ColumnTypeName.STRUCT);
+    assertThat(structInfo.getTypeText()).isEqualTo("struct<zip:int,city:string>");
+  }
+
+  @Test
+  public void testToColumnInfoNestedCatalogString() {
+    // map<string, array<struct<v:double>>> -- the recursion composes the right way down.
+    StructField field =
+        new StructField()
+            .name("data")
+            .type(
+                new MapType()
+                    .type("map")
+                    .keyType(new PrimitiveType().type("string"))
+                    .valueType(
+                        new ArrayType()
+                            .type("array")
+                            .elementType(
+                                new StructType()
+                                    .type("struct")
+                                    .fields(
+                                        List.of(
+                                            new StructField()
+                                                .name("v")
+                                                .type(new PrimitiveType().type("double"))
+                                                .nullable(false)
+                                                .metadata(Map.of()))))))
+            .nullable(true)
+            .metadata(Map.of());
+    assertThat(ColumnUtils.toColumnInfo(field, 0).getTypeText())
+        .isEqualTo("map<string,array<struct<v:double>>>");
+  }
+
+  @Test
+  public void testToColumnInfoLiftsCommentFromMetadata() {
+    // Delta spec stores column comments in metadata.comment; UCSingleCatalog lifts them into
+    // ColumnInfo.comment via field.getComment(), and this mapper does the same so DESCRIBE
+    // renders the comment regardless of which client wrote the table.
+    StructField field =
+        new StructField()
+            .name("id")
+            .type(new PrimitiveType().type("long"))
+            .nullable(false)
+            .metadata(Map.of("comment", "primary key"));
+    assertThat(ColumnUtils.toColumnInfo(field, 0).getComment()).isEqualTo("primary key");
+  }
+
+  @Test
+  public void testToColumnInfoNoCommentWhenMetadataAbsentOrNonString() {
+    StructField noMeta =
+        new StructField()
+            .name("x")
+            .type(new PrimitiveType().type("long"))
+            .nullable(true)
+            .metadata(Map.of());
+    assertThat(ColumnUtils.toColumnInfo(noMeta, 0).getComment()).isNull();
+
+    StructField nonStringComment =
+        new StructField()
+            .name("y")
+            .type(new PrimitiveType().type("long"))
+            .nullable(true)
+            .metadata(Map.of("comment", 42));
+    // Non-string comment values (spec-invalid but tolerated) are ignored, not coerced.
+    assertThat(ColumnUtils.toColumnInfo(nonStringComment, 0).getComment()).isNull();
+  }
+
+  /**
+   * Both "void" (Spark's NullType wire form, which Spark Delta drops before persisting and Kernel
+   * rejects on read) and any other non-spec primitive must be rejected with a clean 400. The
+   * server-side {@code ColumnTypeName} enum has no {@code UNKNOWN_DEFAULT_OPEN_API} sentinel
+   * (OpenAPI generator adds it client-only), so the only safe answer is to reject.
+   */
+  @Test
+  public void testToColumnInfoRejectsUnsupportedPrimitives() {
+    for (String unsupported : List.of("void", "hyperdecimal")) {
+      StructField field =
+          new StructField()
+              .name("x")
+              .type(new PrimitiveType().type(unsupported))
+              .nullable(true)
+              .metadata(Map.of());
+      assertThatThrownBy(() -> ColumnUtils.toColumnInfo(field, 0))
+          .as("unsupported primitive: %s", unsupported)
+          .isInstanceOf(BaseException.class)
+          .hasMessageContaining("Unsupported Delta primitive type: " + unsupported);
+    }
+  }
+
+  // ---------- applyPartitionColumns ----------
+
+  @Test
+  public void testApplyPartitionColumnsStampsIndicesByName() {
+    List<ColumnInfo> columns =
+        new ArrayList<>(
+            List.of(
+                new ColumnInfo().name("id").position(0),
+                new ColumnInfo().name("region").position(1),
+                new ColumnInfo().name("date").position(2)));
+    // Order of the partition list is the partition-index order; not the column position.
+    ColumnUtils.applyPartitionColumns(columns, List.of("date", "region"));
+    assertThat(columns.get(0).getPartitionIndex()).isNull();
+    assertThat(columns.get(1).getPartitionIndex()).isEqualTo(1); // region -> index 1
+    assertThat(columns.get(2).getPartitionIndex()).isEqualTo(0); // date   -> index 0
+  }
+
+  @Test
+  public void testApplyPartitionColumnsNullAndEmptyAreNoOp() {
+    List<ColumnInfo> columns = new ArrayList<>(List.of(new ColumnInfo().name("id").position(0)));
+    ColumnUtils.applyPartitionColumns(columns, null);
+    ColumnUtils.applyPartitionColumns(columns, List.of());
+    assertThat(columns.get(0).getPartitionIndex()).isNull();
+  }
+
+  @Test
+  public void testApplyPartitionColumnsUnknownColumnRejected() {
+    List<ColumnInfo> columns = new ArrayList<>(List.of(new ColumnInfo().name("id").position(0)));
+    assertThatThrownBy(() -> ColumnUtils.applyPartitionColumns(columns, List.of("nope")))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("partition-columns references unknown column: nope");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -199,7 +199,7 @@ public class ColumnUtilsTest {
         .hasMessageContaining("Failed to parse");
   }
 
-  // ---------- toColumnInfo (DRC StructField -> UC ColumnInfo) ----------
+  // ---------- toColumnInfo (Delta StructField -> UC ColumnInfo) ----------
 
   @Test
   public void testToColumnInfoPrimitive() {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1516/files) to review incremental changes.
- [**stack/create_table**](https://github.com/unitycatalog/unitycatalog/pull/1516) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1516/files)]
  - [stack/create_table_last_ts](https://github.com/unitycatalog/unitycatalog/pull/1528) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1528/files/1b4f23bf314badedb5494ff53c1d38b5e23eb15d..f3c906d85402b43558503405f4aaf2d931c40c1b)]
  - [stack/create_table_tests](https://github.com/unitycatalog/unitycatalog/pull/1534) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1534/files/1b4f23bf314badedb5494ff53c1d38b5e23eb15d..65274357915c2ed117a7ace0adc7e9ceb9ade868)]
  - [stack/create_table_uniform](https://github.com/unitycatalog/unitycatalog/pull/1525) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1525/files/1b4f23bf314badedb5494ff53c1d38b5e23eb15d..cdd4b807aed94156712cd088f4dc710e59111322)]
    - stack/drc_update_table
  - [stack/not_supported_format](https://github.com/unitycatalog/unitycatalog/pull/1535) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1535/files/1b4f23bf314badedb5494ff53c1d38b5e23eb15d..74879e2f8a035c658f5b6ed957a552f855f4caff)]
  - stack/temp_path_cred
  - [stack/validate_columns](https://github.com/unitycatalog/unitycatalog/pull/1526) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1526/files/1b4f23bf314badedb5494ff53c1d38b5e23eb15d..4e6e9345b74524dbc1de0e7cdf14b01443eccd64)]
    - [stack/column_case_ins](https://github.com/unitycatalog/unitycatalog/pull/1537) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1537/files/4e6e9345b74524dbc1de0e7cdf14b01443eccd64..97c82cf53a398bd313deb60174de9d668208d03a)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
New endpoint for Delta: createTable

Adds POST /v1/catalogs/{catalog}/schemas/{schema}/tables at parity with UC REST TableService.createTable. MANAGED (finalize a staging table by location) and EXTERNAL flows are supported; DELTA is the only accepted data-source-format.

For MANAGED, UcManagedDeltaContract.validate enforces protocol versions, required features, reader-subset-of-writer, domain-metadata vs feature consistency, and required properties. validateTableIdProperty additionally pins properties[UC_TABLE_ID] to the staging-allocated UUID so a client cannot persist an internally-inconsistent table.

DeltaPropertyMapper projects protocol features (delta.feature.*) and domain-metadata (delta.clusteringColumns, delta.rowTracking.rowIdHighWaterMark) onto stored UC properties and may override client-supplied properties on conflict.

AuthorizeExpressions.CREATE_TABLE replaces the inlined SpEL on TableService.createTable so UC REST and DRC share one source of truth -- drift becomes a compile-time impossibility. AuthorizeKeyLocator.getVariableName maps hyphens to underscores so DRC's kebab-case table-type surfaces as the SpEL variable #table_type; snake_case keys are unaffected.

TableRepository.createTableForDelta returns LoadTableResponse in a single transaction, sharing the persisted DAO with buildLoadTableResponse (extracted from loadTableForDelta). Both create paths go through a generic createTableImpl helper. ColumnUtils gains toColumnInfo / toCatalogString / applyPartitionColumns for DRC StructField -> UC ColumnInfo.

It also tightens the existing UC REST POST /tables MANAGED path to require properties[delta.UCTableId]
