### PR TITLE
Delta: enforce case-insensitive column names

### DIFF
--- a/api/delta-docs/Models/StructField.md
+++ b/api/delta-docs/Models/StructField.md
@@ -3,7 +3,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | Column name | [default to null] |
+| **name** | **String** | Column name. Case-preserving; unique case-insensitively within the parent StructType. | [default to null] |
 | **type** | [**DeltaType**](DeltaType.md) |  | [default to null] |
 | **nullable** | **Boolean** | Whether this column can be null | [default to null] |
 | **metadata** | [**StructFieldMetadata**](StructFieldMetadata.md) |  | [default to null] |

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1330,12 +1330,16 @@ components:
     StructField:
       type: object
       description: |
-        A field in a StructType. Contains the field name, type, nullability,
-        and metadata matching the Delta schema field format.
+        A field in a StructType. Contains the field name, type, nullability, and metadata
+        matching the Delta schema field format.
+        Field names are case-preserving but case-insensitive: within a StructType no two fields
+        may have names equal under ASCII lowercase comparison. Every API reference to a column
+        name (partition-columns, delta.clustering.clusteringColumns, etc.) matches
+        case-insensitively. Per Delta [PROTOCOL.md](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#schema-serialization-format).
       properties:
         name:
           type: string
-          description: Column name
+          description: Column name. Case-preserving; unique case-insensitively within the parent StructType.
         type:
           $ref: '#/components/schemas/DeltaType'
         nullable:

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -414,6 +414,7 @@ public final class DeltaUpdateTableMapper {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT, "set-columns requires at least one column.");
       }
+      ColumnUtils.validateStructType(columns, "columns");
       newColumns = ColumnUtils.toColumnInfos(fields);
     } else {
       newColumns = ColumnInfoDAO.toList(dao.getColumns());

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -489,24 +489,22 @@ public class ColumnUtils {
     if (partitionColumns == null || partitionColumns.isEmpty()) {
       return;
     }
-    // Duplicate detection within partition-columns and the column-name lookup against the schema
-    // both compare case-insensitively, matching the Delta protocol rule that column names are
-    // unique regardless of casing.
-    Set<String> seenLower = new HashSet<>();
-    for (String partName : partitionColumns) {
-      if (!seenLower.add(partName.toLowerCase(Locale.ROOT))) {
-        throw new BaseException(
-            ErrorCode.INVALID_ARGUMENT,
-            "partition-columns contains duplicate entry (case-insensitive): " + partName);
-      }
-    }
     Map<String, ColumnInfo> columnsByLowerName =
         columns.stream()
             .collect(
                 Collectors.toMap(c -> c.getName().toLowerCase(Locale.ROOT), Function.identity()));
+    Set<String> seenLower = new HashSet<>();
     for (int i = 0; i < partitionColumns.size(); i++) {
       String partName = partitionColumns.get(i);
-      ColumnInfo match = columnsByLowerName.get(partName.toLowerCase(Locale.ROOT));
+      String lowerPartName = partName.toLowerCase(Locale.ROOT);
+      // Duplicate detection within partition-columns, comparing case-insensitively.
+      if (!seenLower.add(lowerPartName)) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            "partition-columns contains duplicate entry (case-insensitive): " + partName);
+      }
+      // Column-name lookup against the schema, comparing case-insensitively.
+      ColumnInfo match = columnsByLowerName.get(lowerPartName);
       if (match == null) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT,

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -224,6 +224,10 @@ public class ColumnUtils {
    * Validate that a {@link StructType} is well-formed against the Delta spec's wire shape.
    * Centralizes structural validation so callers can pass {@code columns} directly without
    * pre-checking nullness/emptiness.
+   *
+   * <p>Field-name uniqueness is enforced case-insensitively (per Delta's schema rule "All column
+   * names must be unique regardless of casing"). Names are stored case-preserving on
+   * {@link StructField#getName()}; only the duplicate check ignores case.
    */
   public static void validateStructType(StructType structType, String path) {
     requireNonNull(structType, path);
@@ -233,15 +237,16 @@ public class ColumnUtils {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT, path + ".fields must contain at least one field.");
     }
-    Set<String> seen = new HashSet<>();
+    Set<String> seenLower = new HashSet<>();
     for (int i = 0; i < fields.size(); i++) {
       String fieldPath = path + ".fields[" + i + "]";
       requireNonNull(fields.get(i), fieldPath);
       validateStructField(fields.get(i), fieldPath);
       String name = fields.get(i).getName();
-      if (!seen.add(name)) {
+      if (!seenLower.add(name.toLowerCase(Locale.ROOT))) {
         throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "Duplicate field name in " + fieldPath + ": " + name);
+          ErrorCode.INVALID_ARGUMENT,
+          "Duplicate field name (case-insensitive) in " + fieldPath + ": " + name);
       }
     }
   }
@@ -484,19 +489,24 @@ public class ColumnUtils {
     if (partitionColumns == null || partitionColumns.isEmpty()) {
       return;
     }
-    Set<String> seen = new HashSet<>();
+    // Duplicate detection within partition-columns and the column-name lookup against the schema
+    // both compare case-insensitively, matching the Delta protocol rule that column names are
+    // unique regardless of casing.
+    Set<String> seenLower = new HashSet<>();
     for (String partName : partitionColumns) {
-      if (!seen.add(partName)) {
+      if (!seenLower.add(partName.toLowerCase(Locale.ROOT))) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT,
-            "partition-columns contains duplicate entry: " + partName);
+            "partition-columns contains duplicate entry (case-insensitive): " + partName);
       }
     }
-    Map<String, ColumnInfo> columnsByName =
-        columns.stream().collect(Collectors.toMap(ColumnInfo::getName, Function.identity()));
+    Map<String, ColumnInfo> columnsByLowerName =
+        columns.stream()
+            .collect(
+                Collectors.toMap(c -> c.getName().toLowerCase(Locale.ROOT), Function.identity()));
     for (int i = 0; i < partitionColumns.size(); i++) {
       String partName = partitionColumns.get(i);
-      ColumnInfo match = columnsByName.get(partName);
+      ColumnInfo match = columnsByLowerName.get(partName.toLowerCase(Locale.ROOT));
       if (match == null) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT,

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -283,12 +283,13 @@ public class RawCreateTableTest extends BaseCRUDTest {
     // -------- duplicate field names at the top level --------
     // Error message includes the index of the second occurrence so wide schemas surface the
     // offending position alongside the name.
+    // Uses "id" / "ID" to pin Delta's "unique regardless of casing" rule via validateStructType.
     assertRejected(
         staging,
         """
         {"name": "id", "type": "long", "nullable": false, "metadata": {}},
-        {"name": "id", "type": "string", "nullable": true, "metadata": {}}""",
-        "Duplicate field name in columns.fields[1]: id");
+        {"name": "ID", "type": "string", "nullable": true, "metadata": {}}""",
+        "Duplicate field name (case-insensitive) in columns.fields[1]: ID");
 
     // -------- duplicate field name inside a nested struct --------
     // Proves uniqueness is enforced per StructType level (not only at the top level) -- the
@@ -312,7 +313,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "nullable": true,
           "metadata": {}
         }""",
-        "Duplicate field name in columns.fields[0].type.element-type.fields[1]: x");
+        "Duplicate field name (case-insensitive) in columns.fields[0].type.element-type"
+          + ".fields[1]: x");
   }
 
   // ---------- helpers ----------

--- a/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ColumnUtilsTest.java
@@ -414,11 +414,13 @@ public class ColumnUtilsTest {
                 new ColumnInfo().name("id").position(0),
                 new ColumnInfo().name("region").position(1),
                 new ColumnInfo().name("date").position(2)));
-    // Order of the partition list is the partition-index order; not the column position.
-    ColumnUtils.applyPartitionColumns(columns, List.of("date", "region"));
+    // "DATE" intentionally differs in case from the schema column "date" to also pin the
+    // case-insensitive lookup (Delta: column names match regardless of casing). Order of the
+    // partition list is the partition-index order; not the column position.
+    ColumnUtils.applyPartitionColumns(columns, List.of("DATE", "region"));
     assertThat(columns.get(0).getPartitionIndex()).isNull();
     assertThat(columns.get(1).getPartitionIndex()).isEqualTo(1); // region -> index 1
-    assertThat(columns.get(2).getPartitionIndex()).isEqualTo(0); // date   -> index 0
+    assertThat(columns.get(2).getPartitionIndex()).isEqualTo(0); // DATE -> matches "date" -> 0
   }
 
   @Test
@@ -439,13 +441,16 @@ public class ColumnUtilsTest {
 
   @Test
   public void testApplyPartitionColumnsDuplicateRejected() {
+    // Uses ["a", "A"] to also pin the case-insensitive duplicate rule (Delta: column names must
+    // be unique regardless of casing). Same assertion catches both ["a", "a"] and ["a", "A"]
+    // since the helper reports the (case-insensitive) duplicate the same way.
     List<ColumnInfo> columns =
         new ArrayList<>(
             List.of(
                 new ColumnInfo().name("a").position(0), new ColumnInfo().name("b").position(1)));
-    assertThatThrownBy(() -> ColumnUtils.applyPartitionColumns(columns, List.of("a", "a")))
+    assertThatThrownBy(() -> ColumnUtils.applyPartitionColumns(columns, List.of("a", "A")))
         .isInstanceOf(BaseException.class)
-        .hasMessageContaining("partition-columns contains duplicate entry: a");
+        .hasMessageContaining("partition-columns contains duplicate entry");
   }
 
   // ---------- validateStructType ----------


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1537/files) to review incremental changes.
- [**stack/column_case_ins**](https://github.com/unitycatalog/unitycatalog/pull/1537) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1537/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Delta: enforce case-insensitive column names

Per Delta protocol ("All column names must be unique regardless of casing"). Fixes three case-sensitive sites in `ColumnUtils`: StructType duplicate detection and the duplicate-detection / lookup of partition-columns. Spec note added in `delta.yaml`.
