### PR TITLE
Remove table_uri from commit metrics payload

### DIFF
--- a/spec/protocols/ManagedTablesSpec.md
+++ b/spec/protocols/ManagedTablesSpec.md
@@ -2,7 +2,7 @@
 
 > **Status**: Proposed  
 > **Version**: 0.1.0  
-> **Last Updated**: 2026-02-17
+> **Last Updated**: 2026-05-08
 
 ## Table of Contents
 
@@ -728,7 +728,6 @@ Publishes metrics information for maintenance operations provided by the Unity C
 Field Name | Data Type | Description | Optional/Required
 -|-|-|-
 table_id | string | Uniquely identifies the Delta table in Unity Catalog.<br>Format: UUID string. | required
-table_uri | string | The storage location of the Delta table.<br>Format: URI string (`s3://`, `abfss://`, `gs://`, etc.). | required
 report | Report | Contains information about which metrics are being sent. | optional
 &nbsp;&nbsp;report.commit_report | CommitReport | The commit report metrics. | optional
 &nbsp;&nbsp;&nbsp;&nbsp;report.commit_report.num_files_added | int64 | Number of files added by this commit. | optional
@@ -755,7 +754,6 @@ Request:
 ```json
 {
   "table_id": "abcdef12-3456-7890-abcd-ef1234567890",
-  "table_uri": "s3://my-bucket/main/default/my_table",
   "report": {
     "commit_report": {
       "num_files_added": 10,


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

We are removing `table_uri` as a field from the commit metrics payload. For metrics, only the `table_id ` field is required to uniquely identify a table.