### PR TITLE
Remove clustered bytes numbers from metric reporting RPC.

### DIFF
--- a/api/delta-docs/Models/ReportMetricsRequest_report_commit_report.md
+++ b/api/delta-docs/Models/ReportMetricsRequest_report_commit_report.md
@@ -7,8 +7,6 @@
 | **num-bytes-added** | **Long** | Number of bytes added by this commit | [optional] [default to null] |
 | **num-files-removed** | **Long** | Number of files removed by this commit | [optional] [default to null] |
 | **num-bytes-removed** | **Long** | Number of bytes removed by this commit | [optional] [default to null] |
-| **num-clustered-bytes-added** | **Long** | Number of clustered bytes added by this commit | [optional] [default to null] |
-| **num-clustered-bytes-removed** | **Long** | Number of clustered bytes removed by this commit | [optional] [default to null] |
 | **num-rows-inserted** | **Long** | Number of rows inserted by this commit | [optional] [default to null] |
 | **num-rows-removed** | **Long** | Number of rows removed by this commit | [optional] [default to null] |
 | **num-rows-updated** | **Long** | Number of rows updated by this commit | [optional] [default to null] |

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1493,14 +1493,6 @@ components:
                   type: integer
                   format: int64
                   description: Number of bytes removed by this commit
-                num-clustered-bytes-added:
-                  type: integer
-                  format: int64
-                  description: Number of clustered bytes added by this commit
-                num-clustered-bytes-removed:
-                  type: integer
-                  format: int64
-                  description: Number of clustered bytes removed by this commit
                 num-rows-inserted:
                   type: integer
                   format: int64


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Remove clustered bytes numbers from metric reporting RPC.