### PR TITLE
fix: use bare raise to preserve exception traceback in AI toolkit integrations

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -390,7 +390,7 @@ class DatabricksFunctionClient(BaseFunctionClient):
                     "Specify a SQL body statement for defaults and use the create_function API "
                     "to define functions with default values."
                 ) from e
-            raise e
+            raise
 
     @retry_on_session_expiration
     @override

--- a/ai/integrations/anthropic/src/unitycatalog/ai/anthropic/toolkit.py
+++ b/ai/integrations/anthropic/src/unitycatalog/ai/anthropic/toolkit.py
@@ -109,7 +109,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         fn_schema = generate_function_input_params_schema(function_info)
 

--- a/ai/integrations/autogen/src/unitycatalog/ai/autogen/toolkit.py
+++ b/ai/integrations/autogen/src/unitycatalog/ai/autogen/toolkit.py
@@ -127,7 +127,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         # Use your existing logic to build a dynamic Pydantic model for input parameters
         function_input_params_schema = generate_function_input_params_schema(

--- a/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
+++ b/ai/integrations/crewai/src/unitycatalog/ai/crewai/toolkit.py
@@ -160,7 +160,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         def func(**kwargs: Any) -> str:
             args_json = json.loads(json.dumps(kwargs, default=str))

--- a/ai/integrations/dspy/src/unitycatalog/ai/dspy/toolkit.py
+++ b/ai/integrations/dspy/src/unitycatalog/ai/dspy/toolkit.py
@@ -152,7 +152,7 @@ class UCFunctionToolkit(BaseModel):
                 _logger.info(f"Skipping {function_name} due to permission errors.")
                 if filter_accessible_functions:
                     return None
-                raise e
+                raise
         elif function_info:
             function_name = function_info.full_name
         else:

--- a/ai/integrations/gemini/src/unitycatalog/ai/gemini/toolkit.py
+++ b/ai/integrations/gemini/src/unitycatalog/ai/gemini/toolkit.py
@@ -161,7 +161,7 @@ class UCFunctionToolkit(BaseModel):
                 _logger.info(f"Skipping {function_name} due to permission errors.")
                 if filter_accessible_functions:
                     return None
-                raise e
+                raise
         elif function_info:
             function_name = function_info.full_name
         else:

--- a/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
+++ b/ai/integrations/langchain/src/unitycatalog/ai/langchain/toolkit.py
@@ -91,7 +91,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         def func(*args: Any, **kwargs: Any) -> str:
             args_json = json.loads(json.dumps(kwargs, default=str))

--- a/ai/integrations/litellm/src/unitycatalog/ai/litellm/toolkit.py
+++ b/ai/integrations/litellm/src/unitycatalog/ai/litellm/toolkit.py
@@ -85,7 +85,7 @@ class UCFunctionToolkit(BaseModel):
                 _logger.info(f"Skipping {function_name} due to permission errors.")
                 if filter_accessible_functions:
                     return None
-                raise e
+                raise
         elif function_info:
             function_name = function_info.full_name
         else:

--- a/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
+++ b/ai/integrations/llama_index/src/unitycatalog/ai/llama_index/toolkit.py
@@ -162,7 +162,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         fn_schema = generate_function_input_params_schema(function_info)
 

--- a/ai/integrations/openai/src/unitycatalog/ai/openai/toolkit.py
+++ b/ai/integrations/openai/src/unitycatalog/ai/openai/toolkit.py
@@ -76,7 +76,7 @@ class UCFunctionToolkit(BaseModel):
             _logger.info(f"Skipping {function_name} due to permission errors.")
             if filter_accessible_functions:
                 return None
-            raise e
+            raise
 
         function_input_params_schema = generate_function_input_params_schema(
             function_info, strict=True


### PR DESCRIPTION
## Summary

Replaces `raise e` with bare `raise` across all 10 AI integration toolkit files.

**Why this matters:** Using `raise e` instead of bare `raise` resets the exception's `__traceback__`, causing stack traces to point to the re-raise site (the `raise e` line) rather than the original source of the exception. This makes debugging harder when a `PermissionError` is surfaced to the caller — the traceback doesn't show where the error actually originated.

## Affected files

- `ai/core/src/unitycatalog/ai/core/databricks.py`
- `ai/integrations/anthropic/.../toolkit.py`
- `ai/integrations/autogen/.../toolkit.py`
- `ai/integrations/crewai/.../toolkit.py`
- `ai/integrations/dspy/.../toolkit.py`
- `ai/integrations/gemini/.../toolkit.py`
- `ai/integrations/langchain/.../toolkit.py`
- `ai/integrations/litellm/.../toolkit.py`
- `ai/integrations/llama_index/.../toolkit.py`
- `ai/integrations/openai/.../toolkit.py`

## Change

```python
# Before
raise e

# After
raise
```

The exception object itself is unchanged — bare `raise` re-raises the same exception with its original traceback intact.