### PR TITLE
New endpoint for Delta: UniForm-Iceberg support for createTable

### DIFF
--- a/api/delta-docs/Models/CreateTableRequest.md
+++ b/api/delta-docs/Models/CreateTableRequest.md
@@ -13,6 +13,7 @@
 | **protocol** | [**DeltaProtocol**](DeltaProtocol.md) | Delta protocol version and feature requirements | [default to null] |
 | **properties** | **Map** | Delta table properties | [default to null] |
 | **domain-metadata** | [**DomainMetadataUpdates**](DomainMetadataUpdates.md) |  | [optional] [default to null] |
+| **uniform** | [**UniformMetadata**](UniformMetadata.md) | Optional UniForm conversion metadata. When present, the table is registered as UniForm-enabled, so readers can access it via either the Delta or Iceberg REST Catalog. The engine generates the Iceberg metadata file at the supplied metadata-location before calling createTable.  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -775,6 +775,13 @@ components:
             type: string
         domain-metadata:
           $ref: '#/components/schemas/DomainMetadataUpdates'
+        uniform:
+          $ref: '#/components/schemas/UniformMetadata'
+          description: |
+            Optional UniForm conversion metadata. When present, the table is registered as
+            UniForm-enabled, so readers can access it via either the Delta or Iceberg REST
+            Catalog. The engine generates the Iceberg metadata file at the supplied
+            metadata-location before calling createTable.
       required:
         - name
         - location

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -12,15 +12,14 @@ import io.unitycatalog.server.model.DeltaCommitMetadataProperties;
 import io.unitycatalog.server.model.DeltaGetCommits;
 import io.unitycatalog.server.model.DeltaGetCommitsResponse;
 import io.unitycatalog.server.model.DeltaMetadata;
-import io.unitycatalog.server.model.DeltaUniform;
-import io.unitycatalog.server.model.DeltaUniformIceberg;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.persist.utils.TransactionManager;
-import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.service.delta.DeltaUniformUtils;
+import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
 import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
@@ -87,12 +86,6 @@ public class DeltaCommitRepository {
    * configurable server property.
    */
   private static final int NUM_COMMITS_PER_BATCH = 20;
-
-  /** The maximum size of the JSON that contains the Delta-to-Iceberg conversion information */
-  public static final int MAX_DELTA_UNIFORM_ICEBERG_SIZE = 65535; // The limit from DAO
-
-  public static final String ICEBERG_FORMAT = "iceberg";
-  public static final String UNIFORM_ENABLED_FORMATS = "delta.universalFormat.enabledFormats";
 
   private final SessionFactory sessionFactory;
   private final ServerProperties serverProperties;
@@ -245,6 +238,11 @@ public class DeltaCommitRepository {
   public void postCommit(DeltaCommit commit) {
     serverProperties.checkManagedTableEnabled();
     validateCommit(commit);
+    // Extract + shape-validate uniform fields outside the transaction. The subpath check (which
+    // needs the table URL) happens later inside validateTableForCommit; everything else
+    // uniform-related is settled here.
+    Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields =
+        DeltaUniformUtils.getUniformFields(commit);
     TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
@@ -254,10 +252,10 @@ public class DeltaCommitRepository {
             throw new BaseException(
                 ErrorCode.TABLE_NOT_FOUND, "Table not found: " + commit.getTableId());
           }
-          validateTableForCommit(session, commit, tableInfoDAO);
+          validateTableForCommit(session, commit, tableInfoDAO, uniformFields);
           List<DeltaCommitDAO> firstAndLastCommits = getFirstAndLastCommits(session, tableId);
           if (firstAndLastCommits.isEmpty()) {
-            handleOnboardingCommit(session, tableId, tableInfoDAO, commit);
+            handleOnboardingCommit(session, tableId, tableInfoDAO, commit, uniformFields);
           } else {
             DeltaCommitDAO firstCommitDAO = firstAndLastCommits.get(0);
             DeltaCommitDAO lastCommitDAO = firstAndLastCommits.get(1);
@@ -273,7 +271,13 @@ public class DeltaCommitRepository {
                   lastCommitDAO.getCommitVersion());
             } else {
               handleNormalCommit(
-                  session, tableId, tableInfoDAO, commit, firstCommitDAO, lastCommitDAO);
+                  session,
+                  tableId,
+                  tableInfoDAO,
+                  commit,
+                  uniformFields,
+                  firstCommitDAO,
+                  lastCommitDAO);
             }
           }
           return null;
@@ -299,14 +303,18 @@ public class DeltaCommitRepository {
    * @throws BaseException if the commit info is null
    */
   private static void handleOnboardingCommit(
-      Session session, UUID tableId, TableInfoDAO tableInfoDAO, DeltaCommit commit) {
+      Session session,
+      UUID tableId,
+      TableInfoDAO tableInfoDAO,
+      DeltaCommit commit,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields) {
     DeltaCommitInfo commitInfo = commit.getCommitInfo();
     ValidationUtils.checkArgument(
         commitInfo != null,
         "Field can not be null: %s in onboarding commit",
         DeltaCommit.JSON_PROPERTY_COMMIT_INFO);
     saveCommit(session, tableId, commitInfo);
-    updateTableFromCommit(session, tableId, tableInfoDAO, commit);
+    updateTableFromCommit(session, tableId, tableInfoDAO, commit, uniformFields);
   }
 
   /**
@@ -378,6 +386,7 @@ public class DeltaCommitRepository {
       UUID tableId,
       TableInfoDAO tableInfoDAO,
       DeltaCommit commit,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields,
       DeltaCommitDAO firstCommitDAO,
       DeltaCommitDAO lastCommitDAO) {
     DeltaCommitInfo commitInfo = Objects.requireNonNull(commit.getCommitInfo());
@@ -410,7 +419,7 @@ public class DeltaCommitRepository {
     checkCommitLimit(
         tableId, newCommitVersion, latestBackfilledVersion, firstCommitDAO, lastCommitDAO);
     saveCommit(session, tableId, commitInfo);
-    updateTableFromCommit(session, tableId, tableInfoDAO, commit);
+    updateTableFromCommit(session, tableId, tableInfoDAO, commit, uniformFields);
     latestBackfilledVersion.ifPresent(
         latestBackfilled ->
             backfillCommits(
@@ -703,7 +712,11 @@ public class DeltaCommitRepository {
    * @param commit the commit request containing optional metadata and uniform information
    */
   private static void updateTableFromCommit(
-      Session session, UUID tableId, TableInfoDAO tableInfoDAO, DeltaCommit commit) {
+      Session session,
+      UUID tableId,
+      TableInfoDAO tableInfoDAO,
+      DeltaCommit commit,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields) {
     boolean hasUpdates = false;
 
     if (commit.getMetadata() != null) {
@@ -711,8 +724,8 @@ public class DeltaCommitRepository {
       hasUpdates = true;
     }
 
-    if (commit.getUniform() != null) {
-      updateTableUniform(tableInfoDAO, commit.getUniform());
+    if (uniformFields.isPresent()) {
+      DeltaUniformUtils.applyToDao(tableInfoDAO, uniformFields);
       hasUpdates = true;
     }
 
@@ -771,24 +784,6 @@ public class DeltaCommitRepository {
   }
 
   /**
-   * Updates table uniform metadata based on the uniform information provided in a commit.
-   *
-   * <p>This method updates the table's UniForm conversion metadata, including Iceberg metadata
-   * location, converted Delta version, and conversion timestamp.
-   *
-   * @param tableInfoDAO the table information data access object to update
-   * @param uniform the uniform metadata containing conversion information
-   */
-  private static void updateTableUniform(TableInfoDAO tableInfoDAO, DeltaUniform uniform) {
-    DeltaUniformIceberg icebergMetadata = uniform.getIceberg();
-    tableInfoDAO.setUniformIcebergMetadataLocation(
-        NormalizedURL.normalize(icebergMetadata.getMetadataLocation().toString()));
-    tableInfoDAO.setUniformIcebergConvertedDeltaVersion(icebergMetadata.getConvertedDeltaVersion());
-    tableInfoDAO.setUniformIcebergConvertedDeltaTimestamp(
-        Date.from(java.time.Instant.parse(icebergMetadata.getConvertedDeltaTimestamp())));
-  }
-
-  /**
    * Validates the structure and content of a commit request.
    *
    * <p>This method performs comprehensive validation including:
@@ -802,7 +797,6 @@ public class DeltaCommitRepository {
    *       table ID
    *   <li>If commit info is absent: ensures this is a valid backfill-only commit with backfilled
    *       version set
-   *   <li>If uniform is present: validates required fields and size limits
    * </ul>
    *
    * @param commit the commit request to validate
@@ -862,27 +856,7 @@ public class DeltaCommitRepository {
               "At least one of description, properties, or schema must be set in commit.metadata");
         }
         if (propertiesOpt.isPresent()) {
-          Optional<String> propertiesTableIdOpt =
-              propertiesOpt.map(p -> p.get(TableProperties.UC_TABLE_ID));
-          if (propertiesTableIdOpt.isEmpty()) {
-            throw new BaseException(
-                ErrorCode.INVALID_ARGUMENT,
-                String.format(
-                    "commit does not contain %s in the properties.", TableProperties.UC_TABLE_ID));
-          }
-          if (!propertiesTableIdOpt.get().equals(commit.getTableId())) {
-            // This is to ensure that the Delta table's log on the file system has the table id
-            // stored as a property. An extra check to ensure that the filesystem-based information
-            // and the catalog-based information is in sync. for example, if some buggy connector
-            // accidentally updated table A on the file system, but send the commit to table B in
-            // UC, then this check will catch it as table A's properties in the log will have a
-            // different id than the table B's id in UC.
-            throw new BaseException(
-                ErrorCode.INVALID_ARGUMENT,
-                String.format(
-                    "the table being committed (%s) does not match the properties %s(%s).",
-                    commit.getTableId(), TableProperties.UC_TABLE_ID, propertiesTableIdOpt.get()));
-          }
+          UcManagedDeltaContract.validateTableIdProperty(propertiesOpt.get(), commit.getTableId());
         }
       }
     } else {
@@ -897,63 +871,6 @@ public class DeltaCommitRepository {
             ErrorCode.INVALID_ARGUMENT, "metadata shouldn't be set for backfill only commit");
       }
     }
-
-    // Validate uniform metadata if present
-    if (commit.getUniform() != null) {
-      validateUniformIceberg(commit, commit.getUniform());
-    }
-  }
-
-  /**
-   * Validates Delta UniForm Iceberg metadata to ensure all required fields are present, the size is
-   * within limits, and the converted delta version matches the commit version.
-   *
-   * @param commit the commit containing version information
-   * @param uniform the uniform metadata to validate
-   * @throws BaseException if validation fails
-   */
-  private static void validateUniformIceberg(DeltaCommit commit, DeltaUniform uniform) {
-    if (uniform == null) {
-      return; // DeltaUniform is optional
-    }
-
-    // If uniform is specified, iceberg must be set
-    ValidationUtils.checkArgument(
-        uniform.getIceberg() != null, "Field cannot be null in uniform: iceberg");
-
-    DeltaUniformIceberg iceberg = uniform.getIceberg();
-
-    // Validate that all required fields are present
-    ValidationUtils.checkArgument(
-        iceberg.getMetadataLocation() != null,
-        "Field cannot be null in uniform.iceberg: metadata_location");
-    ValidationUtils.checkArgument(
-        iceberg.getConvertedDeltaVersion() != null,
-        "Field cannot be null in uniform.iceberg: converted_delta_version");
-    ValidationUtils.checkArgument(
-        iceberg.getConvertedDeltaTimestamp() != null
-            && !iceberg.getConvertedDeltaTimestamp().isEmpty(),
-        "Field cannot be null or empty in uniform.iceberg: converted_delta_timestamp");
-
-    // Validate that convertedDeltaVersion matches the commit version
-    if (commit.getCommitInfo() != null) {
-      ValidationUtils.checkArgument(
-          iceberg.getConvertedDeltaVersion().equals(commit.getCommitInfo().getVersion()),
-          "uniform.iceberg.converted_delta_version (%d) must equal commit version (%d)",
-          iceberg.getConvertedDeltaVersion(),
-          commit.getCommitInfo().getVersion());
-    }
-
-    // We check the size of the Delta-to-Iceberg conversion information here to fail early if
-    // it exceeds the maximum size of DAO limit. The size is not accurate in terms of the size of
-    // the object in the database but serves as a sanity check to ensure that we're not storing
-    // excessively large objects.
-    int size = iceberg.getMetadataLocation().toString().length();
-    ValidationUtils.checkArgument(
-        size <= MAX_DELTA_UNIFORM_ICEBERG_SIZE,
-        "Delta UniForm Iceberg metadata size (%d bytes) exceeds maximum allowed size (%d bytes)",
-        size,
-        MAX_DELTA_UNIFORM_ICEBERG_SIZE);
   }
 
   /**
@@ -986,19 +903,25 @@ public class DeltaCommitRepository {
   }
 
   /**
-   * Validates that a table is eligible for the commit and that the commit's table URI matches.
+   * Validate that the table is eligible for the commit and the commit's table URI matches.
    *
-   * <p>This method first validates the table meets all requirements for Delta commits, then ensures
-   * the table URI specified in the commit request matches the table's registered URI. URIs are
-   * standardized before comparison to handle format variations.
+   * <ul>
+   *   <li>Table eligibility ({@link #validateTable}: MANAGED + DELTA + non-null URL).
+   *   <li>Table URI equality: the URI in the commit must match the registered table URL after
+   *       normalization.
+   *   <li>UniForm subpath: when {@code uniformFields} is present, its {@code metadata-location}
+   *       must be a subpath of the table's storage root.
+   *   <li>UniForm property/block consistency via {@link #validateUniformMetadataPresence}.
+   * </ul>
    *
-   * @param session the Hibernate session for database operations
-   * @param commit the commit request containing the table URI
-   * @param tableInfoDAO the table information data access object
-   * @throws BaseException if validation fails or URIs don't match
+   * <p>{@code uniformFields} is the already-validated, already-normalized output of {@link
+   * DeltaUniformUtils#getUniformFields(DeltaCommit)}; this method only does the table-aware checks.
    */
   private static void validateTableForCommit(
-      Session session, DeltaCommit commit, TableInfoDAO tableInfoDAO) {
+      Session session,
+      DeltaCommit commit,
+      TableInfoDAO tableInfoDAO,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields) {
     validateTable(tableInfoDAO);
     NormalizedURL commitTableUri = NormalizedURL.from(commit.getTableUri());
     NormalizedURL tableUri = NormalizedURL.from(tableInfoDAO.getUrl());
@@ -1007,6 +930,8 @@ public class DeltaCommitRepository {
         "Table URI in commit %s does not match the table path %s",
         commit.getTableUri(),
         tableInfoDAO.getUrl());
+    uniformFields.ifPresent(
+        uf -> DeltaUniformUtils.requireMetadataLocationSubpath(uf.metadataLocation(), tableUri));
     validateUniformMetadataPresence(session, commit, tableInfoDAO);
   }
 
@@ -1036,24 +961,7 @@ public class DeltaCommitRepository {
           PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE);
       effectiveProperties = PropertyDAO.toMap(properties);
     }
-    // Check if table has UniForm enabled after this commit
-    boolean uniformEnabled =
-        ICEBERG_FORMAT.equals(effectiveProperties.get(UNIFORM_ENABLED_FORMATS));
-    if (uniformEnabled) {
-      ValidationUtils.checkArgument(
-          commit.getUniform() != null,
-          "Uniform metadata must be set when table has UniForm enabled after the commit. "
-              + "UniForm is enabled when property '%s'='%s'",
-          UNIFORM_ENABLED_FORMATS,
-          ICEBERG_FORMAT);
-    } else {
-      ValidationUtils.checkArgument(
-          commit.getUniform() == null,
-          "Uniform metadata must not be set when table has UniForm disabled after the commit. "
-              + "UniForm is disabled when table does not have property '%s'='%s'",
-          UNIFORM_ENABLED_FORMATS,
-          ICEBERG_FORMAT);
-    }
+    DeltaUniformUtils.validateConsistency(effectiveProperties, commit.getUniform() != null);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -29,6 +29,7 @@ import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.persist.utils.RepositoryUtils;
 import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.service.delta.DeltaUniformUtils;
 import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
 import io.unitycatalog.server.utils.ColumnUtils;
 import io.unitycatalog.server.utils.Constants;
@@ -451,17 +452,25 @@ public class TableRepository {
   }
 
   public TableInfo createTable(CreateTable createTable) {
-    return createTableImpl(createTable, (session, dao, tableInfo) -> tableInfo);
+    return createTableImpl(createTable, Optional.empty(), (session, dao, tableInfo) -> tableInfo);
   }
 
   /**
    * Create a table and return the Delta REST Catalog {@link LoadTableResponse} in a single
    * transaction. The DAO persisted during create is the same one used to build the response, so
    * there's no second lookup or risk of a reader observing an intermediate state.
+   *
+   * <p>If {@code uniformFields} is non-empty the table is registered as UniForm-enabled: the
+   * already-validated, already-normalized Iceberg fields (computed once in {@code
+   * DeltaCreateTableMapper.toCreateTable}) are written onto the DAO before {@code session.persist},
+   * so the create lands as a single INSERT carrying the uniform fields and the metadata-location is
+   * normalized exactly once on this code path.
    */
-  public LoadTableResponse createTableForDelta(CreateTable createTable) {
+  public LoadTableResponse createTableForDelta(
+      CreateTable createTable, Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields) {
     return createTableImpl(
         createTable,
+        uniformFields,
         (session, dao, tableInfo) ->
             buildLoadTableResponse(
                 session,
@@ -473,11 +482,16 @@ public class TableRepository {
 
   /**
    * Shared implementation for the two {@code create} entry points. Validates the name, opens a
-   * write transaction, persists the new table (row, columns, properties), then hands the persisted
-   * DAO + built TableInfo to {@code mapper} which picks the return shape each caller needs. Keeps
-   * the create path as a single operation rather than a chain of private helpers.
+   * write transaction, builds the new {@link TableInfoDAO} (row, columns, properties), applies
+   * UniForm Iceberg metadata when {@code uniformFields} is non-empty, persists the DAO, then hands
+   * it and the built {@link TableInfo} to {@code mapper} which picks the return shape each caller
+   * needs. Keeps the create path as a single operation, and pins all DAO setters before {@code
+   * session.persist} so the create lands as a single INSERT.
    */
-  private <T> T createTableImpl(CreateTable createTable, CreateResultMapper<T> mapper) {
+  private <T> T createTableImpl(
+      CreateTable createTable,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields,
+      CreateResultMapper<T> mapper) {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
     List<ColumnInfo> columnInfos =
@@ -583,6 +597,9 @@ public class TableRepository {
           // create properties
           PropertyDAO.from(tableInfo.getProperties(), tableInfoDAO.getId(), Constants.TABLE)
               .forEach(session::persist);
+          // UniForm Iceberg fields (when supplied by the DRC create path) are written while the
+          // entity is still transient so they're folded into the single INSERT below.
+          DeltaUniformUtils.applyToDao(tableInfoDAO, uniformFields);
           session.persist(tableInfoDAO);
           if (tableType == TableType.METRIC_VIEW) {
             DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -597,7 +597,7 @@ public class TableRepository {
           // create properties
           PropertyDAO.from(tableInfo.getProperties(), tableInfoDAO.getId(), Constants.TABLE)
               .forEach(session::persist);
-          // UniForm Iceberg fields (when supplied by the DRC create path) are written while the
+          // UniForm Iceberg fields (when supplied by the Delta create path) are written while the
           // entity is still transient so they're folded into the single INSERT below.
           DeltaUniformUtils.applyToDao(tableInfoDAO, uniformFields);
           session.persist(tableInfoDAO);

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -137,4 +137,17 @@ public class TableInfoDAO extends IdentifiableDAO {
     }
     return tableInfo;
   }
+
+  /**
+   * Update the UniForm Iceberg metadata fields as an atomic triple. All three fields are written
+   * together; callers must supply the validated, normalized values produced by {@code
+   * DeltaUniformUtils.UniformIcebergFields} so the DAO cannot drift on which fields are touched or
+   * how the location is normalized. Shared between createTable on Delta REST and addCommit.
+   */
+  public void updateUniformIcebergMetadata(
+      NormalizedURL metadataLocation, long convertedDeltaVersion, long convertedDeltaTimestampMs) {
+    setUniformIcebergMetadataLocation(metadataLocation.toString());
+    setUniformIcebergConvertedDeltaVersion(convertedDeltaVersion);
+    setUniformIcebergConvertedDeltaTimestamp(new Date(convertedDeltaTimestampMs));
+  }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
@@ -1,7 +1,7 @@
 package io.unitycatalog.server.service.delta;
 
 /**
- * Spec-defined Delta protocol identifiers referenced by the Delta REST Catalog surface. Centralised
+ * Spec-defined Delta protocol identifiers referenced by the Delta REST Catalog surface. Centralized
  * here so that feature-specific server decisions (e.g. "MANAGED tables must declare {@code
  * catalogManaged}") and required-property declarations cannot silently mismatch the strings the
  * client actually writes into the Delta log.
@@ -113,5 +113,21 @@ public final class DeltaConsts {
      * name as it appears in {@code protocol.reader-features} / {@code protocol.writer-features}.
      */
     public static final String FEATURE_PREFIX = "delta.feature.";
+
+    /**
+     * UniForm enabled-formats property: a comma-separated list naming the additional formats to
+     * expose this Delta table as. Setting it to {@link DeltaConsts#UNIVERSAL_FORMAT_ICEBERG}
+     * declares the table as UniForm-Iceberg-enabled, at which point every commit (including the
+     * initial one via createTable) must carry uniform metadata.
+     */
+    public static final String UNIVERSAL_FORMAT_ENABLED_FORMATS =
+        "delta.universalFormat.enabledFormats";
   }
+
+  /**
+   * Wire value of {@link TableProperties#UNIVERSAL_FORMAT_ENABLED_FORMATS} that turns on UniForm
+   * Iceberg conversion. Per Delta spec the property accepts a comma-separated list of formats; for
+   * now {@code "iceberg"} is the only supported value.
+   */
+  public static final String UNIVERSAL_FORMAT_ICEBERG = "iceberg";
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -9,8 +9,10 @@ import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.utils.ColumnUtils;
+import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Converts a Delta REST Catalog {@link CreateTableRequest} (with typed Delta columns and kebab-case
@@ -29,7 +31,18 @@ public final class DeltaCreateTableMapper {
 
   private DeltaCreateTableMapper() {}
 
-  public static CreateTable toCreateTable(String catalog, String schema, CreateTableRequest req) {
+  /**
+   * Result of mapping a {@link CreateTableRequest}: the assembled UC {@link CreateTable} together
+   * with the validated, normalized UniForm Iceberg fields ({@code Optional.empty()} when no
+   * UniForm metadata was supplied). Callers thread the uniform fields straight to {@code
+   * TableRepository.createTableForDelta} so the metadata-location is normalized exactly once at
+   * the request boundary.
+   */
+  public record Result(
+      CreateTable createTable,
+      Optional<DeltaUniformUtils.UniformIcebergFields> uniformIcebergFields) {}
+
+  public static Result toCreateTable(String catalog, String schema, CreateTableRequest req) {
     if (req == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Request body is required.");
     }
@@ -58,6 +71,13 @@ public final class DeltaCreateTableMapper {
           req.getProtocol(), req.getDomainMetadata(), req.getProperties());
     }
 
+    // Uniform property/block consistency mirrors the addCommit-time check (shared via
+    // DeltaUniformUtils) so a table never starts in a state the next commit would reject.
+    DeltaUniformUtils.validateConsistency(req.getProperties(), req.getUniform() != null);
+    Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields =
+        DeltaUniformUtils.getUniformFields(req.getUniform());
+    DeltaUniformUtils.validateCreate(uniformFields, NormalizedURL.from(req.getLocation()));
+
     List<ColumnInfo> columns = new ArrayList<>();
     List<StructField> fields = req.getColumns().getFields();
     for (int i = 0; i < fields.size(); i++) {
@@ -65,18 +85,20 @@ public final class DeltaCreateTableMapper {
     }
     ColumnUtils.applyPartitionColumns(columns, req.getPartitionColumns());
 
-    return new CreateTable()
-        .name(req.getName())
-        .catalogName(catalog)
-        .schemaName(schema)
-        .tableType(tableType)
-        .dataSourceFormat(toUCDataSourceFormat(req.getDataSourceFormat()))
-        .columns(columns)
-        .comment(req.getComment())
-        .storageLocation(req.getLocation())
-        .properties(
+    CreateTable createTable =
+        new CreateTable()
+            .name(req.getName())
+            .catalogName(catalog)
+            .schemaName(schema)
+            .tableType(tableType)
+            .dataSourceFormat(toUCDataSourceFormat(req.getDataSourceFormat()))
+            .columns(columns)
+            .comment(req.getComment())
+            .storageLocation(req.getLocation())
+            .properties(
             DeltaPropertyMapper.buildStoredProperties(
-                req.getProtocol(), req.getDomainMetadata(), req.getProperties()));
+                    req.getProtocol(), req.getDomainMetadata(), req.getProperties()));
+    return new Result(createTable, uniformFields);
   }
 
   private static TableType toUCTableType(io.unitycatalog.server.delta.model.TableType type) {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogMappers.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogMappers.java
@@ -10,7 +10,7 @@ import io.unitycatalog.server.delta.serde.DeltaTypeModule;
  *
  * <p>The same mapper is used both by the server's request / response converters (see {@code
  * UnityCatalogServer#addDeltaApiServices}) and by tests that want to pin the exact wire-format the
- * server produces. Centralising it here means a change to the Delta response shape -- e.g. adding a
+ * server produces. Centralizing it here means a change to the Delta response shape -- e.g. adding a
  * serialization feature -- takes effect in one place, and regression tests that use the same mapper
  * can't silently drift from production behavior.
  *

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogMappers.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogMappers.java
@@ -10,7 +10,7 @@ import io.unitycatalog.server.delta.serde.DeltaTypeModule;
  *
  * <p>The same mapper is used both by the server's request / response converters (see {@code
  * UnityCatalogServer#addDeltaApiServices}) and by tests that want to pin the exact wire-format the
- * server produces. Centralizing it here means a change to the Delta response shape -- e.g. adding a
+ * server produces. Centralising it here means a change to the Delta response shape -- e.g. adding a
  * serialization feature -- takes effect in one place, and regression tests that use the same mapper
  * can't silently drift from production behavior.
  *

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaRestCatalogService.java
@@ -28,7 +28,6 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.DeltaRestExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.CreateStagingTable;
-import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.StagingTableInfo;
 import io.unitycatalog.server.model.TemporaryCredentials;
 import io.unitycatalog.server.persist.CatalogRepository;
@@ -191,8 +190,10 @@ public class DeltaRestCatalogService extends AuthorizedService {
       @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "location")
           @AuthorizeKey(key = "table-type")
           CreateTableRequest request) {
-    CreateTable createTable = DeltaCreateTableMapper.toCreateTable(catalog, schema, request);
-    LoadTableResponse response = tableRepository.createTableForDelta(createTable);
+    DeltaCreateTableMapper.Result mapped =
+        DeltaCreateTableMapper.toCreateTable(catalog, schema, request);
+    LoadTableResponse response = tableRepository.createTableForDelta(
+        mapped.createTable(), mapped.uniformIcebergFields());
     // Wire the new table into the auth hierarchy under its schema (mirrors
     // TableService.createTable). MANAGED tables reuse the staging-table UUID, whose auth row
     // was already created in createStagingTable, so re-init is unnecessary there.

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUniformUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUniformUtils.java
@@ -1,0 +1,316 @@
+package io.unitycatalog.server.service.delta;
+
+import io.unitycatalog.server.delta.model.UniformMetadata;
+import io.unitycatalog.server.delta.model.UniformMetadataIceberg;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.DeltaCommit;
+import io.unitycatalog.server.model.DeltaUniform;
+import io.unitycatalog.server.model.DeltaUniformIceberg;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ValidationUtils;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Hub for UniForm-Iceberg cross-cutting logic. Shared between the create-time path ({@link
+ * DeltaCreateTableMapper}, {@code TableRepository.createTableForDelta}) and the commit-time path
+ * ({@code DeltaCommitRepository}). Centralized so the two cannot drift on what counts as a valid
+ * UniForm state or on how UniForm fields are written to the DAO. Owns:
+ *
+ * <ul>
+ *   <li>{@link #isIcebergEnabled} -- "is UniForm-Iceberg on?" predicate over a properties map.
+ *   <li>{@link #validateConsistency} -- property/block presence consistency.
+ *   <li>{@link #getUniformFields(UniformMetadata)} -- create-time wire-shape extract.
+ *   <li>{@link #getUniformFields(DeltaCommit)} -- commit-time extract + shape + atomicity.
+ *   <li>{@link #validateCreate} -- create-time atomicity + sequential + subpath check.
+ *   <li>{@link #requireBasicShape} -- presence + size, shared by both extractors.
+ *   <li>{@link #requireMetadataLocationSubpath} -- subpath rule, shared with the commit-time path.
+ *   <li>{@link UniformIcebergFields} -- type-safe carrier for the validated fields
+ *       (metadata-location, version, timestamp-ms, optional base-version) so no field is normalized
+ *       or parsed twice.
+ *   <li>{@link #applyToDao} -- writes the triple to the DAO; no-op when absent.
+ * </ul>
+ */
+public final class DeltaUniformUtils {
+
+  private DeltaUniformUtils() {}
+
+  /**
+   * Maximum byte length the server accepts for {@code uniform.iceberg.metadata-location}. Matches
+   * the DAO column ({@code uniform_iceberg_metadata_location} length=65535) so a request that
+   * passes here cannot fail later at persist time.
+   */
+  public static final int MAX_METADATA_LOCATION_BYTES = 65535;
+
+  /**
+   * UniForm Iceberg fields, normalized once at the request boundary. Callers normalize the
+   * metadata-location (using {@link NormalizedURL#from(String)} or {@link NormalizedURL#from(URI)})
+   * and convert the timestamp to epoch ms (parsing the RFC 3339 string once on the commit-side
+   * path), then assemble this record. After {@link #requireBasicShape} succeeds the first three
+   * fields are non-null and the location is within the size bound, so downstream code (subpath
+   * check, DAO write) reads them without re-checking. {@code baseConvertedDeltaVersion} is the
+   * wire-side optional (a sequential-validation hook for incremental conversion) carried through so
+   * {@link #validateCreate} can reject it without re-reading the wire object; modeled as {@link
+   * Optional} since the wire shape itself marks it optional. Holding the values as a single carrier
+   * guarantees nothing is normalized or parsed twice.
+   */
+  public record UniformIcebergFields(
+      NormalizedURL metadataLocation,
+      Long convertedDeltaVersion,
+      Long convertedDeltaTimestampMs,
+      Optional<Long> baseConvertedDeltaVersion) {}
+
+  /**
+   * True when {@code properties} declares the table as UniForm-Iceberg-enabled, i.e. property
+   * {@link TableProperties#UNIVERSAL_FORMAT_ENABLED_FORMATS} contains {@link
+   * DeltaConsts#UNIVERSAL_FORMAT_ICEBERG} as one of its comma-separated entries. Per Delta spec the
+   * value is a list (today {@code iceberg} and {@code hudi}); a value like {@code "iceberg,hudi"}
+   * still has Iceberg enabled, so a plain equality check would miss it. The single source of truth
+   * for "is UniForm-Iceberg on?" -- callers must not re-derive this from the map directly so that
+   * the property key/value strings live in one place.
+   */
+  public static boolean isIcebergEnabled(Map<String, String> properties) {
+    if (properties == null) {
+      return false;
+    }
+    String value = properties.get(TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS);
+    if (value == null || value.isEmpty()) {
+      return false;
+    }
+    for (String format : value.split(",")) {
+      if (DeltaConsts.UNIVERSAL_FORMAT_ICEBERG.equals(format)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Validate that the {@code uniform} block is present iff {@code properties} declares the table as
+   * UniForm-Iceberg-enabled (via {@code delta.universalFormat.enabledFormats=iceberg}). Either both
+   * or neither must be set; any other combination would leave the table in a state the next commit
+   * would reject.
+   *
+   * <p>{@code uniformPresent} is supplied as a boolean rather than the uniform object itself so
+   * that the create path (delta.yaml's {@code UniformMetadata}) and the commit path (all.yaml's
+   * {@code DeltaUniform}) can share this validator without coupling it to either wire type.
+   */
+  public static void validateConsistency(Map<String, String> properties, boolean uniformPresent) {
+    boolean enabledViaProperty = isIcebergEnabled(properties);
+    if (enabledViaProperty && !uniformPresent) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Uniform metadata must be set when '"
+              + TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS
+              + "' includes '"
+              + DeltaConsts.UNIVERSAL_FORMAT_ICEBERG
+              + "'.");
+    }
+    if (!enabledViaProperty && uniformPresent) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Uniform metadata must not be set unless '"
+              + TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS
+              + "' includes '"
+              + DeltaConsts.UNIVERSAL_FORMAT_ICEBERG
+              + "'.");
+    }
+  }
+
+  /**
+   * Extract and shape-validate the create-time UniForm Iceberg fields from a request. Runs the
+   * wire-shape checks that the commit path also runs:
+   *
+   * <ul>
+   *   <li>{@code uniform.iceberg} is not null;
+   *   <li>basic shape (presence + size) via {@link #requireBasicShape}.
+   * </ul>
+   *
+   * <p>Create-time-specific rules ({@code converted-delta-version} must be 0 or 1, {@code
+   * base-converted-delta-version} must be unset, subpath) live in {@link #validateCreate}, where
+   * the table location is also available. Returns {@code Optional.empty()} when no UniForm metadata
+   * was supplied; otherwise returns a record whose metadata-location has been normalized exactly
+   * once and is reused downstream by {@link #applyToDao}.
+   */
+  public static Optional<UniformIcebergFields> getUniformFields(UniformMetadata uniform) {
+    if (uniform == null) {
+      return Optional.empty();
+    }
+    UniformMetadataIceberg iceberg = uniform.getIceberg();
+    if (iceberg == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "uniform.iceberg is required when uniform is set.");
+    }
+    UniformIcebergFields fields =
+        new UniformIcebergFields(
+            NormalizedURL.from(iceberg.getMetadataLocation()),
+            iceberg.getConvertedDeltaVersion(),
+            iceberg.getConvertedDeltaTimestamp(),
+            Optional.ofNullable(iceberg.getBaseConvertedDeltaVersion()));
+    requireBasicShape(fields);
+    return Optional.of(fields);
+  }
+
+  /**
+   * Extract and shape-validate the commit-time UniForm Iceberg fields. Co-located with the
+   * create-time overload so the two paths can't drift on which fields are required, how the
+   * location is normalized, or how the timestamp is parsed. Runs the validations that don't need
+   * the table's stored URL:
+   *
+   * <ul>
+   *   <li>{@code uniform.iceberg} is not null;
+   *   <li>basic shape (presence + size) via {@link #requireBasicShape};
+   *   <li>commit-version atomicity: {@code converted-delta-version} must equal {@code
+   *       commit.commitInfo.version} when commit-info is present.
+   * </ul>
+   *
+   * <p>The metadata-location is normalized exactly once and the RFC 3339 timestamp parsed exactly
+   * once; both are returned in {@link UniformIcebergFields} so the subpath check ({@code
+   * DeltaCommitRepository.validateTableForCommit}) and the DAO write ({@link #applyToDao}) reuse
+   * them without re-doing the work. Returns {@code Optional.empty()} when no UniForm metadata was
+   * supplied.
+   */
+  public static Optional<UniformIcebergFields> getUniformFields(DeltaCommit commit) {
+    DeltaUniform uniform = commit.getUniform();
+    if (uniform == null) {
+      return Optional.empty();
+    }
+    ValidationUtils.checkArgument(
+        uniform.getIceberg() != null, "Field cannot be null in uniform: iceberg");
+    DeltaUniformIceberg iceberg = uniform.getIceberg();
+    String timestampStr = iceberg.getConvertedDeltaTimestamp();
+    UniformIcebergFields fields =
+        new UniformIcebergFields(
+            NormalizedURL.from(iceberg.getMetadataLocation()),
+            iceberg.getConvertedDeltaVersion(),
+            timestampStr == null ? null : Instant.parse(timestampStr).toEpochMilli(),
+            Optional.ofNullable(iceberg.getBaseConvertedDeltaVersion()));
+    requireBasicShape(fields);
+    if (commit.getCommitInfo() != null) {
+      ValidationUtils.checkArgument(
+          fields.convertedDeltaVersion().equals(commit.getCommitInfo().getVersion()),
+          "uniform.iceberg.converted-delta-version (%d) must equal commit version (%d)",
+          fields.convertedDeltaVersion(),
+          commit.getCommitInfo().getVersion());
+    }
+    return Optional.of(fields);
+  }
+
+  /**
+   * Run the create-time validations that {@link #getUniformFields(UniformMetadata)} cannot:
+   *
+   * <ul>
+   *   <li>create-time atomicity: {@code converted-delta-version} is {@code 0} or {@code 1} (V2 or
+   *       V3-catalog-managed);
+   *   <li>create-time sequential: {@code base-converted-delta-version} must be unset, since there
+   *       is no prior stored {@code converted-delta-version} for an incremental conversion to
+   *       reference;
+   *   <li>create-time subpath: the {@code metadata-location} must be inside the table's storage
+   *       root (mirrors the commit-time {@code DeltaCommitRepository.validateTableForCommit}).
+   * </ul>
+   *
+   * <p>No-op when {@code uniformFields} is empty. Property/block consistency is the caller's
+   * responsibility (see {@link #validateConsistency}); wire-shape is {@link
+   * #getUniformFields(UniformMetadata)}'s.
+   */
+  public static void validateCreate(
+      Optional<UniformIcebergFields> uniformFields, NormalizedURL tableLocation) {
+    if (uniformFields.isEmpty()) {
+      return;
+    }
+    UniformIcebergFields fields = uniformFields.get();
+    long version = fields.convertedDeltaVersion();
+    if (version != 0L && version != 1L) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "uniform.iceberg.converted-delta-version must be 0 or 1 at create time, got %d.",
+              version));
+    }
+    if (fields.baseConvertedDeltaVersion().isPresent()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "uniform.iceberg.base-converted-delta-version must not be set at create time:"
+              + " the table has no prior converted-delta-version for it to reference.");
+    }
+    requireMetadataLocationSubpath(fields.metadataLocation(), tableLocation);
+  }
+
+  /**
+   * Validate the basic shape of an Iceberg block (presence + size). Callers extract their wire
+   * shape into a {@link UniformIcebergFields} -- normalizing the metadata-location and parsing the
+   * timestamp to epoch ms -- and pass the assembled record here. After this method returns, every
+   * field is non-null and the location is within the size bound, so downstream code (subpath check,
+   * DAO write) can read the record without re-checking. Shared between {@link
+   * #getUniformFields(UniformMetadata)} (create-time) and {@link #getUniformFields(DeltaCommit)}
+   * (commit-time).
+   */
+  public static void requireBasicShape(UniformIcebergFields fields) {
+    if (fields.metadataLocation() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "uniform.iceberg.metadata-location is required when uniform is set.");
+    }
+    if (fields.convertedDeltaVersion() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "uniform.iceberg.converted-delta-version is required when uniform is set.");
+    }
+    if (fields.convertedDeltaTimestampMs() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "uniform.iceberg.converted-delta-timestamp is required when uniform is set.");
+    }
+    int locationBytes =
+        fields
+            .metadataLocation()
+            .toString()
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            .length;
+    if (locationBytes > MAX_METADATA_LOCATION_BYTES) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "uniform.iceberg.metadata-location byte size (%d) exceeds the maximum allowed (%d).",
+              locationBytes, MAX_METADATA_LOCATION_BYTES));
+    }
+  }
+
+  /**
+   * Throw {@code INVALID_ARGUMENT} unless {@code metadataLocation} is strictly inside {@code
+   * tableLocation}. Both inputs are typed {@link NormalizedURL} so callers normalize once at the
+   * boundary rather than this helper re-normalizing on every call. The Delta REST Catalog spec
+   * requires the Iceberg sidecar metadata to live under the table's storage root so table-level
+   * credential vending and lifecycle (delete/rename) cover it -- a path outside the root would be
+   * orphaned when the table is dropped. Shared between create-time ({@link #validateCreate}) and
+   * commit-time ({@code DeltaCommitRepository.validateTableForCommit}) call sites.
+   */
+  public static void requireMetadataLocationSubpath(
+      NormalizedURL metadataLocation, NormalizedURL tableLocation) {
+    if (!metadataLocation.toString().startsWith(tableLocation.toString() + "/")) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "uniform.iceberg.metadata-location ('%s') must be a subpath of the table location"
+                  + " ('%s').",
+              metadataLocation, tableLocation));
+    }
+  }
+
+  /**
+   * Apply pre-validated, pre-normalized UniForm Iceberg fields onto a {@link TableInfoDAO}. No-op
+   * when {@code fields} is empty (no UniForm metadata supplied for this request). All
+   * presence/shape validation must already have been done by the caller via {@link #validateCreate}
+   * or commit-time validation; this method only writes.
+   */
+  public static void applyToDao(TableInfoDAO dao, Optional<UniformIcebergFields> fields) {
+    fields.ifPresent(
+        f ->
+            dao.updateUniformIcebergMetadata(
+                f.metadataLocation(), f.convertedDeltaVersion(), f.convertedDeltaTimestampMs()));
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUniformUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUniformUtils.java
@@ -11,6 +11,7 @@ import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ValidationUtils;
+import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -40,11 +41,11 @@ public final class DeltaUniformUtils {
   private DeltaUniformUtils() {}
 
   /**
-   * Maximum byte length the server accepts for {@code uniform.iceberg.metadata-location}. Matches
-   * the DAO column ({@code uniform_iceberg_metadata_location} length=65535) so a request that
-   * passes here cannot fail later at persist time.
+   * Maximum character length the server accepts for {@code uniform.iceberg.metadata-location}.
+   * Matches the DAO column ({@code uniform_iceberg_metadata_location} length=65535) so a request
+   * that passes here cannot fail later at persist time.
    */
-  public static final int MAX_METADATA_LOCATION_BYTES = 65535;
+  public static final int MAX_METADATA_LOCATION_CHARS = 65535;
 
   /**
    * UniForm Iceberg fields, normalized once at the request boundary. Callers normalize the
@@ -140,11 +141,9 @@ public final class DeltaUniformUtils {
     if (uniform == null) {
       return Optional.empty();
     }
-    UniformMetadataIceberg iceberg = uniform.getIceberg();
-    if (iceberg == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "uniform.iceberg is required when uniform is set.");
-    }
+    UniformMetadataIceberg iceberg =
+        ValidationUtils.checkNotNull(
+            uniform.getIceberg(), "uniform.iceberg is required when uniform is set.");
     UniformIcebergFields fields =
         new UniformIcebergFields(
             NormalizedURL.from(iceberg.getMetadataLocation()),
@@ -179,9 +178,9 @@ public final class DeltaUniformUtils {
     if (uniform == null) {
       return Optional.empty();
     }
-    ValidationUtils.checkArgument(
-        uniform.getIceberg() != null, "Field cannot be null in uniform: iceberg");
-    DeltaUniformIceberg iceberg = uniform.getIceberg();
+    DeltaUniformIceberg iceberg =
+        ValidationUtils.checkNotNull(
+            uniform.getIceberg(), "Field cannot be null in uniform: iceberg");
     String timestampStr = iceberg.getConvertedDeltaTimestamp();
     UniformIcebergFields fields =
         new UniformIcebergFields(
@@ -224,19 +223,14 @@ public final class DeltaUniformUtils {
     }
     UniformIcebergFields fields = uniformFields.get();
     long version = fields.convertedDeltaVersion();
-    if (version != 0L && version != 1L) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          String.format(
-              "uniform.iceberg.converted-delta-version must be 0 or 1 at create time, got %d.",
-              version));
-    }
-    if (fields.baseConvertedDeltaVersion().isPresent()) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "uniform.iceberg.base-converted-delta-version must not be set at create time:"
-              + " the table has no prior converted-delta-version for it to reference.");
-    }
+    ValidationUtils.checkArgument(
+        version == 0L || version == 1L,
+        "uniform.iceberg.converted-delta-version must be 0 or 1 at create time, got %d.",
+        version);
+    ValidationUtils.checkArgument(
+        fields.baseConvertedDeltaVersion().isEmpty(),
+        "uniform.iceberg.base-converted-delta-version must not be set at create time:"
+            + " the table has no prior converted-delta-version for it to reference.");
     requireMetadataLocationSubpath(fields.metadataLocation(), tableLocation);
   }
 
@@ -250,34 +244,21 @@ public final class DeltaUniformUtils {
    * (commit-time).
    */
   public static void requireBasicShape(UniformIcebergFields fields) {
-    if (fields.metadataLocation() == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "uniform.iceberg.metadata-location is required when uniform is set.");
-    }
-    if (fields.convertedDeltaVersion() == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "uniform.iceberg.converted-delta-version is required when uniform is set.");
-    }
-    if (fields.convertedDeltaTimestampMs() == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "uniform.iceberg.converted-delta-timestamp is required when uniform is set.");
-    }
-    int locationBytes =
-        fields
-            .metadataLocation()
-            .toString()
-            .getBytes(java.nio.charset.StandardCharsets.UTF_8)
-            .length;
-    if (locationBytes > MAX_METADATA_LOCATION_BYTES) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          String.format(
-              "uniform.iceberg.metadata-location byte size (%d) exceeds the maximum allowed (%d).",
-              locationBytes, MAX_METADATA_LOCATION_BYTES));
-    }
+    ValidationUtils.checkNotNull(
+        fields.metadataLocation(),
+        "uniform.iceberg.metadata-location is required when uniform is set.");
+    ValidationUtils.checkNotNull(
+        fields.convertedDeltaVersion(),
+        "uniform.iceberg.converted-delta-version is required when uniform is set.");
+    ValidationUtils.checkNotNull(
+        fields.convertedDeltaTimestampMs(),
+        "uniform.iceberg.converted-delta-timestamp is required when uniform is set.");
+    int locationChars = fields.metadataLocation().toString().length();
+    ValidationUtils.checkArgument(
+        locationChars <= MAX_METADATA_LOCATION_CHARS,
+        "uniform.iceberg.metadata-location length (%d) exceeds the maximum allowed (%d).",
+        locationChars,
+        MAX_METADATA_LOCATION_CHARS);
   }
 
   /**
@@ -291,14 +272,11 @@ public final class DeltaUniformUtils {
    */
   public static void requireMetadataLocationSubpath(
       NormalizedURL metadataLocation, NormalizedURL tableLocation) {
-    if (!metadataLocation.toString().startsWith(tableLocation.toString() + "/")) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          String.format(
-              "uniform.iceberg.metadata-location ('%s') must be a subpath of the table location"
-                  + " ('%s').",
-              metadataLocation, tableLocation));
-    }
+    ValidationUtils.checkArgument(
+        metadataLocation.toString().startsWith(tableLocation.toString() + "/"),
+        "uniform.iceberg.metadata-location ('%s') must be a subpath of the table location ('%s').",
+        metadataLocation,
+        tableLocation);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -159,18 +159,14 @@ public final class UcManagedDeltaContract {
       Map<String, String> properties, String expectedTableId) {
     ValidationUtils.checkNotNull(expectedTableId, "expectedTableId is required.");
     String actual = properties != null ? properties.get(TableProperties.UC_TABLE_ID) : null;
-    if (actual == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          String.format("Properties does not contain %s.", TableProperties.UC_TABLE_ID));
-    }
-    if (!expectedTableId.equals(actual)) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          String.format(
-              "the table id (%s) does not match the properties %s(%s).",
-              expectedTableId, TableProperties.UC_TABLE_ID, actual));
-    }
+    ValidationUtils.checkNotNull(
+        actual, "Properties does not contain " + TableProperties.UC_TABLE_ID + ".");
+    ValidationUtils.checkArgument(
+        expectedTableId.equals(actual),
+        "the table id (%s) does not match the properties %s(%s).",
+        expectedTableId,
+        TableProperties.UC_TABLE_ID,
+        actual);
   }
 
   private static void validateRequiredVersions(DeltaProtocol protocol) {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -149,20 +149,27 @@ public final class UcManagedDeltaContract {
 
   /**
    * Cross-check the client's claim against UC's own state: {@code properties[UC_TABLE_ID]} must
-   * equal the UC-allocated UUID for the table being created or updated. The {@code expectedTableId}
-   * is the source of truth -- the staging table's UUID at create time, the existing table's UUID at
-   * update time. {@link #validate} only checks presence; this method checks identity.
+   * equal the UC-allocated UUID for the table being created or committed against. The {@code
+   * expectedTableId} is the source of truth -- the staging table's UUID at create time, the
+   * existing table's UUID at commit time. Shared between {@link DeltaCreateTableMapper}'s
+   * MANAGED-create path and {@code DeltaCommitRepository}'s commit-metadata-property path so the
+   * two cannot drift. {@link #validate} only checks presence; this method checks identity.
    */
   public static void validateTableIdProperty(
       Map<String, String> properties, String expectedTableId) {
     ValidationUtils.checkNotNull(expectedTableId, "expectedTableId is required.");
     String actual = properties != null ? properties.get(TableProperties.UC_TABLE_ID) : null;
+    if (actual == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format("Properties does not contain %s.", TableProperties.UC_TABLE_ID));
+    }
     if (!expectedTableId.equals(actual)) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
           String.format(
-              "Property %s (%s) does not match the table id (%s).",
-              TableProperties.UC_TABLE_ID, actual, expectedTableId));
+              "the table id (%s) does not match the properties %s(%s).",
+              expectedTableId, TableProperties.UC_TABLE_ID, actual));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
@@ -64,6 +64,16 @@ public final class NormalizedURL {
   }
 
   /**
+   * Creates a normalized URL from the given URI. Returns null if the input is null. Convenience
+   * overload of {@link #from(String)} for callers that already hold a {@link URI}.
+   *
+   * @param uri the URI to normalize
+   */
+  public static NormalizedURL from(URI uri) {
+    return uri == null ? null : new NormalizedURL(uri.toString());
+  }
+
+  /**
    * Returns the normalized URL as a string.
    *
    * @return the normalized URL string, never null

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -34,9 +34,11 @@ import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Integration tests for the Delta REST Catalog {@code POST /v1/.../tables} endpoint. Consolidated
@@ -69,11 +71,7 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
   public void testCreateTableEndpoint() throws ApiException {
     // -------- MANAGED happy path: staging -> createTable -> LoadTableResponse --------
     String tableName = "tbl_happy";
-    StagingTableResponse staging =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name(tableName));
+    StagingTableResponse staging = createStaging(tableName);
 
     LoadTableResponse resp =
         deltaTablesApi.createTable(
@@ -120,43 +118,36 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     assertThat(extResp.getMetadata().getLocation()).isEqualTo(externalLocation);
 
     // -------- ICEBERG rejected --------
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest("tbl_iceberg", "s3://test-bucket0/unused")
                     .dataSourceFormat(DataSourceFormat.ICEBERG)),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "Unsupported data-source-format");
 
     // -------- name missing --------
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest(null, "s3://test-bucket0/unused")),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "Table name is required");
 
     // -------- protocol missing --------
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest("tbl_no_protocol", "s3://test-bucket0/unused").protocol(null)),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "protocol is required");
 
     // -------- MANAGED without catalogManaged writer feature rejected --------
-    StagingTableResponse stagingNoCm =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_no_cm"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingNoCm = createStaging("tbl_no_cm");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
@@ -169,16 +160,11 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                             .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
                             // catalogManaged intentionally omitted.
                             .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         TableFeature.CATALOG_MANAGED.specName());
 
     // -------- domain-metadata without matching feature rejected --------
-    StagingTableResponse stagingDm =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_bad_domain"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingDm = createStaging("tbl_bad_domain");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
@@ -188,23 +174,17 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                         new DomainMetadataUpdates()
                             .deltaRowTracking(
                                 new RowTrackingDomainMetadata().rowIdHighWaterMark(100L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "'rowTracking' writer feature");
 
     // -------- partition-columns referencing unknown column --------
-    StagingTableResponse stagingForBadPart =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_bad_part"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingForBadPart = createStaging("tbl_bad_part");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest("tbl_bad_part", stagingForBadPart)
                     .partitionColumns(List.of("nope"))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "partition-columns references unknown column: nope");
 
     // -------- UC_TABLE_ID property doesn't match the staging UUID --------
@@ -212,29 +192,20 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     // truth, and a request claiming a different UUID gets rejected. Without this, a buggy or
     // malicious client could persist an internally-inconsistent UC table (UUID-A persisted, but
     // properties[UC_TABLE_ID]=UUID-B) which downstream commits would only catch much later.
-    StagingTableResponse stagingForWrongId =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_wrong_id"));
+    StagingTableResponse stagingForWrongId = createStaging("tbl_wrong_id");
     java.util.Map<String, String> wrongIdProps =
         new java.util.HashMap<>(
             fullManagedProperties("00000000-0000-0000-0000-000000000000")); // not the staging UUID
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest("tbl_wrong_id", stagingForWrongId).properties(wrongIdProps)),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         TableProperties.UC_TABLE_ID);
 
     // -------- partition-columns happy case --------
-    StagingTableResponse stagingPart =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_part"));
+    StagingTableResponse stagingPart = createStaging("tbl_part");
     LoadTableResponse partResp =
         deltaTablesApi.createTable(
             TestUtils.CATALOG_NAME2,
@@ -249,28 +220,17 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     // match the presence of the uniform block (mirrors the addCommit-time check). The response
     // must round-trip the same uniform block so an Iceberg-REST reader can resolve the table
     // without a follow-up commit.
-    StagingTableResponse stagingUniform =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform"));
-    String icebergMetadataLocation = stagingUniform.getLocation() + "/_uniform/iceberg/v1.json";
     LoadTableResponse uniformResp =
-        deltaTablesApi.createTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            managedTableRequest("tbl_uniform", stagingUniform)
-                .properties(uniformEnabledProperties(stagingUniform.getTableId().toString()))
-                .uniform(
-                    new UniformMetadata()
-                        .iceberg(
-                            new UniformMetadataIceberg()
-                                .metadataLocation(icebergMetadataLocation)
-                                .convertedDeltaVersion(0L)
-                                .convertedDeltaTimestamp(1700000000000L))));
+        createTableWithUniform(
+            "tbl_uniform",
+            s ->
+                new UniformMetadataIceberg()
+                    .metadataLocation(s.getLocation() + "/_uniform/iceberg/v1.json")
+                    .convertedDeltaVersion(0L)
+                    .convertedDeltaTimestamp(1700000000000L));
     assertThat(uniformResp.getUniform()).isNotNull();
     assertThat(uniformResp.getUniform().getIceberg().getMetadataLocation())
-        .isEqualTo(icebergMetadataLocation);
+        .endsWith("/_uniform/iceberg/v1.json");
     assertThat(uniformResp.getUniform().getIceberg().getConvertedDeltaVersion()).isEqualTo(0L);
     assertThat(uniformResp.getUniform().getIceberg().getConvertedDeltaTimestamp())
         .isEqualTo(1700000000000L);
@@ -278,54 +238,35 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     // -------- uniform with converted-delta-version=1 (V3 catalog-managed) accepted --------
     // The spec accepts both 0 (V2) and 1 (V3) at create time without committing to which version
     // the table actually is. Pin both so a future regression that hard-codes one is caught.
-    StagingTableResponse stagingV3 =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_v3"));
     LoadTableResponse v3Resp =
-        deltaTablesApi.createTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            managedTableRequest("tbl_uniform_v3", stagingV3)
-                .properties(uniformEnabledProperties(stagingV3.getTableId().toString()))
-                .uniform(
-                    new UniformMetadata()
-                        .iceberg(
-                            new UniformMetadataIceberg()
-                                .metadataLocation(stagingV3.getLocation() + "/_uniform/v1.json")
-                                .convertedDeltaVersion(1L)
-                                .convertedDeltaTimestamp(1700000000000L))));
+        createTableWithUniform(
+            "tbl_uniform_v3",
+            s ->
+                new UniformMetadataIceberg()
+                    .metadataLocation(s.getLocation() + "/_uniform/v1.json")
+                    .convertedDeltaVersion(1L)
+                    .convertedDeltaTimestamp(1700000000000L));
     assertThat(v3Resp.getUniform().getIceberg().getConvertedDeltaVersion()).isEqualTo(1L);
 
     // -------- uniform-enabled property without uniform block rejected --------
     // The property is the master switch. Setting it without supplying the uniform block leaves
     // the table in a state the next addCommit would reject -- catch it at create time.
-    StagingTableResponse stagingPropOnly =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_prop_only"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingPropOnly = createStaging("tbl_uniform_prop_only");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
                 TestUtils.SCHEMA_NAME2,
                 managedTableRequest("tbl_uniform_prop_only", stagingPropOnly)
                     .properties(uniformEnabledProperties(stagingPropOnly.getTableId().toString()))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS);
 
     // -------- uniform block without uniform-enabled property rejected --------
     // The inverse: supplying a uniform block without flipping the master switch is also
     // inconsistent. Without this check a table would accept a uniform write at create time
     // while declaring itself NOT UniForm, contradicting the addCommit-time invariant.
-    StagingTableResponse stagingBlockOnly =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_block_only"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingBlockOnly = createStaging("tbl_uniform_block_only");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
@@ -336,16 +277,11 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                             .iceberg(
                                 new UniformMetadataIceberg()
                                     .metadataLocation("s3://test-bucket0/iceberg/blk.json")))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS);
 
     // -------- uniform without iceberg sub-block rejected --------
-    StagingTableResponse stagingNoIce =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_no_ice"));
-    TestUtils.assertDeltaApiException(
+    StagingTableResponse stagingNoIce = createStaging("tbl_uniform_no_ice");
+    assertDeltaInvalidParam(
         () ->
             deltaTablesApi.createTable(
                 TestUtils.CATALOG_NAME2,
@@ -353,124 +289,64 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                 managedTableRequest("tbl_uniform_no_ice", stagingNoIce)
                     .properties(uniformEnabledProperties(stagingNoIce.getTableId().toString()))
                     .uniform(new UniformMetadata())),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
         "uniform.iceberg");
 
     // -------- uniform.iceberg.metadata-location missing rejected --------
-    StagingTableResponse stagingNoLoc =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_no_loc"));
-    TestUtils.assertDeltaApiException(
-        () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_no_loc", stagingNoLoc)
-                    .properties(uniformEnabledProperties(stagingNoLoc.getTableId().toString()))
-                    .uniform(new UniformMetadata().iceberg(new UniformMetadataIceberg()))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+    assertDeltaInvalidParam(
+        () -> createTableWithUniform("tbl_uniform_no_loc", s -> new UniformMetadataIceberg()),
         "metadata-location");
 
     // -------- uniform.iceberg.converted-delta-version missing rejected --------
-    StagingTableResponse stagingNoVer =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_no_ver"));
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_no_ver", stagingNoVer)
-                    .properties(uniformEnabledProperties(stagingNoVer.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    .metadataLocation(
-                                        stagingNoVer.getLocation() + "/_uniform/v1.json")
-                                    .convertedDeltaTimestamp(1700000000000L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_no_ver",
+                s ->
+                    new UniformMetadataIceberg()
+                        .metadataLocation(s.getLocation() + "/_uniform/v1.json")
+                        .convertedDeltaTimestamp(1700000000000L)),
         "converted-delta-version is required");
 
     // -------- uniform.iceberg.converted-delta-timestamp missing rejected --------
-    StagingTableResponse stagingNoTs =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_no_ts"));
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_no_ts", stagingNoTs)
-                    .properties(uniformEnabledProperties(stagingNoTs.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    .metadataLocation(
-                                        stagingNoTs.getLocation() + "/_uniform/v1.json")
-                                    .convertedDeltaVersion(0L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_no_ts",
+                s ->
+                    new UniformMetadataIceberg()
+                        .metadataLocation(s.getLocation() + "/_uniform/v1.json")
+                        .convertedDeltaVersion(0L)),
         "converted-delta-timestamp is required");
 
     // -------- uniform.iceberg.metadata-location not a subpath of table location rejected --------
     // The Iceberg metadata MUST be inside the table's storage root so that table-level credential
     // vending and lifecycle (delete/rename) cover it. A path outside the root would be orphaned
     // when the table is dropped and is rejected at create time.
-    StagingTableResponse stagingBadPath =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_bad_path"));
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_bad_path", stagingBadPath)
-                    .properties(uniformEnabledProperties(stagingBadPath.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    // Sibling location, not a subpath of the staging location.
-                                    .metadataLocation("s3://test-bucket0/elsewhere/iceberg/v1.json")
-                                    .convertedDeltaVersion(0L)
-                                    .convertedDeltaTimestamp(1700000000000L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_bad_path",
+                s ->
+                    new UniformMetadataIceberg()
+                        // Sibling location, not a subpath of the staging location.
+                        .metadataLocation("s3://test-bucket0/elsewhere/iceberg/v1.json")
+                        .convertedDeltaVersion(0L)
+                        .convertedDeltaTimestamp(1700000000000L)),
         "must be a subpath");
 
     // -------- converted-delta-version != 0 or 1 rejected --------
     // At create time the only legal values are 0 (V2 catalog-managed) and 1 (V3). Anything else
     // would imply this createTable call is replaying a later commit, which is not what create is
     // for.
-    StagingTableResponse stagingBadVer =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_bad_ver"));
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_bad_ver", stagingBadVer)
-                    .properties(uniformEnabledProperties(stagingBadVer.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    .metadataLocation(
-                                        stagingBadVer.getLocation() + "/_uniform/v1.json")
-                                    .convertedDeltaVersion(5L)
-                                    .convertedDeltaTimestamp(1700000000000L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_bad_ver",
+                s ->
+                    new UniformMetadataIceberg()
+                        .metadataLocation(s.getLocation() + "/_uniform/v1.json")
+                        .convertedDeltaVersion(5L)
+                        .convertedDeltaTimestamp(1700000000000L)),
         "must be 0 or 1");
 
     // -------- metadata-location oversized rejected --------
@@ -478,56 +354,32 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     // the validator can never fail at persist time. Constructed by padding a query-string suffix
     // onto a valid subpath so the path-shape rule still passes and we exercise the size check
     // specifically.
-    StagingTableResponse stagingBigLoc =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_big_loc"));
     String oversizedSuffix = "?pad=" + "x".repeat(70_000);
-    String oversizedLocation = stagingBigLoc.getLocation() + "/_uniform/v1.json" + oversizedSuffix;
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_big_loc", stagingBigLoc)
-                    .properties(uniformEnabledProperties(stagingBigLoc.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    .metadataLocation(oversizedLocation)
-                                    .convertedDeltaVersion(0L)
-                                    .convertedDeltaTimestamp(1700000000000L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_big_loc",
+                s ->
+                    new UniformMetadataIceberg()
+                        .metadataLocation(s.getLocation() + "/_uniform/v1.json" + oversizedSuffix)
+                        .convertedDeltaVersion(0L)
+                        .convertedDeltaTimestamp(1700000000000L)),
         "exceeds the maximum allowed");
 
     // -------- base-converted-delta-version supplied at create time rejected --------
     // base-converted-delta-version is the sequential-validation hook for incremental conversion
     // commits; at create time there is no prior stored converted-delta-version for it to match
     // against, so supplying it is always wrong.
-    StagingTableResponse stagingWithBase =
-        deltaTablesApi.createStagingTable(
-            TestUtils.CATALOG_NAME2,
-            TestUtils.SCHEMA_NAME2,
-            new CreateStagingTableRequest().name("tbl_uniform_with_base"));
-    TestUtils.assertDeltaApiException(
+    assertDeltaInvalidParam(
         () ->
-            deltaTablesApi.createTable(
-                TestUtils.CATALOG_NAME2,
-                TestUtils.SCHEMA_NAME2,
-                managedTableRequest("tbl_uniform_with_base", stagingWithBase)
-                    .properties(uniformEnabledProperties(stagingWithBase.getTableId().toString()))
-                    .uniform(
-                        new UniformMetadata()
-                            .iceberg(
-                                new UniformMetadataIceberg()
-                                    .metadataLocation(
-                                        stagingWithBase.getLocation() + "/_uniform/v1.json")
-                                    .convertedDeltaVersion(0L)
-                                    .convertedDeltaTimestamp(1700000000000L)
-                                    .baseConvertedDeltaVersion(0L)))),
-        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+            createTableWithUniform(
+                "tbl_uniform_with_base",
+                s ->
+                    new UniformMetadataIceberg()
+                        .metadataLocation(s.getLocation() + "/_uniform/v1.json")
+                        .convertedDeltaVersion(0L)
+                        .convertedDeltaTimestamp(1700000000000L)
+                        .baseConvertedDeltaVersion(0L)),
         "base-converted-delta-version must not be set at create time");
   }
 
@@ -675,5 +527,42 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
   /** {@code delta.feature.<name>} for the stored UC property assertions. */
   private static String featureKey(String feature) {
     return TableProperties.FEATURE_PREFIX + feature;
+  }
+
+  /**
+   * Shorthand for the {@link ErrorType#INVALID_PARAMETER_VALUE_EXCEPTION} pattern, which is the
+   * only error type the negative cases in this suite assert against.
+   */
+  private static void assertDeltaInvalidParam(
+      Executable executable, String expectedMessageSubstring) {
+    TestUtils.assertDeltaApiException(
+        executable, ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION, expectedMessageSubstring);
+  }
+
+  /** Allocate a fresh managed staging table under {@code CATALOG_NAME2.SCHEMA_NAME2}. */
+  private StagingTableResponse createStaging(String name) throws ApiException {
+    return deltaTablesApi.createStagingTable(
+        TestUtils.CATALOG_NAME2,
+        TestUtils.SCHEMA_NAME2,
+        new CreateStagingTableRequest().name(name));
+  }
+
+  /**
+   * Stage + finalize a managed Delta table whose request carries the uniform-enabled property and a
+   * uniform-iceberg block built from the staging response (so callers can compute {@code
+   * metadata-location} as a subpath of the staging location). For negative cases pass an iceberg
+   * builder that produces an invalid block; the call site wraps this in {@code
+   * assertDeltaInvalidParam}.
+   */
+  private LoadTableResponse createTableWithUniform(
+      String name, Function<StagingTableResponse, UniformMetadataIceberg> icebergBuilder)
+      throws ApiException {
+    StagingTableResponse staging = createStaging(name);
+    return deltaTablesApi.createTable(
+        TestUtils.CATALOG_NAME2,
+        TestUtils.SCHEMA_NAME2,
+        managedTableRequest(name, staging)
+            .properties(uniformEnabledProperties(staging.getTableId().toString()))
+            .uniform(new UniformMetadata().iceberg(icebergBuilder.apply(staging))));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -18,6 +18,8 @@ import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StructField;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableType;
+import io.unitycatalog.client.delta.model.UniformMetadata;
+import io.unitycatalog.client.delta.model.UniformMetadataIceberg;
 import io.unitycatalog.client.model.CreateCatalog;
 import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.server.base.BaseCRUDTestWithMockCredentials;
@@ -26,6 +28,7 @@ import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
@@ -238,6 +241,305 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
             TestUtils.SCHEMA_NAME2,
             managedTableRequest("tbl_part", stagingPart).partitionColumns(List.of("id")));
     assertThat(partResp.getMetadata().getPartitionColumns()).containsExactly("id");
+
+    // -------- uniform happy case: Iceberg sidecar registered at create time --------
+    // Exercises the UniForm path: the engine has converted the initial Delta commit to Iceberg
+    // and supplies the Iceberg metadata location in the same createTable call. The
+    // delta.universalFormat.enabledFormats=iceberg property is the master switch that must
+    // match the presence of the uniform block (mirrors the addCommit-time check). The response
+    // must round-trip the same uniform block so an Iceberg-REST reader can resolve the table
+    // without a follow-up commit.
+    StagingTableResponse stagingUniform =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform"));
+    String icebergMetadataLocation = stagingUniform.getLocation() + "/_uniform/iceberg/v1.json";
+    LoadTableResponse uniformResp =
+        deltaTablesApi.createTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            managedTableRequest("tbl_uniform", stagingUniform)
+                .properties(uniformEnabledProperties(stagingUniform.getTableId().toString()))
+                .uniform(
+                    new UniformMetadata()
+                        .iceberg(
+                            new UniformMetadataIceberg()
+                                .metadataLocation(icebergMetadataLocation)
+                                .convertedDeltaVersion(0L)
+                                .convertedDeltaTimestamp(1700000000000L))));
+    assertThat(uniformResp.getUniform()).isNotNull();
+    assertThat(uniformResp.getUniform().getIceberg().getMetadataLocation())
+        .isEqualTo(icebergMetadataLocation);
+    assertThat(uniformResp.getUniform().getIceberg().getConvertedDeltaVersion()).isEqualTo(0L);
+    assertThat(uniformResp.getUniform().getIceberg().getConvertedDeltaTimestamp())
+        .isEqualTo(1700000000000L);
+
+    // -------- uniform with converted-delta-version=1 (V3 catalog-managed) accepted --------
+    // The spec accepts both 0 (V2) and 1 (V3) at create time without committing to which version
+    // the table actually is. Pin both so a future regression that hard-codes one is caught.
+    StagingTableResponse stagingV3 =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_v3"));
+    LoadTableResponse v3Resp =
+        deltaTablesApi.createTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            managedTableRequest("tbl_uniform_v3", stagingV3)
+                .properties(uniformEnabledProperties(stagingV3.getTableId().toString()))
+                .uniform(
+                    new UniformMetadata()
+                        .iceberg(
+                            new UniformMetadataIceberg()
+                                .metadataLocation(stagingV3.getLocation() + "/_uniform/v1.json")
+                                .convertedDeltaVersion(1L)
+                                .convertedDeltaTimestamp(1700000000000L))));
+    assertThat(v3Resp.getUniform().getIceberg().getConvertedDeltaVersion()).isEqualTo(1L);
+
+    // -------- uniform-enabled property without uniform block rejected --------
+    // The property is the master switch. Setting it without supplying the uniform block leaves
+    // the table in a state the next addCommit would reject -- catch it at create time.
+    StagingTableResponse stagingPropOnly =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_prop_only"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_prop_only", stagingPropOnly)
+                    .properties(uniformEnabledProperties(stagingPropOnly.getTableId().toString()))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS);
+
+    // -------- uniform block without uniform-enabled property rejected --------
+    // The inverse: supplying a uniform block without flipping the master switch is also
+    // inconsistent. Without this check a table would accept a uniform write at create time
+    // while declaring itself NOT UniForm, contradicting the addCommit-time invariant.
+    StagingTableResponse stagingBlockOnly =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_block_only"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_block_only", stagingBlockOnly)
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation("s3://test-bucket0/iceberg/blk.json")))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS);
+
+    // -------- uniform without iceberg sub-block rejected --------
+    StagingTableResponse stagingNoIce =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_no_ice"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_no_ice", stagingNoIce)
+                    .properties(uniformEnabledProperties(stagingNoIce.getTableId().toString()))
+                    .uniform(new UniformMetadata())),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "uniform.iceberg");
+
+    // -------- uniform.iceberg.metadata-location missing rejected --------
+    StagingTableResponse stagingNoLoc =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_no_loc"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_no_loc", stagingNoLoc)
+                    .properties(uniformEnabledProperties(stagingNoLoc.getTableId().toString()))
+                    .uniform(new UniformMetadata().iceberg(new UniformMetadataIceberg()))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "metadata-location");
+
+    // -------- uniform.iceberg.converted-delta-version missing rejected --------
+    StagingTableResponse stagingNoVer =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_no_ver"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_no_ver", stagingNoVer)
+                    .properties(uniformEnabledProperties(stagingNoVer.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation(
+                                        stagingNoVer.getLocation() + "/_uniform/v1.json")
+                                    .convertedDeltaTimestamp(1700000000000L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "converted-delta-version is required");
+
+    // -------- uniform.iceberg.converted-delta-timestamp missing rejected --------
+    StagingTableResponse stagingNoTs =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_no_ts"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_no_ts", stagingNoTs)
+                    .properties(uniformEnabledProperties(stagingNoTs.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation(
+                                        stagingNoTs.getLocation() + "/_uniform/v1.json")
+                                    .convertedDeltaVersion(0L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "converted-delta-timestamp is required");
+
+    // -------- uniform.iceberg.metadata-location not a subpath of table location rejected --------
+    // The Iceberg metadata MUST be inside the table's storage root so that table-level credential
+    // vending and lifecycle (delete/rename) cover it. A path outside the root would be orphaned
+    // when the table is dropped and is rejected at create time.
+    StagingTableResponse stagingBadPath =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_bad_path"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_bad_path", stagingBadPath)
+                    .properties(uniformEnabledProperties(stagingBadPath.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    // Sibling location, not a subpath of the staging location.
+                                    .metadataLocation("s3://test-bucket0/elsewhere/iceberg/v1.json")
+                                    .convertedDeltaVersion(0L)
+                                    .convertedDeltaTimestamp(1700000000000L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "must be a subpath");
+
+    // -------- converted-delta-version != 0 or 1 rejected --------
+    // At create time the only legal values are 0 (V2 catalog-managed) and 1 (V3). Anything else
+    // would imply this createTable call is replaying a later commit, which is not what create is
+    // for.
+    StagingTableResponse stagingBadVer =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_bad_ver"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_bad_ver", stagingBadVer)
+                    .properties(uniformEnabledProperties(stagingBadVer.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation(
+                                        stagingBadVer.getLocation() + "/_uniform/v1.json")
+                                    .convertedDeltaVersion(5L)
+                                    .convertedDeltaTimestamp(1700000000000L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "must be 0 or 1");
+
+    // -------- metadata-location oversized rejected --------
+    // The DAO column is bounded; reject at the API boundary so a request that "succeeds" through
+    // the validator can never fail at persist time. Constructed by padding a query-string suffix
+    // onto a valid subpath so the path-shape rule still passes and we exercise the size check
+    // specifically.
+    StagingTableResponse stagingBigLoc =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_big_loc"));
+    String oversizedSuffix = "?pad=" + "x".repeat(70_000);
+    String oversizedLocation = stagingBigLoc.getLocation() + "/_uniform/v1.json" + oversizedSuffix;
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_big_loc", stagingBigLoc)
+                    .properties(uniformEnabledProperties(stagingBigLoc.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation(oversizedLocation)
+                                    .convertedDeltaVersion(0L)
+                                    .convertedDeltaTimestamp(1700000000000L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "exceeds the maximum allowed");
+
+    // -------- base-converted-delta-version supplied at create time rejected --------
+    // base-converted-delta-version is the sequential-validation hook for incremental conversion
+    // commits; at create time there is no prior stored converted-delta-version for it to match
+    // against, so supplying it is always wrong.
+    StagingTableResponse stagingWithBase =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME2,
+            TestUtils.SCHEMA_NAME2,
+            new CreateStagingTableRequest().name("tbl_uniform_with_base"));
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.createTable(
+                TestUtils.CATALOG_NAME2,
+                TestUtils.SCHEMA_NAME2,
+                managedTableRequest("tbl_uniform_with_base", stagingWithBase)
+                    .properties(uniformEnabledProperties(stagingWithBase.getTableId().toString()))
+                    .uniform(
+                        new UniformMetadata()
+                            .iceberg(
+                                new UniformMetadataIceberg()
+                                    .metadataLocation(
+                                        stagingWithBase.getLocation() + "/_uniform/v1.json")
+                                    .convertedDeltaVersion(0L)
+                                    .convertedDeltaTimestamp(1700000000000L)
+                                    .baseConvertedDeltaVersion(0L)))),
+        ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "base-converted-delta-version must not be set at create time");
+  }
+
+  /**
+   * Full UC-managed properties augmented with the UniForm enabled-formats property so requests that
+   * supply a {@code uniform} block satisfy the create-time consistency check.
+   */
+  private static Map<String, String> uniformEnabledProperties(String tableId) {
+    Map<String, String> props = new java.util.HashMap<>(fullManagedProperties(tableId));
+    props.put(
+        TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS, DeltaConsts.UNIVERSAL_FORMAT_ICEBERG);
+    return props;
   }
 
   /** Creates a catalog + schema whose staging tables resolve under s3://test-bucket0/. */

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -27,14 +27,16 @@ import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.table.BaseTableCRUDTestEnv;
 import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.persist.DeltaCommitRepository;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.service.delta.DeltaConsts;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.service.delta.DeltaUniformUtils;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -237,9 +239,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     properties.putAll(additionalProperties);
     if (isUniFormEnabled) {
       properties.put(
-              DeltaCommitRepository.UNIFORM_ENABLED_FORMATS,
-              DeltaCommitRepository.ICEBERG_FORMAT
-      );
+          DeltaConsts.TableProperties.UNIVERSAL_FORMAT_ENABLED_FORMATS,
+          DeltaConsts.UNIVERSAL_FORMAT_ICEBERG);
     }
     return new DeltaCommitMetadataProperties().properties(properties);
   }
@@ -420,7 +421,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
                 .setProperties(
                     new DeltaCommitMetadataProperties()
                         .properties(Map.of("randomProperty", "randomValue"))),
-        "commit does not contain io.unitycatalog.tableId in the properties");
+        "does not contain io.unitycatalog.tableId");
 
     // Commit with metadata but without io.unitycatalog.tableId in properties
     Map<String, String> properties1 = Map.of("customProperty", "customValue");
@@ -779,7 +780,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaUniform uniform = new DeltaUniform();
     DeltaUniformIceberg icebergMetadata =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(1L)  // Must match commit version
             .convertedDeltaTimestamp(timestamp1);
     uniform.setIceberg(icebergMetadata);
@@ -796,13 +797,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
 
     // Verify the table's uniform metadata was updated
     verifyTableInfoDAO(dao ->
-        verifyUniformFields(dao, "s3://my-bucket/metadata/v1.json", 1L, timestamp1));
+        verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1));
 
     // Update uniform metadata with a new commit
     String timestamp2 = Instant.now().toString();
     DeltaUniformIceberg icebergMetadata2 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v2.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
             .convertedDeltaVersion(2L)  // Must match commit version
             .convertedDeltaTimestamp(timestamp2);
     DeltaUniform uniform2 = new DeltaUniform();
@@ -816,7 +817,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
 
     // Verify the table's uniform metadata was updated to the latest
     verifyTableInfoDAO(dao ->
-        verifyUniformFields(dao, "s3://my-bucket/metadata/v2.json", 2L, timestamp2));
+        verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2));
   }
 
   @Test
@@ -825,7 +826,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaUniform uniform = new DeltaUniform();
     DeltaUniformIceberg icebergMetadata =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(1L)  // Must match commit version
             .convertedDeltaTimestamp(timestamp1);
     uniform.setIceberg(icebergMetadata);
@@ -862,7 +863,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
       // Verify metadata fields
       assertEquals("Test table with both metadata and uniform", dao.getComment());
       // Verify uniform fields
-      verifyUniformFields(dao, "s3://my-bucket/metadata/v1.json", 1L, timestamp1);
+      verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1);
     });
 
     // Now update with new metadata and uniform in a second commit
@@ -879,7 +880,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     String timestamp2 = Instant.now().toString();
     DeltaUniformIceberg icebergMetadata2 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v2.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
             .convertedDeltaVersion(2L)  // Must match commit version
             .convertedDeltaTimestamp(timestamp2);
     DeltaUniform uniform2 = new DeltaUniform();
@@ -900,7 +901,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyTableInfoDAO(dao -> {
       // Verify both metadata and uniform were updated to latest values
       assertEquals("Updated description", dao.getComment());
-      verifyUniformFields(dao, "s3://my-bucket/metadata/v2.json", 2L, timestamp2);
+      verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2);
     });
   }
 
@@ -917,7 +918,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         ErrorCode.INVALID_ARGUMENT,
         "iceberg");
 
-    // Test 1: Missing metadata_location
+    // Test 1: Missing metadata-location
     DeltaUniformIceberg invalidIceberg1 =
         new DeltaUniformIceberg()
             .convertedDeltaVersion(100L)
@@ -930,12 +931,12 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit1),
         ErrorCode.INVALID_ARGUMENT,
-        "metadata_location");
+        "metadata-location");
 
     // Test 2: Missing converted_delta_version
     DeltaUniformIceberg invalidIceberg2 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaTimestamp(Instant.now().toString());
     DeltaUniform invalidUniform2 =
         new DeltaUniform().iceberg(invalidIceberg2);
@@ -945,12 +946,12 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit2),
         ErrorCode.INVALID_ARGUMENT,
-        "converted_delta_version");
+        "converted-delta-version");
 
     // Test 3: Missing converted_delta_timestamp
     DeltaUniformIceberg invalidIceberg3 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(100L);
     DeltaUniform invalidUniform3 =
         new DeltaUniform().iceberg(invalidIceberg3);
@@ -960,16 +961,16 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit3),
         ErrorCode.INVALID_ARGUMENT,
-        "converted_delta_timestamp");
+        "converted-delta-timestamp");
 
     // Test 4: Size exceeds limit
     // Create a very long metadata location that exceeds the maximum allowed size
     String longLocation =
-        "s3://my-bucket/metadata/"
-            + "x".repeat(DeltaCommitRepository.MAX_DELTA_UNIFORM_ICEBERG_SIZE);
+        tableInfo.getStorageLocation() + "/_u/"
+            + "x".repeat(DeltaUniformUtils.MAX_METADATA_LOCATION_BYTES);
     DeltaUniformIceberg invalidIceberg4 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create(longLocation))
+            .metadataLocation(URI.create(longLocation))
             .convertedDeltaVersion(1L)  // Must match commit version
             .convertedDeltaTimestamp(Instant.now().toString());
     DeltaUniform invalidUniform4 =
@@ -980,12 +981,12 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit4),
         ErrorCode.INVALID_ARGUMENT,
-        "exceeds maximum allowed size");
+        "exceeds the maximum allowed");
 
     // Test 5: converted_delta_version doesn't match commit version
     DeltaUniformIceberg invalidIceberg5 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(999L)  // Wrong version - commit is version 1
             .convertedDeltaTimestamp(Instant.now().toString());
     DeltaUniform invalidUniform5 =
@@ -997,6 +998,32 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         () -> deltaCommitsApi.commit(commit5),
         ErrorCode.INVALID_ARGUMENT,
         "must equal commit version");
+
+    // Test 6: metadata-location not a subpath of the table's storage root
+    // Mirrors the create-time check (DeltaUniformUtils.requireMetadataLocationSubpath) so a
+    // commit's Iceberg sidecar can't escape the table's storage tree -- otherwise table-level
+    // credential vending and lifecycle (delete/rename) wouldn't cover it. The commit enables
+    // UniForm via metadata so the subpath check (which lives after the property/block consistency
+    // check) is reachable.
+    DeltaMetadata uniformEnablingMetadata =
+        new DeltaMetadata()
+            .properties(
+                constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */));
+    DeltaUniformIceberg invalidIceberg6 =
+        new DeltaUniformIceberg()
+            // Sibling location, not under tableInfo.getStorageLocation().
+            .metadataLocation(URI.create("s3://elsewhere/iceberg/v1.json"))
+            .convertedDeltaVersion(1L)
+            .convertedDeltaTimestamp(Instant.now().toString());
+    DeltaUniform invalidUniform6 = new DeltaUniform().iceberg(invalidIceberg6);
+    DeltaCommit commit6 =
+        createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
+            .metadata(uniformEnablingMetadata)
+            .uniform(invalidUniform6);
+    assertApiException(
+        () -> deltaCommitsApi.commit(commit6),
+        ErrorCode.INVALID_ARGUMENT,
+        "must be a subpath");
   }
 
   @Test
@@ -1013,7 +1040,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaUniform uniform1 = new DeltaUniform();
     DeltaUniformIceberg icebergMetadata =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v1.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(1L)
             .convertedDeltaTimestamp(Instant.now().toString());
     uniform1.setIceberg(icebergMetadata);
@@ -1037,7 +1064,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit2),
         ErrorCode.INVALID_ARGUMENT,
-        "Uniform metadata must be set when table has UniForm enabled");
+        "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
     // Test 3:
     // Existing Table: uniform enabled;
     // Property Change: disable uniform;
@@ -1049,7 +1076,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
                 constructProperties(tableInfo.getTableId(), false /* isUniFormEnabled */));
     DeltaUniformIceberg icebergMetadata2 =
             new DeltaUniformIceberg()
-                    .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v2.json"))
+                    .metadataLocation(
+                            URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
                     .convertedDeltaVersion(2L)
                     .convertedDeltaTimestamp(Instant.now().toString());
     uniform2.setIceberg(icebergMetadata2);
@@ -1060,7 +1088,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit3),
         ErrorCode.INVALID_ARGUMENT,
-        "Uniform metadata must not be set when table has UniForm disabled");
+        "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
     // Test 4:
     // Existing Table: uniform enabled;
     // Property Change: disable uniform;
@@ -1080,7 +1108,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     String timestamp5 = Instant.now().toString();
     DeltaUniformIceberg icebergMetadata5 =
         new DeltaUniformIceberg()
-            .metadataLocation(java.net.URI.create("s3://my-bucket/metadata/v3.json"))
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v3.json"))
             .convertedDeltaVersion(3L)
             .convertedDeltaTimestamp(timestamp5);
     DeltaUniform uniform5 = new DeltaUniform().iceberg(icebergMetadata5);
@@ -1090,7 +1118,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit5),
         ErrorCode.INVALID_ARGUMENT,
-            "Uniform metadata must not be set when table has UniForm disabled");
+            "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
     // Test 6:
     // Existing Table: uniform disabled;
     // Property Change: enable uniform;
@@ -1103,6 +1131,6 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
             () -> deltaCommitsApi.commit(commit6),
             ErrorCode.INVALID_ARGUMENT,
-            "Uniform metadata must be set when table has UniForm enabled");
+            "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -967,7 +967,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Create a very long metadata location that exceeds the maximum allowed size
     String longLocation =
         tableInfo.getStorageLocation() + "/_u/"
-            + "x".repeat(DeltaUniformUtils.MAX_METADATA_LOCATION_BYTES);
+            + "x".repeat(DeltaUniformUtils.MAX_METADATA_LOCATION_CHARS);
     DeltaUniformIceberg invalidIceberg4 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(longLocation))

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -30,7 +30,8 @@ public class DeltaCreateTableMapperTest {
 
   @Test
   public void happyPathManagedBuildsCreateTable() {
-    CreateTable created = DeltaCreateTableMapper.toCreateTable("cat", "sch", baseManagedRequest());
+    CreateTable created =
+        DeltaCreateTableMapper.toCreateTable("cat", "sch", baseManagedRequest()).createTable();
 
     assertThat(created.getName()).isEqualTo("tbl");
     assertThat(created.getCatalogName()).isEqualTo("cat");
@@ -62,7 +63,7 @@ public class DeltaCreateTableMapperTest {
                     .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
             .properties(Map.of());
 
-    CreateTable created = DeltaCreateTableMapper.toCreateTable("cat", "sch", req);
+    CreateTable created = DeltaCreateTableMapper.toCreateTable("cat", "sch", req).createTable();
     assertThat(created.getTableType()).isEqualTo(io.unitycatalog.server.model.TableType.EXTERNAL);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/utils/NormalizedURLTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/NormalizedURLTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.unitycatalog.server.exception.BaseException;
+import java.net.URI;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -86,7 +87,8 @@ public class NormalizedURLTest {
 
     assertThrows(BaseException.class, () -> NormalizedURL.from(""));
     assertThrows(BaseException.class, () -> NormalizedURL.from("  "));
-    assertThat(NormalizedURL.from(null)).isNull();
+    assertThat(NormalizedURL.from((String) null)).isNull();
+    assertThat(NormalizedURL.from((URI) null)).isNull();
   }
 
   @Test


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1525/files) to review incremental changes.
- [**stack/create_table_uniform**](https://github.com/unitycatalog/unitycatalog/pull/1525) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1525/files)]
  - [stack/findTableOrThrow](https://github.com/unitycatalog/unitycatalog/pull/1543) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1543/files/a25ecb2841a83d9900384a67ba420adf727d7022..cf2f6abc869f852741ba3f58c2c608792bc55932)]
    - [stack/drc_update_table](https://github.com/unitycatalog/unitycatalog/pull/1544) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1544/files/cf2f6abc869f852741ba3f58c2c608792bc55932..a77ff20500b93aadd0ec583c7dec02d4603bbcec)]
      - [stack/drc_update_table_columns](https://github.com/unitycatalog/unitycatalog/pull/1545) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1545/files/a77ff20500b93aadd0ec583c7dec02d4603bbcec..5feea6ea244ffd3dd9279435e0abceac6ded9854)]
        - [stack/drc_commit](https://github.com/unitycatalog/unitycatalog/pull/1546) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1546/files/5feea6ea244ffd3dd9279435e0abceac6ded9854..01a62ec9f49e0ef2359743a273f7c46d25a1f252)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
New endpoint for Delta: UniForm-Iceberg support for createTable

Wires the optional uniform block through delta.yaml and the create handler: validates property/block consistency, wire shape, create-time atomicity (converted-delta-version is 0 or 1, base-converted-delta-version unset), and that the Iceberg metadata-location is a subpath of the table location; writes the validated triple to the DAO in the same INSERT as the table row.

Cross-cutting UniForm logic is centralized in DeltaUniformUtils so the createTable and addCommit paths share one source of truth for "is UniForm-Iceberg on?", basic-shape validation, the subpath rule, the UniformIcebergFields carrier, and the DAO writer.
