### PR TITLE
[Hadoop] Add BoundedKeyedCache and CloseableUtils

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/BoundedKeyedCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/BoundedKeyedCache.java
@@ -1,0 +1,87 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import io.unitycatalog.client.internal.Preconditions;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class BoundedKeyedCache<K, V> {
+  private final int maxSize;
+  private final Consumer<V> evictionListener;
+  private final Object cacheLock = new Object();
+  private final LinkedHashMap<K, V> cache = new LinkedHashMap<>(16, 0.75f, true);
+  private final IdLockMap<K> keyLocks = new IdLockMap<>();
+
+  public BoundedKeyedCache(int maxSize) {
+    this(maxSize, null);
+  }
+
+  public BoundedKeyedCache(int maxSize, Consumer<V> evictionListener) {
+    Preconditions.checkArgument(maxSize > 0, "maxSize must be positive, got %s", maxSize);
+    this.maxSize = maxSize;
+    this.evictionListener = evictionListener == null ? value -> {} : evictionListener;
+  }
+
+  public V getIfPresent(K key) {
+    synchronized (cacheLock) {
+      return cache.get(key);
+    }
+  }
+
+  public <E extends Exception> V getOrLoad(K key, CheckedSupplier<V, E> loader) throws E {
+    V cached = getIfPresent(key);
+    if (cached != null) {
+      return cached;
+    }
+    try (IdLockMap<K>.IdLock ignored = keyLocks.acquire(key)) {
+      V lockedCached = getIfPresent(key);
+      if (lockedCached != null) {
+        return lockedCached;
+      }
+      V loaded = Objects.requireNonNull(loader.get(), "loader returned null");
+      put(key, loaded);
+      return loaded;
+    }
+  }
+
+  public void put(K key, V value) {
+    Objects.requireNonNull(key, "key cannot be null");
+    Objects.requireNonNull(value, "value cannot be null");
+    List<V> evicted = new ArrayList<>();
+    synchronized (cacheLock) {
+      V previous = cache.put(key, value);
+      if (previous != null && previous != value) {
+        evicted.add(previous);
+      }
+      while (cache.size() > maxSize) {
+        Map.Entry<K, V> eldest = cache.entrySet().iterator().next();
+        cache.remove(eldest.getKey());
+        evicted.add(eldest.getValue());
+      }
+    }
+    evicted.forEach(evictionListener);
+  }
+
+  public void clear() {
+    List<V> evicted;
+    synchronized (cacheLock) {
+      evicted = new ArrayList<>(cache.values());
+      cache.clear();
+    }
+    evicted.forEach(evictionListener);
+  }
+
+  int size() {
+    synchronized (cacheLock) {
+      return cache.size();
+    }
+  }
+
+  @FunctionalInterface
+  public interface CheckedSupplier<T, E extends Exception> {
+    T get() throws E;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/CloseableUtils.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/CloseableUtils.java
@@ -1,0 +1,19 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public final class CloseableUtils {
+  private CloseableUtils() {}
+
+  public static void closeQuietly(Closeable closeable) {
+    if (closeable == null) {
+      return;
+    }
+    try {
+      closeable.close();
+    } catch (IOException e) {
+      // Ignore close failures during best-effort cleanup.
+    }
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/IdLockMap.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/IdLockMap.java
@@ -1,0 +1,70 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+final class IdLockMap<K> {
+  private final ConcurrentHashMap<K, RefCountedLock> locks = new ConcurrentHashMap<>();
+
+  IdLock acquire(K key) {
+    Objects.requireNonNull(key, "key cannot be null");
+    RefCountedLock ref =
+        locks.compute(
+            key,
+            (ignored, existing) -> {
+              RefCountedLock lock = existing == null ? new RefCountedLock() : existing;
+              lock.references.incrementAndGet();
+              return lock;
+            });
+    ref.lock.lock();
+    return new IdLock(key, ref);
+  }
+
+  int lockCount() {
+    return locks.size();
+  }
+
+  int referenceCount(K key) {
+    RefCountedLock ref = locks.get(key);
+    return ref == null ? 0 : ref.references.get();
+  }
+
+  private void release(K key, RefCountedLock ref) {
+    locks.computeIfPresent(
+        key,
+        (ignored, existing) -> {
+          if (existing != ref) {
+            return existing;
+          }
+          return existing.references.decrementAndGet() == 0 ? null : existing;
+        });
+  }
+
+  final class IdLock implements AutoCloseable {
+    private final K key;
+    private final RefCountedLock ref;
+    private boolean closed;
+
+    private IdLock(K key, RefCountedLock ref) {
+      this.key = key;
+      this.ref = ref;
+    }
+
+    @Override
+    public void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      ref.lock.unlock();
+      release(key, ref);
+    }
+  }
+
+  private static final class RefCountedLock {
+    private final ReentrantLock lock = new ReentrantLock();
+    private final AtomicInteger references = new AtomicInteger();
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/BoundedKeyedCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/BoundedKeyedCacheTest.java
@@ -1,0 +1,239 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BoundedKeyedCacheTest {
+
+  @Test
+  void evictsLeastRecentlyUsedEntry() {
+    List<String> evicted = new ArrayList<>();
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2, evicted::add);
+
+    cache.put("a", "value-a");
+    cache.put("b", "value-b");
+    assertThat(cache.getIfPresent("a")).isEqualTo("value-a");
+
+    cache.put("c", "value-c");
+
+    assertThat(cache.getIfPresent("a")).isEqualTo("value-a");
+    assertThat(cache.getIfPresent("b")).isNull();
+    assertThat(cache.getIfPresent("c")).isEqualTo("value-c");
+    assertThat(evicted).containsExactly("value-b");
+  }
+
+  @Test
+  void getIfPresentUpdatesLruRecency() {
+    List<String> evicted = new ArrayList<>();
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2, evicted::add);
+
+    cache.put("a", "value-a");
+    cache.put("b", "value-b");
+    // Reading "a" should make "a" the most-recently-used, so the next put evicts "b" not "a".
+    assertThat(cache.getIfPresent("a")).isEqualTo("value-a");
+    cache.put("c", "value-c");
+
+    assertThat(cache.getIfPresent("b")).isNull();
+    assertThat(cache.getIfPresent("a")).isEqualTo("value-a");
+    assertThat(cache.getIfPresent("c")).isEqualTo("value-c");
+    assertThat(evicted).containsExactly("value-b");
+  }
+
+  @Test
+  void putWithDifferentValueFiresEvictionForPrevious() {
+    List<String> evicted = new ArrayList<>();
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2, evicted::add);
+
+    cache.put("a", "v1");
+    cache.put("a", "v2");
+
+    assertThat(cache.getIfPresent("a")).isEqualTo("v2");
+    assertThat(cache.size()).isEqualTo(1);
+    assertThat(evicted).containsExactly("v1");
+  }
+
+  @Test
+  void clearFiresListenerForAllEntries() {
+    List<String> evicted = new ArrayList<>();
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(4, evicted::add);
+
+    cache.put("a", "value-a");
+    cache.put("b", "value-b");
+    cache.clear();
+
+    assertThat(cache.size()).isZero();
+    assertThat(evicted).containsExactlyInAnyOrder("value-a", "value-b");
+  }
+
+  @Test
+  void loaderReturningNullThrows() {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2);
+
+    assertThatThrownBy(() -> cache.getOrLoad("k", () -> null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("loader returned null");
+    assertThat(cache.getIfPresent("k")).isNull();
+  }
+
+  @Test
+  void constructorWithoutEvictionListenerUsesNoOpListener() {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(1);
+
+    cache.put("a", "value-a");
+    cache.put("b", "value-b");
+
+    assertThat(cache.getIfPresent("a")).isNull();
+    assertThat(cache.getIfPresent("b")).isEqualTo("value-b");
+  }
+
+  @Test
+  void getOrLoadPropagatesCheckedException() {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2);
+    IOException boom = new IOException("loader boom");
+
+    assertThatThrownBy(
+            () ->
+                cache.getOrLoad(
+                    "k",
+                    () -> {
+                      throw boom;
+                    }))
+        .isSameAs(boom);
+  }
+
+  @Test
+  void keyLockReleasedAfterLoaderThrows() throws Exception {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2);
+
+    assertThatThrownBy(
+            () ->
+                cache.getOrLoad(
+                    "k",
+                    () -> {
+                      throw new RuntimeException("loader boom");
+                    }))
+        .hasMessageContaining("loader boom");
+
+    // If the per-key lock leaked, this second call would deadlock or block. We use a timeout so
+    // the test fails fast rather than hanging if the lock was not released.
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<String> retry = executor.submit(() -> cache.getOrLoad("k", () -> "loaded"));
+      assertThat(retry.get(2, TimeUnit.SECONDS)).isEqualTo("loaded");
+    } finally {
+      executor.shutdownNow();
+    }
+    assertThat(cache.getIfPresent("k")).isEqualTo("loaded");
+  }
+
+  @Test
+  void getOrLoadLoadsSameKeyOnlyOnce() throws Exception {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2);
+    CountDownLatch firstLoadStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstLoad = new CountDownLatch(1);
+    AtomicInteger loadCount = new AtomicInteger();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<String> first =
+          executor.submit(
+              () ->
+                  cache.getOrLoad(
+                      "key",
+                      () -> {
+                        loadCount.incrementAndGet();
+                        firstLoadStarted.countDown();
+                        assertThat(releaseFirstLoad.await(5, TimeUnit.SECONDS)).isTrue();
+                        return "value";
+                      }));
+      assertThat(firstLoadStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      Future<String> second = executor.submit(() -> cache.getOrLoad("key", () -> "other"));
+
+      releaseFirstLoad.countDown();
+      assertThat(first.get(5, TimeUnit.SECONDS)).isEqualTo("value");
+      assertThat(second.get(5, TimeUnit.SECONDS)).isEqualTo("value");
+      assertThat(loadCount).hasValue(1);
+    } finally {
+      releaseFirstLoad.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void manyThreadsOnSameKeyInvokeLoaderExactlyOnce() throws Exception {
+    int threads = 64;
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(2);
+    AtomicInteger loadCount = new AtomicInteger();
+    CyclicBarrier startBarrier = new CyclicBarrier(threads);
+    String singleton = "value";
+
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    try {
+      List<Future<String>> futures = new ArrayList<>();
+      for (int i = 0; i < threads; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await(5, TimeUnit.SECONDS);
+                  return cache.getOrLoad(
+                      "k",
+                      () -> {
+                        loadCount.incrementAndGet();
+                        return singleton;
+                      });
+                }));
+      }
+      for (Future<String> f : futures) {
+        assertThat(f.get(10, TimeUnit.SECONDS)).isSameAs(singleton);
+      }
+      assertThat(loadCount).hasValue(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void getOrLoadDifferentKeysProgressIndependently() throws Exception {
+    BoundedKeyedCache<String, String> cache = new BoundedKeyedCache<>(4);
+    CountDownLatch slowLoaderStarted = new CountDownLatch(1);
+    CountDownLatch releaseSlowLoader = new CountDownLatch(1);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<String> slowKey =
+          executor.submit(
+              () ->
+                  cache.getOrLoad(
+                      "slow",
+                      () -> {
+                        slowLoaderStarted.countDown();
+                        assertThat(releaseSlowLoader.await(5, TimeUnit.SECONDS)).isTrue();
+                        return "slow-value";
+                      }));
+      assertThat(slowLoaderStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      // While the slow loader on key "slow" is blocked, a load on a different key must complete.
+      Future<String> fastKey = executor.submit(() -> cache.getOrLoad("fast", () -> "fast-value"));
+      assertThat(fastKey.get(5, TimeUnit.SECONDS)).isEqualTo("fast-value");
+
+      releaseSlowLoader.countDown();
+      assertThat(slowKey.get(5, TimeUnit.SECONDS)).isEqualTo("slow-value");
+    } finally {
+      releaseSlowLoader.countDown();
+      executor.shutdownNow();
+    }
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/CloseableUtilsTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/CloseableUtilsTest.java
@@ -1,0 +1,21 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class CloseableUtilsTest {
+
+  @Test
+  void closeQuietlyIgnoresCloseFailuresAndNulls() {
+    Closeable brokenCloseable =
+        () -> {
+          throw new IOException("close failed");
+        };
+
+    assertThatCode(() -> CloseableUtils.closeQuietly(null)).doesNotThrowAnyException();
+    assertThatCode(() -> CloseableUtils.closeQuietly(brokenCloseable)).doesNotThrowAnyException();
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/IdLockMapTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/IdLockMapTest.java
@@ -1,0 +1,164 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class IdLockMapTest {
+
+  @Test
+  void acquireRejectsNullKey() {
+    IdLockMap<String> locks = new IdLockMap<>();
+
+    assertThatThrownBy(() -> locks.acquire(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("key cannot be null");
+  }
+
+  @Test
+  void closeRemovesUnusedLock() {
+    IdLockMap<String> locks = new IdLockMap<>();
+
+    try (IdLockMap<String>.IdLock ignored = locks.acquire("k")) {
+      assertThat(locks.lockCount()).isEqualTo(1);
+      assertThat(locks.referenceCount("k")).isEqualTo(1);
+    }
+
+    assertThat(locks.lockCount()).isZero();
+    assertThat(locks.referenceCount("k")).isZero();
+  }
+
+  @Test
+  void sameKeyWaiterDoesNotEnterUntilCurrentHolderCloses() throws Exception {
+    IdLockMap<String> locks = new IdLockMap<>();
+    CountDownLatch waiterStarted = new CountDownLatch(1);
+    CountDownLatch waiterEntered = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try (IdLockMap<String>.IdLock ignored = locks.acquire("k")) {
+      Future<?> waiter =
+          executor.submit(
+              () -> {
+                waiterStarted.countDown();
+                try (IdLockMap<String>.IdLock ignoredWaiter = locks.acquire("k")) {
+                  waiterEntered.countDown();
+                }
+                return null;
+              });
+
+      assertThat(waiterStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      waitUntil(() -> locks.referenceCount("k") == 2);
+      assertThat(waiterEntered.await(100, TimeUnit.MILLISECONDS)).isFalse();
+
+      ignored.close();
+      waiter.get(5, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(locks.lockCount()).isZero();
+  }
+
+  @Test
+  void differentKeysProgressIndependently() throws Exception {
+    IdLockMap<String> locks = new IdLockMap<>();
+    CountDownLatch otherKeyEntered = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try (IdLockMap<String>.IdLock ignored = locks.acquire("a")) {
+      Future<?> otherKey =
+          executor.submit(
+              () -> {
+                try (IdLockMap<String>.IdLock ignoredOther = locks.acquire("b")) {
+                  otherKeyEntered.countDown();
+                }
+                return null;
+              });
+
+      assertThat(otherKeyEntered.await(5, TimeUnit.SECONDS)).isTrue();
+      otherKey.get(5, TimeUnit.SECONDS);
+      assertThat(locks.referenceCount("a")).isEqualTo(1);
+      assertThat(locks.referenceCount("b")).isZero();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(locks.lockCount()).isZero();
+  }
+
+  @Test
+  void manyThreadsContendOnSameKeySerially() throws Exception {
+    IdLockMap<String> locks = new IdLockMap<>();
+    int threads = 64;
+    CyclicBarrier startBarrier = new CyclicBarrier(threads);
+    AtomicInteger enteredHolders = new AtomicInteger();
+    AtomicInteger activeHolders = new AtomicInteger();
+    AtomicInteger maxActiveHolders = new AtomicInteger();
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    List<Future<?>> futures = new ArrayList<>();
+
+    try {
+      try (IdLockMap<String>.IdLock ignored = locks.acquire("k")) {
+        for (int i = 0; i < threads; i++) {
+          futures.add(
+              executor.submit(
+                  () -> {
+                    startBarrier.await(5, TimeUnit.SECONDS);
+                    try (IdLockMap<String>.IdLock ignoredWaiter = locks.acquire("k")) {
+                      int active = activeHolders.incrementAndGet();
+                      try {
+                        enteredHolders.incrementAndGet();
+                        maxActiveHolders.accumulateAndGet(active, Math::max);
+                        assertThat(active).isEqualTo(1);
+                        Thread.yield();
+                      } finally {
+                        activeHolders.decrementAndGet();
+                      }
+                    }
+                    return null;
+                  }));
+        }
+
+        waitUntil(() -> locks.referenceCount("k") == threads + 1);
+        assertThat(enteredHolders).hasValue(0);
+      }
+
+      for (Future<?> future : futures) {
+        future.get(10, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(enteredHolders).hasValue(threads);
+    assertThat(maxActiveHolders).hasValue(1);
+    assertThat(locks.lockCount()).isZero();
+    assertThat(locks.referenceCount("k")).isZero();
+  }
+
+  private static void waitUntil(BooleanSupplier assertion) throws Exception {
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (!assertion.getAsBoolean()) {
+      if (System.nanoTime() >= deadlineNanos) {
+        fail("condition was not met in time");
+      }
+      Thread.sleep(10);
+    }
+  }
+
+  @FunctionalInterface
+  private interface BooleanSupplier {
+    boolean getAsBoolean();
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1539/files) to review incremental changes.
- [**stack/uc-hadoop-cache**](https://github.com/unitycatalog/unitycatalog/pull/1539) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1539/files)]
  - [stack/uc-hadoop-move-only](https://github.com/unitycatalog/unitycatalog/pull/1538) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1538/files/f3fe43e3b95da1f0047f07f5a4b6e4fdf8a16ce8..633daf3c4edc2983c31682a1d74d0e952b742b82)]
    - [stack/uc-hadoop-drc-creds](https://github.com/unitycatalog/unitycatalog/pull/1527) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1527/files/633daf3c4edc2983c31682a1d74d0e952b742b82..5c73ae379e949cdeb60a4b2f73482456e3b881da)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds two utility classes to the `unitycatalog-hadoop` module so subsequent stacked PRs can move credential providers off Spark-shaded Guava:

- `internal/util/BoundedKeyedCache` — bounded LRU keyed cache built on JDK collections, with per-key locking via `withKeyLock` / `getOrLoad` and an optional eviction listener (used to close evicted FileSystems).
- `internal/util/CloseableUtils` — `closeQuietly(Closeable)` helper used as the default eviction action.

Both classes are package-private under `internal/util`. Tests cover LRU eviction order, eviction-listener invocation (null-safe), and per-key serialization in `getOrLoad`.

Pulled out into its own PR per @openinx's request so the cache can be reviewed and tested in isolation before #1538 starts using it.