### PR TITLE
Remove securable-type from delta.yaml. It's always TABLE for tables.

### DIFF
--- a/api/delta-docs/Models/TableMetadata.md
+++ b/api/delta-docs/Models/TableMetadata.md
@@ -10,7 +10,6 @@
 | **location** | **String** | Storage location of the table | [default to null] |
 | **created-time** | **Long** | Creation time in epoch milliseconds | [default to null] |
 | **updated-time** | **Long** | Last update time in epoch milliseconds | [default to null] |
-| **securable-type** | [**SecurableType**](SecurableType.md) |  | [default to null] |
 | **columns** | [**StructType**](StructType.md) |  | [default to null] |
 | **partition-columns** | **List** | Partition column names | [optional] [default to null] |
 | **properties** | **Map** | Table properties | [default to null] |

--- a/api/delta-docs/README.md
+++ b/api/delta-docs/README.md
@@ -56,7 +56,6 @@ All URIs are relative to *https://localhost:8080/api/2.1/unity-catalog*
  - [ReportMetricsRequest_report_commit_report](./Models/ReportMetricsRequest_report_commit_report.md)
  - [ReportMetricsRequest_report_commit_report_file_size_histogram](./Models/ReportMetricsRequest_report_commit_report_file_size_histogram.md)
  - [RowTrackingDomainMetadata](./Models/RowTrackingDomainMetadata.md)
- - [SecurableType](./Models/SecurableType.md)
  - [SetDomainMetadataUpdate](./Models/SetDomainMetadataUpdate.md)
  - [SetLatestBackfilledVersionUpdate](./Models/SetLatestBackfilledVersionUpdate.md)
  - [SetPartitionColumnsUpdate](./Models/SetPartitionColumnsUpdate.md)

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -579,14 +579,6 @@ components:
         - MANAGED
         - EXTERNAL
 
-    SecurableType:
-      type: string
-      description: The type of securable object.
-      enum:
-        - TABLE
-        - VIEW
-
-
     CredentialOperation:
       type: string
       description: |
@@ -875,8 +867,6 @@ components:
           type: integer
           format: int64
           description: Last update time in epoch milliseconds
-        securable-type:
-          $ref: '#/components/schemas/SecurableType'
         columns:
           $ref: '#/components/schemas/StructType'
         partition-columns:
@@ -905,7 +895,6 @@ components:
         - location
         - created-time
         - updated-time
-        - securable-type
         - columns
         - properties
 

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -394,7 +394,6 @@ public class TableRepository {
     metadata.setLocation(NormalizedURL.normalize(dao.getUrl()));
     metadata.setCreatedTime(dao.getCreatedAt() != null ? dao.getCreatedAt().getTime() : null);
     metadata.setUpdatedTime(dao.getUpdatedAt() != null ? dao.getUpdatedAt().getTime() : null);
-    metadata.setSecurableType(io.unitycatalog.server.delta.model.SecurableType.TABLE);
 
     // Columns -- best-effort; corrupt data should not fail the entire response
     StructType emptySchema = new StructType().fields(List.of());

--- a/server/src/test/resources/delta-model-test/load-table-response.json
+++ b/server/src/test/resources/delta-model-test/load-table-response.json
@@ -7,7 +7,6 @@
     "location": "s3://bucket/warehouse/catalog/schema/sales",
     "created-time": 1700000000000,
     "updated-time": 1700000100000,
-    "securable-type": "TABLE",
     "columns": {
       "type": "struct",
       "fields": [


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Remove securable-type from delta.yaml. It's always TABLE for tables.