### PR TITLE
Run external-table and staging-table access-control suites against both UC REST and Delta REST surfaces

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -1,0 +1,97 @@
+package io.unitycatalog.server.sdk.access;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
+import io.unitycatalog.client.delta.model.CreateTableRequest;
+import io.unitycatalog.client.delta.model.DataSourceFormat;
+import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.PrimitiveType;
+import io.unitycatalog.client.delta.model.StagingTableResponse;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructType;
+import io.unitycatalog.client.delta.model.TableType;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs the staging-table access-control suite against the Delta REST createStagingTable /
+ * createTable. The persist-layer cross-principal check at {@code
+ * StagingTableRepository.commitStagingTable} is shared with UC REST, so finalize must produce the
+ * same allow/deny outcomes as {@link SdkUCStagingTableAccessControlTest}.
+ */
+public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccessControlTest {
+
+  /**
+   * Engine-generated property placeholder timestamps; the contract validates presence + non-null.
+   */
+  private static final String ENGINE_GENERATED_PLACEHOLDER = "1700000000000";
+
+  /** Single-column schema mirroring {@link SdkUCStagingTableAccessControlTest#COLUMNS}. */
+  private static final StructType SCHEMA =
+      new StructType()
+          .type("struct")
+          .fields(
+              List.of(
+                  new StructField()
+                      .name("test_column")
+                      .type(new PrimitiveType().type("integer"))
+                      .nullable(true)
+                      .metadata(Map.of())));
+
+  @Override
+  protected StagingHandle createStaging(
+      ServerConfig config, String catalog, String schema, String name) throws Exception {
+    StagingTableResponse resp =
+        deltaTablesApi(config)
+            .createStagingTable(catalog, schema, new CreateStagingTableRequest().name(name));
+    return new StagingHandle(resp.getTableId().toString(), resp.getLocation());
+  }
+
+  @Override
+  protected FinalizedTable finalizeManagedTable(
+      ServerConfig config, StagingHandle staging, String name) throws Exception {
+    LoadTableResponse resp =
+        deltaTablesApi(config)
+            .createTable(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, buildCreateRequest(staging, name));
+    return new FinalizedTable(
+        resp.getMetadata().getTableUuid().toString(), resp.getMetadata().getLocation());
+  }
+
+  private static TablesApi deltaTablesApi(ServerConfig config) {
+    return new TablesApi(TestUtils.createApiClient(config));
+  }
+
+  /**
+   * Build a MANAGED Delta REST createTable request that satisfies the full UC catalog-managed
+   * contract enforced by {@code DeltaCreateTableMapper} -- protocol versions + required features +
+   * fixed properties + engine-generated property placeholders + UC_TABLE_ID. Constants come from
+   * {@link UcManagedDeltaContract} so this fixture stays in sync if the contract evolves.
+   */
+  private static CreateTableRequest buildCreateRequest(StagingHandle staging, String name) {
+    Map<String, String> properties =
+        new HashMap<>(UcManagedDeltaContract.REQUIRED_FIXED_PROPERTIES);
+    properties.put(TableProperties.UC_TABLE_ID, staging.id());
+    UcManagedDeltaContract.ENGINE_GENERATED_PROPERTY_KEYS.forEach(
+        key -> properties.put(key, ENGINE_GENERATED_PLACEHOLDER));
+    return new CreateTableRequest()
+        .name(name)
+        .location(staging.location())
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .protocol(
+            new DeltaProtocol()
+                .minReaderVersion(UcManagedDeltaContract.REQUIRED_MIN_READER_VERSION)
+                .minWriterVersion(UcManagedDeltaContract.REQUIRED_MIN_WRITER_VERSION)
+                .readerFeatures(UcManagedDeltaContract.REQUIRED_READER_FEATURES)
+                .writerFeatures(UcManagedDeltaContract.REQUIRED_WRITER_FEATURES))
+        .columns(SCHEMA)
+        .properties(properties);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.sdk.access;
 
 import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
 import io.unitycatalog.client.delta.model.CreateTableRequest;
 import io.unitycatalog.client.delta.model.DataSourceFormat;
@@ -18,6 +19,7 @@ import io.unitycatalog.server.utils.TestUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Runs the staging-table access-control suite against the Delta REST createStagingTable /
@@ -62,6 +64,12 @@ public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccess
                 TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, buildCreateRequest(staging, name));
     return new FinalizedTable(
         resp.getMetadata().getTableUuid().toString(), resp.getMetadata().getLocation());
+  }
+
+  @Override
+  protected void fetchTempCreds(ServerConfig config, String tableId) throws Exception {
+    new TemporaryCredentialsApi(TestUtils.createApiClient(config))
+        .getStagingTableCredentials(UUID.fromString(tableId));
   }
 
   private static TablesApi deltaTablesApi(ServerConfig config) {

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -1,7 +1,6 @@
 package io.unitycatalog.server.sdk.access;
 
 import static io.unitycatalog.server.utils.TestUtils.assertApiException;
-import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.ApiClient;
@@ -22,7 +21,6 @@ import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.ExternalLocationInfo;
 import io.unitycatalog.client.model.ListExternalLocationsResponse;
 import io.unitycatalog.client.model.SecurableType;
-import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.client.model.UpdateExternalLocation;
 import io.unitycatalog.client.model.VolumeInfo;
@@ -37,6 +35,7 @@ import lombok.Singular;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCRUDTest {
 
@@ -320,6 +319,38 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
    */
   @Test
   public void testCreateExternalTableVolumePermissions() throws Exception {
+    runExternalTableVolumePermissionsTest(
+        (apiClient, name, location) ->
+            new TablesApi(apiClient)
+                .createTable(createExternalTableRequest(name, location))
+                .getStorageLocation());
+  }
+
+  /**
+   * Test that creating external tables and volumes requires appropriate permissions on external
+   * locations, using Delta RPCs.
+   */
+  @Test
+  public void testCreateExternalTableVolumePermissionsViaDelta() throws Exception {
+    runExternalTableVolumePermissionsTest(
+        (apiClient, name, location) ->
+            new io.unitycatalog.client.delta.api.TablesApi(apiClient)
+                .createTable(
+                    TestUtils.CATALOG_NAME,
+                    TestUtils.SCHEMA_NAME,
+                    deltaExternalTableRequest(name, location))
+                .getMetadata()
+                .getLocation());
+  }
+
+  @FunctionalInterface
+  private interface ExternalTableCreator {
+    /** Creates the table and returns the resulting storage location; throws on denial. */
+    String create(ApiClient apiClient, String name, String location) throws Exception;
+  }
+
+  private void runExternalTableVolumePermissionsTest(ExternalTableCreator tableCreator)
+      throws Exception {
     // Create external location as userC
     String externalLocationName = "test_external_loc";
     String extLocationUrl = "s3://ext-bucket/tables";
@@ -420,21 +451,16 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
       // Verify that the Table creation is as expected
       String tableName = TestUtils.TABLE_NAME + counter;
       String tableLocation = storageRoot + "/" + tableName;
-      TablesApi tablesApi = new TablesApi(apiClient);
       if (testCase.expectCanCreateExternalTable) {
-        TableInfo tableInfo =
-            tablesApi.createTable(createExternalTableRequest(tableName, tableLocation));
-        assertThat(tableInfo).isNotNull();
-        assertThat(tableInfo.getStorageLocation()).startsWith(storageRoot);
+        String resultLocation = tableCreator.create(apiClient, tableName, tableLocation);
+        assertThat(resultLocation).startsWith(storageRoot);
 
         // Verify that we can not create another under the same path, or subdir, or parent
         for (String url : List.of(tableLocation, tableLocation + "/subdir", storageRoot)) {
-          assertPermissionDenied(
-              () -> tablesApi.createTable(createExternalTableRequest(tableName + "_another", url)));
+          assertPermissionDenied(() -> tableCreator.create(apiClient, tableName + "_another", url));
         }
       } else {
-        assertPermissionDenied(
-            () -> tablesApi.createTable(createExternalTableRequest(tableName, tableLocation)));
+        assertPermissionDenied(() -> tableCreator.create(apiClient, tableName, tableLocation));
       }
 
       // Verify that the Volume creation is as expected
@@ -467,11 +493,45 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                 volumesApi.createVolume(
                     createExternalVolumeRequest(volumeName + "_another", tableLocation)));
         assertPermissionDenied(
-            () ->
-                tablesApi.createTable(
-                    createExternalTableRequest(tableName + "_another", volumeLocation)));
+            () -> tableCreator.create(apiClient, tableName + "_another", volumeLocation));
       }
     }
+  }
+
+  /**
+   * 403-only check that works for both UC REST and Delta error responses (their JSON bodies use
+   * different message conventions: {@code PERMISSION_DENIED} vs {@code PermissionDeniedException}).
+   */
+  private static void assertPermissionDenied(Executable executable) {
+    TestUtils.assertPermissionDenied(executable, "");
+  }
+
+  /** Minimum valid Delta CreateTableRequest for an EXTERNAL Delta table. */
+  private static io.unitycatalog.client.delta.model.CreateTableRequest deltaExternalTableRequest(
+      String name, String location) {
+    return new io.unitycatalog.client.delta.model.CreateTableRequest()
+        .name(name)
+        .location(location)
+        .tableType(io.unitycatalog.client.delta.model.TableType.EXTERNAL)
+        .dataSourceFormat(io.unitycatalog.client.delta.model.DataSourceFormat.DELTA)
+        .protocol(
+            new io.unitycatalog.client.delta.model.DeltaProtocol()
+                .minReaderVersion(3)
+                .minWriterVersion(7)
+                .readerFeatures(List.of("deletionVectors"))
+                .writerFeatures(List.of("deletionVectors")))
+        .columns(
+            new io.unitycatalog.client.delta.model.StructType()
+                .type("struct")
+                .fields(
+                    List.of(
+                        new io.unitycatalog.client.delta.model.StructField()
+                            .name("id")
+                            .type(
+                                new io.unitycatalog.client.delta.model.PrimitiveType().type("long"))
+                            .nullable(true)
+                            .metadata(java.util.Map.of()))))
+        .properties(java.util.Map.of("delta.enableDeletionVectors", "true"));
   }
 
   private CreateTable createExternalTableRequest(String name, String storageLocation) {

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -35,7 +35,6 @@ import lombok.Singular;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCRUDTest {
 
@@ -218,7 +217,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
   }
 
   private void assertCreateFailure(ExternalLocationsApi api, String name) {
-    assertPermissionDenied(() -> api.createExternalLocation(createRequest(name)));
+    TestUtils.assertPermissionDenied(() -> api.createExternalLocation(createRequest(name)));
   }
 
   @SneakyThrows
@@ -234,7 +233,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
       assertThat(retrieved.getUrl()).isNotNull().isNotEmpty();
     }
     for (String name : deniedExternalLocationNames) {
-      assertPermissionDenied(() -> api.getExternalLocation(name));
+      TestUtils.assertPermissionDenied(() -> api.getExternalLocation(name));
     }
     // Test list operation
     ListExternalLocationsResponse response = api.listExternalLocations(100, null);
@@ -261,7 +260,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
   }
 
   private void assertUpdateUrlFailure(ExternalLocationsApi api, String name) {
-    assertPermissionDenied(
+    TestUtils.assertPermissionDenied(
         () ->
             api.updateExternalLocation(
                 name, new UpdateExternalLocation().url("s3://test-bucket/fail-path-" + name)));
@@ -269,7 +268,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
 
   private void assertUpdateCredentialFailure(
       ExternalLocationsApi api, String name, String newCredentialName) {
-    assertPermissionDenied(
+    TestUtils.assertPermissionDenied(
         () ->
             api.updateExternalLocation(
                 name, new UpdateExternalLocation().credentialName(newCredentialName)));
@@ -282,7 +281,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
   }
 
   private void assertDeleteFailure(ExternalLocationsApi api, String name) {
-    assertPermissionDenied(() -> api.deleteExternalLocation(name, false));
+    TestUtils.assertPermissionDenied(() -> api.deleteExternalLocation(name, false));
   }
 
   /**
@@ -323,7 +322,8 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
         (apiClient, name, location) ->
             new TablesApi(apiClient)
                 .createTable(createExternalTableRequest(name, location))
-                .getStorageLocation());
+                .getStorageLocation(),
+      "PERMISSION_DENIED");
   }
 
   /**
@@ -340,7 +340,8 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                     TestUtils.SCHEMA_NAME,
                     deltaExternalTableRequest(name, location))
                 .getMetadata()
-                .getLocation());
+                .getLocation(),
+      "PermissionDeniedException");
   }
 
   @FunctionalInterface
@@ -349,7 +350,8 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
     String create(ApiClient apiClient, String name, String location) throws Exception;
   }
 
-  private void runExternalTableVolumePermissionsTest(ExternalTableCreator tableCreator)
+  private void runExternalTableVolumePermissionsTest(
+      ExternalTableCreator tableCreator, String createTablePermissionDeniedMessage)
       throws Exception {
     // Create external location as userC
     String externalLocationName = "test_external_loc";
@@ -457,10 +459,14 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
 
         // Verify that we can not create another under the same path, or subdir, or parent
         for (String url : List.of(tableLocation, tableLocation + "/subdir", storageRoot)) {
-          assertPermissionDenied(() -> tableCreator.create(apiClient, tableName + "_another", url));
+          TestUtils.assertPermissionDenied(
+              () -> tableCreator.create(apiClient, tableName + "_another", url),
+              createTablePermissionDeniedMessage);
         }
       } else {
-        assertPermissionDenied(() -> tableCreator.create(apiClient, tableName, tableLocation));
+        TestUtils.assertPermissionDenied(
+            () -> tableCreator.create(apiClient, tableName, tableLocation),
+            createTablePermissionDeniedMessage);
       }
 
       // Verify that the Volume creation is as expected
@@ -475,35 +481,28 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
 
         // Verify that we can not create another under the same path, or subdir, or parent
         for (String url : List.of(volumeLocation, volumeLocation + "/subdir", storageRoot)) {
-          assertPermissionDenied(
+          TestUtils.assertPermissionDenied(
               () ->
                   volumesApi.createVolume(
                       createExternalVolumeRequest(volumeName + "_another", url)));
         }
       } else {
-        assertPermissionDenied(
+        TestUtils.assertPermissionDenied(
             () -> volumesApi.createVolume(createExternalVolumeRequest(volumeName, volumeLocation)));
       }
 
       // Verify that creation of a table at storage location of an existing volume should fail,
       // vice versa.
       if (testCase.expectCanCreateExternalTable && testCase.expectCanCreateExternalVolume) {
-        assertPermissionDenied(
+        TestUtils.assertPermissionDenied(
             () ->
                 volumesApi.createVolume(
                     createExternalVolumeRequest(volumeName + "_another", tableLocation)));
-        assertPermissionDenied(
-            () -> tableCreator.create(apiClient, tableName + "_another", volumeLocation));
+        TestUtils.assertPermissionDenied(
+            () -> tableCreator.create(apiClient, tableName + "_another", volumeLocation),
+            createTablePermissionDeniedMessage);
       }
     }
-  }
-
-  /**
-   * 403-only check that works for both UC REST and Delta error responses (their JSON bodies use
-   * different message conventions: {@code PERMISSION_DENIED} vs {@code PermissionDeniedException}).
-   */
-  private static void assertPermissionDenied(Executable executable) {
-    TestUtils.assertPermissionDenied(executable, "");
   }
 
   /** Minimum valid Delta CreateTableRequest for an EXTERNAL Delta table. */

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
@@ -3,49 +3,50 @@ package io.unitycatalog.server.sdk.access;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.api.SchemasApi;
-import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
-import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
-import io.unitycatalog.client.model.ColumnInfo;
-import io.unitycatalog.client.model.ColumnTypeName;
 import io.unitycatalog.client.model.CreateSchema;
-import io.unitycatalog.client.model.CreateStagingTable;
-import io.unitycatalog.client.model.CreateTable;
-import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.client.model.SecurableType;
-import io.unitycatalog.client.model.StagingTableInfo;
-import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableOperation;
-import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.persist.model.Privileges;
-import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /**
  * Access control tests for staging tables that require authorization to be enabled.
  *
- * <p>This test class extends {@link SdkAccessControlBaseCRUDTest} which provides common support
- * functionality for SDK-based access control tests, including user management, permission
- * management, and resource setup.
+ * <p>Abstract base class. {@link SdkUCStagingTableAccessControlTest} runs the suite using UC REST
+ * createStagingTable / createTable; {@link SdkDeltaStagingTableAccessControlTest} runs the same
+ * suite against the Delta REST endpoints. The two surfaces share the persist-layer cross-principal
+ * check at {@code StagingTableRepository.commitStagingTable}, so both subclasses must observe
+ * identical staging-table access-control behavior; running the same {@code @Test} against both
+ * ensures they don't drift.
+ *
+ * <p>This class does not import either {@code io.unitycatalog.client.api.TablesApi} or {@code
+ * io.unitycatalog.client.delta.api.TablesApi}; subclasses encapsulate all surface-specific table
+ * RPCs behind {@link #createStaging} and {@link #finalizeManagedTable}. Other APIs reachable
+ * regardless of subclass (TemporaryCredentialsApi, SchemasApi) are used inline for cross-cutting
+ * checks that don't vary by surface.
  */
-public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTest {
+public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTest {
 
-  private final List<ColumnInfo> columns =
-      List.of(
-          new ColumnInfo()
-              .name("test_column")
-              .typeText("INTEGER")
-              .typeJson("{\"type\": \"integer\"}")
-              .typeName(ColumnTypeName.INT)
-              .position(0)
-              .nullable(true));
+  /** Just-created staging table identifier (id + storage location). */
+  protected record StagingHandle(String id, String location) {}
+
+  /** Result of finalizing a managed table from a staging location. */
+  protected record FinalizedTable(String tableId, String storageLocation) {}
+
+  /** Surface-specific {@code createStagingTable} RPC. */
+  protected abstract StagingHandle createStaging(
+      ServerConfig config, String catalog, String schema, String name) throws Exception;
+
+  /** Surface-specific {@code createTable} RPC that finalizes a managed table from a staging. */
+  protected abstract FinalizedTable finalizeManagedTable(
+      ServerConfig config, StagingHandle staging, String name) throws Exception;
 
   /**
    * Test that attempting to create a managed table from another user's staging table fails with
@@ -80,33 +81,24 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
           Privileges.CREATE_TABLE);
     }
 
-    // Create API clients for both users
     ServerConfig userAConfig = createTestUserServerConfig(userAEmail);
     ServerConfig userBConfig = createTestUserServerConfig(userBEmail);
-    TablesApi userATablesApi = new TablesApi(TestUtils.createApiClient(userAConfig));
-    TablesApi userBTablesApi = new TablesApi(TestUtils.createApiClient(userBConfig));
     TemporaryCredentialsApi userATempCredsApi =
         new TemporaryCredentialsApi(TestUtils.createApiClient(userAConfig));
     TemporaryCredentialsApi userBTempCredsApi =
         new TemporaryCredentialsApi(TestUtils.createApiClient(userBConfig));
 
-    // Step 1: User A creates a staging table
-    CreateStagingTable createStagingTableRequest =
-        new CreateStagingTable()
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .name(TestUtils.TABLE_NAME);
-
-    StagingTableInfo stagingTableInfo =
-        userATablesApi.createStagingTable(createStagingTableRequest);
-    assertThat(stagingTableInfo).isNotNull();
-    assertThat(stagingTableInfo.getStagingLocation()).isNotNull();
+    // Step 1: User A creates a staging table (surface-specific).
+    StagingHandle staging =
+        createStaging(
+            userAConfig, TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
+    assertThat(staging.location()).isNotNull();
 
     // Step 2: Test temporary credentials generation
     // User A (owner) should be able to get temporary credentials
     GenerateTemporaryTableCredential tempCredRequest =
         new GenerateTemporaryTableCredential()
-            .tableId(stagingTableInfo.getId())
+            .tableId(staging.id())
             .operation(TableOperation.READ_WRITE);
 
     TemporaryCredentials tempCredsA =
@@ -124,7 +116,7 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
     io.unitycatalog.client.delta.api.TemporaryCredentialsApi userBDeltaCredsApi =
         new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(
             TestUtils.createApiClient(userBConfig));
-    UUID stagingId = UUID.fromString(stagingTableInfo.getId());
+    UUID stagingId = UUID.fromString(staging.id());
 
     // User A (owner) -> allowed
     assertThat(userADeltaCredsApi.getStagingTableCredentials(stagingId)).isNotNull();
@@ -133,25 +125,24 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
     TestUtils.assertPermissionDenied(
         () -> userBDeltaCredsApi.getStagingTableCredentials(stagingId));
 
-    // Delta REST createStagingTable: same authz rule as UC REST StagingTableService (catalog
-    // USE_CATALOG/OWNER + schema USE_SCHEMA+CREATE_TABLE OR schema OWNER). Verify here that both
-    // entry points grant equivalent access so they don't silently drift apart.
+    // createStagingTable authz (catalog USE_CATALOG/OWNER + schema USE_SCHEMA+CREATE_TABLE OR
+    // schema OWNER). Both surfaces share the same SpEL constant
+    // AuthorizeExpressions.CREATE_STAGING_TABLE; this section exercises both arms of the OR
+    // through the abstract createStaging so each subclass tests its own RPC.
 
-    // User A covers the `USE_SCHEMA + CREATE_TABLE` arm of the OR -- User A's schema grants
-    // are USE_SCHEMA + CREATE_TABLE (set up at the top of the test), but NOT OWNER.
+    // User A covers the `USE_SCHEMA + CREATE_TABLE` arm -- granted at the top of the test, but
+    // not schema OWNER.
     assertThat(
-            deltaTablesApi(userAConfig)
-                .createStagingTable(
-                    TestUtils.CATALOG_NAME,
-                    TestUtils.SCHEMA_NAME,
-                    new CreateStagingTableRequest().name("drc_staging_allowed_via_use_schema")))
+            createStaging(
+                userAConfig,
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                "staging_allowed_via_use_schema"))
         .isNotNull();
 
-    // User D covers the `schema OWNER` arm of the OR. OWNER is not grantable via the API (it's
-    // implicit from creating a resource), so User D creates their own schema and then creates a
-    // staging table in it -- with no explicit CREATE_TABLE grant, only the schema OWNER path can
-    // admit this call. Pairing with User A above, both branches of the OR in
-    // AuthorizeExpressions.CREATE_STAGING_TABLE are exercised.
+    // User D covers the `schema OWNER` arm. OWNER is not grantable via the API (it's implicit from
+    // creating a resource), so User D creates their own schema and then creates a staging table in
+    // it -- with no explicit CREATE_TABLE grant, only the schema OWNER path can admit this call.
     String userDEmail = "user_d@example.com";
     String userDSchema = "user_d_schema";
     createTestUser(userDEmail, "User D");
@@ -165,11 +156,11 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
     new SchemasApi(TestUtils.createApiClient(userDConfig))
         .createSchema(new CreateSchema().name(userDSchema).catalogName(TestUtils.CATALOG_NAME));
     assertThat(
-            deltaTablesApi(userDConfig)
-                .createStagingTable(
-                    TestUtils.CATALOG_NAME,
-                    userDSchema,
-                    new CreateStagingTableRequest().name("drc_staging_allowed_via_schema_owner")))
+            createStaging(
+                userDConfig,
+                TestUtils.CATALOG_NAME,
+                userDSchema,
+                "staging_allowed_via_schema_owner"))
         .isNotNull();
 
     // User C has USE_CATALOG only (neither arm of the OR satisfied) -- denied.
@@ -180,35 +171,18 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
     ServerConfig userCConfig = createTestUserServerConfig(userCEmail);
     TestUtils.assertPermissionDenied(
         () ->
-            deltaTablesApi(userCConfig)
-                .createStagingTable(
-                    TestUtils.CATALOG_NAME,
-                    TestUtils.SCHEMA_NAME,
-                    new CreateStagingTableRequest().name("drc_staging_denied")));
+            createStaging(
+                userCConfig, TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "staging_denied"));
 
-    // Step 3: User B attempts to create a managed table using User A's staging location
-    CreateTable createTableRequest =
-        new CreateTable()
-            .name(TestUtils.TABLE_NAME)
-            .catalogName(TestUtils.CATALOG_NAME)
-            .schemaName(TestUtils.SCHEMA_NAME)
-            .columns(columns)
-            .tableType(TableType.MANAGED)
-            .dataSourceFormat(DataSourceFormat.DELTA)
-            .storageLocation(stagingTableInfo.getStagingLocation())
-            .properties(Map.of(TableProperties.UC_TABLE_ID, stagingTableInfo.getId()))
-            .comment("Table created by different user - should fail");
-
-    // This by user B should fail with PERMISSION_DENIED and a message identifying the check.
+    // Steps 3+4: User B's createTable on User A's staging is rejected at commitStagingTable;
+    // User A's same request succeeds and produces a regular table that reuses the staging UUID
+    // and storage location.
     TestUtils.assertPermissionDenied(
-        () -> userBTablesApi.createTable(createTableRequest),
+        () -> finalizeManagedTable(userBConfig, staging, TestUtils.TABLE_NAME),
         "User attempts to create table on a staging location without ownership");
-
-    // Step 4: The same request by user A should succeed
-    TableInfo tableInfo = userATablesApi.createTable(createTableRequest);
-    assertThat(tableInfo).isNotNull();
-    assertThat(tableInfo.getStorageLocation()).isEqualTo(stagingTableInfo.getStagingLocation());
-    assertThat(tableInfo.getTableId()).isEqualTo(stagingTableInfo.getId());
+    FinalizedTable finalized = finalizeManagedTable(userAConfig, staging, TestUtils.TABLE_NAME);
+    assertThat(finalized.storageLocation()).isEqualTo(staging.location());
+    assertThat(finalized.tableId()).isEqualTo(staging.id());
 
     // Step 5: User B calls getStagingTableCredentials with User A's regular-table UUID.
     // This is not the same as the SdkDeltaCredentialsTest case (owner passes regular-table UUID
@@ -216,14 +190,8 @@ public class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTe
     // authz (@AuthorizeResourceKey(TABLE)) resolves the regular-table UUID in the graph, finds
     // that User B is not OWNER, and rejects with 403 before the handler runs. The 404 path is
     // therefore unreachable for non-owners -- which is fail-closed and the desired behavior.
-    UUID tableUuid = UUID.fromString(tableInfo.getTableId());
+    UUID tableUuid = UUID.fromString(finalized.tableId());
     TestUtils.assertPermissionDenied(
         () -> userBDeltaCredsApi.getStagingTableCredentials(tableUuid));
-  }
-
-  // FQCN kept at this single site because io.unitycatalog.client.delta.api.TablesApi has the same
-  // simple name as io.unitycatalog.client.api.TablesApi that's imported for createTable above.
-  private static io.unitycatalog.client.delta.api.TablesApi deltaTablesApi(ServerConfig config) {
-    return new io.unitycatalog.client.delta.api.TablesApi(TestUtils.createApiClient(config));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
@@ -3,17 +3,12 @@ package io.unitycatalog.server.sdk.access;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.api.SchemasApi;
-import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.model.CreateSchema;
-import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.client.model.SecurableType;
-import io.unitycatalog.client.model.TableOperation;
-import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,11 +21,10 @@ import org.junit.jupiter.api.Test;
  * identical staging-table access-control behavior; running the same {@code @Test} against both
  * ensures they don't drift.
  *
- * <p>This class does not import either {@code io.unitycatalog.client.api.TablesApi} or {@code
- * io.unitycatalog.client.delta.api.TablesApi}; subclasses encapsulate all surface-specific table
- * RPCs behind {@link #createStaging} and {@link #finalizeManagedTable}. Other APIs reachable
- * regardless of subclass (TemporaryCredentialsApi, SchemasApi) are used inline for cross-cutting
- * checks that don't vary by surface.
+ * <p>All surface-specific RPCs are encapsulated behind {@link #createStaging}, {@link
+ * #finalizeManagedTable}, and {@link #fetchTempCreds}; the abstract test body imports neither
+ * surface's TablesApi nor TemporaryCredentialsApi. SchemasApi is used inline because it's
+ * surface-independent.
  */
 public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlBaseCRUDTest {
 
@@ -47,6 +41,16 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
   /** Surface-specific {@code createTable} RPC that finalizes a managed table from a staging. */
   protected abstract FinalizedTable finalizeManagedTable(
       ServerConfig config, StagingHandle staging, String name) throws Exception;
+
+  /**
+   * Surface-specific temporary-credentials RPC for the table identified by {@code tableId} (which
+   * may be a staging-table UUID or a regular-table UUID). The UC REST and Delta REST surfaces
+   * expose different RPCs ({@code generateTemporaryTableCredentials} vs {@code
+   * getStagingTableCredentials}) but both gate through the same {@code @AuthorizeResourceKey}-
+   * resolved ownership check, so the access-control semantics this test pins must hold on either
+   * surface; each subclass implements this against its own RPC.
+   */
+  protected abstract void fetchTempCreds(ServerConfig config, String tableId) throws Exception;
 
   /**
    * Test that attempting to create a managed table from another user's staging table fails with
@@ -83,10 +87,6 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
 
     ServerConfig userAConfig = createTestUserServerConfig(userAEmail);
     ServerConfig userBConfig = createTestUserServerConfig(userBEmail);
-    TemporaryCredentialsApi userATempCredsApi =
-        new TemporaryCredentialsApi(TestUtils.createApiClient(userAConfig));
-    TemporaryCredentialsApi userBTempCredsApi =
-        new TemporaryCredentialsApi(TestUtils.createApiClient(userBConfig));
 
     // Step 1: User A creates a staging table (surface-specific).
     StagingHandle staging =
@@ -94,36 +94,12 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
             userAConfig, TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
     assertThat(staging.location()).isNotNull();
 
-    // Step 2: Test temporary credentials generation
-    // User A (owner) should be able to get temporary credentials
-    GenerateTemporaryTableCredential tempCredRequest =
-        new GenerateTemporaryTableCredential()
-            .tableId(staging.id())
-            .operation(TableOperation.READ_WRITE);
-
-    TemporaryCredentials tempCredsA =
-        userATempCredsApi.generateTemporaryTableCredentials(tempCredRequest);
-    assertThat(tempCredsA).isNotNull();
-
-    // User B (non-owner) should fail to get temporary credentials with PERMISSION_DENIED
-    TestUtils.assertPermissionDenied(
-        () -> userBTempCredsApi.generateTemporaryTableCredentials(tempCredRequest));
-
-    // Delta REST getStagingTableCredentials follows the same OWNER-only authz.
-    io.unitycatalog.client.delta.api.TemporaryCredentialsApi userADeltaCredsApi =
-        new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(
-            TestUtils.createApiClient(userAConfig));
-    io.unitycatalog.client.delta.api.TemporaryCredentialsApi userBDeltaCredsApi =
-        new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(
-            TestUtils.createApiClient(userBConfig));
-    UUID stagingId = UUID.fromString(staging.id());
-
-    // User A (owner) -> allowed
-    assertThat(userADeltaCredsApi.getStagingTableCredentials(stagingId)).isNotNull();
-
-    // User B (non-owner) -> denied
-    TestUtils.assertPermissionDenied(
-        () -> userBDeltaCredsApi.getStagingTableCredentials(stagingId));
+    // Step 2: temp-creds access control on the staging table -- exercised against the subclass's
+    // own surface (UC REST generateTemporaryTableCredentials / Delta REST
+    // getStagingTableCredentials).
+    // Owner allowed; non-owner denied.
+    fetchTempCreds(userAConfig, staging.id());
+    TestUtils.assertPermissionDenied(() -> fetchTempCreds(userBConfig, staging.id()));
 
     // createStagingTable authz (catalog USE_CATALOG/OWNER + schema USE_SCHEMA+CREATE_TABLE OR
     // schema OWNER). Both surfaces share the same SpEL constant
@@ -184,14 +160,14 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
     assertThat(finalized.storageLocation()).isEqualTo(staging.location());
     assertThat(finalized.tableId()).isEqualTo(staging.id());
 
-    // Step 5: User B calls getStagingTableCredentials with User A's regular-table UUID.
-    // This is not the same as the SdkDeltaCredentialsTest case (owner passes regular-table UUID
-    // and gets 404 from the reject-regular-table logic); here the caller is a non-owner, so
-    // authz (@AuthorizeResourceKey(TABLE)) resolves the regular-table UUID in the graph, finds
-    // that User B is not OWNER, and rejects with 403 before the handler runs. The 404 path is
-    // therefore unreachable for non-owners -- which is fail-closed and the desired behavior.
-    UUID tableUuid = UUID.fromString(finalized.tableId());
-    TestUtils.assertPermissionDenied(
-        () -> userBDeltaCredsApi.getStagingTableCredentials(tableUuid));
+    // Step 5: User B calls the temp-creds RPC with User A's regular-table UUID. The
+    // surface-specific Delta {@code getStagingTableCredentials} handler has a "reject if not a
+    // staging table" branch that returns 404 -- but that 404 is unreachable for a non-owner
+    // because authz (@AuthorizeResourceKey resolves the UUID in the graph, finds User B is not
+    // OWNER) rejects with 403 before the handler runs. UC REST's
+    // {@code generateTemporaryTableCredentials} reaches the same 403 via its own ownership check.
+    // Either subclass's surface must exhibit the fail-closed 403; we don't pin which one wins for
+    // an owner-with-regular-UUID call here.
+    TestUtils.assertPermissionDenied(() -> fetchTempCreds(userBConfig, finalized.tableId()));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
@@ -1,13 +1,16 @@
 package io.unitycatalog.server.sdk.access;
 
 import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
 import io.unitycatalog.client.model.CreateStagingTable;
 import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.client.model.StagingTableInfo;
 import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
@@ -56,5 +59,14 @@ public class SdkUCStagingTableAccessControlTest extends SdkStagingTableAccessCon
                     .storageLocation(staging.location())
                     .properties(Map.of(TableProperties.UC_TABLE_ID, staging.id())));
     return new FinalizedTable(info.getTableId(), info.getStorageLocation());
+  }
+
+  @Override
+  protected void fetchTempCreds(ServerConfig config, String tableId) throws Exception {
+    new TemporaryCredentialsApi(TestUtils.createApiClient(config))
+        .generateTemporaryTableCredentials(
+            new GenerateTemporaryTableCredential()
+                .tableId(tableId)
+                .operation(TableOperation.READ_WRITE));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
@@ -1,0 +1,60 @@
+package io.unitycatalog.server.sdk.access;
+
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateStagingTable;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.StagingTableInfo;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs the staging-table access-control suite against the UC REST createStagingTable / createTable.
+ */
+public class SdkUCStagingTableAccessControlTest extends SdkStagingTableAccessControlTest {
+
+  private static final List<ColumnInfo> COLUMNS =
+      List.of(
+          new ColumnInfo()
+              .name("test_column")
+              .typeText("INTEGER")
+              .typeJson("{\"type\": \"integer\"}")
+              .typeName(ColumnTypeName.INT)
+              .position(0)
+              .nullable(true));
+
+  @Override
+  protected StagingHandle createStaging(
+      ServerConfig config, String catalog, String schema, String name) throws Exception {
+    StagingTableInfo info =
+        new TablesApi(TestUtils.createApiClient(config))
+            .createStagingTable(
+                new CreateStagingTable().catalogName(catalog).schemaName(schema).name(name));
+    return new StagingHandle(info.getId(), info.getStagingLocation());
+  }
+
+  @Override
+  protected FinalizedTable finalizeManagedTable(
+      ServerConfig config, StagingHandle staging, String name) throws Exception {
+    TableInfo info =
+        new TablesApi(TestUtils.createApiClient(config))
+            .createTable(
+                new CreateTable()
+                    .name(name)
+                    .catalogName(TestUtils.CATALOG_NAME)
+                    .schemaName(TestUtils.SCHEMA_NAME)
+                    .columns(COLUMNS)
+                    .tableType(TableType.MANAGED)
+                    .dataSourceFormat(DataSourceFormat.DELTA)
+                    .storageLocation(staging.location())
+                    .properties(Map.of(TableProperties.UC_TABLE_ID, staging.id())));
+    return new FinalizedTable(info.getTableId(), info.getStorageLocation());
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1534/files) to review incremental changes.
- [**stack/create_table_tests**](https://github.com/unitycatalog/unitycatalog/pull/1534) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1534/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Run external-table and staging-table access-control suites against both UC REST and Delta REST surfaces

`SdkExternalLocationAccessControlTest` parameterizes its existing 7-case table-creator loop and runs it for UC REST and Delta REST. `SdkStagingTableAccessControlTest` becomes abstract, with `SdkUCStagingTableAccessControlTest` and `SdkDeltaStagingTableAccessControlTest` providing surface-specific `createStaging` / `finalizeManagedTable`.
