### PR TITLE
Add DeltaApiException for typed Delta error envelope access

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
@@ -1,0 +1,100 @@
+package io.unitycatalog.client.delta;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.model.ErrorModel;
+import io.unitycatalog.client.delta.model.ErrorResponse;
+import io.unitycatalog.client.delta.model.ErrorType;
+import java.util.Optional;
+
+/**
+ * Delta-specific specialization of {@link ApiException}. Parses the spec-defined error envelope
+ * ({@code {"error": {"code", "type", "message", "stack"}}}) once at construction and exposes typed
+ * accessors so call sites don't repeat the parse-from-responseBody dance.
+ *
+ * <p>Designed to wrap an existing {@link ApiException}: callers that catch the generated base type
+ * can upgrade it with {@link #from(ApiException)} when they want the typed view. The wrapping is
+ * caller-driven for now; the structure is set up so a future {@code ApiClient} interceptor can do
+ * the wrap automatically without touching call sites that already use this class. Until then, both
+ * shapes co-exist:
+ *
+ * <pre>{@code
+ * try {
+ *   deltaTablesApi.updateTable(...);
+ * } catch (ApiException ex) {
+ *   DeltaApiException.from(ex).ifPresent(d -> {
+ *     ErrorType type = d.getErrorType();      // spec-defined enum
+ *     String message = d.getErrorMessage();   // spec-defined message
+ *     // ...
+ *   });
+ *   throw ex;
+ * }
+ * }</pre>
+ */
+public class DeltaApiException extends ApiException {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** {@code null} if the response body wasn't parseable as a Delta error envelope. */
+  private final ErrorModel error;
+
+  /**
+   * Wrap an existing {@link ApiException}, copying its HTTP code, headers, body, cause, and message
+   * through, and parsing the response body into the Delta error envelope. If the body isn't
+   * parseable, {@link #getError()} (and the typed accessors derived from it) return null; callers
+   * wanting a hard parse failure should use {@link #from(ApiException)} instead and react to an
+   * empty {@link Optional}.
+   */
+  public DeltaApiException(ApiException source) {
+    super(
+        source.getMessage(),
+        source.getCause(),
+        source.getCode(),
+        source.getResponseHeaders(),
+        source.getResponseBody());
+    this.error = parse(source.getResponseBody());
+  }
+
+  /**
+   * Lenient upgrade: returns a {@link DeltaApiException} only when the response body parses cleanly
+   * as a Delta error envelope. {@link Optional#empty()} typically means the response wasn't from
+   * the Delta surface, or the server emitted a non-spec body -- in either case the caller can fall
+   * back to the generic {@link ApiException} it was given.
+   */
+  public static Optional<DeltaApiException> from(ApiException ex) {
+    DeltaApiException upgraded = new DeltaApiException(ex);
+    return upgraded.error == null ? Optional.empty() : Optional.of(upgraded);
+  }
+
+  /** The full parsed error envelope. {@code null} if the body wasn't a Delta error response. */
+  public ErrorModel getError() {
+    return error;
+  }
+
+  /** {@code error.code}: spec-defined HTTP status code (typically matches {@link #getCode()}). */
+  public Integer getErrorCode() {
+    return error == null ? null : error.getCode();
+  }
+
+  /** {@code error.type}: spec-defined error-type enum, e.g. {@code TABLE_NOT_FOUND_EXCEPTION}. */
+  public ErrorType getErrorType() {
+    return error == null ? null : error.getType();
+  }
+
+  /** {@code error.message}: spec-defined human-readable message. */
+  public String getErrorMessage() {
+    return error == null ? null : error.getMessage();
+  }
+
+  private static ErrorModel parse(String body) {
+    if (body == null || body.isEmpty()) {
+      return null;
+    }
+    try {
+      ErrorResponse response = MAPPER.readValue(body, ErrorResponse.class);
+      return response == null ? null : response.getError();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.client.delta;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.ApiException;
@@ -36,7 +37,7 @@ public class DeltaApiException extends ApiException {
 
   private static final ObjectMapper MAPPER = createObjectMapper();
 
-  protected static ObjectMapper createObjectMapper() {
+  private static ObjectMapper createObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
@@ -53,10 +54,10 @@ public class DeltaApiException extends ApiException {
    * wanting a hard parse failure should use {@link #from(ApiException)} instead and react to an
    * empty {@link Optional}.
    */
-  public DeltaApiException(ApiException source) {
+  private DeltaApiException(ApiException source) {
     super(
         source.getMessage(),
-        source.getCause(),
+        source, // preserve original ApiException stack/cause
         source.getCode(),
         source.getResponseHeaders(),
         source.getResponseBody());
@@ -65,9 +66,8 @@ public class DeltaApiException extends ApiException {
 
   /**
    * Lenient upgrade: returns a {@link DeltaApiException} only when the response body parses cleanly
-   * as a Delta error envelope. {@link Optional#empty()} typically means the response wasn't from
-   * the Delta surface, or the server emitted a non-spec body -- in either case the caller can fall
-   * back to the generic {@link ApiException} it was given.
+   * as a Delta error envelope. Returns empty when the body is null/empty, isn't valid JSON, is
+   * missing the error envelope, or has "error": null.
    */
   public static Optional<DeltaApiException> from(ApiException ex) {
     DeltaApiException upgraded = new DeltaApiException(ex);
@@ -84,7 +84,7 @@ public class DeltaApiException extends ApiException {
     return error == null ? null : error.getCode();
   }
 
-  /** {@code error.type}: spec-defined error-type enum, e.g. {@code TABLE_NOT_FOUND_EXCEPTION}. */
+  /** {@code error.type}: spec-defined error-type enum, e.g. {@code NO_SUCH_TABLE_EXCEPTION}. */
   public ErrorType getErrorType() {
     return error == null ? null : error.getType();
   }
@@ -101,7 +101,7 @@ public class DeltaApiException extends ApiException {
     try {
       ErrorResponse response = MAPPER.readValue(body, ErrorResponse.class);
       return response == null ? null : response.getError();
-    } catch (Exception e) {
+    } catch (JacksonException e) {
       return null;
     }
   }

--- a/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/delta/DeltaApiException.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.client.delta;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.model.ErrorModel;
@@ -33,7 +34,14 @@ import java.util.Optional;
  */
 public class DeltaApiException extends ApiException {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = createObjectMapper();
+
+  protected static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    return mapper;
+  }
 
   /** {@code null} if the response body wasn't parseable as a Delta error envelope. */
   private final ErrorModel error;

--- a/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
@@ -51,25 +51,26 @@ public class DeltaApiExceptionTest {
 
   @Test
   public void constructorTolerantOfUnparseableBody() {
-    // The public constructor is lenient: parse failures leave error == null rather than throw.
-    // Callers wanting a hard parse failure should use from() and react to the empty Optional.
-    DeltaApiException delta = new DeltaApiException(new ApiException(400, "msg", null, "not json"));
-    assertThat(delta.getError()).isNull();
-    assertThat(delta.getErrorCode()).isNull();
-    assertThat(delta.getErrorType()).isNull();
-    assertThat(delta.getErrorMessage()).isNull();
-    // Passthrough still works.
-    assertThat(delta.getCode()).isEqualTo(400);
-    assertThat(delta.getResponseBody()).isEqualTo("not json");
+    // The public constructor is lenient: parse failures leave error == empty rather than throw.
+    Optional<DeltaApiException> delta =
+        DeltaApiException.from(new ApiException(400, "msg", null, "not json"));
+    assertThat(delta).isEmpty();
   }
 
   @Test
   public void resultIsAlsoAnApiException() {
-    // Callers that catch ApiException continue to work after the upgrade.
-    Optional<DeltaApiException> upgraded =
-        DeltaApiException.from(new ApiException(404, "msg", null, VALID_BODY));
-    assertThat(upgraded).isPresent();
-    assertThat(upgraded.get()).isInstanceOf(ApiException.class);
+    // Callers that catch ApiException continue to work after the upgrade..
+    DeltaApiException upgraded =
+        DeltaApiException.from(
+                new ApiException("msg", new RuntimeException("re"), 404, null, VALID_BODY))
+            .get();
+    assertThat(upgraded).isInstanceOf(ApiException.class);
+    assertThat(upgraded.getErrorCode()).isEqualTo(404);
+    // The cause is the original ApiException
+    assertThat(upgraded.getCause()).isInstanceOf(ApiException.class);
+    ApiException cause = (ApiException) upgraded.getCause();
+    // The cause.cause is the original cause RuntimeException
+    assertThat(cause.getCause()).isInstanceOf(RuntimeException.class);
   }
 
   @Test

--- a/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
@@ -1,0 +1,74 @@
+package io.unitycatalog.client.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.model.ErrorType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DeltaApiException}: parsing the Delta error envelope, the lenient {@link
+ * DeltaApiException#from} factory's empty/present return values, and field passthrough from the
+ * wrapped {@link ApiException}.
+ */
+public class DeltaApiExceptionTest {
+
+  private static final String VALID_BODY =
+      "{\"error\":{\"code\":404,\"type\":\"NoSuchTableException\","
+          + "\"message\":\"Table not found: c.s.t\"}}";
+
+  @Test
+  public void fromParsesValidErrorEnvelope() {
+    ApiException source = new ApiException(404, "msg", null, VALID_BODY);
+    DeltaApiException delta = DeltaApiException.from(source).orElseThrow();
+    assertThat(delta.getErrorCode()).isEqualTo(404);
+    assertThat(delta.getErrorType()).isEqualTo(ErrorType.NO_SUCH_TABLE_EXCEPTION);
+    assertThat(delta.getErrorMessage()).isEqualTo("Table not found: c.s.t");
+    // ApiException fields pass through unchanged.
+    assertThat(delta.getCode()).isEqualTo(404);
+    assertThat(delta.getResponseBody()).isEqualTo(VALID_BODY);
+  }
+
+  @Test
+  public void fromReturnsEmptyOnNullBody() {
+    ApiException source = new ApiException(500, "msg", null, null);
+    assertThat(DeltaApiException.from(source)).isEmpty();
+  }
+
+  @Test
+  public void fromReturnsEmptyOnMalformedJson() {
+    ApiException source = new ApiException(400, "msg", null, "this is not json");
+    assertThat(DeltaApiException.from(source)).isEmpty();
+  }
+
+  @Test
+  public void fromReturnsEmptyWhenErrorEnvelopeAbsent() {
+    // Well-formed JSON, but no "error" key -- the body isn't a Delta error response.
+    ApiException source = new ApiException(400, "msg", null, "{\"unrelated\":\"x\"}");
+    assertThat(DeltaApiException.from(source)).isEmpty();
+  }
+
+  @Test
+  public void constructorTolerantOfUnparseableBody() {
+    // The public constructor is lenient: parse failures leave error == null rather than throw.
+    // Callers wanting a hard parse failure should use from() and react to the empty Optional.
+    DeltaApiException delta = new DeltaApiException(new ApiException(400, "msg", null, "not json"));
+    assertThat(delta.getError()).isNull();
+    assertThat(delta.getErrorCode()).isNull();
+    assertThat(delta.getErrorType()).isNull();
+    assertThat(delta.getErrorMessage()).isNull();
+    // Passthrough still works.
+    assertThat(delta.getCode()).isEqualTo(400);
+    assertThat(delta.getResponseBody()).isEqualTo("not json");
+  }
+
+  @Test
+  public void resultIsAlsoAnApiException() {
+    // Callers that catch ApiException continue to work after the upgrade.
+    Optional<DeltaApiException> upgraded =
+        DeltaApiException.from(new ApiException(404, "msg", null, VALID_BODY));
+    assertThat(upgraded).isPresent();
+    assertThat(upgraded.get()).isInstanceOf(ApiException.class);
+  }
+}

--- a/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/delta/DeltaApiExceptionTest.java
@@ -71,4 +71,42 @@ public class DeltaApiExceptionTest {
     assertThat(upgraded).isPresent();
     assertThat(upgraded.get()).isInstanceOf(ApiException.class);
   }
+
+  @Test
+  public void fromReturnsEmptyWhenErrorFieldIsNull() {
+    // `{"error":null}` -- the envelope is well-formed but carries no error block. Treated the
+    // same as a missing envelope: from() returns empty so callers fall back to the raw
+    // ApiException.
+    ApiException source = new ApiException(500, "msg", null, "{\"error\":null}");
+    assertThat(DeltaApiException.from(source)).isEmpty();
+  }
+
+  @Test
+  public void parsesEmptyErrorBlockWithNullSubfields() {
+    // `{"error":{}}` -- the error block is present but every subfield is null. By design we return
+    // a present DeltaApiException (the envelope was parseable) with null typed accessors; callers
+    // wanting a "no useful info" signal should null-check the accessors. Locks the best-effort
+    // contract described in the from() Javadoc.
+    DeltaApiException delta =
+        DeltaApiException.from(new ApiException(400, "msg", null, "{\"error\":{}}")).orElseThrow();
+    assertThat(delta.getErrorCode()).isNull();
+    assertThat(delta.getErrorType()).isNull();
+    assertThat(delta.getErrorMessage()).isNull();
+    assertThat(delta.getError()).isNotNull();
+  }
+
+  @Test
+  public void tolerantOfUnknownFields() {
+    // Pins the FAIL_ON_UNKNOWN_PROPERTIES=false setting in createObjectMapper(). If someone
+    // removes that configure() call, this test catches the regression: a server emitting a new
+    // spec field would otherwise stop parsing entirely.
+    String body =
+        "{\"error\":{\"code\":404,\"type\":\"NoSuchTableException\","
+            + "\"message\":\"Table not found\",\"unknownField\":\"ignored\"}}";
+    DeltaApiException delta =
+        DeltaApiException.from(new ApiException(404, "msg", null, body)).orElseThrow();
+    assertThat(delta.getErrorCode()).isEqualTo(404);
+    assertThat(delta.getErrorType()).isEqualTo(ErrorType.NO_SUCH_TABLE_EXCEPTION);
+    assertThat(delta.getErrorMessage()).isEqualTo("Table not found");
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -3,12 +3,11 @@ package io.unitycatalog.server.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.delta.model.ErrorResponse;
+import io.unitycatalog.client.delta.DeltaApiException;
 import io.unitycatalog.client.delta.model.ErrorType;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.server.base.ServerConfig;
@@ -16,6 +15,7 @@ import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.function.Executable;
 
 public class TestUtils {
@@ -84,8 +84,6 @@ public class TestUtils {
     assertThat(ex.getCode()).isEqualTo(errorCode.getHttpStatus().code());
   }
 
-  private static final ObjectMapper DELTA_ERROR_MAPPER = new ObjectMapper();
-
   public static void assertDeltaApiException(
       Executable executable, ErrorType expectedType, String expectedMessageSubstring) {
     int expectedCode = ErrorCode.getDeltaHttpStatus(expectedType.getValue()).code();
@@ -93,17 +91,14 @@ public class TestUtils {
     // Check message first for better diagnostics on failure (includes the full response body)
     assertThat(ex.getMessage()).contains(expectedMessageSubstring);
     assertThat(ex.getCode()).isEqualTo(expectedCode);
-    try {
-      ErrorResponse errorResponse =
-          DELTA_ERROR_MAPPER.readValue(ex.getResponseBody(), ErrorResponse.class);
-      assertThat(errorResponse.getError().getCode()).isEqualTo(expectedCode);
-      assertThat(errorResponse.getError().getType()).isEqualTo(expectedType);
-      assertThat(errorResponse.getError().getMessage()).contains(expectedMessageSubstring);
-    } catch (Exception e) {
-      assertThat(false)
-          .as("Failed to parse Delta error response: " + ex.getResponseBody())
-          .isTrue();
-    }
+    Optional<DeltaApiException> deltaExOpt = DeltaApiException.from(ex);
+    assertThat(deltaExOpt)
+        .as("Failed to parse Delta error response: " + ex.getResponseBody())
+        .isPresent();
+    DeltaApiException delta = deltaExOpt.get();
+    assertThat(delta.getErrorCode()).isEqualTo(expectedCode);
+    assertThat(delta.getErrorType()).isEqualTo(expectedType);
+    assertThat(delta.getErrorMessage()).contains(expectedMessageSubstring);
   }
 
   /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1547/files) to review incremental changes.
- [**stack/client_error**](https://github.com/unitycatalog/unitycatalog/pull/1547) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1547/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Add DeltaApiException for typed Delta error envelope access

A specialization of ApiException that parses the Delta error envelope ({error: {code, type, message, stack}}) and exposes typed accessors (getErrorCode, getErrorType, getErrorMessage). Construct via DeltaApiException.from(ApiException) when a Delta error body is expected; falls back to Optional.empty() if the body isn't parseable. TestUtils.assertDeltaApiException now goes through it, replacing the inline ObjectMapper.readValue. Sets up the path to a future ApiClient-level auto-wrap without touching call sites.
