### PR TITLE
New endpoint for Delta: updateTable supports set-columns / set-partition-columns

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -277,7 +277,7 @@ public class TableRepository {
           lockTableForDeltaUpdate(session, dao, catalog, schema, table);
           DeltaUpdateTableMapper.checkRequirements(dao, collected);
           MutablePropertyMap properties = MutablePropertyMap.load(session, dao.getId());
-          DeltaUpdateTableMapper.applyUpdates(dao, properties, collected);
+          DeltaUpdateTableMapper.applyUpdates(session, dao, properties, collected);
           properties.flush(session, dao.getId());
           dao.setUpdatedAt(new Date());
           dao.setUpdatedBy(callerId);

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -1,7 +1,6 @@
 package io.unitycatalog.server.service.delta;
 
 import io.unitycatalog.server.delta.model.CreateTableRequest;
-import io.unitycatalog.server.delta.model.StructField;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
@@ -10,7 +9,6 @@ import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.utils.ColumnUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,11 +79,7 @@ public final class DeltaCreateTableMapper {
         DeltaUniformUtils.getUniformFields(req.getUniform());
     DeltaUniformUtils.validateCreate(uniformFields, NormalizedURL.from(req.getLocation()));
 
-    List<ColumnInfo> columns = new ArrayList<>();
-    List<StructField> fields = req.getColumns().getFields();
-    for (int i = 0; i < fields.size(); i++) {
-      columns.add(ColumnUtils.toColumnInfo(fields.get(i), i));
-    }
+    List<ColumnInfo> columns = ColumnUtils.toColumnInfos(req.getColumns().getFields());
     ColumnUtils.applyPartitionColumns(columns, req.getPartitionColumns());
 
     CreateTable createTable =

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -351,6 +351,10 @@ public final class DeltaUpdateTableMapper {
       List<StructField> fields =
           ValidationUtils.checkNotNull(
               columns.getFields(), "set-columns requires columns.fields.");
+      if (fields.isEmpty()) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT, "set-columns requires at least one column.");
+      }
       newColumns = ColumnUtils.toColumnInfos(fields);
     } else {
       newColumns = ColumnInfoDAO.toList(dao.getColumns());
@@ -358,10 +362,15 @@ public final class DeltaUpdateTableMapper {
     }
     // Source of the partition list: the request when set-partition-columns is present, otherwise
     // the existing DAO's partition columns (preserved by name across a column-only action).
-    List<String> partitionNames =
-        setPartition
-            .map(SetPartitionColumnsUpdate::getPartitionColumns)
-            .orElseGet(() -> currentPartitionColumnNames(dao));
+    List<String> partitionNames;
+    if (setPartition.isPresent()) {
+      partitionNames =
+          ValidationUtils.checkNotNull(
+              setPartition.get().getPartitionColumns(),
+              "set-partition-columns requires a partition-columns list.");
+    } else {
+      partitionNames = currentPartitionColumnNames(dao);
+    }
     ColumnUtils.applyPartitionColumns(newColumns, partitionNames);
     List<ColumnInfoDAO> newColumnDAOs = ColumnInfoDAO.fromList(newColumns);
     newColumnDAOs.forEach(

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -7,21 +7,29 @@ import io.unitycatalog.server.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.server.delta.model.RemoveDomainMetadataUpdate;
 import io.unitycatalog.server.delta.model.RemovePropertiesUpdate;
 import io.unitycatalog.server.delta.model.SetDomainMetadataUpdate;
+import io.unitycatalog.server.delta.model.SetPartitionColumnsUpdate;
 import io.unitycatalog.server.delta.model.SetPropertiesUpdate;
 import io.unitycatalog.server.delta.model.SetProtocolUpdate;
+import io.unitycatalog.server.delta.model.SetSchemaUpdate;
 import io.unitycatalog.server.delta.model.SetTableCommentUpdate;
+import io.unitycatalog.server.delta.model.StructField;
+import io.unitycatalog.server.delta.model.StructType;
 import io.unitycatalog.server.delta.model.TableRequirement;
 import io.unitycatalog.server.delta.model.TableUpdate;
 import io.unitycatalog.server.delta.model.UpdateSnapshotVersionUpdate;
 import io.unitycatalog.server.delta.model.UpdateTableRequest;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.MutablePropertyMap;
+import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.service.delta.DeltaConsts.DomainMetadataNames;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
+import io.unitycatalog.server.utils.ColumnUtils;
 import io.unitycatalog.server.utils.ValidationUtils;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +38,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.hibernate.Session;
 
 /**
  * Translates a Delta {@link UpdateTableRequest} into in-memory mutations on a {@link TableInfoDAO}
@@ -153,6 +164,8 @@ public final class DeltaUpdateTableMapper {
     private Optional<SetPropertiesUpdate> setProperties = Optional.empty();
     private Optional<RemovePropertiesUpdate> removeProperties = Optional.empty();
     private Optional<SetProtocolUpdate> setProtocol = Optional.empty();
+    private Optional<SetSchemaUpdate> setSchema = Optional.empty();
+    private Optional<SetPartitionColumnsUpdate> setPartitionColumns = Optional.empty();
     private Optional<SetTableCommentUpdate> setTableComment = Optional.empty();
     private Optional<SetDomainMetadataUpdate> setDomainMetadata = Optional.empty();
     private Optional<RemoveDomainMetadataUpdate> removeDomainMetadata = Optional.empty();
@@ -165,6 +178,10 @@ public final class DeltaUpdateTableMapper {
         removeProperties = fillOnce(removeProperties, u, TableUpdate::getAction);
       } else if (update instanceof SetProtocolUpdate u) {
         setProtocol = fillOnce(setProtocol, u, TableUpdate::getAction);
+      } else if (update instanceof SetSchemaUpdate u) {
+        setSchema = fillOnce(setSchema, u, TableUpdate::getAction);
+      } else if (update instanceof SetPartitionColumnsUpdate u) {
+        setPartitionColumns = fillOnce(setPartitionColumns, u, TableUpdate::getAction);
       } else if (update instanceof SetTableCommentUpdate u) {
         setTableComment = fillOnce(setTableComment, u, TableUpdate::getAction);
       } else if (update instanceof SetDomainMetadataUpdate u) {
@@ -253,8 +270,12 @@ public final class DeltaUpdateTableMapper {
 
   /** Actions run in canonical order, not request order. */
   public static void applyUpdates(
-      TableInfoDAO dao, MutablePropertyMap properties, CollectedRequest collected) {
+      Session session,
+      TableInfoDAO dao,
+      MutablePropertyMap properties,
+      CollectedRequest collected) {
     CollectedUpdates c = collected.updates();
+    applySchemaAndPartitionColumns(session, dao, c.setSchema, c.setPartitionColumns);
     c.setProtocol.ifPresent(u -> applySetProtocol(properties, u.getProtocol()));
     c.setProperties.ifPresent(u -> applySetProperties(properties, u.getUpdates()));
     c.removeProperties.ifPresent(u -> applyRemoveProperties(properties, u.getRemovals()));
@@ -298,6 +319,68 @@ public final class DeltaUpdateTableMapper {
     Map<String, String> derived = new HashMap<>();
     DeltaPropertyMapper.deriveFromProtocol(derived, protocol);
     properties.putAll(derived);
+  }
+
+  /**
+   * Apply schema and/or partition-column changes by building the post-update column list once and
+   * swapping the DAO column collection. The spec frames {@code set-columns} and {@code
+   * set-partition-columns} as independent actions; the absent action's concern is preserved from
+   * the existing DAO so a column-only request can't silently desync the partition list (and vice
+   * versa). If a partition column is missing from the resulting schema, the request is rejected
+   * with {@code partition-columns references unknown column: ...}.
+   *
+   * <p>Swap semantics rely on the orphanRemoval mapping on {@link TableInfoDAO#getColumns()} to
+   * clean up the old rows; the intervening flush ensures the deletes hit the DB before the
+   * inserts, so the {@code (table_id, ordinal_position, name)} unique constraint doesn't trip.
+   */
+  private static void applySchemaAndPartitionColumns(
+      Session session,
+      TableInfoDAO dao,
+      Optional<SetSchemaUpdate> setSchema,
+      Optional<SetPartitionColumnsUpdate> setPartition) {
+    if (setSchema.isEmpty() && setPartition.isEmpty()) {
+      return;
+    }
+    // Source of the new schema: the request when set-columns is present, otherwise the existing
+    // DAO with partition indices cleared so applyPartitionColumns can re-stamp them below.
+    List<ColumnInfo> newColumns;
+    if (setSchema.isPresent()) {
+      StructType columns =
+          ValidationUtils.checkNotNull(
+              setSchema.get().getColumns(), "set-columns requires a columns block.");
+      List<StructField> fields =
+          ValidationUtils.checkNotNull(
+              columns.getFields(), "set-columns requires columns.fields.");
+      newColumns = ColumnUtils.toColumnInfos(fields);
+    } else {
+      newColumns = ColumnInfoDAO.toList(dao.getColumns());
+      newColumns.forEach(c -> c.setPartitionIndex(null));
+    }
+    // Source of the partition list: the request when set-partition-columns is present, otherwise
+    // the existing DAO's partition columns (preserved by name across a column-only action).
+    List<String> partitionNames =
+        setPartition
+            .map(SetPartitionColumnsUpdate::getPartitionColumns)
+            .orElseGet(() -> currentPartitionColumnNames(dao));
+    ColumnUtils.applyPartitionColumns(newColumns, partitionNames);
+    List<ColumnInfoDAO> newColumnDAOs = ColumnInfoDAO.fromList(newColumns);
+    newColumnDAOs.forEach(
+        c -> {
+          c.setId(UUID.randomUUID());
+          c.setTable(dao);
+        });
+    dao.getColumns().clear();
+    session.flush();
+    dao.getColumns().addAll(newColumnDAOs);
+  }
+
+  /** Names of the DAO's partition columns, ordered by partition index. */
+  private static List<String> currentPartitionColumnNames(TableInfoDAO dao) {
+    return ColumnInfoDAO.toList(dao.getColumns()).stream()
+        .filter(c -> c.getPartitionIndex() != null)
+        .sorted(Comparator.comparingInt(ColumnInfo::getPartitionIndex))
+        .map(ColumnInfo::getName)
+        .collect(Collectors.toList());
   }
 
   private static void applySetDomainMetadata(

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -272,7 +272,7 @@ public class ColumnUtils {
   /**
    * Project a list of Delta {@link StructField}s into UC {@link ColumnInfo}s, stamping each
    * column's {@code position} from its index in the list. Used by both the create and update paths
-   * of the Delta REST Catalog so the wire-order-to-position mapping stays in one place.
+   * of the UC Delta API so the wire-order-to-position mapping stays in one place.
    */
   public static List<ColumnInfo> toColumnInfos(List<StructField> fields) {
     List<ColumnInfo> columns = new ArrayList<>(fields.size());

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -17,6 +17,7 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.ColumnTypeName;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -266,6 +267,19 @@ public class ColumnUtils {
       column.comment(comment);
     }
     return column;
+  }
+
+  /**
+   * Project a list of Delta {@link StructField}s into UC {@link ColumnInfo}s, stamping each
+   * column's {@code position} from its index in the list. Used by both the create and update paths
+   * of the Delta REST Catalog so the wire-order-to-position mapping stays in one place.
+   */
+  public static List<ColumnInfo> toColumnInfos(List<StructField> fields) {
+    List<ColumnInfo> columns = new ArrayList<>(fields.size());
+    for (int i = 0; i < fields.size(); i++) {
+      columns.add(toColumnInfo(fields.get(i), i));
+    }
+    return columns;
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -10,13 +10,18 @@ import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.ErrorType;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.PrimitiveType;
 import io.unitycatalog.client.delta.model.RemoveDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.SetDomainMetadataUpdate;
+import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
 import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
 import io.unitycatalog.client.delta.model.SetProtocolUpdate;
+import io.unitycatalog.client.delta.model.SetSchemaUpdate;
 import io.unitycatalog.client.delta.model.SetTableCommentUpdate;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableRequirement;
 import io.unitycatalog.client.delta.model.TableUpdate;
 import io.unitycatalog.client.delta.model.UpdateSnapshotVersionUpdate;
@@ -198,6 +203,131 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                       .lastCommitTimestampMs(1700000000000L)),
           ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
           "EXTERNAL");
+    }
+
+    // -------- set-columns + set-partition-columns --------
+    {
+      Handle h = createDeltaExternal("tbl_setcols");
+      LoadTableResponse r =
+          updateTable(
+              h,
+              new SetSchemaUpdate()
+                  .columns(
+                      new StructType()
+                          .type("struct")
+                          .fields(
+                              List.of(
+                                  new StructField()
+                                      .name("new_id")
+                                      .type(new PrimitiveType().type("long"))
+                                      .nullable(false)
+                                      .metadata(Map.of()),
+                                  new StructField()
+                                      .name("flag")
+                                      .type(new PrimitiveType().type("boolean"))
+                                      .nullable(true)
+                                      .metadata(Map.of())))),
+              new SetPartitionColumnsUpdate().partitionColumns(List.of("flag")));
+      assertThat(r.getMetadata().getColumns().getFields())
+          .extracting(StructField::getName)
+          .containsExactly("new_id", "flag");
+      assertThat(r.getMetadata().getPartitionColumns()).containsExactly("flag");
+    }
+
+    // -------- set-partition-columns references unknown column --------
+    {
+      Handle h = createDeltaExternal("tbl_setpart_bad");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h, new SetPartitionColumnsUpdate().partitionColumns(List.of("nope"))),
+          ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+          "partition-columns references unknown column: nope");
+    }
+
+    // -------- set-columns with no columns block is rejected --------
+    {
+      Handle h = createDeltaExternal("tbl_setcols_no_block");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h, new SetSchemaUpdate()),
+          ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+          "set-columns requires a columns block");
+    }
+
+    // -------- set-partition-columns alone --------
+    // The partition-only branch of the unified schema/partition path: the existing schema is
+    // carried over (with partition indices cleared) and re-stamped with the requested partition
+    // list. Verify the partition is set and the column list itself is unchanged.
+    {
+      Handle h = createDeltaExternal("tbl_setpart_only");
+      LoadTableResponse r =
+          updateTable(h, new SetPartitionColumnsUpdate().partitionColumns(List.of("amount")));
+      assertThat(r.getMetadata().getColumns().getFields())
+          .extracting(StructField::getName)
+          .containsExactly("id", "amount");
+      assertThat(r.getMetadata().getPartitionColumns()).containsExactly("amount");
+    }
+
+    // -------- set-columns alone preserves existing partition columns by name --------
+    // Establish a partitioned table partitioned by id, then send set-columns alone with a new
+    // schema that still contains id. Partition list must survive the schema swap; a silent
+    // clear would desynchronize the partition list from the column definitions.
+    // (createDeltaExternal seeds (id long, amount double); only `id` exists in both old and new.)
+    {
+      Handle h = createDeltaExternal("tbl_setcols_preserve_part");
+      LoadTableResponse partitionSetup =
+          updateTable(h, new SetPartitionColumnsUpdate().partitionColumns(List.of("id")));
+      Handle h1 = h.withEtag(partitionSetup.getMetadata().getEtag());
+      LoadTableResponse r =
+          updateTable(
+              h1,
+              new SetSchemaUpdate()
+                  .columns(
+                      new StructType()
+                          .type("struct")
+                          .fields(
+                              List.of(
+                                  new StructField()
+                                      .name("id")
+                                      .type(new PrimitiveType().type("long"))
+                                      .nullable(false)
+                                      .metadata(Map.of()),
+                                  new StructField()
+                                      .name("flag")
+                                      .type(new PrimitiveType().type("boolean"))
+                                      .nullable(true)
+                                      .metadata(Map.of())))));
+      assertThat(r.getMetadata().getColumns().getFields())
+          .extracting(StructField::getName)
+          .containsExactly("id", "flag");
+      assertThat(r.getMetadata().getPartitionColumns()).containsExactly("id");
+    }
+
+    // -------- set-columns alone that drops a previously-partition column is rejected --------
+    // Partition is on `id`; the new schema replaces `id` with `id2`. Silent partition clearing
+    // would leave the table inconsistent, so this must fail with the unknown-column error.
+    {
+      Handle h = createDeltaExternal("tbl_setcols_drop_part");
+      Handle h1 =
+          h.withEtag(
+              updateTable(h, new SetPartitionColumnsUpdate().partitionColumns(List.of("id")))
+                  .getMetadata()
+                  .getEtag());
+      TestUtils.assertDeltaApiException(
+          () ->
+              updateTable(
+                  h1,
+                  new SetSchemaUpdate()
+                      .columns(
+                          new StructType()
+                              .type("struct")
+                              .fields(
+                                  List.of(
+                                      new StructField()
+                                          .name("id2")
+                                          .type(new PrimitiveType().type("long"))
+                                          .nullable(false)
+                                          .metadata(Map.of()))))),
+          ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+          "partition-columns references unknown column: id");
     }
 
     // -------- assert-etag conflict: mutate once to roll the etag, then resubmit with the stale

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -252,6 +252,26 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
           "set-columns requires a columns block");
     }
 
+    // -------- set-columns with an empty fields list is rejected --------
+    {
+      Handle h = createDeltaExternal("tbl_setcols_empty_fields");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h, new SetSchemaUpdate().columns(new StructType().fields(List.of()))),
+          ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+          "set-columns requires at least one column");
+    }
+
+    // -------- set-partition-columns with a null partition-columns field is rejected --------
+    // The Java client model defaults the field to an empty list, so an explicit null is needed
+    // to exercise the wire-level "field missing" case (Jackson NON_NULL inclusion omits it).
+    {
+      Handle h = createDeltaExternal("tbl_setpart_null_field");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h, new SetPartitionColumnsUpdate().partitionColumns(null)),
+          ErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+          "set-partition-columns requires a partition-columns list");
+    }
+
     // -------- set-partition-columns alone --------
     // The partition-only branch of the unified schema/partition path: the existing schema is
     // carried over (with partition indices cleared) and re-stamped with the requested partition


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1545/files) to review incremental changes.
- [**stack/drc_update_table_columns**](https://github.com/unitycatalog/unitycatalog/pull/1545) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1545/files)]
  - [stack/drc_commit](https://github.com/unitycatalog/unitycatalog/pull/1546) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1546/files/54dea8f73ea105edb5afffb93d9e786163e5752f..5425098d6a18abac44fa16a58f3acc148e17f0c2)]
    - [stack/phaseout](https://github.com/unitycatalog/unitycatalog/pull/1555) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1555/files/5425098d6a18abac44fa16a58f3acc148e17f0c2..063190cae2c6ff52e04de2faaad3c4f459f954f6)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
New endpoint for Delta: updateTable supports set-columns / set-partition-columns

Adds schema and partition-column mutation actions to the Delta updateTable endpoint. set-columns replaces the column definitions; set-partition-columns replaces the partition list. The two are independent per spec, so a column-only request preserves the existing partition columns by name (rejecting if a previously-partition column is missing from the new schema), and a partition-only request leaves the schema untouched. Both actions share one combined pass that builds the post-update column list and swaps the DAO column collection once.

Not in this PR (follow-up): add-commit / set-latest-backfilled-version on the commit endpoint.
