### PR TITLE
[Hadoop] Add UC Delta credential support to UCCredentialHadoopConfs

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -1,12 +1,14 @@
 package io.unitycatalog.hadoop;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.model.StorageCredential;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -55,6 +57,7 @@ public final class UCCredentialHadoopConfs {
 
     private TokenProvider tokenProvider;
     private TemporaryCredentials initialCredentials;
+    private StorageCredential initialStorageCredential;
     private boolean credentialRenewalEnabled = true;
     private boolean credentialScopedFsEnabled = true;
     private Configuration hadoopConf = new Configuration(false);
@@ -80,9 +83,30 @@ public final class UCCredentialHadoopConfs {
      * (Required) The initial temporary credentials vended by UC (AWS session credentials, GCP OAuth
      * token, or Azure SAS). Typically, allocated once by the job driver and propagated to all
      * worker nodes so that each worker reuses the same credential rather than vending a new one.
+     *
+     * <p>Mutually exclusive with {@link #initialStorageCredential(StorageCredential)}.
      */
     public Builder initialCredentials(TemporaryCredentials initialCredentials) {
+      Preconditions.checkState(
+          initialStorageCredential == null,
+          "initialStorageCredential is already set; cannot also set initialCredentials. The two"
+              + " select different credentials APIs (UC vs UC Delta).");
       this.initialCredentials = initialCredentials;
+      return this;
+    }
+
+    /**
+     * (Required for UC Delta) The initial UC Delta storage credential returned by the UC Delta
+     * table API.
+     *
+     * <p>Mutually exclusive with {@link #initialCredentials(TemporaryCredentials)}.
+     */
+    public Builder initialStorageCredential(StorageCredential initialStorageCredential) {
+      Preconditions.checkState(
+          initialCredentials == null,
+          "initialCredentials is already set; cannot also set initialStorageCredential. The two"
+              + " select different credentials APIs (UC vs UC Delta).");
+      this.initialStorageCredential = initialStorageCredential;
       return this;
     }
 
@@ -132,7 +156,7 @@ public final class UCCredentialHadoopConfs {
       Preconditions.checkArgument(name != null && !name.isEmpty(), "engine version name required");
       Preconditions.checkArgument(
           version != null && !version.isEmpty(), "engine version value for '%s' required", name);
-      engineVersionProps.put(UCHadoopConf.UC_ENGINE_VERSION_PREFIX + name, version);
+      engineVersionProps.put(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + name, version);
     }
 
     /**
@@ -142,7 +166,7 @@ public final class UCCredentialHadoopConfs {
      * @throws IllegalStateException if a required field is missing
      */
     public Map<String, String> buildForTable(String tableId, TableOperation tableOperation) {
-      validate();
+      validateUcApi();
       return withEngineVersionProps(
           CredPropsUtil.createTableCredProps(
               credentialRenewalEnabled,
@@ -157,13 +181,59 @@ public final class UCCredentialHadoopConfs {
     }
 
     /**
+     * Builds Hadoop properties for a UC Delta table's storage location.
+     *
+     * @param tableId the UC table UUID, used to scope the credential cache and filesystem cache
+     * @param catalog the UC catalog name
+     * @param schema the UC schema name
+     * @param table the UC table name
+     * @param location the table storage location used to select a returned storage credential
+     * @return unmodifiable map; empty if the scheme is unrecognized
+     * @throws IllegalArgumentException if a table identity field is missing
+     * @throws IllegalStateException if a required builder field is missing
+     */
+    public Map<String, String> buildForTable(
+        String tableId, String catalog, String schema, String table, String location) {
+      Preconditions.checkArgument(tableId != null && !tableId.isEmpty(), "tableId is required");
+      Preconditions.checkArgument(catalog != null && !catalog.isEmpty(), "catalog is required");
+      Preconditions.checkArgument(schema != null && !schema.isEmpty(), "schema is required");
+      Preconditions.checkArgument(table != null && !table.isEmpty(), "table is required");
+      Preconditions.checkArgument(location != null && !location.isEmpty(), "location is required");
+      validateUcDeltaApi();
+      TemporaryCredentials tempCreds =
+          DeltaStorageCredentialUtil.toTemporaryCredentials(initialStorageCredential);
+      Map<String, String> props =
+          CredPropsUtil.createTableCredProps(
+              credentialRenewalEnabled,
+              credentialScopedFsEnabled,
+              hadoopConf,
+              scheme,
+              catalogUri,
+              tokenProvider,
+              tableId,
+              DeltaStorageCredentialUtil.toTableOperation(initialStorageCredential.getOperation()),
+              tempCreds);
+      if (props.isEmpty()) {
+        return props;
+      }
+      Map<String, String> deltaProps = new HashMap<>(props);
+      deltaProps.put(
+          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, Boolean.TRUE.toString());
+      deltaProps.put(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, catalog);
+      deltaProps.put(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, schema);
+      deltaProps.put(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, table);
+      deltaProps.put(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+      return withEngineVersionProps(Collections.unmodifiableMap(deltaProps));
+    }
+
+    /**
      * Builds Hadoop properties for an <em>external path</em>.
      *
      * @return unmodifiable map; empty if the scheme is unrecognized
      * @throws IllegalStateException if a required field is missing
      */
     public Map<String, String> buildForPath(String path, PathOperation pathOperation) {
-      validate();
+      validateUcApi();
       return withEngineVersionProps(
           CredPropsUtil.createPathCredProps(
               credentialRenewalEnabled,
@@ -186,11 +256,23 @@ public final class UCCredentialHadoopConfs {
       return Collections.unmodifiableMap(merged);
     }
 
-    private void validate() {
+    private void validateCommon() {
       Preconditions.checkState(
           !credentialRenewalEnabled || tokenProvider != null,
           "tokenProvider is required when credential renewal is enabled");
-      Preconditions.checkState(initialCredentials != null, "initialCredentials is required");
+    }
+
+    private void validateUcApi() {
+      validateCommon();
+      Preconditions.checkState(
+          initialCredentials != null, "initialCredentials is required for the UC credentials API");
+    }
+
+    private void validateUcDeltaApi() {
+      validateCommon();
+      Preconditions.checkState(
+          initialStorageCredential != null,
+          "initialStorageCredential is required for the UC Delta credentials API");
     }
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -1,9 +1,5 @@
 package io.unitycatalog.hadoop.internal;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConf.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME;
-import static io.unitycatalog.hadoop.internal.UCHadoopConf.FS_AZURE_ACCOUNT_IS_HNS_ENABLED;
-import static io.unitycatalog.hadoop.internal.UCHadoopConf.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE;
-
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.model.AwsCredentials;
@@ -53,7 +49,7 @@ public class CredPropsUtil {
     }
 
     public T uri(String uri) {
-      builder.put(UCHadoopConf.UC_URI_KEY, uri);
+      builder.put(UCHadoopConfConstants.UC_URI_KEY, uri);
       return self();
     }
 
@@ -62,42 +58,42 @@ public class CredPropsUtil {
       // implementation. So let's add the prefix here.
       tokenProvider
           .configs()
-          .forEach((key, value) -> builder.put(UCHadoopConf.UC_AUTH_PREFIX + key, value));
+          .forEach((key, value) -> builder.put(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
       return self();
     }
 
     public T uid(String uid) {
-      builder.put(UCHadoopConf.UC_CREDENTIALS_UID_KEY, uid);
+      builder.put(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, uid);
       return self();
     }
 
     public T credentialType(String credType) {
       Preconditions.checkArgument(
-          UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(credType)
-              || UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(credType),
+          UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(credType)
+              || UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(credType),
           "Invalid credential type '%s', must be either 'path' or 'table'.",
           credType);
-      builder.put(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, credType);
+      builder.put(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY, credType);
       return self();
     }
 
     public T tableId(String tableId) {
-      builder.put(UCHadoopConf.UC_TABLE_ID_KEY, tableId);
+      builder.put(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
       return self();
     }
 
     public T tableOperation(TableOperation tableOp) {
-      builder.put(UCHadoopConf.UC_TABLE_OPERATION_KEY, tableOp.getValue());
+      builder.put(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, tableOp.getValue());
       return self();
     }
 
     public T path(String path) {
-      builder.put(UCHadoopConf.UC_PATH_KEY, path);
+      builder.put(UCHadoopConfConstants.UC_PATH_KEY, path);
       return self();
     }
 
     public T pathOperation(PathOperation pathOp) {
-      builder.put(UCHadoopConf.UC_PATH_OPERATION_KEY, pathOp.getValue());
+      builder.put(UCHadoopConfConstants.UC_PATH_OPERATION_KEY, pathOp.getValue());
       return self();
     }
 
@@ -189,8 +185,8 @@ public class CredPropsUtil {
   private static class AbfsPropsBuilder extends PropsBuilder<AbfsPropsBuilder> {
 
     AbfsPropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
-      set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, "SAS");
-      set(FS_AZURE_ACCOUNT_IS_HNS_ENABLED, "true");
+      set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, "SAS");
+      set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_IS_HNS_ENABLED, "true");
       set("fs.abfs.impl.disable.cache", "true");
       set("fs.abfss.impl.disable.cache", "true");
 
@@ -243,18 +239,19 @@ public class CredPropsUtil {
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     S3PropsBuilder builder =
         new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
-            .set(UCHadoopConf.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS)
+            .set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS)
             .uri(uri)
             .tokenProvider(tokenProvider)
             .uid(UUID.randomUUID().toString())
-            .set(UCHadoopConf.S3A_INIT_ACCESS_KEY, awsCred.getAccessKeyId())
-            .set(UCHadoopConf.S3A_INIT_SECRET_KEY, awsCred.getSecretAccessKey())
-            .set(UCHadoopConf.S3A_INIT_SESSION_TOKEN, awsCred.getSessionToken());
+            .set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, awsCred.getAccessKeyId())
+            .set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, awsCred.getSecretAccessKey())
+            .set(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, awsCred.getSessionToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
       builder.set(
-          UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME, String.valueOf(tempCreds.getExpirationTime()));
+          UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME,
+          String.valueOf(tempCreds.getExpirationTime()));
     }
 
     return builder;
@@ -269,7 +266,7 @@ public class CredPropsUtil {
       TableOperation tableOp,
       TemporaryCredentials tempCreds) {
     return s3TempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
         .tableId(tableId)
         .tableOperation(tableOp)
         .build();
@@ -284,7 +281,7 @@ public class CredPropsUtil {
       PathOperation pathOp,
       TemporaryCredentials tempCreds) {
     return s3TempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE)
         .path(path)
         .pathOperation(pathOp)
         .build();
@@ -315,12 +312,12 @@ public class CredPropsUtil {
             .uri(uri)
             .tokenProvider(tokenProvider)
             .uid(UUID.randomUUID().toString())
-            .set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN, gcpToken.getOauthToken());
+            .set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, gcpToken.getOauthToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
       builder.set(
-          UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
+          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
           String.valueOf(tempCreds.getExpirationTime()));
     }
 
@@ -336,7 +333,7 @@ public class CredPropsUtil {
       TableOperation tableOp,
       TemporaryCredentials tempCreds) {
     return gcsTempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
         .tableId(tableId)
         .tableOperation(tableOp)
         .build();
@@ -351,7 +348,7 @@ public class CredPropsUtil {
       PathOperation pathOp,
       TemporaryCredentials tempCreds) {
     return gcsTempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE)
         .path(path)
         .pathOperation(pathOp)
         .build();
@@ -374,16 +371,18 @@ public class CredPropsUtil {
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     AbfsPropsBuilder builder =
         new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
-            .set(FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, ABFS_VENDED_TOKEN_PROVIDER_CLASS)
+            .set(
+                UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE,
+                ABFS_VENDED_TOKEN_PROVIDER_CLASS)
             .uri(uri)
             .tokenProvider(tokenProvider)
             .uid(UUID.randomUUID().toString())
-            .set(UCHadoopConf.AZURE_INIT_SAS_TOKEN, azureSas.getSasToken());
+            .set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, azureSas.getSasToken());
 
     // For the static credential case, nullable expiration time is possible.
     if (tempCreds.getExpirationTime() != null) {
       builder.set(
-          UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
+          UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
           String.valueOf(tempCreds.getExpirationTime()));
     }
 
@@ -399,7 +398,7 @@ public class CredPropsUtil {
       TableOperation tableOp,
       TemporaryCredentials tempCreds) {
     return abfsTempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
         .tableId(tableId)
         .tableOperation(tableOp)
         .build();
@@ -414,7 +413,7 @@ public class CredPropsUtil {
       PathOperation pathOp,
       TemporaryCredentials tempCreds) {
     return abfsTempCredPropsBuilder(credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-        .credentialType(UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE)
+        .credentialType(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE)
         .path(path)
         .pathOperation(pathOp)
         .build();

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -1,0 +1,133 @@
+package io.unitycatalog.hadoop.internal;
+
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.StorageCredential;
+import io.unitycatalog.client.delta.model.StorageCredentialConfig;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.client.model.AwsCredentials;
+import io.unitycatalog.client.model.AzureUserDelegationSAS;
+import io.unitycatalog.client.model.GcpOauthToken;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.List;
+
+/** Internal utility for UC Delta storage credentials. */
+public final class DeltaStorageCredentialUtil {
+  private DeltaStorageCredentialUtil() {}
+
+  /** Converts a UC Delta credential operation to the equivalent standard UC table operation. */
+  public static TableOperation toTableOperation(CredentialOperation op) {
+    Preconditions.checkArgument(op != null, "StorageCredential.operation is required");
+    switch (op) {
+      case READ:
+        return TableOperation.READ;
+      case READ_WRITE:
+        return TableOperation.READ_WRITE;
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported UC Delta table credential operation: " + op);
+    }
+  }
+
+  /** Converts one UC Delta storage credential into standard UC temporary credentials. */
+  public static TemporaryCredentials toTemporaryCredentials(StorageCredential cred) {
+    StorageCredentialConfig config = requireSingleCloudConfig(cred);
+    long expiry = cred.getExpirationTimeMs() == null ? Long.MAX_VALUE : cred.getExpirationTimeMs();
+    TemporaryCredentials out = new TemporaryCredentials().expirationTime(expiry);
+    if (isS3Config(config)) {
+      out.awsTempCredentials(
+          new AwsCredentials()
+              .accessKeyId(field(config.getS3AccessKeyId(), cred, "S3 access key"))
+              .secretAccessKey(field(config.getS3SecretAccessKey(), cred, "S3 secret key"))
+              .sessionToken(field(config.getS3SessionToken(), cred, "S3 session token")));
+    } else if (isAzureConfig(config)) {
+      out.azureUserDelegationSas(
+          new AzureUserDelegationSAS()
+              .sasToken(field(config.getAzureSasToken(), cred, "Azure SAS token")));
+    } else {
+      out.gcpOauthToken(
+          new GcpOauthToken()
+              .oauthToken(field(config.getGcsOauthToken(), cred, "GCS OAuth token")));
+    }
+    return out;
+  }
+
+  /** Selects the credential whose prefix covers the requested location. */
+  public static StorageCredential selectForLocation(
+      String location, List<StorageCredential> creds) {
+    Preconditions.checkArgument(
+        creds != null && !creds.isEmpty(),
+        "UC Delta API response for '%s' has no storage credentials.",
+        location);
+    if (creds.size() == 1) {
+      Preconditions.checkNotNull(
+          creds.get(0), "UC Delta API response for '%s' contains null.", location);
+    }
+    StorageCredential best = null;
+    int bestLen = -1;
+    for (StorageCredential c : creds) {
+      if (c == null || c.getPrefix() == null || !prefixCovers(location, c.getPrefix())) {
+        continue;
+      }
+      int len = stripTrailingSlashes(c.getPrefix()).length();
+      if (len > bestLen) {
+        best = c;
+        bestLen = len;
+      }
+    }
+    Preconditions.checkArgument(
+        best != null, "No UC Delta credential matched location '%s'.", location);
+    return best;
+  }
+
+  static boolean prefixCovers(String location, String prefix) {
+    String l = stripTrailingSlashes(location);
+    String p = stripTrailingSlashes(prefix);
+    return !p.isEmpty() && (l.equals(p) || (l.startsWith(p) && l.charAt(p.length()) == '/'));
+  }
+
+  private static String stripTrailingSlashes(String value) {
+    int end = value.length();
+    int min = value.indexOf("://");
+    min = min >= 0 ? min + 3 : 1;
+    while (end > min && value.charAt(end - 1) == '/') {
+      end--;
+    }
+    return value.substring(0, end);
+  }
+
+  private static StorageCredentialConfig requireSingleCloudConfig(StorageCredential cred) {
+    Preconditions.checkNotNull(cred, "storageCredential cannot be null");
+    StorageCredentialConfig c = cred.getConfig();
+    Preconditions.checkArgument(
+        c != null, "UC Delta credential for '%s' is missing config.", cred.getPrefix());
+    int clouds =
+        (isS3Config(c) ? 1 : 0)
+            + (c.getAzureSasToken() != null ? 1 : 0)
+            + (c.getGcsOauthToken() != null ? 1 : 0);
+    Preconditions.checkArgument(
+        clouds == 1,
+        "UC Delta credential for '%s' must contain exactly one cloud credential config.",
+        cred.getPrefix());
+    return c;
+  }
+
+  private static boolean isS3Config(StorageCredentialConfig c) {
+    return c.getS3AccessKeyId() != null
+        || c.getS3SecretAccessKey() != null
+        || c.getS3SessionToken() != null;
+  }
+
+  private static boolean isAzureConfig(StorageCredentialConfig c) {
+    return c.getAzureSasToken() != null;
+  }
+
+  private static String field(String value, StorageCredential cred, String label) {
+    Preconditions.checkArgument(
+        value != null && !value.isEmpty(),
+        "UC Delta credential for '%s' is missing %s.",
+        cred.getPrefix(),
+        label);
+    return value;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -4,8 +4,8 @@ import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.client.retry.RetryPolicy;
 import org.apache.hadoop.conf.Configuration;
 
-public class UCHadoopConf {
-  private UCHadoopConf() {}
+public class UCHadoopConfConstants {
+  private UCHadoopConfConstants() {}
 
   // Key for the AWS S3 credential provider, same as org.apache.hadoop.fs.s3a.Constants
   // #AWS_CREDENTIALS_PROVIDER, but defined here to avoid an extra hadoop-aws dependency.
@@ -65,9 +65,20 @@ public class UCHadoopConf {
   // credentials are indexed by this key and are not reused across different jobs.
   public static final String UC_CREDENTIALS_UID_KEY = "fs.unitycatalog.credentials.uid";
 
+  // Enables the UC Delta temporary credentials API. false uses the standard UC API.
+  public static final String UC_DELTA_CREDENTIALS_API_ENABLED_KEY =
+      "fs.unitycatalog.delta.credentials.api.enabled";
+  public static final boolean UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE = false;
+
   // Keys for table based temporary credential requests
   public static final String UC_TABLE_ID_KEY = "fs.unitycatalog.table.id";
   public static final String UC_TABLE_OPERATION_KEY = "fs.unitycatalog.table.operation";
+
+  // Keys for UC Delta table credential requests.
+  public static final String UC_DELTA_CATALOG_KEY = "fs.unitycatalog.delta.catalog";
+  public static final String UC_DELTA_SCHEMA_KEY = "fs.unitycatalog.delta.schema";
+  public static final String UC_DELTA_TABLE_NAME_KEY = "fs.unitycatalog.delta.table.name";
+  public static final String UC_DELTA_LOCATION_KEY = "fs.unitycatalog.delta.location";
 
   // Keys for path based temporary credential requests.
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProvider.java
@@ -1,11 +1,12 @@
 package io.unitycatalog.hadoop.internal.auth;
 
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
 import org.apache.hadoop.util.Preconditions;
 
+/** Hadoop ABFS SAS token provider backed by Unity Catalog temporary credentials. */
 public class AbfsVendedTokenProvider extends GenericCredentialProvider implements SASTokenProvider {
   public static final String ACCESS_TOKEN_KEY = "fs.azure.sas.fixed.token";
 
@@ -18,21 +19,22 @@ public class AbfsVendedTokenProvider extends GenericCredentialProvider implement
 
   @Override
   public GenericCredential initGenericCredential(Configuration conf) {
-    if (conf.get(UCHadoopConf.AZURE_INIT_SAS_TOKEN) != null
-        && conf.get(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME) != null) {
+    if (conf.get(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN) != null
+        && conf.get(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME) != null) {
 
-      String sasToken = conf.get(UCHadoopConf.AZURE_INIT_SAS_TOKEN);
+      String sasToken = conf.get(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN);
       Preconditions.checkNotNull(
           sasToken,
           "Azure SAS token not set, please check " + "'%s' in hadoop configuration",
-          UCHadoopConf.AZURE_INIT_SAS_TOKEN);
+          UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN);
 
-      long expiredTimeMillis = conf.getLong(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, 0L);
+      long expiredTimeMillis =
+          conf.getLong(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, 0L);
       Preconditions.checkState(
           expiredTimeMillis > 0,
           "Azure SAS token expired time must be greater than 0, please check '%s' in hadoop "
               + "configuration",
-          UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME);
+          UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME);
 
       return GenericCredential.forAzure(sasToken, expiredTimeMillis);
     } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProvider.java
@@ -1,12 +1,13 @@
 package io.unitycatalog.hadoop.internal.auth;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Preconditions;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
+/** Hadoop S3A credentials provider backed by Unity Catalog temporary credentials. */
 public class AwsVendedTokenProvider extends GenericCredentialProvider
     implements AwsCredentialsProvider {
 
@@ -19,21 +20,21 @@ public class AwsVendedTokenProvider extends GenericCredentialProvider
 
   @Override
   public GenericCredential initGenericCredential(Configuration conf) {
-    if (conf.get(UCHadoopConf.S3A_INIT_ACCESS_KEY) != null
-        && conf.get(UCHadoopConf.S3A_INIT_SECRET_KEY) != null
-        && conf.get(UCHadoopConf.S3A_INIT_SESSION_TOKEN) != null) {
+    if (conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY) != null
+        && conf.get(UCHadoopConfConstants.S3A_INIT_SECRET_KEY) != null
+        && conf.get(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN) != null) {
 
-      String accessKey = conf.get(UCHadoopConf.S3A_INIT_ACCESS_KEY);
-      String secretKey = conf.get(UCHadoopConf.S3A_INIT_SECRET_KEY);
-      String sessionToken = conf.get(UCHadoopConf.S3A_INIT_SESSION_TOKEN);
+      String accessKey = conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY);
+      String secretKey = conf.get(UCHadoopConfConstants.S3A_INIT_SECRET_KEY);
+      String sessionToken = conf.get(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
 
       long expiredTimeMillis =
-          conf.getLong(UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME, Long.MAX_VALUE);
+          conf.getLong(UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME, Long.MAX_VALUE);
       Preconditions.checkState(
           expiredTimeMillis > 0,
           "Expired time %s must be greater than 0, " + "please check configure key '%s'",
           expiredTimeMillis,
-          UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME);
+          UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME);
 
       return GenericCredential.forAws(accessKey, secretKey, sessionToken, expiredTimeMillis);
     } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProvider.java
@@ -2,12 +2,13 @@ package io.unitycatalog.hadoop.internal.auth;
 
 import com.google.cloud.hadoop.util.AccessTokenProvider;
 import io.unitycatalog.client.model.GcpOauthToken;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.io.IOException;
 import java.time.Instant;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Preconditions;
 
+/** Hadoop GCS access token provider backed by Unity Catalog temporary credentials. */
 public class GcsVendedTokenProvider extends GenericCredentialProvider
     implements AccessTokenProvider {
 
@@ -19,20 +20,20 @@ public class GcsVendedTokenProvider extends GenericCredentialProvider
 
   @Override
   public GenericCredential initGenericCredential(Configuration conf) {
-    if (conf.get(UCHadoopConf.GCS_INIT_OAUTH_TOKEN) != null) {
-      String oauthToken = conf.get(UCHadoopConf.GCS_INIT_OAUTH_TOKEN);
+    if (conf.get(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN) != null) {
+      String oauthToken = conf.get(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN);
       Preconditions.checkNotNull(
           oauthToken,
           "GCS OAuth token not set, please check '%s' in hadoop " + "configuration",
-          UCHadoopConf.GCS_INIT_OAUTH_TOKEN);
+          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN);
 
       long expiredTimeMillis =
-          conf.getLong(UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, Long.MAX_VALUE);
+          conf.getLong(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, Long.MAX_VALUE);
       Preconditions.checkState(
           expiredTimeMillis > 0,
           "Expired time %s must be greater than 0, " + "please check configure key '%s'",
           expiredTimeMillis,
-          UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME);
+          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME);
 
       return GenericCredential.forGcs(oauthToken, expiredTimeMillis);
     } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
@@ -7,6 +7,11 @@ import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import java.util.Objects;
 
+/**
+ * Internal credential wrapper used by Hadoop token providers.
+ *
+ * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values.
+ */
 public class GenericCredential {
   private final TemporaryCredentials tempCred;
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -1,21 +1,18 @@
 package io.unitycatalog.hadoop.internal.auth;
 
 import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.api.TemporaryCredentialsApi;
-import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.internal.Clock;
-import io.unitycatalog.client.model.GenerateTemporaryPathCredential;
-import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
-import io.unitycatalog.client.model.PathOperation;
-import io.unitycatalog.client.model.TableOperation;
-import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Preconditions;
 
+/**
+ * Base class for Hadoop credential providers backed by Unity Catalog temporary credentials.
+ *
+ * <p>Subclasses expose cloud-specific provider interfaces while this class handles renewal and
+ * cache lookup.
+ */
 public abstract class GenericCredentialProvider {
   // The credential cache, for saving QPS to unity catalog server.
   static final BoundedKeyedCache<String, GenericCredential> globalCache;
@@ -32,43 +29,34 @@ public abstract class GenericCredentialProvider {
   private Configuration conf;
   private Clock clock;
   private long renewalLeadTimeMillis;
-  private URI ucUri;
-  private TokenProvider tokenProvider;
   private String credUid;
   private boolean credCacheEnabled;
 
   private volatile GenericCredential credential;
-  private volatile TemporaryCredentialsApi tempCredApi;
+  private volatile TempCredentialApi credentialApi;
 
   protected void initialize(Configuration conf) {
     this.conf = conf;
 
     // Use the test clock if one is intentionally configured for testing.
-    String clockName = conf.get(UCHadoopConf.UC_TEST_CLOCK_NAME);
+    String clockName = conf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
     this.clock = clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
 
     this.renewalLeadTimeMillis =
         conf.getLong(
-            UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, UCHadoopConf.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY,
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
 
-    String ucUriStr = conf.get(UCHadoopConf.UC_URI_KEY);
-    Preconditions.checkNotNull(
-        ucUriStr, "'%s' is not set in hadoop configuration", UCHadoopConf.UC_URI_KEY);
-    this.ucUri = URI.create(ucUriStr);
-
-    // Initialize the UCTokenProvider.
-    this.tokenProvider = TokenProvider.create(conf.getPropsWithPrefix(UCHadoopConf.UC_AUTH_PREFIX));
-
-    this.credUid = conf.get(UCHadoopConf.UC_CREDENTIALS_UID_KEY);
+    this.credUid = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
     Preconditions.checkState(
         credUid != null && !credUid.isEmpty(),
         "Credential UID cannot be null or empty, '%s' is not set in hadoop configuration",
-        UCHadoopConf.UC_CREDENTIALS_UID_KEY);
+        UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
 
     this.credCacheEnabled =
         conf.getBoolean(
-            UCHadoopConf.UC_CREDENTIAL_CACHE_ENABLED_KEY,
-            UCHadoopConf.UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE);
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY,
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE);
 
     // The initialized credentials passing-through the hadoop configuration.
     this.credential = initGenericCredential(conf);
@@ -92,28 +80,15 @@ public abstract class GenericCredentialProvider {
     return credential;
   }
 
-  protected TemporaryCredentialsApi temporaryCredentialsApi() {
-    // Retry is automatically handled by RetryingHttpClient when configured
-    // via fs.unitycatalog.request.retry*
-    if (tempCredApi == null) {
+  TempCredentialApi tempCredentialApi() {
+    if (credentialApi == null) {
       synchronized (this) {
-        if (tempCredApi == null) {
-          // Propagate engine version metadata into the User-Agent header so the UC server can
-          // trace which engine versions are calling. Engines register these via
-          // UCCredentialHadoopConfs.Builder#addEngineVersions, which writes them into the Hadoop
-          // configuration under UC_ENGINE_VERSION_PREFIX.
-          tempCredApi =
-              new TemporaryCredentialsApi(
-                  ApiClientUtils.create(
-                      ucUri,
-                      tokenProvider,
-                      UCHadoopConf.createRequestRetryPolicy(conf),
-                      conf.getPropsWithPrefix(UCHadoopConf.UC_ENGINE_VERSION_PREFIX)));
+        if (credentialApi == null) {
+          credentialApi = TempCredentialApi.create(conf);
         }
       }
     }
-
-    return tempCredApi;
+    return credentialApi;
   }
 
   private GenericCredential renewCredential() throws ApiException {
@@ -124,47 +99,12 @@ public abstract class GenericCredentialProvider {
         if (cached != null && !cached.readyToRenew(clock, renewalLeadTimeMillis)) {
           return cached;
         }
-        // Renew the credential and update the cache.
-        GenericCredential renewed = createGenericCredentials();
-        globalCache.put(credUid, renewed);
-        return renewed;
+        GenericCredential created = tempCredentialApi().createCredential();
+        globalCache.put(credUid, created);
+        return created;
       }
     } else {
-      return createGenericCredentials();
+      return tempCredentialApi().createCredential();
     }
-  }
-
-  private GenericCredential createGenericCredentials() throws ApiException {
-    TemporaryCredentialsApi tempCredApi = temporaryCredentialsApi();
-
-    // Generate the temporary credential via requesting UnityCatalog.
-    TemporaryCredentials tempCred;
-    String type = conf.get(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY);
-    if (UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
-      String path = conf.get(UCHadoopConf.UC_PATH_KEY);
-      String pathOperation = conf.get(UCHadoopConf.UC_PATH_OPERATION_KEY);
-
-      tempCred =
-          tempCredApi.generateTemporaryPathCredentials(
-              new GenerateTemporaryPathCredential()
-                  .url(path)
-                  .operation(PathOperation.fromValue(pathOperation)));
-    } else if (UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
-      String tableId = conf.get(UCHadoopConf.UC_TABLE_ID_KEY);
-      String tableOperation = conf.get(UCHadoopConf.UC_TABLE_OPERATION_KEY);
-
-      tempCred =
-          tempCredApi.generateTemporaryTableCredentials(
-              new GenerateTemporaryTableCredential()
-                  .tableId(tableId)
-                  .operation(TableOperation.fromValue(tableOperation)));
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Unsupported unity catalog temporary credentials type '%s', please check '%s'",
-              type, UCHadoopConf.UC_CREDENTIALS_TYPE_KEY));
-    }
-
-    return new GenericCredential(tempCred);
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/TempCredentialApi.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/TempCredentialApi.java
@@ -1,0 +1,55 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.ApiClientUtils;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Creates internal Hadoop credential wrappers from Unity Catalog temporary credential APIs.
+ *
+ * <p>This is an adapter over SDK-generated API clients, not a generated API client itself.
+ */
+interface TempCredentialApi {
+  GenericCredential createCredential() throws ApiException;
+
+  static TempCredentialApi create(Configuration conf) {
+    String useDeltaCredentialsApiValue =
+        conf.get(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY);
+    if (useDeltaCredentialsApiValue != null) {
+      useDeltaCredentialsApiValue = useDeltaCredentialsApiValue.trim();
+    }
+    Preconditions.checkArgument(
+        useDeltaCredentialsApiValue == null
+            || "true".equalsIgnoreCase(useDeltaCredentialsApiValue)
+            || "false".equalsIgnoreCase(useDeltaCredentialsApiValue),
+        "Unsupported value '%s' for '%s', expected true or false",
+        useDeltaCredentialsApiValue,
+        UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY);
+    boolean useDeltaCredentialsApi =
+        useDeltaCredentialsApiValue == null
+            ? UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE
+            : Boolean.parseBoolean(useDeltaCredentialsApiValue);
+
+    String ucUriStr = conf.get(UCHadoopConfConstants.UC_URI_KEY);
+    Preconditions.checkNotNull(
+        ucUriStr, "'%s' is not set in hadoop configuration", UCHadoopConfConstants.UC_URI_KEY);
+
+    ApiClient apiClient =
+        ApiClientUtils.create(
+            URI.create(ucUriStr),
+            TokenProvider.create(conf.getPropsWithPrefix(UCHadoopConfConstants.UC_AUTH_PREFIX)),
+            UCHadoopConfConstants.createRequestRetryPolicy(conf),
+            conf.getPropsWithPrefix(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX));
+    if (useDeltaCredentialsApi) {
+      return new UCDeltaTempCredentialApi(
+          conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+    }
+    return new UCTempCredentialApi(
+        conf, new io.unitycatalog.client.api.TemporaryCredentialsApi(apiClient));
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApi.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApi.java
@@ -1,0 +1,77 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+
+/** Adapts the UC Delta temporary credentials SDK API for Hadoop token providers. */
+final class UCDeltaTempCredentialApi implements TempCredentialApi {
+  private final TemporaryCredentialsApi api;
+  private final CredentialOperation operation;
+  private final String catalog;
+  private final String schema;
+  private final String tableName;
+  private final String location;
+
+  UCDeltaTempCredentialApi(Configuration conf, TemporaryCredentialsApi api) {
+    Preconditions.checkNotNull(api, "api is required");
+    this.api = api;
+    this.operation =
+        toCredentialOperation(require(conf, UCHadoopConfConstants.UC_TABLE_OPERATION_KEY));
+    this.catalog = require(conf, UCHadoopConfConstants.UC_DELTA_CATALOG_KEY);
+    this.schema = require(conf, UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY);
+    this.tableName = require(conf, UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY);
+    this.location = require(conf, UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+  }
+
+  @Override
+  public GenericCredential createCredential() throws ApiException {
+    return createDeltaTableCredential(api, operation, catalog, schema, tableName, location);
+  }
+
+  private static GenericCredential createDeltaTableCredential(
+      TemporaryCredentialsApi api,
+      CredentialOperation operation,
+      String catalog,
+      String schema,
+      String tableName,
+      String location)
+      throws ApiException {
+    CredentialsResponse response = api.getTableCredentials(operation, catalog, schema, tableName);
+    Preconditions.checkArgument(
+        response != null,
+        "UC Delta API returned no credentials response for '%s.%s.%s'.",
+        catalog,
+        schema,
+        tableName);
+    return new GenericCredential(
+        DeltaStorageCredentialUtil.toTemporaryCredentials(
+            DeltaStorageCredentialUtil.selectForLocation(
+                location, response.getStorageCredentials())));
+  }
+
+  static CredentialOperation toCredentialOperation(String tableOperation) {
+    switch (TableOperation.fromValue(tableOperation)) {
+      case READ:
+        return CredentialOperation.READ;
+      case READ_WRITE:
+        return CredentialOperation.READ_WRITE;
+      default:
+        throw new IllegalArgumentException(
+            "UC Delta supports READ and READ_WRITE table operations, got: " + tableOperation);
+    }
+  }
+
+  private static String require(Configuration conf, String key) {
+    String value = conf.get(key);
+    Preconditions.checkArgument(
+        value != null && !value.isEmpty(), "'%s' is not set in hadoop configuration", key);
+    return value;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCTempCredentialApi.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCTempCredentialApi.java
@@ -1,0 +1,64 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.client.model.GenerateTemporaryPathCredential;
+import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
+import io.unitycatalog.client.model.PathOperation;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+
+/** Adapts the standard Unity Catalog temporary credentials SDK API for Hadoop token providers. */
+final class UCTempCredentialApi implements TempCredentialApi {
+  private final TemporaryCredentialsApi api;
+  private final GenerateTemporaryPathCredential pathRequest;
+  private final GenerateTemporaryTableCredential tableRequest;
+
+  UCTempCredentialApi(Configuration conf, TemporaryCredentialsApi api) {
+    Preconditions.checkNotNull(api, "api is required");
+    this.api = api;
+    String type = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
+    Preconditions.checkArgument(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)
+            || UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type),
+        "Unsupported unity catalog temporary credentials type '%s', please check '%s'",
+        type,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
+    if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
+      this.pathRequest =
+          new GenerateTemporaryPathCredential()
+              .url(require(conf, UCHadoopConfConstants.UC_PATH_KEY))
+              .operation(
+                  PathOperation.fromValue(
+                      require(conf, UCHadoopConfConstants.UC_PATH_OPERATION_KEY)));
+      this.tableRequest = null;
+    } else {
+      this.pathRequest = null;
+      this.tableRequest =
+          new GenerateTemporaryTableCredential()
+              .tableId(require(conf, UCHadoopConfConstants.UC_TABLE_ID_KEY))
+              .operation(
+                  TableOperation.fromValue(
+                      require(conf, UCHadoopConfConstants.UC_TABLE_OPERATION_KEY)));
+    }
+  }
+
+  @Override
+  public GenericCredential createCredential() throws ApiException {
+    TemporaryCredentials tempCred =
+        pathRequest != null
+            ? api.generateTemporaryPathCredentials(pathRequest)
+            : api.generateTemporaryTableCredentials(tableRequest);
+    return new GenericCredential(tempCred);
+  }
+
+  private static String require(Configuration conf, String key) {
+    String value = conf.get(key);
+    Preconditions.checkArgument(
+        value != null && !value.isEmpty(), "'%s' is not set in hadoop configuration", key);
+    return value;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -1,6 +1,6 @@
 package io.unitycatalog.hadoop.internal.fs;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
@@ -23,15 +23,15 @@ import org.apache.hadoop.fs.FileSystem;
 public interface CredScopedKey {
 
   static CredScopedKey create(URI uri, Configuration conf) {
-    String type = conf.get(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY);
-    if (UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
-      String path = conf.get(UCHadoopConf.UC_PATH_KEY);
-      String pathOperation = conf.get(UCHadoopConf.UC_PATH_OPERATION_KEY);
+    String type = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
+    if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
+      String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
+      String pathOperation = conf.get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY);
 
       return new PathCredScopedKey(path, pathOperation);
-    } else if (UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
-      String tableId = conf.get(UCHadoopConf.UC_TABLE_ID_KEY);
-      String tableOperation = conf.get(UCHadoopConf.UC_TABLE_OPERATION_KEY);
+    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
+      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
+      String tableOperation = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
       return new TableCredScopedKey(tableId, tableOperation);
     }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
@@ -4,13 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.StorageCredential;
+import io.unitycatalog.client.delta.model.StorageCredentialConfig;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
@@ -229,8 +232,8 @@ class UCCredentialHadoopConfsTest {
             .buildForTable("tid", TableOperation.READ);
 
     assertThat(props)
-        .containsEntry(UCHadoopConf.UC_ENGINE_VERSION_PREFIX + "Spark", "4.0.0")
-        .containsEntry(UCHadoopConf.UC_ENGINE_VERSION_PREFIX + "Delta", "3.3.0");
+        .containsEntry(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + "Spark", "4.0.0")
+        .containsEntry(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + "Delta", "3.3.0");
   }
 
   @Test
@@ -242,7 +245,7 @@ class UCCredentialHadoopConfsTest {
             .buildForPath("s3://bucket/key", PathOperation.PATH_READ);
 
     assertThat(props)
-        .containsEntry(UCHadoopConf.UC_ENGINE_VERSION_PREFIX + "Spark", "4.0.0")
+        .containsEntry(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + "Spark", "4.0.0")
         .containsEntry("fs.unitycatalog.path", "s3://bucket/key");
   }
 
@@ -404,5 +407,172 @@ class UCCredentialHadoopConfsTest {
   private static TemporaryCredentials abfsCreds() {
     return new TemporaryCredentials()
         .azureUserDelegationSas(new AzureUserDelegationSAS().sasToken("sas-token"));
+  }
+
+  private static StorageCredential deltaS3Credential() {
+    return new StorageCredential()
+        .prefix("s3://bucket/table")
+        .operation(CredentialOperation.READ_WRITE)
+        .config(
+            new StorageCredentialConfig()
+                .s3AccessKeyId("ak")
+                .s3SecretAccessKey("sk")
+                .s3SessionToken("st"));
+  }
+
+  private static StorageCredential deltaGcsCredential() {
+    return new StorageCredential()
+        .prefix("gs://bucket/table")
+        .operation(CredentialOperation.READ)
+        .expirationTimeMs(4242L)
+        .config(new StorageCredentialConfig().gcsOauthToken("gcs-oauth-token"));
+  }
+
+  private static StorageCredential deltaAzureCredential() {
+    return new StorageCredential()
+        .prefix("abfss://container@account.dfs.core.windows.net/table")
+        .operation(CredentialOperation.READ_WRITE)
+        .expirationTimeMs(5151L)
+        .config(new StorageCredentialConfig().azureSasToken("sas-token"));
+  }
+
+  @Test
+  void s3DeltaTableBuildsExpectedKeys() {
+    Map<String, String> props =
+        renewalBuilder("s3")
+            .initialStorageCredential(deltaS3Credential())
+            .buildForTable("table-uuid", "catalog", "schema", "table", "s3://bucket/table");
+
+    assertThat(props)
+        .containsEntry(
+            UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, Boolean.TRUE.toString())
+        .containsEntry(
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
+        .containsEntry(UCHadoopConfConstants.UC_TABLE_ID_KEY, "table-uuid")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "catalog")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "schema")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "table")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/table")
+        .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, "sk")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, "st");
+  }
+
+  @Test
+  void deltaTableBuildsExpectedCloudSpecificInitialCredentialKeys() {
+    Map<String, String> gcsProps =
+        renewalBuilder("gs")
+            .initialStorageCredential(deltaGcsCredential())
+            .buildForTable("gcs-table-uuid", "catalog", "schema", "table", "gs://bucket/table");
+    assertThat(gcsProps)
+        .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ")
+        .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "gcs-oauth-token")
+        .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, "4242");
+
+    Map<String, String> azureProps =
+        renewalBuilder("abfss")
+            .initialStorageCredential(deltaAzureCredential())
+            .buildForTable(
+                "azure-table-uuid",
+                "catalog",
+                "schema",
+                "table",
+                "abfss://container@account.dfs.core.windows.net/table");
+    assertThat(azureProps)
+        .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE")
+        .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, "sas-token")
+        .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, "5151");
+  }
+
+  @Test
+  void deltaTableBuildRejectsMultiCloudInitialStorageCredential() {
+    StorageCredential credential =
+        new StorageCredential()
+            .prefix("gs://bucket/table")
+            .operation(CredentialOperation.READ)
+            .config(
+                new StorageCredentialConfig()
+                    .gcsOauthToken("gcs-oauth-token")
+                    .azureSasToken("sas-token"));
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("gs")
+                    .initialStorageCredential(credential)
+                    .buildForTable("table-uuid", "catalog", "schema", "table", "gs://b/t"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must contain exactly one cloud credential config");
+  }
+
+  @Test
+  void initialStorageCredentialRequiredForDeltaApi() {
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .buildForTable("table-uuid", "catalog", "schema", "table", "s3://b/t"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("initialStorageCredential is required");
+  }
+
+  @Test
+  void cannotSetBothInitialCredentialAndInitialStorageCredential() {
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialCredentials(s3Creds())
+                    .initialStorageCredential(deltaS3Credential()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot also set initialStorageCredential");
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .initialCredentials(s3Creds()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot also set initialCredentials");
+  }
+
+  @Test
+  void deltaTableBuildRejectsInitialCredentials() {
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialCredentials(s3Creds())
+                    .buildForTable("table-uuid", "catalog", "schema", "table", "s3://b/t"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("initialStorageCredential is required");
+  }
+
+  @Test
+  void ucBuilderRejectsInitialStorageCredential() {
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable("tid", TableOperation.READ_WRITE))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("initialCredentials is required");
+  }
+
+  @Test
+  void deltaTableBuildRejectsMissingFields() {
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable(null, "catalog", "schema", "table", "s3://bucket/table"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tableId is required");
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable("table-uuid", null, "schema", "table", "s3://bucket/table"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("catalog is required");
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtilTest.java
@@ -1,0 +1,174 @@
+package io.unitycatalog.hadoop.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.StorageCredential;
+import io.unitycatalog.client.delta.model.StorageCredentialConfig;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DeltaStorageCredentialUtilTest {
+
+  @Test
+  void selectorRejectsMissingResponse() {
+    assertThatThrownBy(() -> DeltaStorageCredentialUtil.selectForLocation("s3://bucket/t", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("has no storage credentials");
+    assertThatThrownBy(
+            () ->
+                DeltaStorageCredentialUtil.selectForLocation(
+                    "s3://bucket/t", Collections.emptyList()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("has no storage credentials");
+  }
+
+  @Test
+  void selectorRejectsSingleWithoutPrefixMatch() {
+    StorageCredential only = credAt("s3://other-bucket");
+    assertThatThrownBy(
+            () -> DeltaStorageCredentialUtil.selectForLocation("s3://bucket/t", List.of(only)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No UC Delta credential matched");
+  }
+
+  @Test
+  void selectorRejectsSingleNull() {
+    assertThatThrownBy(
+            () ->
+                DeltaStorageCredentialUtil.selectForLocation(
+                    "s3://bucket/t", Collections.singletonList(null)))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("contains null");
+  }
+
+  @Test
+  void selectorPicksLongestMatchingPrefix() {
+    StorageCredential bucket = credAt("s3://bucket");
+    StorageCredential table = credAt("s3://bucket/t");
+    StorageCredential child = credAt("s3://bucket/t/child");
+    assertThat(
+            DeltaStorageCredentialUtil.selectForLocation(
+                "s3://bucket/t/child/file", Arrays.asList(bucket, table, child)))
+        .isSameAs(child);
+  }
+
+  @Test
+  void selectorMatchesAtPathBoundary() {
+    assertThat(DeltaStorageCredentialUtil.prefixCovers("s3://bucket/t", "s3://bucket/t")).isTrue();
+    assertThat(DeltaStorageCredentialUtil.prefixCovers("s3://bucket/t/x", "s3://bucket/t"))
+        .isTrue();
+    assertThat(DeltaStorageCredentialUtil.prefixCovers("s3://bucket/t-other", "s3://bucket/t"))
+        .isFalse();
+  }
+
+  @Test
+  void selectorNormalizesTrailingSlashes() {
+    assertThat(DeltaStorageCredentialUtil.prefixCovers("s3://bucket/t//", "s3://bucket/t"))
+        .isTrue();
+    assertThat(DeltaStorageCredentialUtil.prefixCovers("s3://bucket/t", "s3://bucket/t///"))
+        .isTrue();
+  }
+
+  @Test
+  void selectorIgnoresNullAndPrefixlessInMultiResponse() {
+    List<StorageCredential> creds =
+        Arrays.asList(null, new StorageCredential(), credAt("s3://bucket/t"));
+    assertThat(DeltaStorageCredentialUtil.selectForLocation("s3://bucket/t", creds).getPrefix())
+        .isEqualTo("s3://bucket/t");
+  }
+
+  @Test
+  void selectorThrowsWhenMultiResponseHasNoMatch() {
+    List<StorageCredential> creds =
+        Arrays.asList(credAt("s3://other"), credAt("s3://bucket/sibling"));
+    assertThatThrownBy(() -> DeltaStorageCredentialUtil.selectForLocation("s3://bucket/t", creds))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No UC Delta credential matched");
+  }
+
+  @Test
+  void toTemporaryCredentialsExtractsAwsKeysAndExpiry() {
+    StorageCredential c =
+        new StorageCredential()
+            .prefix("s3://bucket")
+            .operation(CredentialOperation.READ_WRITE)
+            .expirationTimeMs(123L)
+            .config(
+                new StorageCredentialConfig()
+                    .s3AccessKeyId("ak")
+                    .s3SecretAccessKey("sk")
+                    .s3SessionToken("st"));
+    TemporaryCredentials tc = DeltaStorageCredentialUtil.toTemporaryCredentials(c);
+    assertThat(tc.getExpirationTime()).isEqualTo(123L);
+    assertThat(tc.getAwsTempCredentials().getAccessKeyId()).isEqualTo("ak");
+    assertThat(tc.getAwsTempCredentials().getSecretAccessKey()).isEqualTo("sk");
+    assertThat(tc.getAwsTempCredentials().getSessionToken()).isEqualTo("st");
+  }
+
+  @Test
+  void toTemporaryCredentialsRejectsMultiCloudConfig() {
+    StorageCredential c =
+        new StorageCredential()
+            .prefix("s3://bucket")
+            .operation(CredentialOperation.READ)
+            .config(new StorageCredentialConfig().s3AccessKeyId("ak").gcsOauthToken("gcs"));
+    assertThatThrownBy(() -> DeltaStorageCredentialUtil.toTemporaryCredentials(c))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must contain exactly one cloud credential config");
+  }
+
+  @Test
+  void toTemporaryCredentialsRejectsMissingConfig() {
+    StorageCredential c =
+        new StorageCredential().prefix("s3://bucket").operation(CredentialOperation.READ);
+    assertThatThrownBy(() -> DeltaStorageCredentialUtil.toTemporaryCredentials(c))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("missing config");
+  }
+
+  @Test
+  void toTemporaryCredentialsExtractsAzureSasToken() {
+    StorageCredential c =
+        new StorageCredential()
+            .prefix("abfss://container@account.dfs.core.windows.net/")
+            .operation(CredentialOperation.READ_WRITE)
+            .config(new StorageCredentialConfig().azureSasToken("sas-token"));
+    TemporaryCredentials tc = DeltaStorageCredentialUtil.toTemporaryCredentials(c);
+    assertThat(tc.getAzureUserDelegationSas().getSasToken()).isEqualTo("sas-token");
+    assertThat(tc.getExpirationTime()).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void toTemporaryCredentialsExtractsGcsOauthToken() {
+    StorageCredential c =
+        new StorageCredential()
+            .prefix("gs://bucket/")
+            .operation(CredentialOperation.READ)
+            .expirationTimeMs(456L)
+            .config(new StorageCredentialConfig().gcsOauthToken("gcs-oauth-token"));
+    TemporaryCredentials tc = DeltaStorageCredentialUtil.toTemporaryCredentials(c);
+    assertThat(tc.getGcpOauthToken().getOauthToken()).isEqualTo("gcs-oauth-token");
+    assertThat(tc.getExpirationTime()).isEqualTo(456L);
+  }
+
+  @Test
+  void toTemporaryCredentialsRejectsPartialS3WithMissingAccessKey() {
+    StorageCredential c =
+        new StorageCredential()
+            .prefix("s3://bucket")
+            .operation(CredentialOperation.READ)
+            .config(new StorageCredentialConfig().s3SessionToken("st"));
+    assertThatThrownBy(() -> DeltaStorageCredentialUtil.toTemporaryCredentials(c))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("missing S3 access key");
+  }
+
+  private static StorageCredential credAt(String prefix) {
+    return new StorageCredential().prefix(prefix);
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProviderTest.java
@@ -1,18 +1,17 @@
 package io.unitycatalog.hadoop.internal.auth;
 
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME;
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE;
-import static org.apache.hadoop.fs.azurebfs.services.AuthType.SAS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
+import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.junit.jupiter.api.Test;
 
 public class AbfsVendedTokenProviderTest extends BaseTokenProviderTest<AbfsVendedTokenProvider> {
@@ -23,16 +22,16 @@ public class AbfsVendedTokenProviderTest extends BaseTokenProviderTest<AbfsVende
   }
 
   static class TestAbfsVendedTokenProvider extends AbfsVendedTokenProvider {
-    private final TemporaryCredentialsApi mockApi;
+    private final TempCredentialApi credentialApi;
 
     TestAbfsVendedTokenProvider(Configuration conf, TemporaryCredentialsApi mockApi) {
       initialize(conf);
-      this.mockApi = mockApi;
+      this.credentialApi = new UCTempCredentialApi(conf, mockApi);
     }
 
     @Override
-    protected TemporaryCredentialsApi temporaryCredentialsApi() {
-      return mockApi;
+    TempCredentialApi tempCredentialApi() {
+      return credentialApi;
     }
   }
 
@@ -51,8 +50,9 @@ public class AbfsVendedTokenProviderTest extends BaseTokenProviderTest<AbfsVende
   protected void setInitialCred(Configuration conf, TemporaryCredentials cred) {
     assertThat(cred.getAzureUserDelegationSas()).isNotNull();
     assertThat(cred.getExpirationTime()).isNotNull();
-    conf.set(UCHadoopConf.AZURE_INIT_SAS_TOKEN, cred.getAzureUserDelegationSas().getSasToken());
-    conf.setLong(UCHadoopConf.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, cred.getExpirationTime());
+    conf.set(
+        UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, cred.getAzureUserDelegationSas().getSasToken());
+    conf.setLong(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME, cred.getExpirationTime());
   }
 
   @Override
@@ -70,32 +70,20 @@ public class AbfsVendedTokenProviderTest extends BaseTokenProviderTest<AbfsVende
     Configuration conf = new Configuration();
     AbfsVendedTokenProvider provider = new AbfsVendedTokenProvider();
 
-    // Verify the UC URI validation error message.
-    assertThatThrownBy(() -> provider.initialize(conf))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("'%s' is not set in hadoop configuration", UCHadoopConf.UC_URI_KEY);
-
-    // Verify the UC Token validation error message.
-    conf.set(UCHadoopConf.UC_URI_KEY, "http://localhost:8080");
-    assertThatThrownBy(() -> provider.initialize(conf))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Required configuration key 'type' is missing or empty");
-
-    // Verify the UID validation error message.
-    conf.set(UCHadoopConf.UC_AUTH_TYPE, "static");
-    conf.set(UCHadoopConf.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
     assertThatThrownBy(() -> provider.initialize(conf))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Credential UID cannot be null or empty, '%s' is not set in hadoop configuration",
-            UCHadoopConf.UC_CREDENTIALS_UID_KEY);
+            UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
   }
 
   @Test
   public void testLoadProvider() throws Exception {
     Configuration conf = newTableBasedConf();
-    conf.setEnum(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, SAS);
-    conf.set(FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, AbfsVendedTokenProvider.class.getName());
+    conf.setEnum(ConfigurationKeys.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, AuthType.SAS);
+    conf.set(
+        ConfigurationKeys.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE,
+        AbfsVendedTokenProvider.class.getName());
 
     AbfsConfiguration abfsConf = new AbfsConfiguration(conf, "account");
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProviderTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -29,16 +29,16 @@ public class AwsVendedTokenProviderTest extends BaseTokenProviderTest<AwsVendedT
   }
 
   static class TestAwsVendedTokenProvider extends AwsVendedTokenProvider {
-    private final TemporaryCredentialsApi tempCredApi;
+    private final TempCredentialApi credentialApi;
 
     TestAwsVendedTokenProvider(Configuration conf, TemporaryCredentialsApi tempCredApi) {
       super(conf);
-      this.tempCredApi = tempCredApi;
+      this.credentialApi = new UCTempCredentialApi(conf, tempCredApi);
     }
 
     @Override
-    protected TemporaryCredentialsApi temporaryCredentialsApi() {
-      return tempCredApi;
+    TempCredentialApi tempCredentialApi() {
+      return credentialApi;
     }
   }
 
@@ -58,10 +58,15 @@ public class AwsVendedTokenProviderTest extends BaseTokenProviderTest<AwsVendedT
 
   @Override
   protected void setInitialCred(Configuration conf, TemporaryCredentials cred) {
-    conf.set(UCHadoopConf.S3A_INIT_ACCESS_KEY, cred.getAwsTempCredentials().getAccessKeyId());
-    conf.set(UCHadoopConf.S3A_INIT_SECRET_KEY, cred.getAwsTempCredentials().getSecretAccessKey());
-    conf.set(UCHadoopConf.S3A_INIT_SESSION_TOKEN, cred.getAwsTempCredentials().getSessionToken());
-    conf.setLong(UCHadoopConf.S3A_INIT_CRED_EXPIRED_TIME, cred.getExpirationTime());
+    conf.set(
+        UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, cred.getAwsTempCredentials().getAccessKeyId());
+    conf.set(
+        UCHadoopConfConstants.S3A_INIT_SECRET_KEY,
+        cred.getAwsTempCredentials().getSecretAccessKey());
+    conf.set(
+        UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN,
+        cred.getAwsTempCredentials().getSessionToken());
+    conf.setLong(UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME, cred.getExpirationTime());
   }
 
   @Override
@@ -83,25 +88,11 @@ public class AwsVendedTokenProviderTest extends BaseTokenProviderTest<AwsVendedT
   public void testConstructor() {
     Configuration conf = new Configuration();
 
-    // Verify the UC URI validation error message.
-    assertThatThrownBy(() -> new AwsVendedTokenProvider(conf))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("'%s' is not set in hadoop configuration", UCHadoopConf.UC_URI_KEY);
-
-    // Verify the UC Token validation error message.
-    conf.set(UCHadoopConf.UC_URI_KEY, "http://localhost:8080");
-    assertThatThrownBy(() -> new AwsVendedTokenProvider(conf))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Required configuration key 'type' is missing or empty");
-
-    // Verify the UID validation error message.
-    conf.set(UCHadoopConf.UC_AUTH_TYPE, "static");
-    conf.set(UCHadoopConf.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
     assertThatThrownBy(() -> new AwsVendedTokenProvider(conf))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Credential UID cannot be null or empty, '%s' is not set in hadoop configuration",
-            UCHadoopConf.UC_CREDENTIALS_UID_KEY);
+            UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -10,7 +10,7 @@ import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.time.Duration;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
@@ -52,8 +52,8 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   @Test
   public void testTableTemporaryCredentialsRenew() throws Exception {
     Configuration conf = newTableBasedConf();
-    conf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    conf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     TemporaryCredentials cred1 = newTempCred("1", clock.now().toEpochMilli() + 2000L);
     TemporaryCredentials cred2 = newTempCred("2", clock.now().toEpochMilli() + 3000L);
@@ -83,8 +83,8 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   @Test
   public void testTableTemporaryCredentialsRenewWithInitialCredentials() throws Exception {
     Configuration conf = newTableBasedConf();
-    conf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    conf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     // Use the generated credential to initialize the provider.
     TemporaryCredentials cred0 = newTempCred("0", clock.now().toEpochMilli() + 2000L);
@@ -126,8 +126,8 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   @Test
   public void testPathTemporaryCredentialsRenew() throws Exception {
     Configuration conf = newPathBasedConf();
-    conf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    conf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     TemporaryCredentials cred1 = newTempCred("1", clock.now().toEpochMilli() + 2000L);
     TemporaryCredentials cred2 = newTempCred("2", clock.now().toEpochMilli() + 3000L);
@@ -157,8 +157,8 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   @Test
   public void testPathTemporaryCredentialsRenewWithInitialCredentials() throws Exception {
     Configuration conf = newPathBasedConf();
-    conf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    conf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     // Use the generated credential to initialize the provider.
     TemporaryCredentials cred0 = newTempCred("0", clock.now().toEpochMilli() + 2000L);
@@ -199,20 +199,20 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   @Test
   public void testGlobalCredCache() throws Exception {
     Configuration tableAconf = newTableBasedConf("tableA");
-    tableAconf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    tableAconf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    tableAconf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    tableAconf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     Configuration tableBconf = newTableBasedConf("tableB");
-    tableBconf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    tableBconf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    tableBconf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    tableBconf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     Configuration pathAconf = newPathBasedConf("pathA");
-    pathAconf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    pathAconf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    pathAconf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    pathAconf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     Configuration pathBconf = newPathBasedConf("pathB");
-    pathBconf.set(UCHadoopConf.UC_TEST_CLOCK_NAME, clockName);
-    pathBconf.setLong(UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    pathBconf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    pathBconf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     TemporaryCredentialsApi tempCredApi = mock(TemporaryCredentialsApi.class);
     // Mock the temporary table credential API.
@@ -315,15 +315,17 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newTableBasedConf(String tableId) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConf.UC_URI_KEY, "http://localhost:8080");
-    conf.set(UCHadoopConf.UC_AUTH_TYPE, "static");
-    conf.set(UCHadoopConf.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
-    conf.set(UCHadoopConf.UC_CREDENTIALS_UID_KEY, UUID.randomUUID().toString());
+    conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
+    conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
+    conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
+    conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, UUID.randomUUID().toString());
 
     // For table-based temporary requests.
-    conf.set(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE);
-    conf.set(UCHadoopConf.UC_TABLE_ID_KEY, tableId);
-    conf.set(UCHadoopConf.UC_TABLE_OPERATION_KEY, TableOperation.READ.getValue());
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, TableOperation.READ.getValue());
 
     return conf;
   }
@@ -334,15 +336,17 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newPathBasedConf(String path) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConf.UC_URI_KEY, "http://localhost:8080");
-    conf.set(UCHadoopConf.UC_AUTH_TYPE, "static");
-    conf.set(UCHadoopConf.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
-    conf.set(UCHadoopConf.UC_CREDENTIALS_UID_KEY, UUID.randomUUID().toString());
+    conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
+    conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
+    conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
+    conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, UUID.randomUUID().toString());
 
     // For path-based temporary requests.
-    conf.set(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE);
-    conf.set(UCHadoopConf.UC_PATH_KEY, path);
-    conf.set(UCHadoopConf.UC_PATH_OPERATION_KEY, PathOperation.PATH_READ.getValue());
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE);
+    conf.set(UCHadoopConfConstants.UC_PATH_KEY, path);
+    conf.set(UCHadoopConfConstants.UC_PATH_OPERATION_KEY, PathOperation.PATH_READ.getValue());
 
     return conf;
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProviderTest.java
@@ -11,7 +11,7 @@ import com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.AccessTokenPr
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -26,16 +26,16 @@ public class GcsVendedTokenProviderTest extends BaseTokenProviderTest<GcsVendedT
   }
 
   static class TestGcsVendedTokenProvider extends GcsVendedTokenProvider {
-    private final TemporaryCredentialsApi mockApi;
+    private final TempCredentialApi credentialApi;
 
     TestGcsVendedTokenProvider(Configuration conf, TemporaryCredentialsApi mockApi) {
       setConf(conf);
-      this.mockApi = mockApi;
+      this.credentialApi = new UCTempCredentialApi(conf, mockApi);
     }
 
     @Override
-    protected TemporaryCredentialsApi temporaryCredentialsApi() {
-      return mockApi;
+    TempCredentialApi tempCredentialApi() {
+      return credentialApi;
     }
   }
 
@@ -54,9 +54,10 @@ public class GcsVendedTokenProviderTest extends BaseTokenProviderTest<GcsVendedT
   @Override
   protected void setInitialCred(Configuration conf, TemporaryCredentials cred) {
     assertThat(cred.getGcpOauthToken()).isNotNull();
-    conf.set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN, cred.getGcpOauthToken().getOauthToken());
+    conf.set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, cred.getGcpOauthToken().getOauthToken());
     if (cred.getExpirationTime() != null) {
-      conf.setLong(UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, cred.getExpirationTime());
+      conf.setLong(
+          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, cred.getExpirationTime());
     }
   }
 
@@ -83,21 +84,10 @@ public class GcsVendedTokenProviderTest extends BaseTokenProviderTest<GcsVendedT
     GcsVendedTokenProvider provider = new GcsVendedTokenProvider();
 
     assertThatThrownBy(() -> provider.setConf(conf))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("'%s' is not set in hadoop configuration", UCHadoopConf.UC_URI_KEY);
-
-    conf.set(UCHadoopConf.UC_URI_KEY, "http://localhost:8080");
-    assertThatThrownBy(() -> provider.setConf(conf))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Required configuration key 'type' is missing or empty");
-
-    conf.set(UCHadoopConf.UC_AUTH_TYPE, "static");
-    conf.set(UCHadoopConf.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
-    assertThatThrownBy(() -> provider.setConf(conf))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Credential UID cannot be null or empty, '%s' is not set in hadoop configuration",
-            UCHadoopConf.UC_CREDENTIALS_UID_KEY);
+            UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
   }
 
   @Test
@@ -109,9 +99,10 @@ public class GcsVendedTokenProviderTest extends BaseTokenProviderTest<GcsVendedT
     conf.set("fs.gs.project.id", "test-project");
     conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER");
     conf.set("fs.gs.auth.access.token.provider", GcsVendedTokenProvider.class.getName());
-    conf.set(UCHadoopConf.GCS_INIT_OAUTH_TOKEN, "dummy-token");
+    conf.set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "dummy-token");
     conf.setLong(
-        UCHadoopConf.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME, System.currentTimeMillis() + 60_000);
+        UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
+        System.currentTimeMillis() + 60_000);
 
     try (FileSystem fs = FileSystem.newInstance(new URI("gs://test-bucket0"), conf)) {
       assertThat(fs.getClass().getName()).isEqualTo(ghfsClassName);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApiTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApiTest.java
@@ -1,0 +1,148 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.delta.model.StorageCredential;
+import io.unitycatalog.client.delta.model.StorageCredentialConfig;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+class UCDeltaTempCredentialApiTest {
+
+  @Test
+  void createCredentialCallsDeltaApiWithConfFieldsAndReturnsCredential() throws Exception {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "main");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "default");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "events");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/events");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE");
+
+    StorageCredential sc =
+        new StorageCredential()
+            .prefix("s3://bucket/events")
+            .operation(CredentialOperation.READ_WRITE)
+            .expirationTimeMs(789L)
+            .config(
+                new StorageCredentialConfig()
+                    .s3AccessKeyId("ak")
+                    .s3SecretAccessKey("sk")
+                    .s3SessionToken("st"));
+    CredentialsResponse response = new CredentialsResponse().addStorageCredentialsItem(sc);
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getTableCredentials(CredentialOperation.READ_WRITE, "main", "default", "events"))
+        .thenReturn(response);
+
+    GenericCredential cred = new UCDeltaTempCredentialApi(conf, api).createCredential();
+
+    assertThat(cred).isNotNull();
+    TemporaryCredentials out = cred.temporaryCredentials();
+    assertThat(out.getAwsTempCredentials().getAccessKeyId()).isEqualTo("ak");
+    assertThat(out.getAwsTempCredentials().getSecretAccessKey()).isEqualTo("sk");
+    assertThat(out.getAwsTempCredentials().getSessionToken()).isEqualTo("st");
+    assertThat(out.getExpirationTime()).isEqualTo(789L);
+    verify(api).getTableCredentials(CredentialOperation.READ_WRITE, "main", "default", "events");
+  }
+
+  @Test
+  void createCredentialUsesFieldsParsedAtConstruction() throws Exception {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "main");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "default");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "events");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/events");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE");
+
+    StorageCredential sc =
+        new StorageCredential()
+            .prefix("s3://bucket/events")
+            .operation(CredentialOperation.READ_WRITE)
+            .config(
+                new StorageCredentialConfig()
+                    .s3AccessKeyId("ak")
+                    .s3SecretAccessKey("sk")
+                    .s3SessionToken("st"));
+    CredentialsResponse response = new CredentialsResponse().addStorageCredentialsItem(sc);
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getTableCredentials(CredentialOperation.READ_WRITE, "main", "default", "events"))
+        .thenReturn(response);
+    TempCredentialApi credentialApi = new UCDeltaTempCredentialApi(conf, api);
+
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "mutated-catalog");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "mutated-schema");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "mutated-name");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/mutated");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "UNKNOWN");
+
+    credentialApi.createCredential();
+
+    verify(api).getTableCredentials(CredentialOperation.READ_WRITE, "main", "default", "events");
+  }
+
+  @Test
+  void createCredentialRejectsMissingCredentialsResponse() throws Exception {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "main");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "default");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "events");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/events");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE");
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getTableCredentials(CredentialOperation.READ_WRITE, "main", "default", "events"))
+        .thenReturn(null);
+
+    assertThatThrownBy(() -> new UCDeltaTempCredentialApi(conf, api).createCredential())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("returned no credentials response");
+  }
+
+  @Test
+  void constructorThrowsWhenConfMissingCatalog() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "s");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "n");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://b/p");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    assertThatThrownBy(() -> new UCDeltaTempCredentialApi(conf, api))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("fs.unitycatalog.delta.catalog");
+  }
+
+  @Test
+  void constructorRejectsUnsupportedTableOperation() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "c");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "s");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "n");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://b/p");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "UNKNOWN");
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    assertThatThrownBy(() -> new UCDeltaTempCredentialApi(conf, api))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void tempCredentialApiRejectsInvalidDeltaApiEnabledValue() {
+    Configuration conf = BaseTokenProviderTest.newTableBasedConf();
+    conf.set(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "other");
+
+    assertThatThrownBy(() -> TempCredentialApi.create(conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY);
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCTempCredentialApiTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCTempCredentialApiTest.java
@@ -1,0 +1,96 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.model.GenerateTemporaryPathCredential;
+import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
+import io.unitycatalog.client.model.PathOperation;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UCTempCredentialApiTest {
+
+  @Test
+  void factoryRequiresUcUri() {
+    Configuration conf = BaseTokenProviderTest.newTableBasedConf();
+    conf.unset(UCHadoopConfConstants.UC_URI_KEY);
+
+    assertThatThrownBy(() -> TempCredentialApi.create(conf))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("'%s' is not set in hadoop configuration", UCHadoopConfConstants.UC_URI_KEY);
+  }
+
+  @Test
+  void factoryRequiresTokenProviderConfig() {
+    Configuration conf = BaseTokenProviderTest.newTableBasedConf();
+    conf.unset(UCHadoopConfConstants.UC_AUTH_TYPE);
+    conf.unset(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY);
+
+    assertThatThrownBy(() -> TempCredentialApi.create(conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Required configuration key 'type' is missing or empty");
+  }
+
+  @Test
+  void tableRequestArgumentsAreParsedOnceAtConstruction() throws Exception {
+    Configuration conf = BaseTokenProviderTest.newTableBasedConf("original-table-id");
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.generateTemporaryTableCredentials(any())).thenReturn(new TemporaryCredentials());
+
+    TempCredentialApi credentialApi = new UCTempCredentialApi(conf, api);
+
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "mutated-table-id");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "UNKNOWN");
+    conf.set(UCHadoopConfConstants.UC_PATH_KEY, "s3://mutated/path");
+    conf.set(UCHadoopConfConstants.UC_PATH_OPERATION_KEY, PathOperation.PATH_READ_WRITE.getValue());
+
+    credentialApi.createCredential();
+
+    ArgumentCaptor<GenerateTemporaryTableCredential> request =
+        ArgumentCaptor.forClass(GenerateTemporaryTableCredential.class);
+    verify(api).generateTemporaryTableCredentials(request.capture());
+    verify(api, never()).generateTemporaryPathCredentials(any());
+    assertThat(request.getValue().getTableId()).isEqualTo("original-table-id");
+    assertThat(request.getValue().getOperation()).isEqualTo(TableOperation.READ);
+  }
+
+  @Test
+  void pathRequestArgumentsAreParsedOnceAtConstruction() throws Exception {
+    Configuration conf = BaseTokenProviderTest.newPathBasedConf("s3://bucket/original-path");
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.generateTemporaryPathCredentials(any())).thenReturn(new TemporaryCredentials());
+
+    TempCredentialApi credentialApi = new UCTempCredentialApi(conf, api);
+
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_PATH_KEY, "s3://bucket/mutated-path");
+    conf.set(UCHadoopConfConstants.UC_PATH_OPERATION_KEY, "UNKNOWN");
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "mutated-table-id");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, TableOperation.READ_WRITE.getValue());
+
+    credentialApi.createCredential();
+
+    ArgumentCaptor<GenerateTemporaryPathCredential> request =
+        ArgumentCaptor.forClass(GenerateTemporaryPathCredential.class);
+    verify(api).generateTemporaryPathCredentials(request.capture());
+    verify(api, never()).generateTemporaryTableCredentials(any());
+    assertThat(request.getValue().getUrl()).isEqualTo("s3://bucket/original-path");
+    assertThat(request.getValue().getOperation()).isEqualTo(PathOperation.PATH_READ);
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -32,9 +32,11 @@ class CredScopedFileSystemCacheTest {
 
   private static Configuration tableConf(String tableId, String op) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE);
-    conf.set(UCHadoopConf.UC_TABLE_ID_KEY, tableId);
-    conf.set(UCHadoopConf.UC_TABLE_OPERATION_KEY, op);
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, op);
     // Disable Hadoop's internal filesystem cache so newFileSystem() creates a fresh instance per
     // credential scope, making it possible to assert identity inequality across scopes.
     conf.set("fs.file.impl.disable.cache", "true");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
@@ -2,7 +2,7 @@ package io.unitycatalog.hadoop.internal.fs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
@@ -62,9 +62,11 @@ class CredScopedKeyTest {
   @Test
   void createReturnsTableKey() {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, UCHadoopConf.UC_CREDENTIALS_TYPE_TABLE_VALUE);
-    conf.set(UCHadoopConf.UC_TABLE_ID_KEY, "tid");
-    conf.set(UCHadoopConf.UC_TABLE_OPERATION_KEY, "READ");
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
 
     assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
         .isInstanceOf(CredScopedKey.TableCredScopedKey.class)
@@ -74,9 +76,11 @@ class CredScopedKeyTest {
   @Test
   void createReturnsPathKey() {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConf.UC_CREDENTIALS_TYPE_KEY, UCHadoopConf.UC_CREDENTIALS_TYPE_PATH_VALUE);
-    conf.set(UCHadoopConf.UC_PATH_KEY, "s3://b/p");
-    conf.set(UCHadoopConf.UC_PATH_OPERATION_KEY, "WRITE");
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE);
+    conf.set(UCHadoopConfConstants.UC_PATH_KEY, "s3://b/p");
+    conf.set(UCHadoopConfConstants.UC_PATH_OPERATION_KEY, "WRITE");
 
     assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
         .isInstanceOf(CredScopedKey.PathCredScopedKey.class)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ApiClientFactoryTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ApiClientFactoryTest.java
@@ -13,7 +13,7 @@ import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.client.retry.RetryPolicy;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.util.Map;
@@ -149,7 +149,8 @@ public class ApiClientFactoryTest {
     assertThat(versions).containsKeys("Spark", "Delta", "Java", "Scala");
     versions.forEach(
         (name, version) ->
-            assertThat(props).containsEntry(UCHadoopConf.UC_ENGINE_VERSION_PREFIX + name, version));
+            assertThat(props)
+                .containsEntry(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + name, version));
   }
 
   private static TokenProvider createStaticTokenProvider(String token) {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/AzureCredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/AzureCredentialTestFileSystem.java
@@ -1,8 +1,8 @@
 package io.unitycatalog.spark;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConf.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AbfsVendedTokenProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -44,7 +44,7 @@ public class AzureCredentialTestFileSystem extends CredentialTestFileSystem {
     if (provider == null) {
       synchronized (this) {
         if (provider == null) {
-          String clazz = conf.get(FS_AZURE_SAS_TOKEN_PROVIDER_TYPE);
+          String clazz = conf.get(UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE);
           if (Objects.equal(clazz, AbfsVendedTokenProvider.class.getName())) {
             provider = new AbfsVendedTokenProvider();
             provider.initialize(conf, "testAccountName");

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/S3CredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/S3CredentialTestFileSystem.java
@@ -2,7 +2,7 @@ package io.unitycatalog.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
 import java.io.IOException;
 import java.net.URI;
@@ -61,7 +61,7 @@ public class S3CredentialTestFileSystem extends CredentialTestFileSystem {
       synchronized (this) {
         if (provider == null) {
           // Assert that it's the expected credential provider.
-          String clazz = conf.get(UCHadoopConf.S3A_CREDENTIALS_PROVIDER);
+          String clazz = conf.get(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER);
           if (Objects.equals(clazz, AwsVendedTokenProvider.class.getName())) {
             provider = new AwsVendedTokenProvider(conf);
           }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
@@ -2,7 +2,7 @@ package io.unitycatalog.spark.auth.storage;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AbfsVendedTokenProvider;
 import io.unitycatalog.server.service.credential.azure.ADLSStorageConfig;
 import io.unitycatalog.server.service.credential.azure.AzureCredential;
@@ -57,7 +57,7 @@ public class AbfsCredRenewITTest extends BaseCredRenewITTest {
 
     @Override
     protected AbfsVendedTokenProvider createProvider() {
-      String clazz = getConf().get(UCHadoopConf.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE);
+      String clazz = getConf().get(UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE);
       assertThat(clazz).isEqualTo(AbfsVendedTokenProvider.class.getName());
 
       AbfsVendedTokenProvider provider = new AbfsVendedTokenProvider();

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
@@ -2,7 +2,7 @@ package io.unitycatalog.spark.auth.storage;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
 import io.unitycatalog.server.service.credential.aws.AwsCredentialGenerator;
 import java.time.Instant;
@@ -59,7 +59,7 @@ public class AwsCredRenewITTest extends BaseCredRenewITTest {
 
     @Override
     protected AwsCredentialsProvider createProvider() {
-      String clazz = getConf().get(UCHadoopConf.S3A_CREDENTIALS_PROVIDER);
+      String clazz = getConf().get(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER);
       assertThat(clazz).isEqualTo(AwsVendedTokenProvider.class.getName());
 
       // This will validate if the hadoop configuration is correct or not, since it will fail the

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/BaseCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/BaseCredRenewITTest.java
@@ -7,7 +7,7 @@ import io.delta.tables.DeltaTable;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.CreateCatalog;
 import io.unitycatalog.client.model.CreateSchema;
-import io.unitycatalog.hadoop.internal.UCHadoopConf;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem;
 import io.unitycatalog.server.base.BaseCRUDTest;
 import io.unitycatalog.server.base.ServerConfig;
@@ -86,8 +86,8 @@ public abstract class BaseCredRenewITTest extends BaseCRUDTest {
             .config(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-            .config("spark.hadoop." + UCHadoopConf.UC_TEST_CLOCK_NAME, CLOCK_NAME)
-            .config("spark.hadoop." + UCHadoopConf.UC_RENEWAL_LEAD_TIME_KEY, 0L)
+            .config("spark.hadoop." + UCHadoopConfConstants.UC_TEST_CLOCK_NAME, CLOCK_NAME)
+            .config("spark.hadoop." + UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 0L)
             .config("spark.sql.shuffle.partitions", "1");
 
     // Set the default catalog properties.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1527/files) to review incremental changes.
- [**stack/uc-hadoop-drc-creds**](https://github.com/unitycatalog/unitycatalog/pull/1527) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1527/files)]

---------

**PR Checklist**

- [x] A description of the changes is added.
- [ ] Tests are added or updated for behavior changes.
- [x] This change does not fix a GitHub issue.
- [ ] Documentation is updated, if needed.

**Description of changes**

Adds UC Delta credential support to the Hadoop credential configuration flow.

This PR:
- lets `UCCredentialHadoopConfs.Builder` accept an initial Delta `StorageCredential` and a `DeltaTableRef`
- routes renewal through the UC Delta `TemporaryCredentialsApi` when `fs.unitycatalog.credentials.api=uc_delta`
- converts Delta storage credentials into the existing S3, ABFS, and GCS temporary credential shapes
- selects the matching storage credential by table location, using longest prefix match when the API returns multiple credentials

Tests cover builder validation, Delta config keys, credential conversion, prefix selection, and Delta API renewal.