### PR TITLE
Strict column-shape validation for Delta createTable

### DIFF
--- a/api/delta-docs/Models/MapType.md
+++ b/api/delta-docs/Models/MapType.md
@@ -5,7 +5,7 @@
 |------------ | ------------- | ------------- | -------------|
 | **key-type** | [**DeltaType**](DeltaType.md) |  | [default to null] |
 | **value-type** | [**DeltaType**](DeltaType.md) |  | [default to null] |
-| **value-contains-null** | **Boolean** | Whether map values can be null | [default to true] |
+| **value-contains-null** | **Boolean** | Whether map values can be null | [default to null] |
 | **type** | **String** | Type identifier | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/delta-docs/Models/StructField.md
+++ b/api/delta-docs/Models/StructField.md
@@ -6,7 +6,7 @@
 | **name** | **String** | Column name | [default to null] |
 | **type** | [**DeltaType**](DeltaType.md) |  | [default to null] |
 | **nullable** | **Boolean** | Whether this column can be null | [default to null] |
-| **metadata** | [**Map**](AnyType.md) | Additional column metadata (arbitrary key-value pairs, e.g., comment, delta.columnMapping.id) | [default to null] |
+| **metadata** | [**StructFieldMetadata**](StructFieldMetadata.md) |  | [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/delta-docs/Models/StructFieldMetadata.md
+++ b/api/delta-docs/Models/StructFieldMetadata.md
@@ -1,11 +1,9 @@
-# ArrayType
+# StructFieldMetadata
 ## Properties
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **element-type** | [**DeltaType**](DeltaType.md) |  | [default to null] |
-| **contains-null** | **Boolean** | Whether array elements can be null | [default to null] |
-| **type** | **String** | Type identifier | [default to null] |
+| **comment** | **String** |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/delta-docs/README.md
+++ b/api/delta-docs/README.md
@@ -69,6 +69,7 @@ All URIs are relative to *https://localhost:8080/api/2.1/unity-catalog*
  - [StorageCredential](./Models/StorageCredential.md)
  - [StorageCredential_config](./Models/StorageCredential_config.md)
  - [StructField](./Models/StructField.md)
+ - [StructFieldMetadata](./Models/StructFieldMetadata.md)
  - [StructType](./Models/StructType.md)
  - [TableIdentifierWithDataSourceFormat](./Models/TableIdentifierWithDataSourceFormat.md)
  - [TableMetadata](./Models/TableMetadata.md)

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1342,15 +1342,21 @@ components:
           type: boolean
           description: Whether this column can be null
         metadata:
-          type: object
-          description: Additional column metadata (arbitrary key-value pairs, e.g., comment, delta.columnMapping.id)
-          additionalProperties:
-            description: Metadata values can be strings, numbers, booleans, or nested objects
+          $ref: '#/components/schemas/StructFieldMetadata'
       required:
         - name
         - type
         - nullable
         - metadata
+
+    StructFieldMetadata:
+      type: object
+      description: Additional column metadata (arbitrary key-value pairs, e.g., comment, delta.columnMapping.id)
+      additionalProperties:
+        description: Metadata values can be strings, numbers, booleans, or nested objects
+      properties:
+        comment:
+          type: string
 
     DeltaType:
       description: |
@@ -1408,7 +1414,6 @@ components:
         contains-null:
           type: boolean
           description: Whether array elements can be null
-          default: true
       required:
         - element-type
         - contains-null
@@ -1425,7 +1430,6 @@ components:
         value-contains-null:
           type: boolean
           description: Whether map values can be null
-          default: true
       required:
         - key-type
         - value-type

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1355,8 +1355,14 @@ components:
       additionalProperties:
         description: Metadata values can be strings, numbers, booleans, or nested objects
       properties:
-        comment:
-          type: string
+        _placeholder:
+          type: object
+          description: |
+            Schema-only marker; never sent on the wire. Declared so the OpenAPI generator emits a
+            wrapper class for this schema instead of inlining `metadata` on the parent StructField
+            `new HashMap<>()` -- that would erase the "metadata absent" signal. Use the Map
+            accessors (e.g., `metadata.put("comment", ...)` and `metadata.get("comment")`) for 
+            actual metadata keys.
 
     DeltaType:
       description: |

--- a/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaModelSerializationTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaModelSerializationTest.java
@@ -27,6 +27,7 @@ import io.unitycatalog.client.delta.model.SetProtocolUpdate;
 import io.unitycatalog.client.delta.model.SetSchemaUpdate;
 import io.unitycatalog.client.delta.model.SetTableCommentUpdate;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableUpdate;
 import io.unitycatalog.client.delta.model.UniformMetadata;
@@ -306,8 +307,7 @@ public class DeltaModelSerializationTest {
   }
 
   @Test
-  public void testDeserOmittedContainsNull() throws Exception {
-    // When contains-null / value-contains-null are omitted, defaults apply
+  public void testDeserOmittedContainsNullLeavesNull() throws Exception {
     String arrayJson =
         "{"
             + " \"name\": \"tags\","
@@ -316,14 +316,7 @@ public class DeltaModelSerializationTest {
             + " \"metadata\": {}"
             + "}";
     StructField arrCol = MAPPER.readValue(arrayJson, StructField.class);
-    ArrayType at = (ArrayType) arrCol.getType();
-    // Default: containsNull = true
-    assertThat(at.getContainsNull()).isTrue();
-
-    // Round-trip preserves the default
-    String serialized = MAPPER.writeValueAsString(arrCol);
-    StructField roundTrip = MAPPER.readValue(serialized, StructField.class);
-    assertThat(((ArrayType) roundTrip.getType()).getContainsNull()).isTrue();
+    assertThat(((ArrayType) arrCol.getType()).getContainsNull()).isNull();
 
     String mapJson =
         "{"
@@ -337,14 +330,7 @@ public class DeltaModelSerializationTest {
             + " \"metadata\": {}"
             + "}";
     StructField mapCol = MAPPER.readValue(mapJson, StructField.class);
-    MapType mt = (MapType) mapCol.getType();
-    // Default: valueContainsNull = true
-    assertThat(mt.getValueContainsNull()).isTrue();
-
-    // Round-trip preserves the default
-    String mapSerialized = MAPPER.writeValueAsString(mapCol);
-    StructField mapRoundTrip = MAPPER.readValue(mapSerialized, StructField.class);
-    assertThat(((MapType) mapRoundTrip.getType()).getValueContainsNull()).isTrue();
+    assertThat(((MapType) mapCol.getType()).getValueContainsNull()).isNull();
   }
 
   // ==================== Serialization ====================
@@ -398,20 +384,23 @@ public class DeltaModelSerializationTest {
             .type(new PrimitiveType().type("long"))
             .nullable(false)
             .metadata(
-                Map.of("delta.columnMapping.id", 1, "delta.columnMapping.physicalName", "col-1"));
+                meta(
+                    null,
+                    Map.of(
+                        "delta.columnMapping.id", 1, "delta.columnMapping.physicalName", "col-1")));
     StructField colPrice =
         new StructField()
             .name("price")
             .type(new DecimalType().precision(10).scale(2))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     StructField colTags =
         new StructField()
             .name("tags")
             .type(
                 new ArrayType().elementType(new PrimitiveType().type("string")).containsNull(true))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     StructField colScores =
         new StructField()
             .name("scores")
@@ -427,18 +416,22 @@ public class DeltaModelSerializationTest {
                                         .type(new PrimitiveType().type("double"))
                                         .nullable(false)
                                         .metadata(
-                                            Map.of(
-                                                "delta.columnMapping.id", 10,
-                                                "delta.columnMapping.physicalName", "col-10",
-                                                "comment", "score value")),
+                                            meta(
+                                                "score value",
+                                                Map.of(
+                                                    "delta.columnMapping.id",
+                                                    10,
+                                                    "delta.columnMapping.physicalName",
+                                                    "col-10"))),
                                     new StructField()
                                         .name("timestamp")
                                         .type(new PrimitiveType().type("long"))
                                         .nullable(true)
-                                        .metadata(Map.of("delta.columnMapping.id", 11)))))
+                                        .metadata(
+                                            meta(null, Map.of("delta.columnMapping.id", 11))))))
                     .valueContainsNull(true))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     SetSchemaUpdate setSchema =
         new SetSchemaUpdate()
             .action("set-columns")
@@ -593,5 +586,22 @@ public class DeltaModelSerializationTest {
     try (InputStream is = DeltaModelSerializationTest.class.getResourceAsStream(resourcePath)) {
       return new String(is.readAllBytes(), StandardCharsets.UTF_8);
     }
+  }
+
+  /**
+   * Build a {@link StructFieldMetadata} with the optional {@code comment} plus a bag of additional
+   * properties for the spec's dotted Delta keys (e.g. {@code delta.columnMapping.id}). Both the
+   * server-side and client-side {@code StructFieldMetadata} extend {@code HashMap<String, Object>};
+   * Jackson treats them as Maps for serialization (and skips the generated {@code @JsonAnyGetter}
+   * when extending a Map), so we write everything via {@code put} into the inherited Map view
+   * rather than the typed setter or {@code putAdditionalProperty}.
+   */
+  private static StructFieldMetadata meta(String comment, Map<String, Object> additional) {
+    StructFieldMetadata m = new StructFieldMetadata();
+    if (comment != null) {
+      m.put("comment", comment);
+    }
+    m.putAll(additional);
+    return m;
   }
 }

--- a/clients/python/src/unitycatalog/delta/serde/delta_type_module.py
+++ b/clients/python/src/unitycatalog/delta/serde/delta_type_module.py
@@ -87,7 +87,7 @@ def _field_to_dict(sf):
         "name": sf.name,
         "type": _type_to_dict(sf.type),
         "nullable": sf.nullable,
-        "metadata": sf.metadata,
+        "metadata": sf.metadata.to_dict() if sf.metadata is not None else {},
     }
 
 

--- a/clients/python/tests/test_delta_type_module.py
+++ b/clients/python/tests/test_delta_type_module.py
@@ -19,6 +19,7 @@ from unitycatalog.delta.models.array_type import ArrayType
 from unitycatalog.delta.models.map_type import MapType
 from unitycatalog.delta.models.struct_type import StructType
 from unitycatalog.delta.models.struct_field import StructField
+from unitycatalog.delta.models.struct_field_metadata import StructFieldMetadata
 
 # Importing delta_type_module applies the monkey-patches
 import unitycatalog.delta.serde.delta_type_module  # noqa: F401
@@ -40,6 +41,9 @@ class TestDeserFromJson:
             col = StructField.from_json(json_str)
             assert isinstance(col.type, PrimitiveType)
             assert col.type.type == t
+            # Pydantic must coerce the dict `metadata` into a typed StructFieldMetadata
+            # instance -- _field_to_dict relies on this to call `.to_dict()` on serialization.
+            assert isinstance(col.metadata, StructFieldMetadata)
 
     def test_decimal_type(self):
         json_str = json.dumps({
@@ -203,6 +207,11 @@ class TestJsonRoundTrip:
             "metadata": {},
         }
         col = StructField.from_json(json.dumps(original))
+        # Metadata at every level (root, each leaf) must be StructFieldMetadata so the
+        # `.to_dict()` call in _field_to_dict succeeds during the round-trip below.
+        assert isinstance(col.metadata, StructFieldMetadata)
+        for inner in col.type.fields:
+            assert isinstance(inner.metadata, StructFieldMetadata)
         reserialized = json.loads(col.to_json())
         assert reserialized == original
 

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -594,11 +594,12 @@ public class TableRepository {
       CreateResultMapper<T> mapper) {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
+    DataSourceFormat format = createTable.getDataSourceFormat();
     List<ColumnInfo> columnInfos =
         createTable.getColumns().stream()
             .map(
                 c -> {
-                  ColumnUtils.validateTypeJson(c);
+                  ColumnUtils.validateTypeJson(c, format);
                   return c.typeText(c.getTypeText().toLowerCase(Locale.ROOT));
                 })
             .toList();

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -49,11 +49,6 @@ public final class DeltaCreateTableMapper {
     if (req.getLocation() == null || req.getLocation().isBlank()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table location is required.");
     }
-    if (req.getColumns() == null
-        || req.getColumns().getFields() == null
-        || req.getColumns().getFields().isEmpty()) {
-      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table columns are required.");
-    }
     ColumnUtils.validateStructType(req.getColumns(), "columns");
 
     TableType tableType = toUCTableType(req.getTableType());

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -54,6 +54,11 @@ public final class DeltaCreateTableMapper {
         || req.getColumns().getFields().isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table columns are required.");
     }
+    if (req.getColumns().getFields().isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "Table must have at least one column.");
+    }
+    ColumnUtils.validateStructType(req.getColumns(), "columns");
 
     TableType tableType = toUCTableType(req.getTableType());
     if (req.getProtocol() == null) {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -54,10 +54,6 @@ public final class DeltaCreateTableMapper {
         || req.getColumns().getFields().isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Table columns are required.");
     }
-    if (req.getColumns().getFields().isEmpty()) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "Table must have at least one column.");
-    }
     ColumnUtils.validateStructType(req.getColumns(), "columns");
 
     TableType tableType = toUCTableType(req.getTableType());

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -21,7 +21,9 @@ import io.unitycatalog.server.model.ColumnTypeName;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
@@ -240,8 +242,15 @@ public class ColumnUtils {
   public static void validateStructType(StructType structType, String path) {
     requireNonNull(structType.getFields(), path + ".fields");
     List<StructField> fields = structType.getFields();
+    Set<String> seen = new HashSet<>();
     for (int i = 0; i < fields.size(); i++) {
       validateStructField(fields.get(i), path + ".fields[" + i + "]");
+      String name = fields.get(i).getName();
+      if (!seen.add(name)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "Duplicate field name in " + path + ".fields: " + name);
+      }
     }
   }
 
@@ -463,6 +472,14 @@ public class ColumnUtils {
       List<ColumnInfo> columns, List<String> partitionColumns) {
     if (partitionColumns == null || partitionColumns.isEmpty()) {
       return;
+    }
+    Set<String> seen = new HashSet<>();
+    for (String partName : partitionColumns) {
+      if (!seen.add(partName)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "partition-columns contains duplicate entry: " + partName);
+      }
     }
     Map<String, ColumnInfo> columnsByName =
         columns.stream().collect(Collectors.toMap(ColumnInfo::getName, Function.identity()));

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -3,7 +3,6 @@ package io.unitycatalog.server.utils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.delta.model.ArrayType;
 import io.unitycatalog.server.delta.model.DecimalType;
@@ -154,27 +153,22 @@ public class ColumnUtils {
   }
 
   /**
-   * Validate that a UC column stores typeJson as Spark StructField JSON. The Spark connector and
-   * Delta REST APIs depend on name, type, nullable, and metadata being present in this payload.
+   * Validate that a UC column stores {@code typeJson} as Spark {@link StructField} JSON.
    */
   public static void validateTypeJson(ColumnInfo column) {
     if (column == null) {
       throw invalidTypeJson(null, "column cannot be null");
     }
-    JsonNode typeJson = parseTypeJson(column);
-    requireTypeJsonField(column, typeJson, StructField.JSON_PROPERTY_NAME);
-    requireTypeJsonField(column, typeJson, StructField.JSON_PROPERTY_TYPE);
-    requireTypeJsonField(column, typeJson, StructField.JSON_PROPERTY_NULLABLE);
-    JsonNode metadata = requireTypeJsonField(column, typeJson, StructField.JSON_PROPERTY_METADATA);
-    if (!metadata.isObject()) {
-      throw invalidTypeJson(column, "type_json.metadata must be a JSON object");
-    }
-
     StructField field;
     try {
       field = toStructField(column);
     } catch (IllegalStateException e) {
       throw invalidTypeJson(column, e.getMessage(), e);
+    }
+    try {
+      validateStructField(field, "type_json");
+    } catch (BaseException e) {
+      throw invalidTypeJson(column, e.getErrorMessage(), e);
     }
     if (!field.getName().equals(column.getName())) {
       throw invalidTypeJson(
@@ -189,29 +183,6 @@ public class ColumnUtils {
               "field nullable %s does not match column nullable %s",
               field.getNullable(), column.getNullable()));
     }
-  }
-
-  private static JsonNode parseTypeJson(ColumnInfo column) {
-    if (column.getTypeJson() == null || column.getTypeJson().isEmpty()) {
-      throw invalidTypeJson(column, "type_json cannot be null or empty");
-    }
-    try {
-      JsonNode typeJson = TYPE_MAPPER.readTree(column.getTypeJson());
-      if (typeJson == null || !typeJson.isObject()) {
-        throw invalidTypeJson(column, "type_json must be a JSON object");
-      }
-      return typeJson;
-    } catch (JsonProcessingException e) {
-      throw invalidTypeJson(column, "Failed to parse typeJson: " + column.getTypeJson(), e);
-    }
-  }
-
-  private static JsonNode requireTypeJsonField(ColumnInfo column, JsonNode typeJson, String name) {
-    JsonNode field = typeJson.get(name);
-    if (field == null || field.isNull()) {
-      throw invalidTypeJson(column, "type_json." + name + " is required");
-    }
-    return field;
   }
 
   private static BaseException invalidTypeJson(ColumnInfo column, String message) {
@@ -244,7 +215,9 @@ public class ColumnUtils {
     List<StructField> fields = structType.getFields();
     Set<String> seen = new HashSet<>();
     for (int i = 0; i < fields.size(); i++) {
-      validateStructField(fields.get(i), path + ".fields[" + i + "]");
+      String fieldPath = path + ".fields[" + i + "]";
+      requireNonNull(fields.get(i), fieldPath);
+      validateStructField(fields.get(i), fieldPath);
       String name = fields.get(i).getName();
       if (!seen.add(name)) {
         throw new BaseException(

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -17,14 +17,15 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.ColumnTypeName;
+import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -153,9 +154,13 @@ public class ColumnUtils {
   }
 
   /**
-   * Validate that a UC column stores {@code typeJson} as Spark {@link StructField} JSON.
+   * Validate that a UC column stores {@code typeJson} as Spark {@link StructField} JSON. Shape
+   * (deserializability) and name/nullable cross-match run for all formats. The
+   * Delta-protocol primitive-type closed-set check runs only for {@link DataSourceFormat#DELTA} --
+   * non-Delta tables (Parquet, CSV, ...) may legitimately carry Spark types that the closed set
+   * rejects (e.g. {@code char(N)} / {@code varchar(N)}).
    */
-  public static void validateTypeJson(ColumnInfo column) {
+  public static void validateTypeJson(ColumnInfo column, DataSourceFormat format) {
     if (column == null) {
       throw invalidTypeJson(null, "column cannot be null");
     }
@@ -165,10 +170,12 @@ public class ColumnUtils {
     } catch (IllegalStateException e) {
       throw invalidTypeJson(column, e.getMessage(), e);
     }
-    try {
-      validateStructField(field, "type_json");
-    } catch (BaseException e) {
-      throw invalidTypeJson(column, e.getErrorMessage(), e);
+    if (format == DataSourceFormat.DELTA) {
+      try {
+        validateStructField(field, "type_json");
+      } catch (BaseException e) {
+        throw invalidTypeJson(column, e.getErrorMessage(), e);
+      }
     }
     if (!field.getName().equals(column.getName())) {
       throw invalidTypeJson(
@@ -209,10 +216,17 @@ public class ColumnUtils {
 
   /**
    * Validate that a {@link StructType} is well-formed against the Delta spec's wire shape.
+   * Centralizes structural validation so callers can pass {@code columns} directly without
+   * pre-checking nullness/emptiness.
    */
   public static void validateStructType(StructType structType, String path) {
+    requireNonNull(structType, path);
     requireNonNull(structType.getFields(), path + ".fields");
     List<StructField> fields = structType.getFields();
+    if (fields.isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, path + ".fields must contain at least one field.");
+    }
     Set<String> seen = new HashSet<>();
     for (int i = 0; i < fields.size(); i++) {
       String fieldPath = path + ".fields[" + i + "]";
@@ -221,14 +235,16 @@ public class ColumnUtils {
       String name = fields.get(i).getName();
       if (!seen.add(name)) {
         throw new BaseException(
-            ErrorCode.INVALID_ARGUMENT,
-            "Duplicate field name in " + path + ".fields: " + name);
+          ErrorCode.INVALID_ARGUMENT, "Duplicate field name in " + fieldPath + ": " + name);
       }
     }
   }
 
   private static void validateStructField(StructField field, String path) {
-    requireNonNull(field.getName(), path + ".name");
+    String name = field.getName();
+    if (name == null || name.isBlank()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, path + ".name is required.");
+    }
     requireNonNull(field.getType(), path + ".type");
     requireNonNull(field.getNullable(), path + ".nullable");
     requireNonNull(field.getMetadata(), path + ".metadata");
@@ -268,6 +284,8 @@ public class ColumnUtils {
     requireNonNull(decimal.getScale(), path + ".scale");
     int precision = decimal.getPrecision();
     int scale = decimal.getScale();
+    // Matches io.delta.kernel.types.DecimalType bounds (precision=0 is allowed there, even
+    // though it's degenerate).
     if (precision < 0 || precision > 38) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
@@ -281,7 +299,17 @@ public class ColumnUtils {
   }
 
   private static void validatePrimitiveType(PrimitiveType primitive, String path) {
-    requireNonNull(primitive.getType(), path + ".type");
+    // The PrimitiveType discriminator (the "type" string) IS the primitive name; the caller's
+    // path already ends in `.type`, so no further suffix here. Resolve to confirm the name is in
+    // the closed set we support; rethrow with the field path attached so the error mirrors the
+    // shape of every other validation message in this file (downstream toColumnInfos would
+    // otherwise throw without path context).
+    requireNonNull(primitive.getType(), path);
+    try {
+      resolveColumnTypeName(primitive);
+    } catch (BaseException e) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, path + ": " + e.getMessage(), e);
+    }
   }
 
   private static void requireNonNull(Object value, String path) {
@@ -294,6 +322,12 @@ public class ColumnUtils {
    * Convert a UC Delta API {@link StructField} into a UC {@link ColumnInfo}, mirroring
    * {@code UCSingleCatalog.createTable}'s per-column projection so Delta-created tables render
    * identically to Spark-created ones.
+   *
+   * <p>Caller contract: {@code field} must have already been validated by
+   * {@link #validateStructType}. This method does not re-check shape -- malformed input will
+   * surface as a downstream {@link IllegalStateException} from {@link #toTypeJson} or a
+   * {@link BaseException} from {@link #resolveColumnTypeName}, without the path-context that
+   * {@code validateStructType} provides.
    *
    * <p>Fields populated (matching UCSingleCatalog exactly):
    * <ul>
@@ -377,12 +411,10 @@ public class ColumnUtils {
   private static String extractComment(StructField field) {
     StructFieldMetadata metadata = field.getMetadata();
     if (metadata == null) return null;
-    if (metadata.getComment() != null) {
-      return metadata.getComment();
-    }
+    // StructFieldMetadata extends HashMap via additionalProperties; the schema deliberately does
+    // not promote "comment" to a typed property (see api/delta.yaml). Read via Map access.
     Object fromMap = metadata.get("comment");
-    if (fromMap instanceof String s) return s;
-    return null;
+    return fromMap instanceof String s ? s : null;
   }
 
   private static ColumnTypeName resolveColumnTypeName(DeltaType type) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -176,6 +176,12 @@ public class ColumnUtils {
       } catch (BaseException e) {
         throw invalidTypeJson(column, e.getErrorMessage(), e);
       }
+    } else {
+      // A shallow check for non-Delta
+      requireNonNull(field.getName(), "type_json.name");
+      requireNonNull(field.getType(), "type_json.type");
+      requireNonNull(field.getNullable(), "type_json.nullable");
+      requireNonNull(field.getMetadata(), "type_json.metadata");
     }
     if (!field.getName().equals(column.getName())) {
       throw invalidTypeJson(

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -9,7 +9,9 @@ import io.unitycatalog.server.delta.model.ArrayType;
 import io.unitycatalog.server.delta.model.DecimalType;
 import io.unitycatalog.server.delta.model.DeltaType;
 import io.unitycatalog.server.delta.model.MapType;
+import io.unitycatalog.server.delta.model.PrimitiveType;
 import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructFieldMetadata;
 import io.unitycatalog.server.delta.model.StructType;
 import io.unitycatalog.server.delta.serde.DeltaTypeModule;
 import io.unitycatalog.server.exception.BaseException;
@@ -233,6 +235,80 @@ public class ColumnUtils {
   }
 
   /**
+   * Validate that a {@link StructType} is well-formed against the Delta spec's wire shape.
+   */
+  public static void validateStructType(StructType structType, String path) {
+    requireNonNull(structType.getFields(), path + ".fields");
+    List<StructField> fields = structType.getFields();
+    for (int i = 0; i < fields.size(); i++) {
+      validateStructField(fields.get(i), path + ".fields[" + i + "]");
+    }
+  }
+
+  private static void validateStructField(StructField field, String path) {
+    requireNonNull(field.getName(), path + ".name");
+    requireNonNull(field.getType(), path + ".type");
+    requireNonNull(field.getNullable(), path + ".nullable");
+    requireNonNull(field.getMetadata(), path + ".metadata");
+    validateType(field.getType(), path + ".type");
+  }
+
+  private static void validateType(DeltaType type, String path) {
+    if (type instanceof StructType s) {
+      validateStructType(s, path);
+    } else if (type instanceof ArrayType a) {
+      validateArrayType(a, path);
+    } else if (type instanceof MapType m) {
+      validateMapType(m, path);
+    } else if (type instanceof DecimalType d) {
+      validateDecimalType(d, path);
+    } else if (type instanceof PrimitiveType p) {
+      validatePrimitiveType(p, path);
+    }
+  }
+
+  private static void validateArrayType(ArrayType array, String path) {
+    requireNonNull(array.getElementType(), path + ".element-type");
+    requireNonNull(array.getContainsNull(), path + ".contains-null");
+    validateType(array.getElementType(), path + ".element-type");
+  }
+
+  private static void validateMapType(MapType map, String path) {
+    requireNonNull(map.getKeyType(), path + ".key-type");
+    requireNonNull(map.getValueType(), path + ".value-type");
+    requireNonNull(map.getValueContainsNull(), path + ".value-contains-null");
+    validateType(map.getKeyType(), path + ".key-type");
+    validateType(map.getValueType(), path + ".value-type");
+  }
+
+  private static void validateDecimalType(DecimalType decimal, String path) {
+    requireNonNull(decimal.getPrecision(), path + ".precision");
+    requireNonNull(decimal.getScale(), path + ".scale");
+    int precision = decimal.getPrecision();
+    int scale = decimal.getScale();
+    if (precision < 0 || precision > 38) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format("%s.precision must be in [0, 38], got %d.", path, precision));
+    }
+    if (scale < 0 || scale > precision) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format("%s.scale must be in [0, precision=%d], got %d.", path, precision, scale));
+    }
+  }
+
+  private static void validatePrimitiveType(PrimitiveType primitive, String path) {
+    requireNonNull(primitive.getType(), path + ".type");
+  }
+
+  private static void requireNonNull(Object value, String path) {
+    if (value == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, path + " is required.");
+    }
+  }
+
+  /**
    * Convert a UC Delta API {@link StructField} into a UC {@link ColumnInfo}, mirroring
    * {@code UCSingleCatalog.createTable}'s per-column projection so Delta-created tables render
    * identically to Spark-created ones.
@@ -317,10 +393,14 @@ public class ColumnUtils {
   }
 
   private static String extractComment(StructField field) {
-    Map<String, Object> metadata = field.getMetadata();
+    StructFieldMetadata metadata = field.getMetadata();
     if (metadata == null) return null;
-    Object comment = metadata.get("comment");
-    return comment instanceof String s ? s : null;
+    if (metadata.getComment() != null) {
+      return metadata.getComment();
+    }
+    Object fromMap = metadata.get("comment");
+    if (fromMap instanceof String s) return s;
+    return null;
   }
 
   private static ColumnTypeName resolveColumnTypeName(DeltaType type) {

--- a/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
+++ b/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
@@ -12,6 +12,7 @@ import io.unitycatalog.client.delta.model.PrimitiveType;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableType;
 import io.unitycatalog.server.base.ServerConfig;
@@ -151,12 +152,12 @@ public abstract class DeltaBaseTableCRUDTestEnv extends BaseTableCRUDTestEnv {
                     .name("id")
                     .type(new PrimitiveType().type("long"))
                     .nullable(false)
-                    .metadata(Map.of()),
+                    .metadata(new StructFieldMetadata()),
                 new StructField()
                     .name("amount")
                     .type(new PrimitiveType().type("double"))
                     .nullable(true)
-                    .metadata(Map.of())));
+                    .metadata(new StructFieldMetadata())));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -10,6 +10,7 @@ import io.unitycatalog.client.delta.model.LoadTableResponse;
 import io.unitycatalog.client.delta.model.PrimitiveType;
 import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableType;
 import io.unitycatalog.server.base.ServerConfig;
@@ -44,7 +45,7 @@ public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccess
                       .name("test_column")
                       .type(new PrimitiveType().type("integer"))
                       .nullable(true)
-                      .metadata(Map.of())));
+                      .metadata(new StructFieldMetadata())));
 
   @Override
   protected StagingHandle createStaging(

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -9,6 +9,7 @@ import io.unitycatalog.client.api.CredentialsApi;
 import io.unitycatalog.client.api.ExternalLocationsApi;
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.api.VolumesApi;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.model.AwsIamRoleRequest;
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
@@ -529,7 +530,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                             .type(
                                 new io.unitycatalog.client.delta.model.PrimitiveType().type("long"))
                             .nullable(true)
-                            .metadata(java.util.Map.of()))))
+                            .metadata(new StructFieldMetadata()))))
         .properties(java.util.Map.of("delta.enableDeletionVectors", "true"))
         .lastCommitTimestampMs(1700000000000L);
   }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -14,6 +14,7 @@ import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 import io.unitycatalog.client.delta.model.PrimitiveType;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.client.model.CreateTable;
@@ -251,7 +252,7 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
                                     .name("id")
                                     .type(new PrimitiveType().type("long"))
                                     .nullable(false)
-                                    .metadata(Map.of()))))
+                                    .metadata(new StructFieldMetadata()))))
                 .protocol(
                     new DeltaProtocol()
                         .minReaderVersion(3)

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -1,0 +1,288 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.auth.AuthToken;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
+import io.unitycatalog.client.delta.model.ErrorType;
+import io.unitycatalog.client.delta.model.StagingTableResponse;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.server.base.BaseCRUDTest;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Raw-HTTP integration tests for the Delta REST Catalog {@code POST /v1/.../tables} endpoint.
+ *
+ * <p>The auto-generated {@code unitycatalog-client} can't construct certain malformed payloads --
+ * its DTOs reject them at compile time -- but a non-SDK client (Rust, Kernel) is not bound by the
+ * SDK's typed shape. This test posts hand-crafted JSON straight at the endpoint to pin server-
+ * side validation that the SDK tests cannot reach. Sister to {@link SdkCreateTableTest}, which
+ * covers everything reachable through the typed client.
+ */
+public class RawCreateTableTest extends BaseCRUDTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final String CREATE_TABLE_PATH =
+      "/api/2.1/unity-catalog/delta/v1/catalogs/"
+          + TestUtils.CATALOG_NAME
+          + "/schemas/"
+          + TestUtils.SCHEMA_NAME
+          + "/tables";
+
+  private TablesApi deltaTablesApi;
+  private WebClient client;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @BeforeEach
+  @Override
+  @SneakyThrows
+  public void setUp() {
+    super.setUp();
+    deltaTablesApi = new TablesApi(TestUtils.createApiClient(serverConfig));
+    SdkSchemaOperations schemaOperations =
+        new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+    catalogOperations.createCatalog(new CreateCatalog().name(TestUtils.CATALOG_NAME));
+    schemaOperations.createSchema(
+        new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
+    client =
+        WebClient.builder(serverConfig.getServerUrl())
+            .auth(AuthToken.ofOAuth2(serverConfig.getAuthToken()))
+            .build();
+  }
+
+  @Test
+  public void rawHttpRejectsMalformedColumnRequests() throws Exception {
+    StagingTableResponse staging =
+        deltaTablesApi.createStagingTable(
+            TestUtils.CATALOG_NAME,
+            TestUtils.SCHEMA_NAME,
+            new CreateStagingTableRequest().name("tbl_raw"));
+
+    // -------- StructField missing 'name' --------
+    // Caught by ColumnUtils.validateStructType, called from DeltaCreateTableMapper before the
+    // per-column conversion runs. The path locates the offending field.
+    assertRejected(
+        staging,
+        """
+        {"type": "long", "nullable": false, "metadata": {}}""",
+        "columns.fields[0].name is required.");
+
+    // -------- StructField missing 'type', second column in a multi-column request --------
+    // Pins that the validator iterates every column (not just the first) and that the path index
+    // reflects the offending column's position. A valid first column should pass and the
+    // malformed second column should be the one that surfaces in the error.
+    assertRejected(
+        staging,
+        """
+        {"name": "id", "type": "long", "nullable": false, "metadata": {}},
+        {"name": "amount", "nullable": true, "metadata": {}}""",
+        "columns.fields[1].type is required.");
+
+    // -------- a field element that is the bare string instead of a StructField object --------
+    // Pins the bug shape from PR #1524: a client serializes the value of `type` (the bare
+    // string "long") in the field position rather than the full StructField wrapper. Jackson
+    // can't coerce the string to a StructField bean, so the request must be rejected at the
+    // deserialization boundary before any validator runs. Substring match because the Jackson +
+    // Armeria envelope adds source-location and reference-chain noise we don't want to pin.
+    assertRejectedMessageContains(
+        staging,
+        "\"long\"",
+        "Cannot construct instance of"
+            + " `io.unitycatalog.server.delta.model.StructField`"
+            + " (although at least one Creator exists):"
+            + " no String-argument constructor/factory method"
+            + " to deserialize from String value ('long')");
+
+    // -------- column with an unsupported primitive type --------
+    // Pins that primitive type names go through validatePrimitiveType -> resolveColumnTypeName
+    // at the API boundary. "void" is Spark's NullType wire form, which Delta rejects on read;
+    // PR #1524 hardened the closely-related Spark-connector type_json path, so we mirror that
+    // rejection on the DRC create-table path with a raw-HTTP test.
+    assertRejected(
+        staging,
+        """
+        {"name": "x", "type": "void", "nullable": false, "metadata": {}}""",
+        "Unsupported Delta primitive type: void");
+
+    // -------- StructField missing 'nullable' --------
+    // Per Delta PROTOCOL.md every StructField must carry nullable.
+    assertRejected(
+        staging,
+        """
+        {"name": "id", "type": "long", "metadata": {}}""",
+        "columns.fields[0].nullable is required.");
+
+    // -------- StructField missing 'metadata' --------
+    // Enforceable now that delta.yaml types StructField.metadata as a typed wrapper class
+    // (StructFieldMetadata) instead of a raw Map -- the generator no longer auto-fills the
+    // field with new HashMap<>(), so a JSON omitting "metadata" leaves the field at null.
+    assertRejected(
+        staging,
+        """
+        {"name": "id", "type": "long", "nullable": false}""",
+        "columns.fields[0].metadata is required.");
+
+    // -------- ArrayType missing 'contains-null' --------
+    // Validator descends into the StructField's nested type. Path picks up ".type" as it crosses
+    // into the array. Enforceable now that delta.yaml dropped `default: true` for this field.
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "tags",
+          "type": {"type": "array", "element-type": "string"},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.contains-null is required.");
+
+    // -------- MapType missing 'value-contains-null' --------
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "props",
+          "type": {"type": "map", "key-type": "string", "value-type": "string"},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.value-contains-null is required.");
+
+    // -------- nested StructField inside an array of structs --------
+    // Pins that recursion descends into array elementType -> struct fields. The malformed inner
+    // field has no name; the path captures the full descent.
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "items",
+          "type": {
+            "type": "array",
+            "element-type": {
+              "type": "struct",
+              "fields": [{"type": "long", "nullable": false, "metadata": {}}]
+            },
+            "contains-null": true
+          },
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.element-type.fields[0].name is required.");
+
+    // -------- columns.fields is an empty list --------
+    assertRejected(staging, "", "Table must have at least one column.");
+  }
+
+  // ---------- helpers ----------
+
+  /**
+   * Post a createTable request whose {@code columns.fields} contains the supplied {@code
+   * columnJson} (or no fields at all when {@code columnJson} is empty), and assert the server
+   * rejects it with HTTP 400 and the exact {@code expectedMessage} in {@code error.message}. The
+   * surrounding request body is a full UC-managed shape (location/table-type/data-source-format/
+   * protocol/properties) bound to the given staging response, so cases that pass the column
+   * gates land on a request the rest of the server would normally accept.
+   */
+  @SneakyThrows
+  private void assertRejected(
+      StagingTableResponse staging, String columnJson, String expectedMessage) {
+    JsonNode error = postAndAssertRejected(staging, columnJson);
+    assertThat(error.get("message").asText()).isEqualTo(expectedMessage);
+  }
+
+  /**
+   * Like {@link #assertRejected} but matches a substring of {@code error.message} -- used when
+   * the response message comes from Jackson + Armeria framework wrapping (e.g. a deserialization
+   * mismatch) and contains source-location / reference-chain noise we don't want to pin.
+   */
+  @SneakyThrows
+  private void assertRejectedMessageContains(
+      StagingTableResponse staging, String columnJson, String messageSubstring) {
+    JsonNode error = postAndAssertRejected(staging, columnJson);
+    assertThat(error.get("message").asText()).contains(messageSubstring);
+  }
+
+  /**
+   * Posts a createTable request whose {@code columns.fields} contains {@code columnJson} and
+   * asserts the envelope (HTTP 400, {@code error.code} 400, {@code error.type}
+   * "InvalidParameterValueException"). Returns {@code error} so the caller can additionally
+   * assert on {@code message}.
+   */
+  @SneakyThrows
+  private JsonNode postAndAssertRejected(StagingTableResponse staging, String columnJson) {
+    String body =
+        String.format(
+            """
+            {
+              "name": "tbl_raw",
+              "location": "%s",
+              "table-type": "MANAGED",
+              "data-source-format": "DELTA",
+              "columns": {
+                "type": "struct",
+                "fields": [%s]
+              },
+              "protocol": {
+                "min-reader-version": 3,
+                "min-writer-version": 7,
+                "reader-features": [
+                  "catalogManaged", "deletionVectors", "v2Checkpoint", "vacuumProtocolCheck"
+                ],
+                "writer-features": [
+                  "catalogManaged", "deletionVectors", "inCommitTimestamp",
+                  "v2Checkpoint", "vacuumProtocolCheck"
+                ]
+              },
+              "properties": {
+                "delta.checkpointPolicy": "v2",
+                "delta.enableDeletionVectors": "true",
+                "delta.enableInCommitTimestamps": "true",
+                "io.unitycatalog.tableId": "%s",
+                "delta.inCommitTimestampEnablementVersion": "0",
+                "delta.inCommitTimestampEnablementTimestamp": "1700000000000"
+              }
+            }
+            """,
+            staging.getLocation(), columnJson, staging.getTableId().toString());
+
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(CREATE_TABLE_PATH)
+            .contentType(MediaType.JSON)
+            .build();
+    AggregatedHttpResponse resp =
+        client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
+
+    String content = resp.contentUtf8();
+    assertThat(resp.status().code()).as("body: %s", content).isEqualTo(400);
+    JsonNode error = MAPPER.readTree(content).get("error");
+    assertThat(error).as("body: %s", content).isNotNull();
+    assertThat(error.get("code").asInt()).isEqualTo(400);
+    assertThat(error.get("type").asText())
+        .isEqualTo(ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION.getValue());
+    return error;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -192,7 +192,15 @@ public class RawCreateTableTest extends BaseCRUDTest {
         "columns.fields[0].type.element-type.fields[0].name is required.");
 
     // -------- columns.fields is an empty list --------
-    assertRejected(staging, "", "Table must have at least one column.");
+    assertRejected(staging, "", "Table columns are required.");
+
+    // -------- duplicate field names at the top level --------
+    assertRejected(
+        staging,
+        """
+        {"name": "id", "type": "long", "nullable": false, "metadata": {}},
+        {"name": "id", "type": "string", "nullable": true, "metadata": {}}""",
+        "Duplicate field name in columns.fields: id");
   }
 
   // ---------- helpers ----------

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -119,12 +119,23 @@ public class RawCreateTableTest extends BaseCRUDTest {
     // Pins that primitive type names go through validatePrimitiveType -> resolveColumnTypeName
     // at the API boundary. "void" is Spark's NullType wire form, which Delta rejects on read;
     // PR #1524 hardened the closely-related Spark-connector type_json path, so we mirror that
-    // rejection on the DRC create-table path with a raw-HTTP test.
+    // rejection on the DRC create-table path with a raw-HTTP test. The validator prefixes the
+    // resolver's error with the field path so the message follows the same shape as every other
+    // validation error in this file.
     assertRejected(
         staging,
         """
         {"name": "x", "type": "void", "nullable": false, "metadata": {}}""",
-        "Unsupported Delta primitive type: void");
+        "columns.fields[0].type: Unsupported Delta primitive type: void");
+
+    // -------- StructField with a blank name --------
+    // Per Delta PROTOCOL.md column names must be non-empty. The validator rejects null AND
+    // blank (whitespace-only) names with the same message; both flow into the DB otherwise.
+    assertRejected(
+        staging,
+        """
+        {"name": "   ", "type": "long", "nullable": false, "metadata": {}}""",
+        "columns.fields[0].name is required.");
 
     // -------- StructField missing 'nullable' --------
     // Per Delta PROTOCOL.md every StructField must carry nullable.
@@ -170,6 +181,74 @@ public class RawCreateTableTest extends BaseCRUDTest {
         }""",
         "columns.fields[0].type.value-contains-null is required.");
 
+    // -------- MapType missing 'key-type' --------
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "props",
+          "type": {"type": "map", "value-type": "string", "value-contains-null": false},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.key-type is required.");
+
+    // -------- MapType missing 'value-type' --------
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "props",
+          "type": {"type": "map", "key-type": "string", "value-contains-null": false},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.value-type is required.");
+
+    // -------- DecimalType: precision > 38 (string wire form) --------
+    // String form "decimal(P,S)" is what Spark emits; the deserializer parses it into
+    // DecimalType so the validator's bound check fires.
+    assertRejected(
+        staging,
+        """
+        {"name": "price", "type": "decimal(50,2)", "nullable": true, "metadata": {}}""",
+        "columns.fields[0].type.precision must be in [0, 38], got 50.");
+
+    // -------- DecimalType: precision < 0 (object wire form) --------
+    // The "decimal(P,S)" string form's regex doesn't accept a negative precision, so the only
+    // way to land in validateDecimalType with a negative value is the typed object form a
+    // non-Spark client could emit.
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "price",
+          "type": {"type": "decimal", "precision": -1, "scale": 0},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.precision must be in [0, 38], got -1.");
+
+    // -------- DecimalType: scale > precision (string wire form) --------
+    assertRejected(
+        staging,
+        """
+        {"name": "price", "type": "decimal(5,10)", "nullable": true, "metadata": {}}""",
+        "columns.fields[0].type.scale must be in [0, precision=5], got 10.");
+
+    // -------- DecimalType: missing precision (object wire form) --------
+    // String form can't express a missing precision; this exercises the requireNonNull branch.
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "price",
+          "type": {"type": "decimal", "scale": 0},
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "columns.fields[0].type.precision is required.");
+
     // -------- nested StructField inside an array of structs --------
     // Pins that recursion descends into array elementType -> struct fields. The malformed inner
     // field has no name; the path captures the full descent.
@@ -192,15 +271,48 @@ public class RawCreateTableTest extends BaseCRUDTest {
         "columns.fields[0].type.element-type.fields[0].name is required.");
 
     // -------- columns.fields is an empty list --------
-    assertRejected(staging, "", "Table columns are required.");
+    // Validator centralizes both null and empty-array rejection so callers can pass `columns`
+    // straight through (DeltaCreateTableMapper no longer needs its own pre-check).
+    assertRejected(staging, "", "columns.fields must contain at least one field.");
+
+    // -------- no `columns` key in the request at all --------
+    // Distinct code path from the empty-fields case above: `req.getColumns()` is null, not a
+    // StructType with empty fields. The validator's top-level requireNonNull catches this.
+    assertRejectedRaw(staging, /* includeColumns= */ false, "columns is required.");
 
     // -------- duplicate field names at the top level --------
+    // Error message includes the index of the second occurrence so wide schemas surface the
+    // offending position alongside the name.
     assertRejected(
         staging,
         """
         {"name": "id", "type": "long", "nullable": false, "metadata": {}},
         {"name": "id", "type": "string", "nullable": true, "metadata": {}}""",
-        "Duplicate field name in columns.fields: id");
+        "Duplicate field name in columns.fields[1]: id");
+
+    // -------- duplicate field name inside a nested struct --------
+    // Proves uniqueness is enforced per StructType level (not only at the top level) -- the
+    // recursion in validateStructType applies the same check inside an array of structs.
+    assertRejected(
+        staging,
+        """
+        {
+          "name": "items",
+          "type": {
+            "type": "array",
+            "element-type": {
+              "type": "struct",
+              "fields": [
+                {"name": "x", "type": "long", "nullable": false, "metadata": {}},
+                {"name": "x", "type": "string", "nullable": true, "metadata": {}}
+              ]
+            },
+            "contains-null": true
+          },
+          "nullable": true,
+          "metadata": {}
+        }""",
+        "Duplicate field name in columns.fields[0].type.element-type.fields[1]: x");
   }
 
   // ---------- helpers ----------
@@ -230,6 +342,65 @@ public class RawCreateTableTest extends BaseCRUDTest {
       StagingTableResponse staging, String columnJson, String messageSubstring) {
     JsonNode error = postAndAssertRejected(staging, columnJson);
     assertThat(error.get("message").asText()).contains(messageSubstring);
+  }
+
+  /**
+   * Variant of {@link #assertRejected} that posts a body with no {@code columns} key at all when
+   * {@code includeColumns} is false. This exercises the {@code req.getColumns() == null} branch,
+   * distinct from the empty-fields-array case the other helper covers.
+   */
+  @SneakyThrows
+  private void assertRejectedRaw(
+      StagingTableResponse staging, boolean includeColumns, String expectedMessage) {
+    String columnsBlock =
+        includeColumns ? "\"columns\": {\"type\": \"struct\", \"fields\": []}," : "";
+    String body =
+        String.format(
+            """
+            {
+              "name": "tbl_raw",
+              "location": "%s",
+              "table-type": "MANAGED",
+              "data-source-format": "DELTA",
+              %s
+              "protocol": {
+                "min-reader-version": 3,
+                "min-writer-version": 7,
+                "reader-features": [
+                  "catalogManaged", "deletionVectors", "v2Checkpoint", "vacuumProtocolCheck"
+                ],
+                "writer-features": [
+                  "catalogManaged", "deletionVectors", "inCommitTimestamp",
+                  "v2Checkpoint", "vacuumProtocolCheck"
+                ]
+              },
+              "properties": {
+                "delta.checkpointPolicy": "v2",
+                "delta.enableDeletionVectors": "true",
+                "delta.enableInCommitTimestamps": "true",
+                "io.unitycatalog.tableId": "%s",
+                "delta.inCommitTimestampEnablementVersion": "0",
+                "delta.inCommitTimestampEnablementTimestamp": "1700000000000"
+              },
+              "last-commit-timestamp-ms": 1700000000000
+            }
+            """,
+            staging.getLocation(), columnsBlock, staging.getTableId());
+
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(CREATE_TABLE_PATH)
+            .contentType(MediaType.JSON)
+            .build();
+    AggregatedHttpResponse resp =
+        client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
+
+    String content = resp.contentUtf8();
+    assertThat(resp.status().code()).as("body: %s", content).isEqualTo(400);
+    JsonNode error = MAPPER.readTree(content).get("error");
+    assertThat(error).as("body: %s", content).isNotNull();
+    assertThat(error.get("message").asText()).isEqualTo(expectedMessage);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -270,7 +270,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
                 "io.unitycatalog.tableId": "%s",
                 "delta.inCommitTimestampEnablementVersion": "0",
                 "delta.inCommitTimestampEnablementTimestamp": "1700000000000"
-              }
+              },
+              "last-commit-timestamp-ms": 1700000000000
             }
             """,
             staging.getLocation(), columnJson, staging.getTableId().toString());

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -16,6 +16,7 @@ import io.unitycatalog.client.delta.model.PrimitiveType;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableType;
 import io.unitycatalog.client.delta.model.UniformMetadata;
@@ -416,12 +417,12 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                     .name("id")
                     .type(new PrimitiveType().type("long"))
                     .nullable(false)
-                    .metadata(Map.of()),
+                    .metadata(new StructFieldMetadata()),
                 new StructField()
                     .name("amount")
                     .type(new PrimitiveType().type("double"))
                     .nullable(true)
-                    .metadata(Map.of())));
+                    .metadata(new StructFieldMetadata())));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -24,6 +24,7 @@ import io.unitycatalog.client.delta.model.SetProtocolUpdate;
 import io.unitycatalog.client.delta.model.SetSchemaUpdate;
 import io.unitycatalog.client.delta.model.SetTableCommentUpdate;
 import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructFieldMetadata;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableRequirement;
 import io.unitycatalog.client.delta.model.TableUpdate;
@@ -226,12 +227,12 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                                       .name("new_id")
                                       .type(new PrimitiveType().type("long"))
                                       .nullable(false)
-                                      .metadata(Map.of()),
+                                      .metadata(new StructFieldMetadata()),
                                   new StructField()
                                       .name("flag")
                                       .type(new PrimitiveType().type("boolean"))
                                       .nullable(true)
-                                      .metadata(Map.of())))),
+                                      .metadata(new StructFieldMetadata())))),
               new SetPartitionColumnsUpdate().partitionColumns(List.of("flag")));
       assertThat(r.getMetadata().getColumns().getFields())
           .extracting(StructField::getName)
@@ -314,12 +315,12 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                                       .name("id")
                                       .type(new PrimitiveType().type("long"))
                                       .nullable(false)
-                                      .metadata(Map.of()),
+                                      .metadata(new StructFieldMetadata()),
                                   new StructField()
                                       .name("flag")
                                       .type(new PrimitiveType().type("boolean"))
                                       .nullable(true)
-                                      .metadata(Map.of())))));
+                                      .metadata(new StructFieldMetadata())))));
       assertThat(r.getMetadata().getColumns().getFields())
           .extracting(StructField::getName)
           .containsExactly("id", "flag");
@@ -350,7 +351,7 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                                           .name("id2")
                                           .type(new PrimitiveType().type("long"))
                                           .nullable(false)
-                                          .metadata(Map.of()))))),
+                                          .metadata(new StructFieldMetadata()))))),
           ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
           "partition-columns references unknown column: id");
     }
@@ -926,7 +927,7 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                                       .name("c1")
                                       .type(new PrimitiveType().type("long"))
                                       .nullable(false)
-                                      .metadata(Map.of())))));
+                                      .metadata(new StructFieldMetadata())))));
       assertThat(r.getMetadata().getLastCommitVersion()).isEqualTo(1L);
       assertThat(r.getMetadata().getLastCommitTimestampMs()).isEqualTo(1700000001L);
     }

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -8,6 +8,7 @@ import io.unitycatalog.server.delta.model.DataSourceFormat;
 import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.PrimitiveType;
 import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructFieldMetadata;
 import io.unitycatalog.server.delta.model.StructType;
 import io.unitycatalog.server.delta.model.TableType;
 import io.unitycatalog.server.exception.BaseException;
@@ -118,7 +119,7 @@ public class DeltaCreateTableMapperTest {
                     .name("id")
                     .type(new PrimitiveType().type("long"))
                     .nullable(false)
-                    .metadata(Map.of())));
+                    .metadata(new StructFieldMetadata())));
   }
 
   private static DeltaProtocol managedProtocol() {

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
@@ -25,6 +25,7 @@ import io.unitycatalog.server.delta.model.SetProtocolUpdate;
 import io.unitycatalog.server.delta.model.SetSchemaUpdate;
 import io.unitycatalog.server.delta.model.SetTableCommentUpdate;
 import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructFieldMetadata;
 import io.unitycatalog.server.delta.model.StructType;
 import io.unitycatalog.server.delta.model.TableUpdate;
 import io.unitycatalog.server.delta.model.UniformMetadata;
@@ -303,8 +304,11 @@ public class DeltaModelSerializationTest {
   }
 
   @Test
-  public void testDeserOmittedContainsNull() throws Exception {
-    // When contains-null / value-contains-null are omitted, defaults apply
+  public void testDeserOmittedContainsNullLeavesNull() throws Exception {
+    // delta.yaml dropped `default: true` on contains-null / value-contains-null so the generated
+    // POJOs no longer auto-fill those fields; an omitted JSON property leaves the POJO field at
+    // null. The mapper's per-column validator (ColumnUtils.validateStructType) then rejects with
+    // a 400. Pinned here so a future regen that re-introduces a default is caught.
     String arrayJson =
         """
         {
@@ -315,14 +319,7 @@ public class DeltaModelSerializationTest {
         }
         """;
     StructField arrCol = MAPPER.readValue(arrayJson, StructField.class);
-    ArrayType at = (ArrayType) arrCol.getType();
-    // Default: containsNull = true
-    assertThat(at.getContainsNull()).isTrue();
-
-    // Round-trip preserves the default
-    String serialized = MAPPER.writeValueAsString(arrCol);
-    StructField roundTrip = MAPPER.readValue(serialized, StructField.class);
-    assertThat(((ArrayType) roundTrip.getType()).getContainsNull()).isTrue();
+    assertThat(((ArrayType) arrCol.getType()).getContainsNull()).isNull();
 
     String mapJson =
         """
@@ -338,14 +335,7 @@ public class DeltaModelSerializationTest {
         }
         """;
     StructField mapCol = MAPPER.readValue(mapJson, StructField.class);
-    MapType mt = (MapType) mapCol.getType();
-    // Default: valueContainsNull = true
-    assertThat(mt.getValueContainsNull()).isTrue();
-
-    // Round-trip preserves the default
-    String mapSerialized = MAPPER.writeValueAsString(mapCol);
-    StructField mapRoundTrip = MAPPER.readValue(mapSerialized, StructField.class);
-    assertThat(((MapType) mapRoundTrip.getType()).getValueContainsNull()).isTrue();
+    assertThat(((MapType) mapCol.getType()).getValueContainsNull()).isNull();
   }
 
   // ==================== Serialization ====================
@@ -385,20 +375,24 @@ public class DeltaModelSerializationTest {
             .type(new PrimitiveType().type("long"))
             .nullable(false)
             .metadata(
-                Map.of("delta.columnMapping.id", 1, "delta.columnMapping.physicalName", "col-1"));
+                meta(
+                    null,
+                    Map.of(
+                        "delta.columnMapping.id", 1,
+                        "delta.columnMapping.physicalName", "col-1")));
     StructField colPrice =
         new StructField()
             .name("price")
             .type(new DecimalType().precision(10).scale(2))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     StructField colTags =
         new StructField()
             .name("tags")
             .type(
                 new ArrayType().elementType(new PrimitiveType().type("string")).containsNull(true))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     StructField colScores =
         new StructField()
             .name("scores")
@@ -414,18 +408,20 @@ public class DeltaModelSerializationTest {
                                         .type(new PrimitiveType().type("double"))
                                         .nullable(false)
                                         .metadata(
-                                            Map.of(
-                                                "delta.columnMapping.id", 10,
-                                                "delta.columnMapping.physicalName", "col-10",
-                                                "comment", "score value")),
+                                            meta(
+                                                "score value",
+                                                Map.of(
+                                                    "delta.columnMapping.id", 10,
+                                                    "delta.columnMapping.physicalName", "col-10"))),
                                     new StructField()
                                         .name("timestamp")
                                         .type(new PrimitiveType().type("long"))
                                         .nullable(true)
-                                        .metadata(Map.of("delta.columnMapping.id", 11)))))
+                                        .metadata(
+                                            meta(null, Map.of("delta.columnMapping.id", 11))))))
                     .valueContainsNull(true))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     SetSchemaUpdate setSchema =
         new SetSchemaUpdate()
             .action("set-columns")
@@ -580,5 +576,22 @@ public class DeltaModelSerializationTest {
     try (InputStream is = DeltaModelSerializationTest.class.getResourceAsStream(resourcePath)) {
       return new String(is.readAllBytes(), StandardCharsets.UTF_8);
     }
+  }
+
+  /**
+   * Build a {@link StructFieldMetadata} with the optional {@code comment} plus a bag of
+   * additional properties for the spec's dotted Delta keys (e.g. {@code delta.columnMapping.id}).
+   * The server-side {@code StructFieldMetadata} extends {@code HashMap<String, Object>}; Jackson
+   * treats it as a Map for serialization (and skips the named {@code comment} getter), so we
+   * write the comment into the map view via {@code put} rather than the typed setter so the wire
+   * shape matches the fixture.
+   */
+  private static StructFieldMetadata meta(String comment, Map<String, Object> additional) {
+    StructFieldMetadata m = new StructFieldMetadata();
+    if (comment != null) {
+      m.put("comment", comment);
+    }
+    m.putAll(additional);
+    return m;
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
@@ -581,10 +581,9 @@ public class DeltaModelSerializationTest {
   /**
    * Build a {@link StructFieldMetadata} with the optional {@code comment} plus a bag of
    * additional properties for the spec's dotted Delta keys (e.g. {@code delta.columnMapping.id}).
-   * The server-side {@code StructFieldMetadata} extends {@code HashMap<String, Object>}; Jackson
-   * treats it as a Map for serialization (and skips the named {@code comment} getter), so we
-   * write the comment into the map view via {@code put} rather than the typed setter so the wire
-   * shape matches the fixture.
+   * The schema models {@code StructFieldMetadata} as a bare additionalProperties wrapper, so the
+   * generated class extends {@code HashMap<String, Object>}; all keys (including {@code comment})
+   * go through the map view.
    */
   private static StructFieldMetadata meta(String comment, Map<String, Object> additional) {
     StructFieldMetadata m = new StructFieldMetadata();

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -3,18 +3,20 @@ package io.unitycatalog.server.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.delta.model.ArrayType;
 import io.unitycatalog.server.delta.model.DecimalType;
 import io.unitycatalog.server.delta.model.MapType;
 import io.unitycatalog.server.delta.model.PrimitiveType;
 import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructFieldMetadata;
 import io.unitycatalog.server.delta.model.StructType;
+import io.unitycatalog.server.delta.serde.DeltaTypeModule;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.ColumnTypeName;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /** Tests for ColumnUtils.toStructField parsing typeJson into typed Delta StructField. */
@@ -208,7 +210,7 @@ public class ColumnUtilsTest {
             .name("id")
             .type(new PrimitiveType().type("long"))
             .nullable(false)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     ColumnInfo info = ColumnUtils.toColumnInfo(field, 0);
     assertThat(info.getName()).isEqualTo("id");
     assertThat(info.getNullable()).isFalse();
@@ -226,7 +228,7 @@ public class ColumnUtilsTest {
             .name("amount")
             .type(new DecimalType().precision(10).scale(2))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     ColumnInfo info = ColumnUtils.toColumnInfo(field, 1);
     assertThat(info.getTypeName()).isEqualTo(ColumnTypeName.DECIMAL);
     // Precision/scale must reach typeText so DESCRIBE TABLE renders the right SQL type.
@@ -240,7 +242,7 @@ public class ColumnUtilsTest {
             .name("tags")
             .type(new ArrayType().type("array").elementType(new PrimitiveType().type("string")))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     ColumnInfo arrInfo = ColumnUtils.toColumnInfo(arr, 0);
     assertThat(arrInfo.getTypeName()).isEqualTo(ColumnTypeName.ARRAY);
     // typeText is the Spark catalogString-equivalent, recursively parameterized.
@@ -255,7 +257,7 @@ public class ColumnUtilsTest {
                     .keyType(new PrimitiveType().type("string"))
                     .valueType(new PrimitiveType().type("double")))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     ColumnInfo mapInfo = ColumnUtils.toColumnInfo(map, 0);
     assertThat(mapInfo.getTypeName()).isEqualTo(ColumnTypeName.MAP);
     assertThat(mapInfo.getTypeText()).isEqualTo("map<string,double>");
@@ -272,14 +274,14 @@ public class ColumnUtilsTest {
                                 .name("zip")
                                 .type(new PrimitiveType().type("integer"))
                                 .nullable(false)
-                                .metadata(Map.of()),
+                                .metadata(new StructFieldMetadata()),
                             new StructField()
                                 .name("city")
                                 .type(new PrimitiveType().type("string"))
                                 .nullable(true)
-                                .metadata(Map.of()))))
+                                .metadata(new StructFieldMetadata()))))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     ColumnInfo structInfo = ColumnUtils.toColumnInfo(struct, 0);
     assertThat(structInfo.getTypeName()).isEqualTo(ColumnTypeName.STRUCT);
     assertThat(structInfo.getTypeText()).isEqualTo("struct<zip:int,city:string>");
@@ -307,45 +309,78 @@ public class ColumnUtilsTest {
                                                 .name("v")
                                                 .type(new PrimitiveType().type("double"))
                                                 .nullable(false)
-                                                .metadata(Map.of()))))))
+                                                .metadata(new StructFieldMetadata()))))))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     assertThat(ColumnUtils.toColumnInfo(field, 0).getTypeText())
         .isEqualTo("map<string,array<struct<v:double>>>");
   }
 
   @Test
   public void testToColumnInfoLiftsCommentFromMetadata() {
-    // Delta spec stores column comments in metadata.comment; UCSingleCatalog lifts them into
+    // Delta spec stores column comments at metadata.comment; UCSingleCatalog lifts them into
     // ColumnInfo.comment via field.getComment(), and this mapper does the same so DESCRIBE
-    // renders the comment regardless of which client wrote the table.
+    // renders the comment regardless of which client wrote the table. We construct the metadata
+    // via map-put rather than the typed StructFieldMetadata.comment(...) setter to mirror the
+    // wire-deserialization path: server-side StructFieldMetadata extends HashMap, so Jackson
+    // populates the map view (not the typed field) for incoming JSON.
+    StructFieldMetadata metadata = new StructFieldMetadata();
+    metadata.put("comment", "primary key");
     StructField field =
         new StructField()
             .name("id")
             .type(new PrimitiveType().type("long"))
             .nullable(false)
-            .metadata(Map.of("comment", "primary key"));
+            .metadata(metadata);
     assertThat(ColumnUtils.toColumnInfo(field, 0).getComment()).isEqualTo("primary key");
   }
 
   @Test
-  public void testToColumnInfoNoCommentWhenMetadataAbsentOrNonString() {
+  public void testCommentLiftedFromJsonWire() throws Exception {
+    // Production flow: client sends JSON, server deserializes, ColumnUtils.toColumnInfo lifts
+    // metadata.comment into ColumnInfo.comment. This pins that the typed-comment route still
+    // resolves through extractComment when the StructField arrives over the wire (i.e. that
+    // Jackson's HashMap-subclass handling correctly populates metadata.comment from the JSON
+    // key "comment", not just the additional-properties map).
+    String wire =
+        "{\"name\":\"id\",\"type\":\"long\",\"nullable\":false,"
+            + "\"metadata\":{\"comment\":\"primary key\"}}";
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new DeltaTypeModule());
+    StructField field = mapper.readValue(wire, StructField.class);
+
+    assertThat(ColumnUtils.toColumnInfo(field, 0).getComment()).isEqualTo("primary key");
+  }
+
+  @Test
+  public void testTypeJsonRoundTripPreservesComment() throws Exception {
+    // Pin what the server-side StructFieldMetadata (a HashMap subclass) does with the typed
+    // `comment` field across deser -> ser. A wire request with `{"comment": "foo"}` must
+    // round-trip through toTypeJson so the value lands in ColumnInfo.typeJson stored in UC.
+    String wire =
+        "{\"name\":\"id\",\"type\":\"long\",\"nullable\":false,"
+            + "\"metadata\":{\"comment\":\"primary key\",\"delta.columnMapping.id\":1}}";
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new DeltaTypeModule());
+    StructField field = mapper.readValue(wire, StructField.class);
+
+    String roundTrip = ColumnUtils.toTypeJson(field);
+    assertThat(roundTrip).contains("\"comment\":\"primary key\"");
+    assertThat(roundTrip).contains("\"delta.columnMapping.id\":1");
+  }
+
+  @Test
+  public void testToColumnInfoNoCommentWhenMetadataEmpty() {
+    // The wire-side comment getter is now typed (String); a non-string comment fails at
+    // Jackson deserialization, so the only "no comment" path that survives to the mapper is an
+    // explicitly-empty StructFieldMetadata.
     StructField noMeta =
         new StructField()
             .name("x")
             .type(new PrimitiveType().type("long"))
             .nullable(true)
-            .metadata(Map.of());
+            .metadata(new StructFieldMetadata());
     assertThat(ColumnUtils.toColumnInfo(noMeta, 0).getComment()).isNull();
-
-    StructField nonStringComment =
-        new StructField()
-            .name("y")
-            .type(new PrimitiveType().type("long"))
-            .nullable(true)
-            .metadata(Map.of("comment", 42));
-    // Non-string comment values (spec-invalid but tolerated) are ignored, not coerced.
-    assertThat(ColumnUtils.toColumnInfo(nonStringComment, 0).getComment()).isNull();
   }
 
   /**
@@ -362,7 +397,7 @@ public class ColumnUtilsTest {
               .name("x")
               .type(new PrimitiveType().type(unsupported))
               .nullable(true)
-              .metadata(Map.of());
+              .metadata(new StructFieldMetadata());
       assertThatThrownBy(() -> ColumnUtils.toColumnInfo(field, 0))
           .as("unsupported primitive: %s", unsupported)
           .isInstanceOf(BaseException.class)

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -320,10 +320,9 @@ public class ColumnUtilsTest {
   public void testToColumnInfoLiftsCommentFromMetadata() {
     // Delta spec stores column comments at metadata.comment; UCSingleCatalog lifts them into
     // ColumnInfo.comment via field.getComment(), and this mapper does the same so DESCRIBE
-    // renders the comment regardless of which client wrote the table. We construct the metadata
-    // via map-put rather than the typed StructFieldMetadata.comment(...) setter to mirror the
-    // wire-deserialization path: server-side StructFieldMetadata extends HashMap, so Jackson
-    // populates the map view (not the typed field) for incoming JSON.
+    // renders the comment regardless of which client wrote the table. StructFieldMetadata is
+    // schemed as a bare additionalProperties wrapper (no typed `comment` property), so callers
+    // use map-put and the reader uses map-get -- one source of truth, no dual-write hazard.
     StructFieldMetadata metadata = new StructFieldMetadata();
     metadata.put("comment", "primary key");
     StructField field =
@@ -447,5 +446,115 @@ public class ColumnUtilsTest {
     assertThatThrownBy(() -> ColumnUtils.applyPartitionColumns(columns, List.of("a", "a")))
         .isInstanceOf(BaseException.class)
         .hasMessageContaining("partition-columns contains duplicate entry: a");
+  }
+
+  // ---------- validateStructType ----------
+  // RawCreateTableTest covers the common malformed-shape cases via raw HTTP; these tests pin the
+  // edge cases that don't have an obvious HTTP form (null inputs, decimal precision/scale bounds).
+
+  @Test
+  public void testValidateStructTypeRejectsNullStruct() {
+    assertThatThrownBy(() -> ColumnUtils.validateStructType(null, "columns"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("columns is required.");
+  }
+
+  @Test
+  public void testValidateStructTypeRejectsEmptyFieldsList() {
+    // The generator initialises StructType.fields to an empty ArrayList, so reaching the
+    // `fields == null` branch from Java requires setFields(null) which the setter would
+    // happily accept. We pin the more reachable "empty fields" case here; the null-fields
+    // branch is covered indirectly by the JSON-wire path (RawCreateTableTest).
+    StructType st = new StructType();
+    assertThatThrownBy(() -> ColumnUtils.validateStructType(st, "columns"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("columns.fields must contain at least one field.");
+  }
+
+  @Test
+  public void testValidateStructTypeRejectsNullFieldElement() {
+    List<StructField> fields = new ArrayList<>();
+    fields.add(null);
+    StructType st = new StructType().fields(fields);
+    assertThatThrownBy(() -> ColumnUtils.validateStructType(st, "columns"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("columns.fields[0] is required.");
+  }
+
+  @Test
+  public void testValidateStructTypeAcceptsWellFormed() {
+    StructType st =
+        new StructType()
+            .type("struct")
+            .fields(
+                List.of(
+                    new StructField()
+                        .name("id")
+                        .type(new PrimitiveType().type("long"))
+                        .nullable(false)
+                        .metadata(new StructFieldMetadata())));
+    ColumnUtils.validateStructType(st, "columns"); // does not throw
+  }
+
+  @Test
+  public void testValidateStructTypeRejectsDecimalPrecisionOutOfRange() {
+    // precision must be in [0, 38]; 39 and -1 both fail. The bounds match Kernel's DecimalType.
+    for (int bad : new int[] {-1, 39, 100}) {
+      StructType st = decimalColumn(bad, 0);
+      assertThatThrownBy(() -> ColumnUtils.validateStructType(st, "columns"))
+          .as("precision=%d", bad)
+          .isInstanceOf(BaseException.class)
+          .hasMessageContaining("precision must be in [0, 38]");
+    }
+  }
+
+  @Test
+  public void testValidateStructTypeRejectsDecimalScaleOutOfRange() {
+    // scale must be in [0, precision]; scale=5 with precision=3 and scale=-1 both fail.
+    for (int[] ps : new int[][] {{3, 5}, {10, -1}, {10, 11}}) {
+      StructType st = decimalColumn(ps[0], ps[1]);
+      assertThatThrownBy(() -> ColumnUtils.validateStructType(st, "columns"))
+          .as("precision=%d scale=%d", ps[0], ps[1])
+          .isInstanceOf(BaseException.class)
+          .hasMessageContaining("scale must be in [0, precision");
+    }
+  }
+
+  @Test
+  public void testValidateStructTypeAcceptsDecimalBoundary() {
+    // precision=0, precision=38, scale=precision are all valid per Kernel's DecimalType.
+    for (int[] ps : new int[][] {{0, 0}, {38, 0}, {38, 38}, {10, 10}}) {
+      StructType st = decimalColumn(ps[0], ps[1]);
+      ColumnUtils.validateStructType(st, "columns"); // does not throw
+    }
+  }
+
+  @Test
+  public void testValidatePrimitiveTypeWrapsUnsupportedWithPath() {
+    StructType st =
+        new StructType()
+            .type("struct")
+            .fields(
+                List.of(
+                    new StructField()
+                        .name("x")
+                        .type(new PrimitiveType().type("void"))
+                        .nullable(true)
+                        .metadata(new StructFieldMetadata())));
+    assertThatThrownBy(() -> ColumnUtils.validateStructType(st, "columns"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("columns.fields[0].type: Unsupported Delta primitive type: void");
+  }
+
+  private static StructType decimalColumn(int precision, int scale) {
+    return new StructType()
+        .type("struct")
+        .fields(
+            List.of(
+                new StructField()
+                    .name("amount")
+                    .type(new DecimalType().type("decimal").precision(precision).scale(scale))
+                    .nullable(true)
+                    .metadata(new StructFieldMetadata())));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -437,4 +437,15 @@ public class ColumnUtilsTest {
         .isInstanceOf(BaseException.class)
         .hasMessageContaining("partition-columns references unknown column: nope");
   }
+
+  @Test
+  public void testApplyPartitionColumnsDuplicateRejected() {
+    List<ColumnInfo> columns =
+        new ArrayList<>(
+            List.of(
+                new ColumnInfo().name("a").position(0), new ColumnInfo().name("b").position(1)));
+    assertThatThrownBy(() -> ColumnUtils.applyPartitionColumns(columns, List.of("a", "a")))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("partition-columns contains duplicate entry: a");
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1526/files) to review incremental changes.
- [**stack/validate_columns**](https://github.com/unitycatalog/unitycatalog/pull/1526) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1526/files)]
  - [stack/column_case_ins](https://github.com/unitycatalog/unitycatalog/pull/1537) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1537/files/9cd3fd2bbd8fcbdeb23a20fcecadbe94b1306817..296a93b3f3307250a2d2bbfdb463ddcd682fe479)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Strict column-shape validation for Delta createTable

Validate every required field on StructField, ArrayType, MapType, DecimalType, and PrimitiveType at the API boundary so non-SDK clients can't drive the server to 500s or persist malformed schemas. Adds a typed StructFieldMetadata wrapper in delta.yaml, drops `default: true` on contains-null / value-contains-null to match Kernel's parser, and pins the rules with raw-HTTP tests.
