### PR TITLE
[Hadoop] Add unitycatalog-hadoop connector module scaffold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,9 @@
 # Spark Connector
 /connectors/spark/ @tdas @openinx
 
+# Hadoop Connector
+/connectors/hadoop/ @tdas @openinx @TimothyW553
+
 # Java clients.
 /clients/java/ @tdas @openinx
 

--- a/build.sbt
+++ b/build.sbt
@@ -692,6 +692,37 @@ lazy val spark = (project in file("connectors/spark"))
     }
   )
 
+lazy val hadoop = (project in file("connectors/hadoop"))
+  .dependsOn(client)
+  .enablePlugins(CheckstylePlugin)
+  .settings(
+    name := s"$artifactNamePrefix-hadoop",
+    commonSettings,
+    javaOnlyReleaseSettings,
+    javafmtCheckSettings(),
+    javaCheckstyleSettings("dev/checkstyle-config.xml"),
+    Compile / compile / javacOptions ++= javacRelease11,
+    libraryDependencies ++= Seq(
+      "org.apache.hadoop" % "hadoop-client-api" % hadoopVersion % Provided,
+      "com.google.cloud.bigdataoss" % "util-hadoop" % "3.0.2" % Provided,
+      "org.apache.hadoop" % "hadoop-azure" % hadoopVersion % Provided,
+      "software.amazon.awssdk" % "auth" % "2.25.37" % Provided,
+    ),
+    libraryDependencies ++= Seq(
+      // Test dependencies
+      "org.junit.jupiter" % "junit-jupiter" % "5.10.3" % Test,
+      "org.assertj" % "assertj-core" % "3.26.3" % Test,
+      "org.mockito" % "mockito-core" % "5.11.0" % Test,
+      "org.mockito" % "mockito-inline" % "5.2.0" % Test,
+      "org.mockito" % "mockito-junit-jupiter" % "5.12.0" % Test,
+      "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+      "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion % Test,
+      "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % Test,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",
+    ),
+    Test / unmanagedJars += (serverShaded / assembly).value,
+  )
+
 lazy val integrationTests = (project in file("integration-tests"))
   .enablePlugins(CheckstylePlugin)
   .dependsOn(spark)
@@ -730,7 +761,7 @@ lazy val integrationTests = (project in file("integration-tests"))
   )
 
 lazy val root = (project in file("."))
-  .aggregate(serverModels, client, pythonClient, server, cli, spark, controlApi, controlModels, apiDocs)
+  .aggregate(serverModels, client, pythonClient, server, cli, spark, hadoop, controlApi, controlModels, apiDocs)
   .settings(
     name := s"$artifactNamePrefix",
     createTarballSettings(),


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Introduces the `unitycatalog-hadoop` connector module under `connectors/hadoop/`, following the same structure as `unitycatalog-spark`.

- **`build.sbt`**: adds `lazy val hadoop` project definition that depends on `client`, uses `javaOnlyReleaseSettings` with Java 11, and declares Hadoop/cloud-provider dependencies (hadoop-client-api, hadoop-azure, util-hadoop, AWS SDK) as `Provided`, with standard test dependencies (JUnit 5, Mockito, hadoop-aws, gcs-connector). The module is included in the root `.aggregate()`.
- **`.github/CODEOWNERS`**: adds `@tdas @openinx @TimothyW553` as codeowners for `/connectors/hadoop/`.