### PR TITLE
Honor aws.endpoint for STS and S3 clients

### DIFF
--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -48,6 +48,8 @@ aws.accessKey=
 aws.secretKey=
 # The region of AWS. If running on-premises, pick the nearest region.
 aws.region=
+# Optional STS/S3 endpoint override for self-hosted S3-compatible backends.
+aws.endpoint=
 
 #### The following "s3.*" configs are legacy per-bucket hardcoded credential config
 
@@ -60,6 +62,8 @@ s3.accessKey.0=
 s3.secretKey.0=
 # Test Only (If you provide a session token, it will just use those session creds, no downscoping)
 s3.sessionToken.0=
+# Optional per-bucket endpoint override.
+s3.endpoint.0=
 
 ## ADLS Storage Config (Multiple configs can be added by incrementing the index)
 adls.storageAccountName.0=

--- a/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
@@ -168,6 +168,17 @@ public class DeltaKernelUtils {
       conf.set("fs.s3a.session.token", awsTempCredentials.getSessionToken());
       conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
       conf.set("fs.s3a.path.style.access", "true");
+      // Hadoop S3A doesn't read AWS_ENDPOINT_URL; it only honors fs.s3a.endpoint.
+      String s3Endpoint = System.getenv("AWS_ENDPOINT_URL_S3");
+      if (s3Endpoint == null || s3Endpoint.isEmpty()) {
+        s3Endpoint = System.getenv("AWS_ENDPOINT_URL");
+      }
+      if (s3Endpoint == null || s3Endpoint.isEmpty()) {
+        s3Endpoint = System.getProperty("aws.endpoint");
+      }
+      if (s3Endpoint != null && !s3Endpoint.isEmpty()) {
+        conf.set("fs.s3a.endpoint", s3Endpoint);
+      }
     } else if (scheme.equals(Constants.URI_SCHEME_FILE)) {
       conf.set("fs.file.impl", "org.apache.hadoop.fs.LocalFileSystem");
     } else {

--- a/examples/cli/src/test/java/io/unitycatalog/cli/delta/DeltaKernelUtilsTest.java
+++ b/examples/cli/src/test/java/io/unitycatalog/cli/delta/DeltaKernelUtilsTest.java
@@ -1,0 +1,60 @@
+package io.unitycatalog.cli.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.model.AwsCredentials;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DeltaKernelUtilsTest {
+
+  private static final String AWS_ENDPOINT_PROP = "aws.endpoint";
+  private String savedEndpoint;
+
+  private TemporaryCredentials creds() {
+    return new TemporaryCredentials()
+        .awsTempCredentials(
+            new AwsCredentials()
+                .accessKeyId("AKIDEMO")
+                .secretAccessKey("SECRETDEMO")
+                .sessionToken("TOKENDEMO"));
+  }
+
+  @BeforeEach
+  void saveEndpoint() {
+    savedEndpoint = System.getProperty(AWS_ENDPOINT_PROP);
+    System.clearProperty(AWS_ENDPOINT_PROP);
+  }
+
+  @AfterEach
+  void restoreEndpoint() {
+    if (savedEndpoint == null) {
+      System.clearProperty(AWS_ENDPOINT_PROP);
+    } else {
+      System.setProperty(AWS_ENDPOINT_PROP, savedEndpoint);
+    }
+  }
+
+  @Test
+  void s3Config_setsEndpointFromAwsEndpointSystemProperty() {
+    System.setProperty(AWS_ENDPOINT_PROP, "http://localhost:8333");
+
+    Configuration conf =
+        DeltaKernelUtils.getHDFSConfiguration(URI.create("s3://lakehouse/warehouse"), creds());
+
+    assertThat(conf.get("fs.s3a.endpoint")).isEqualTo("http://localhost:8333");
+    assertThat(conf.get("fs.s3a.path.style.access")).isEqualTo("true");
+  }
+
+  @Test
+  void s3Config_doesNotSetEndpointWhenUnset() {
+    Configuration conf =
+        DeltaKernelUtils.getHDFSConfiguration(URI.create("s3://lakehouse/warehouse"), creds());
+
+    assertThat(conf.get("fs.s3a.endpoint")).isNull();
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.service.credential.aws;
 import io.unitycatalog.server.model.AwsIamRoleResponse;
 import io.unitycatalog.server.persist.dao.CredentialDAO;
 import io.unitycatalog.server.service.credential.CredentialContext;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -85,7 +86,11 @@ public interface AwsCredentialGenerator {
         credentialsProvider = DefaultCredentialsProvider.create();
       }
 
-      this.stsClient = builder.region(region).credentialsProvider(credentialsProvider).build();
+      StsClientBuilder configured = builder.region(region).credentialsProvider(credentialsProvider);
+      if (config.getEndpoint() != null && !config.getEndpoint().isEmpty()) {
+        configured = configured.endpointOverride(URI.create(config.getEndpoint()));
+      }
+      this.stsClient = configured.build();
       this.staticAwsRoleArn = config.getAwsRoleArn();
     }
 

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
@@ -15,4 +15,5 @@ public class S3StorageConfig {
   private final String secretKey;
   private final String sessionToken;
   private final String credentialGenerator;
+  private final String endpoint;
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
@@ -86,20 +87,25 @@ public class FileIOFactory {
     S3StorageConfig s3StorageConfig = s3Configurations.get(location.getStorageBase());
 
     S3FileIO s3FileIO =
-        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location),
-            s3StorageConfig.getRegion()));
+        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location), s3StorageConfig));
 
     s3FileIO.initialize(Map.of());
 
     return s3FileIO;
   }
 
-  protected S3Client getS3Client(AwsCredentialsProvider awsCredentialsProvider, String region) {
-    return S3Client.builder()
-        .region(Region.of(region))
+  protected S3Client getS3Client(
+      AwsCredentialsProvider awsCredentialsProvider, S3StorageConfig s3StorageConfig) {
+    String endpoint = s3StorageConfig.getEndpoint();
+    boolean hasEndpoint = endpoint != null && !endpoint.isEmpty();
+    var builder = S3Client.builder()
+        .region(Region.of(s3StorageConfig.getRegion()))
         .credentialsProvider(awsCredentialsProvider)
-        .forcePathStyle(false)
-        .build();
+        .forcePathStyle(hasEndpoint);
+    if (hasEndpoint) {
+      builder = builder.endpointOverride(URI.create(endpoint));
+    }
+    return builder.build();
   }
 
   private AwsCredentialsProvider getAwsCredentialsProvider(NormalizedURL location) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -205,6 +205,7 @@ public class ServerProperties {
     AWS_SECRET_KEY("aws.secretKey"),
     AWS_SESSION_TOKEN("aws.sessionToken"),
     AWS_REGION("aws.region"),
+    AWS_ENDPOINT("aws.endpoint"),
     INCLUDE_STACK_TRACE_IN_ERROR("server.include-stacktrace-in-error", "false", BOOLEAN_VALIDATOR);
     // The is not an exhaustive list. Some property keys like s3.bucketPath.0 with a numbering
     // suffix is not included. They are only accessed internally from functions like
@@ -300,6 +301,7 @@ public class ServerProperties {
         .accessKey(get(Property.AWS_ACCESS_KEY))
         .secretKey(get(Property.AWS_SECRET_KEY))
         // Does not take AWS_SESSION_TOKEN as it's only part of a temporary credential.
+        .endpoint(get(Property.AWS_ENDPOINT))
         .build();
   }
 
@@ -314,6 +316,7 @@ public class ServerProperties {
       String secretKey = getProperty("s3.secretKey." + i);
       String sessionToken = getProperty("s3.sessionToken." + i);
       String credentialGenerator = getProperty("s3.credentialGenerator." + i);
+      String endpoint = getProperty("s3.endpoint." + i);
       if ((bucketPath == null || region == null || awsRoleArn == null)
           && (accessKey == null || secretKey == null || sessionToken == null)) {
         break;
@@ -327,6 +330,7 @@ public class ServerProperties {
               .secretKey(secretKey)
               .sessionToken(sessionToken)
               .credentialGenerator(credentialGenerator)
+              .endpoint(endpoint)
               .build();
       s3BucketConfigMap.put(NormalizedURL.from(bucketPath), s3StorageConfig);
       i++;

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -26,6 +26,7 @@ import io.unitycatalog.server.service.credential.gcp.StaticTestingCredentialGene
 import io.unitycatalog.server.service.credential.gcp.TestingCredentialGenerator;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -286,5 +287,96 @@ public class CloudCredentialVendorTest {
       assertThat(capturedRequest.roleArn()).isEqualTo(CREDENTIAL_ROLE_ARN);
       assertThat(capturedRequest.externalId()).isEqualTo(expectedExternalId);
     }
+  }
+
+  @Test
+  public void testStsClientHonorsAwsEndpointOverride() {
+    final String S3_PATH = "s3://my-bucket/path/to/data";
+    final String CUSTOM_ENDPOINT = "http://host.docker.internal:8333";
+
+    when(serverProperties.getS3Configurations())
+        .thenReturn(
+            Map.of(
+                NormalizedURL.from("s3://my-bucket"),
+                S3StorageConfig.builder()
+                    .bucketPath("s3://my-bucket")
+                    .region("us-east-1")
+                    .awsRoleArn("arn:aws:iam::000000000000:role/UCVendedRole")
+                    .accessKey("admin")
+                    .secretKey("admin")
+                    .endpoint(CUSTOM_ENDPOINT)
+                    .build()));
+
+    StsClient mockStsClient = Mockito.mock(StsClient.class);
+    when(mockStsClient.assumeRole(any(AssumeRoleRequest.class)))
+        .thenReturn(
+            AssumeRoleResponse.builder()
+                .credentials(
+                    Credentials.builder()
+                        .accessKeyId("ak")
+                        .secretAccessKey("sk")
+                        .sessionToken("st")
+                        .build())
+                .build());
+
+    StsClientBuilder mockBuilder = Mockito.mock(StsClientBuilder.class);
+    when(mockBuilder.region(any())).thenReturn(mockBuilder);
+    when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
+    when(mockBuilder.endpointOverride(any())).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockStsClient);
+    ArgumentCaptor<URI> endpointCaptor = ArgumentCaptor.forClass(URI.class);
+
+    try (MockedStatic<StsClient> mockedStsClient = Mockito.mockStatic(StsClient.class)) {
+      mockedStsClient.when(StsClient::builder).thenReturn(mockBuilder);
+      AwsCredentialVendor awsCredentialVendor = new AwsCredentialVendor(serverProperties);
+      credentialsOperations = new CloudCredentialVendor(awsCredentialVendor, null, null);
+      vendCredential(S3_PATH, Set.of(CredentialContext.Privilege.SELECT));
+    }
+
+    verify(mockBuilder).endpointOverride(endpointCaptor.capture());
+    assertThat(endpointCaptor.getValue()).isEqualTo(URI.create(CUSTOM_ENDPOINT));
+  }
+
+  @Test
+  public void testStsClientSkipsEndpointOverrideWhenUnset() {
+    final String S3_PATH = "s3://my-bucket/path/to/data";
+
+    when(serverProperties.getS3Configurations())
+        .thenReturn(
+            Map.of(
+                NormalizedURL.from("s3://my-bucket"),
+                S3StorageConfig.builder()
+                    .bucketPath("s3://my-bucket")
+                    .region("us-east-1")
+                    .awsRoleArn("arn:aws:iam::123:role/r")
+                    .accessKey("ak")
+                    .secretKey("sk")
+                    .build()));
+
+    StsClient mockStsClient = Mockito.mock(StsClient.class);
+    when(mockStsClient.assumeRole(any(AssumeRoleRequest.class)))
+        .thenReturn(
+            AssumeRoleResponse.builder()
+                .credentials(
+                    Credentials.builder()
+                        .accessKeyId("ak")
+                        .secretAccessKey("sk")
+                        .sessionToken("st")
+                        .build())
+                .build());
+
+    StsClientBuilder mockBuilder = Mockito.mock(StsClientBuilder.class);
+    when(mockBuilder.region(any())).thenReturn(mockBuilder);
+    when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockStsClient);
+
+    try (MockedStatic<StsClient> mockedStsClient = Mockito.mockStatic(StsClient.class)) {
+      mockedStsClient.when(StsClient::builder).thenReturn(mockBuilder);
+      AwsCredentialVendor awsCredentialVendor = new AwsCredentialVendor(serverProperties);
+      credentialsOperations = new CloudCredentialVendor(awsCredentialVendor, null, null);
+      vendCredential(S3_PATH, Set.of(CredentialContext.Privilege.SELECT));
+    }
+
+    verify(mockBuilder, Mockito.never()).endpointOverride(any());
   }
 }


### PR DESCRIPTION
## What this fixes

Today UC's STS and S3 clients always target real AWS, regardless of \`aws.endpoint\` in \`server.properties\` or any of the AWS SDK env vars / system properties. That makes UC unusable end-to-end against any S3-compatible self-hosted backend (SeaweedFS, MinIO, Ceph RGW, LocalStack), even though the rest of the configuration is wired up.

Two builders inside the server need an \`endpointOverride\`:

\`AwsCredentialGenerator.StsAwsCredentialGenerator\` (\`v0.4.0\`):

\`\`\`java
this.stsClient = builder.region(region).credentialsProvider(credentialsProvider).build();
//                                                                              ^ no .endpointOverride
\`\`\`

\`FileIOFactory.getS3Client\`:

\`\`\`java
return S3Client.builder()
    .region(Region.of(region))
    .credentialsProvider(awsCredentialsProvider)
    .forcePathStyle(false)
    .build();
\`\`\`

The AWS Java SDK's generic env-var fallback (\`AWS_ENDPOINT_URL_STS\`, \`aws.endpointUrlSts\` system property, the catch-all \`AWS_ENDPOINT_URL\`) doesn't kick in for that builder shape. I confirmed by pointing \`AWS_ENDPOINT_URL_STS\` at port 1 (deliberately unreachable) and getting back the same real-AWS \`InvalidClientTokenId\` 403, with zero traffic to the configured port (HTTP sniffer in front of the local STS endpoint recorded nothing).

## What this PR does

1. Adds an \`AWS_ENDPOINT(\"aws.endpoint\")\` property and per-bucket \`s3.endpoint.N\`. Plumbs both through \`S3StorageConfig\`. Empty -> SDK default resolution (unchanged AWS path).
2. \`StsAwsCredentialGenerator\`: applies \`endpointOverride(URI.create(config.getEndpoint()))\` when set.
3. \`FileIOFactory.getS3Client\`: applies \`endpointOverride\` and flips to \`forcePathStyle(true)\` when an endpoint is set, since self-hosted backends typically can't issue wildcard certs for \`bucket.host\` (real AWS keeps virtual-hosted-style).
4. \`etc/conf/server.properties\`: documents the two new keys.
5. Two new unit tests in \`CloudCredentialVendorTest\`:
   - \`testStsClientHonorsAwsEndpointOverride\` -- endpoint set, expects \`endpointOverride(URI)\` to be called with that URI.
   - \`testStsClientSkipsEndpointOverrideWhenUnset\` -- endpoint unset, expects \`endpointOverride\` never to be called.

After this change, pointing UC at SeaweedFS / MinIO / Ceph RGW / LocalStack works end-to-end:

- catalog/schema/EXTERNAL Delta CRUD already worked
- \`/temporary-table-credentials\` now reaches the local STS, gets a real session token back, and \`uc table read\` works without forcing clients to bypass UC and use static keys directly

Repro and trace details for the original failure: <https://github.com/seaweedfs/seaweedfs/pull/9308> (SeaweedFS-side integration test that runs UC v0.4.0 in Docker and currently logs the broken handoff via \`t.Logf\` instead of asserting it).

## Compatibility

- \`aws.endpoint\` and \`s3.endpoint.N\` are both optional and default to empty.
- When empty, all builder shapes are byte-identical to before this PR (no \`endpointOverride\` call, \`forcePathStyle(false)\`).
- No breaking change to \`server.properties\` or to the existing test fixtures.

I wasn't able to run the full test suite locally (Maven Central is returning 404 for everything from this network -- \`net.bytebuddy\`, \`org.junit.platform\`, etc.), so this relies on the project's CI to validate. Happy to iterate on any feedback.