### PR TITLE
Delta: last-commit-timestamp-ms on createTable

### DIFF
--- a/api/delta-docs/Models/CreateTableRequest.md
+++ b/api/delta-docs/Models/CreateTableRequest.md
@@ -13,6 +13,7 @@
 | **protocol** | [**DeltaProtocol**](DeltaProtocol.md) | Delta protocol version and feature requirements | [default to null] |
 | **properties** | **Map** | Delta table properties | [default to null] |
 | **domain-metadata** | [**DomainMetadataUpdates**](DomainMetadataUpdates.md) |  | [optional] [default to null] |
+| **last-commit-timestamp-ms** | **Long** | Timestamp of version 0 (the commit the client wrote  before calling this endpoint), in epoch milliseconds.  | [default to null] |
 | **uniform** | [**UniformMetadata**](UniformMetadata.md) | Optional UniForm conversion metadata. When present, the table is registered as UniForm-enabled, so readers can access it via either the Delta or Iceberg REST Catalog. The engine generates the Iceberg metadata file at the supplied metadata-location before calling createTable.  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -775,6 +775,12 @@ components:
             type: string
         domain-metadata:
           $ref: '#/components/schemas/DomainMetadataUpdates'
+        last-commit-timestamp-ms:
+          type: integer
+          format: int64
+          description: |
+            Timestamp of version 0 (the commit the client wrote  before calling this endpoint),
+            in epoch milliseconds.
         uniform:
           $ref: '#/components/schemas/UniformMetadata'
           description: |
@@ -790,6 +796,7 @@ components:
         - columns
         - protocol
         - properties
+        - last-commit-timestamp-ms
       example:
         name: "sales"
         location: "s3://bucket/warehouse/catalog/schema/sales"

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -15,10 +15,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Converts a Delta REST Catalog {@link CreateTableRequest} (with typed Delta columns and kebab-case
- * field names) into the UC {@link CreateTable} (with UC {@link ColumnInfo}s and
- * partition-index-per-column). The server holds path params for catalog and schema; the rest comes
- * from the request body.
+ * Converts a Delta {@link CreateTableRequest} (with typed Delta columns and kebab-case field names)
+ * into the UC {@link CreateTable} (with UC {@link ColumnInfo}s and partition-index-per-column). The
+ * server holds path params for catalog and schema; the rest comes from the request body.
  *
  * <p>Required-field checks (name, location, columns, protocol, table-type, data-source-format) and
  * the DELTA-only format rule apply to all tables. The full UC catalog-managed contract ({@link
@@ -62,6 +61,10 @@ public final class DeltaCreateTableMapper {
     if (req.getProtocol() == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "protocol is required.");
     }
+    if (req.getLastCommitTimestampMs() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "last-commit-timestamp-ms is required.");
+    }
 
     // MANAGED-only: full UC catalog-managed contract (protocol versions + features + reader-subset
     // + domain-metadata consistency + properties). EXTERNAL tables get a pass: UC mirrors what the
@@ -95,9 +98,7 @@ public final class DeltaCreateTableMapper {
             .columns(columns)
             .comment(req.getComment())
             .storageLocation(req.getLocation())
-            .properties(
-            DeltaPropertyMapper.buildStoredProperties(
-                    req.getProtocol(), req.getDomainMetadata(), req.getProperties()));
+        .properties(DeltaPropertyMapper.buildStoredProperties(req));
     return new Result(createTable, uniformFields);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.service.delta;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.server.delta.model.CreateTableRequest;
 import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.server.delta.model.RowTrackingDomainMetadata;
@@ -14,10 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Maps Delta REST Catalog {@code protocol} and {@code domain-metadata} blocks onto UC table
- * properties. Designed to be shared by create, update, and commit endpoints: the mapping rules are
- * specified by the Delta spec and don't vary by endpoint (only create is wired up today; update and
- * commit are on follow-ups).
+ * Assembles the stored UC table-property map from a Delta {@link CreateTableRequest} and the
+ * per-block helpers ({@link #deriveFromProtocol} / {@link #deriveFromDomainMetadata}). Designed to
+ * be shared by create, update, and commit endpoints: the mapping rules are specified by the Delta
+ * spec and don't vary by endpoint (only create is wired up today; update and commit are on
+ * follow-ups).
  *
  * <p>Every feature in {@code protocol.reader-features} and {@code protocol.writer-features} yields
  * {@code delta.feature.<name> = supported}. Reader-writer features (which appear in both lists)
@@ -55,16 +57,17 @@ public final class DeltaPropertyMapper {
    * silently override the projection. Client-only properties (e.g. {@code
    * delta.rowTracking.materializedRowIdColumnName}) flow through untouched.
    */
-  public static Map<String, String> buildStoredProperties(
-      DeltaProtocol protocol,
-      DomainMetadataUpdates domainMetadata,
-      Map<String, String> clientProperties) {
+  public static Map<String, String> buildStoredProperties(CreateTableRequest req) {
     Map<String, String> merged = new HashMap<>();
-    if (clientProperties != null) {
-      merged.putAll(clientProperties);
+    if (req.getProperties() != null) {
+      merged.putAll(req.getProperties());
     }
-    deriveFromProtocol(merged, protocol);
-    deriveFromDomainMetadata(merged, domainMetadata);
+    deriveFromProtocol(merged, req.getProtocol());
+    deriveFromDomainMetadata(merged, req.getDomainMetadata());
+    if (req.getLastCommitTimestampMs() != null) {
+      merged.put(
+          TableProperties.LAST_COMMIT_TIMESTAMP, String.valueOf(req.getLastCommitTimestampMs()));
+    }
     return merged;
   }
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -100,6 +100,7 @@ public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccess
                 .readerFeatures(UcManagedDeltaContract.REQUIRED_READER_FEATURES)
                 .writerFeatures(UcManagedDeltaContract.REQUIRED_WRITER_FEATURES))
         .columns(SCHEMA)
-        .properties(properties);
+        .properties(properties)
+        .lastCommitTimestampMs(1700000000000L);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -530,7 +530,8 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                                 new io.unitycatalog.client.delta.model.PrimitiveType().type("long"))
                             .nullable(true)
                             .metadata(java.util.Map.of()))))
-        .properties(java.util.Map.of("delta.enableDeletionVectors", "true"));
+        .properties(java.util.Map.of("delta.enableDeletionVectors", "true"))
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   private CreateTable createExternalTableRequest(String name, String storageLocation) {

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -258,7 +258,8 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
                         .minWriterVersion(7)
                         .readerFeatures(List.of("deletionVectors"))
                         .writerFeatures(List.of("deletionVectors")))
-                .properties(Map.of("delta.enableDeletionVectors", "true")));
+                .properties(Map.of("delta.enableDeletionVectors", "true"))
+                .lastCommitTimestampMs(1700000000000L));
     assertThat(
             regular1DeltaApi
                 .loadTable("cat_pr1", "sch_pr1", deltaExternalName)

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -488,7 +488,8 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
             new DomainMetadataUpdates()
                 .deltaClustering(
                     new ClusteringDomainMetadata().clusteringColumns(List.of(List.of("id")))))
-        .properties(fullManagedProperties(staging.getTableId().toString()));
+        .properties(fullManagedProperties(staging.getTableId().toString()))
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   /**
@@ -503,7 +504,8 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
         .dataSourceFormat(DataSourceFormat.DELTA)
         .columns(simpleSchema())
         .protocol(managedProtocol())
-        .properties(fullManagedProperties("00000000-0000-0000-0000-000000000000"));
+        .properties(fullManagedProperties("00000000-0000-0000-0000-000000000000"))
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   /** Build an EXTERNAL Delta table request at an arbitrary storage path. */
@@ -521,7 +523,8 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
                 .minWriterVersion(7)
                 .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
                 .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
-        .properties(Map.of("delta.enableDeletionVectors", "true"));
+        .properties(Map.of("delta.enableDeletionVectors", "true"))
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   /** {@code delta.feature.<name>} for the stored UC property assertions. */

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -87,7 +87,8 @@ public class DeltaCreateTableMapperTest {
         .dataSourceFormat(DataSourceFormat.DELTA)
         .columns(simpleColumns())
         .protocol(managedProtocol())
-        .properties(fullManagedProperties("uuid-x"));
+        .properties(fullManagedProperties("uuid-x"))
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   /** A minimal EXTERNAL createTable request (UC mirrors whatever the client sends). */
@@ -104,7 +105,8 @@ public class DeltaCreateTableMapperTest {
                 .minWriterVersion(7)
                 .readerFeatures(List.of(TableFeature.DELETION_VECTORS.specName()))
                 .writerFeatures(List.of(TableFeature.DELETION_VECTORS.specName())))
-        .properties(Map.of());
+        .properties(Map.of())
+        .lastCommitTimestampMs(1700000000000L);
   }
 
   private static StructType simpleColumns() {

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -157,12 +157,14 @@ public class DeltaPropertyMapperTest {
             .domainMetadata(
                 new DomainMetadataUpdates()
                     .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(100L)))
-            .properties(Map.of("custom.key", "custom.value"));
+            .properties(Map.of("custom.key", "custom.value"))
+            .lastCommitTimestampMs(1700000000000L);
     Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(req);
     assertThat(merged)
         .containsEntry(featureKey(TableFeature.ROW_TRACKING.specName()), "supported")
         .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "100")
-        .containsEntry("custom.key", "custom.value");
+        .containsEntry("custom.key", "custom.value")
+        .containsEntry(TableProperties.LAST_COMMIT_TIMESTAMP, "1700000000000");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.server.delta.model.CreateTableRequest;
 import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.server.delta.model.RowTrackingDomainMetadata;
@@ -126,9 +127,12 @@ public class DeltaPropertyMapperTest {
             .minReaderVersion(3)
             .minWriterVersion(7)
             .writerFeatures(List.of(TableFeature.CATALOG_MANAGED.specName()));
-    Map<String, String> client =
-        Map.of(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override");
-    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(protocol, null, client);
+    CreateTableRequest req =
+        new CreateTableRequest()
+            .protocol(protocol)
+            .properties(
+                Map.of(featureKey(TableFeature.CATALOG_MANAGED.specName()), "client-override"));
+    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(req);
     // Server-derived projection of the structured protocol block wins over a stray client entry
     // under the same key, so the structured block remains the single source of truth.
     assertThat(merged)
@@ -137,25 +141,42 @@ public class DeltaPropertyMapperTest {
 
   @Test
   public void mergeTolerantOfAllNulls() {
-    assertThat(DeltaPropertyMapper.buildStoredProperties(null, null, null)).isEmpty();
+    // Empty request: no protocol, no domain-metadata, no properties, no timestamp.
+    assertThat(DeltaPropertyMapper.buildStoredProperties(new CreateTableRequest())).isEmpty();
   }
 
   @Test
   public void mergeCombinesProtocolDomainMetadataAndClient() {
-    DeltaProtocol protocol =
-        new DeltaProtocol()
-            .minReaderVersion(3)
-            .minWriterVersion(7)
-            .writerFeatures(List.of(TableFeature.ROW_TRACKING.specName()));
-    DomainMetadataUpdates dm =
-        new DomainMetadataUpdates()
-            .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(100L));
-    Map<String, String> client = Map.of("custom.key", "custom.value");
-    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(protocol, dm, client);
+    CreateTableRequest req =
+        new CreateTableRequest()
+            .protocol(
+                new DeltaProtocol()
+                    .minReaderVersion(3)
+                    .minWriterVersion(7)
+                    .writerFeatures(List.of(TableFeature.ROW_TRACKING.specName())))
+            .domainMetadata(
+                new DomainMetadataUpdates()
+                    .deltaRowTracking(new RowTrackingDomainMetadata().rowIdHighWaterMark(100L)))
+            .properties(Map.of("custom.key", "custom.value"));
+    Map<String, String> merged = DeltaPropertyMapper.buildStoredProperties(req);
     assertThat(merged)
         .containsEntry(featureKey(TableFeature.ROW_TRACKING.specName()), "supported")
         .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "100")
         .containsEntry("custom.key", "custom.value");
+  }
+
+  @Test
+  public void mergeServerDerivedLastCommitTimestamp() {
+    // The top-level last-commit-timestamp-ms field is the source of truth for the metastore-state
+    // delta.lastCommitTimestamp property. A client-supplied delta.lastCommitTimestamp entry in
+    // `properties` (today's OSS Delta + Kernel-UC pattern) gets overwritten by the server-derived
+    // value so engines can't desynchronize the property bag from the catalog's view of v0.
+    CreateTableRequest req =
+        new CreateTableRequest()
+            .properties(Map.of(TableProperties.LAST_COMMIT_TIMESTAMP, "999"))
+            .lastCommitTimestampMs(1700000000000L);
+    assertThat(DeltaPropertyMapper.buildStoredProperties(req))
+        .containsEntry(TableProperties.LAST_COMMIT_TIMESTAMP, "1700000000000");
   }
 
   private static String featureKey(String feature) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1528/files) to review incremental changes.
- [**stack/create_table_last_ts**](https://github.com/unitycatalog/unitycatalog/pull/1528) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1528/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Delta: last-commit-timestamp-ms on createTable

Adds a required top-level `last-commit-timestamp-ms` field to the createTable request so engines hand UC the v0 commit's timestamp out-of-band rather than smuggling it through `properties`. Server derives `delta.lastCommitTimestamp` from this field at create-time.
