### PR TITLE
[Hadoop] Revisit Hadoop credential API for Delta tables

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.hadoop;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.StorageCredential;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.model.PathOperation;
@@ -8,6 +9,7 @@ import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,10 +65,10 @@ public final class UCCredentialHadoopConfs {
     private Configuration hadoopConf = new Configuration(false);
     private final Map<String, String> engineVersionProps = new LinkedHashMap<>();
 
-    private Builder(String uri, String scheme) {
-      Preconditions.checkArgument(uri != null, "catalogUri is required");
+    private Builder(String catalogUri, String scheme) {
+      Preconditions.checkArgument(catalogUri != null, "catalogUri is required");
       Preconditions.checkArgument(scheme != null, "scheme is required");
-      this.catalogUri = uri;
+      this.catalogUri = catalogUri;
       this.scheme = scheme;
     }
 
@@ -183,47 +185,39 @@ public final class UCCredentialHadoopConfs {
     /**
      * Builds Hadoop properties for a UC Delta table's storage location.
      *
-     * @param tableId the UC table UUID, used to scope the credential cache and filesystem cache
      * @param catalog the UC catalog name
      * @param schema the UC schema name
      * @param table the UC table name
+     * @param operation the credential operation to request from the UC Delta credentials API
      * @param location the table storage location used to select a returned storage credential
      * @return unmodifiable map; empty if the scheme is unrecognized
-     * @throws IllegalArgumentException if a table identity field is missing
+     * @throws IllegalArgumentException if a table identity, operation, or location field is missing
      * @throws IllegalStateException if a required builder field is missing
      */
     public Map<String, String> buildForTable(
-        String tableId, String catalog, String schema, String table, String location) {
-      Preconditions.checkArgument(tableId != null && !tableId.isEmpty(), "tableId is required");
-      Preconditions.checkArgument(catalog != null && !catalog.isEmpty(), "catalog is required");
-      Preconditions.checkArgument(schema != null && !schema.isEmpty(), "schema is required");
-      Preconditions.checkArgument(table != null && !table.isEmpty(), "table is required");
+        String catalog,
+        String schema,
+        String table,
+        CredentialOperation operation,
+        String location) {
+      UCDeltaTableIdentifier identifier = UCDeltaTableIdentifier.of(catalog, schema, table);
+      Preconditions.checkArgument(operation != null, "operation is required");
       Preconditions.checkArgument(location != null && !location.isEmpty(), "location is required");
       validateUcDeltaApi();
       TemporaryCredentials tempCreds =
           DeltaStorageCredentialUtil.toTemporaryCredentials(initialStorageCredential);
-      Map<String, String> props =
-          CredPropsUtil.createTableCredProps(
+      return withEngineVersionProps(
+          CredPropsUtil.createDeltaTableCredProps(
               credentialRenewalEnabled,
               credentialScopedFsEnabled,
               hadoopConf,
               scheme,
               catalogUri,
               tokenProvider,
-              tableId,
-              DeltaStorageCredentialUtil.toTableOperation(initialStorageCredential.getOperation()),
-              tempCreds);
-      if (props.isEmpty()) {
-        return props;
-      }
-      Map<String, String> deltaProps = new HashMap<>(props);
-      deltaProps.put(
-          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, Boolean.TRUE.toString());
-      deltaProps.put(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, catalog);
-      deltaProps.put(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, schema);
-      deltaProps.put(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, table);
-      deltaProps.put(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
-      return withEngineVersionProps(Collections.unmodifiableMap(deltaProps));
+              identifier,
+              location,
+              operation,
+              tempCreds));
     }
 
     /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.hadoop.internal;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
@@ -78,12 +79,40 @@ public class CredPropsUtil {
     }
 
     public T tableId(String tableId) {
+      Preconditions.checkState(
+          !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
+          "tableId cannot be set with UC Delta table identifier");
       builder.put(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
+      return self();
+    }
+
+    public T ucDeltaTableIdentifier(UCDeltaTableIdentifier identifier, String location) {
+      Preconditions.checkState(
+          !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY),
+          "UC Delta table identifier cannot be set with tableId");
+      builder.put(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
+      builder.put(
+          UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+          UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+      builder.put(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, identifier.catalog());
+      builder.put(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, identifier.schema());
+      builder.put(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, identifier.table());
+      builder.put(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
       return self();
     }
 
     public T tableOperation(TableOperation tableOp) {
       builder.put(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, tableOp.getValue());
+      return self();
+    }
+
+    public T credentialOperation(CredentialOperation credentialOp) {
+      Preconditions.checkArgument(
+          credentialOp == CredentialOperation.READ
+              || credentialOp == CredentialOperation.READ_WRITE,
+          "UC Delta supports READ and READ_WRITE credential operations, got: %s",
+          credentialOp);
+      builder.put(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, credentialOp.getValue());
       return self();
     }
 
@@ -117,7 +146,7 @@ public class CredPropsUtil {
     }
   }
 
-  private static class S3PropsBuilder extends PropsBuilder<S3PropsBuilder> {
+  static class S3PropsBuilder extends PropsBuilder<S3PropsBuilder> {
 
     S3PropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
       // Common properties for S3.
@@ -417,6 +446,67 @@ public class CredPropsUtil {
         .path(path)
         .pathOperation(pathOp)
         .build();
+  }
+
+  /**
+   * Builds the Hadoop configuration properties needed to access a UC Delta table's storage.
+   *
+   * @param renewCredEnabled when {@code true}, configures a vended-token provider that
+   *     automatically refreshes credentials before expiry; when {@code false}, embeds the initial
+   *     credentials as static keys.
+   * @param credScopedFsEnabled when {@code true}, overrides {@code fs.<scheme>.impl} with
+   *     CredScopedFileSystem so that filesystem instances are reused per credential scope rather
+   *     than created anew for every file access.
+   * @param hadoopConf the engine's existing Hadoop configuration, used to read any previously
+   *     configured {@code fs.<scheme>.impl} values before they are overridden by
+   *     CredScopedFileSystem.
+   */
+  public static Map<String, String> createDeltaTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      String uri,
+      TokenProvider tokenProvider,
+      UCDeltaTableIdentifier identifier,
+      String location,
+      CredentialOperation credentialOp,
+      TemporaryCredentials tempCreds) {
+    switch (scheme) {
+      case "s3":
+        if (renewCredEnabled) {
+          return s3TempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .ucDeltaTableIdentifier(identifier, location)
+              .credentialOperation(credentialOp)
+              .build();
+        } else {
+          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      case "gs":
+        if (renewCredEnabled) {
+          return gcsTempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .ucDeltaTableIdentifier(identifier, location)
+              .credentialOperation(credentialOp)
+              .build();
+        } else {
+          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      case "abfss":
+      case "abfs":
+        if (renewCredEnabled) {
+          return abfsTempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .ucDeltaTableIdentifier(identifier, location)
+              .credentialOperation(credentialOp)
+              .build();
+        } else {
+          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      default:
+        return Collections.emptyMap();
+    }
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -1,33 +1,17 @@
 package io.unitycatalog.hadoop.internal;
 
-import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.StorageCredential;
 import io.unitycatalog.client.delta.model.StorageCredentialConfig;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
-import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import java.util.List;
 
 /** Internal utility for UC Delta storage credentials. */
 public final class DeltaStorageCredentialUtil {
   private DeltaStorageCredentialUtil() {}
-
-  /** Converts a UC Delta credential operation to the equivalent standard UC table operation. */
-  public static TableOperation toTableOperation(CredentialOperation op) {
-    Preconditions.checkArgument(op != null, "StorageCredential.operation is required");
-    switch (op) {
-      case READ:
-        return TableOperation.READ;
-      case READ_WRITE:
-        return TableOperation.READ_WRITE;
-      default:
-        throw new IllegalArgumentException(
-            "Unsupported UC Delta table credential operation: " + op);
-    }
-  }
 
   /** Converts one UC Delta storage credential into standard UC temporary credentials. */
   public static TemporaryCredentials toTemporaryCredentials(StorageCredential cred) {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCDeltaTableIdentifier.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCDeltaTableIdentifier.java
@@ -1,0 +1,68 @@
+package io.unitycatalog.hadoop.internal;
+
+import io.unitycatalog.client.internal.Preconditions;
+import java.util.Objects;
+
+/**
+ * Internal identifier for a UC Delta table by catalog, schema, and table name.
+ *
+ * <p>This identifier is used when building Hadoop configuration properties for the UC Delta
+ * temporary credentials API.
+ */
+public final class UCDeltaTableIdentifier {
+  private final String catalog;
+  private final String schema;
+  private final String table;
+
+  private UCDeltaTableIdentifier(String catalog, String schema, String table) {
+    Preconditions.checkArgument(catalog != null && !catalog.isEmpty(), "catalog is required");
+    Preconditions.checkArgument(schema != null && !schema.isEmpty(), "schema is required");
+    Preconditions.checkArgument(table != null && !table.isEmpty(), "table is required");
+    this.catalog = catalog;
+    this.schema = schema;
+    this.table = table;
+  }
+
+  /** Creates an identifier for the table {@code catalog.schema.table}. */
+  public static UCDeltaTableIdentifier of(String catalog, String schema, String table) {
+    return new UCDeltaTableIdentifier(catalog, schema, table);
+  }
+
+  /** Returns the UC catalog name. */
+  public String catalog() {
+    return catalog;
+  }
+
+  /** Returns the UC schema name. */
+  public String schema() {
+    return schema;
+  }
+
+  /** Returns the UC table name. */
+  public String table() {
+    return table;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(catalog, schema, table);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof UCDeltaTableIdentifier)) {
+      return false;
+    } else if (this == o) {
+      return true;
+    }
+    UCDeltaTableIdentifier that = (UCDeltaTableIdentifier) o;
+    return Objects.equals(catalog, that.catalog)
+        && Objects.equals(schema, that.schema)
+        && Objects.equals(table, that.table);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s.%s.%s", catalog, schema, table);
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApi.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaTempCredentialApi.java
@@ -5,7 +5,6 @@ import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.CredentialsResponse;
 import io.unitycatalog.client.internal.Preconditions;
-import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import org.apache.hadoop.conf.Configuration;
@@ -57,7 +56,7 @@ final class UCDeltaTempCredentialApi implements TempCredentialApi {
   }
 
   static CredentialOperation toCredentialOperation(String tableOperation) {
-    switch (TableOperation.fromValue(tableOperation)) {
+    switch (CredentialOperation.fromValue(tableOperation)) {
       case READ:
         return CredentialOperation.READ;
       case READ_WRITE:

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.fs;
 
+import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.Objects;
@@ -9,11 +10,13 @@ import org.apache.hadoop.fs.FileSystem;
 /**
  * Cache key that identifies a credential scope for {@link CredScopedFileSystem}.
  *
- * <p>There are three implementations:
+ * <p>There are four implementations:
  *
  * <ul>
  *   <li>{@link TableCredScopedKey} — keyed by table ID and operation; used for table-level
- *       temporary credentials.
+ *       temporary credentials via the UC credentials API.
+ *   <li>{@link DeltaTableCredScopedKey} — keyed by table identity, operation, and location; used
+ *       for table-level temporary credentials via the UC Delta credentials API.
  *   <li>{@link PathCredScopedKey} — keyed by path and operation; used for path-level temporary
  *       credentials.
  *   <li>{@link DefaultCredScopedKey} — keyed by URI scheme and authority; used as a fallback when
@@ -27,11 +30,20 @@ public interface CredScopedKey {
     if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
       String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
       String pathOperation = conf.get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY);
-
       return new PathCredScopedKey(path, pathOperation);
     } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
-      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
       String tableOperation = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
+      if (conf.getBoolean(
+          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
+          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE)) {
+        String catalog = conf.get(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY);
+        String schema = conf.get(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY);
+        String tableName = conf.get(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY);
+        String location = conf.get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+        UCDeltaTableIdentifier identifier = UCDeltaTableIdentifier.of(catalog, schema, tableName);
+        return new DeltaTableCredScopedKey(identifier, tableOperation, location);
+      }
+      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
       return new TableCredScopedKey(tableId, tableOperation);
     }
 
@@ -92,6 +104,45 @@ public interface CredScopedKey {
     @Override
     public String toString() {
       return "TableCredScopedKey{tableId=" + tableId + ", op=" + tableOperation + "}";
+    }
+  }
+
+  class DeltaTableCredScopedKey implements CredScopedKey {
+    private final UCDeltaTableIdentifier identifier;
+    private final String tableOperation;
+    private final String location;
+
+    public DeltaTableCredScopedKey(
+        UCDeltaTableIdentifier identifier, String tableOperation, String location) {
+      this.identifier = identifier;
+      this.tableOperation = tableOperation;
+      this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof DeltaTableCredScopedKey)) return false;
+      DeltaTableCredScopedKey that = (DeltaTableCredScopedKey) o;
+      return Objects.equals(identifier, that.identifier)
+          && Objects.equals(tableOperation, that.tableOperation)
+          && Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(identifier, tableOperation, location);
+    }
+
+    @Override
+    public String toString() {
+      return "DeltaTableCredScopedKey{table="
+          + identifier
+          + ", op="
+          + tableOperation
+          + ", location="
+          + location
+          + "}";
     }
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
@@ -441,7 +441,8 @@ class UCCredentialHadoopConfsTest {
     Map<String, String> props =
         renewalBuilder("s3")
             .initialStorageCredential(deltaS3Credential())
-            .buildForTable("table-uuid", "catalog", "schema", "table", "s3://bucket/table");
+            .buildForTable(
+                "catalog", "schema", "table", CredentialOperation.READ_WRITE, "s3://bucket/table");
 
     assertThat(props)
         .containsEntry(
@@ -449,7 +450,7 @@ class UCCredentialHadoopConfsTest {
         .containsEntry(
             UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
             UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
-        .containsEntry(UCHadoopConfConstants.UC_TABLE_ID_KEY, "table-uuid")
+        .doesNotContainKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
         .containsEntry(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "catalog")
         .containsEntry(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "schema")
         .containsEntry(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "table")
@@ -465,7 +466,8 @@ class UCCredentialHadoopConfsTest {
     Map<String, String> gcsProps =
         renewalBuilder("gs")
             .initialStorageCredential(deltaGcsCredential())
-            .buildForTable("gcs-table-uuid", "catalog", "schema", "table", "gs://bucket/table");
+            .buildForTable(
+                "catalog", "schema", "table", CredentialOperation.READ, "gs://bucket/table");
     assertThat(gcsProps)
         .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ")
         .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "gcs-oauth-token")
@@ -475,10 +477,10 @@ class UCCredentialHadoopConfsTest {
         renewalBuilder("abfss")
             .initialStorageCredential(deltaAzureCredential())
             .buildForTable(
-                "azure-table-uuid",
                 "catalog",
                 "schema",
                 "table",
+                CredentialOperation.READ_WRITE,
                 "abfss://container@account.dfs.core.windows.net/table");
     assertThat(azureProps)
         .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE")
@@ -501,7 +503,8 @@ class UCCredentialHadoopConfsTest {
             () ->
                 renewalBuilder("gs")
                     .initialStorageCredential(credential)
-                    .buildForTable("table-uuid", "catalog", "schema", "table", "gs://b/t"))
+                    .buildForTable(
+                        "catalog", "schema", "table", CredentialOperation.READ, "gs://b/t"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must contain exactly one cloud credential config");
   }
@@ -511,7 +514,8 @@ class UCCredentialHadoopConfsTest {
     assertThatThrownBy(
             () ->
                 renewalBuilder("s3")
-                    .buildForTable("table-uuid", "catalog", "schema", "table", "s3://b/t"))
+                    .buildForTable(
+                        "catalog", "schema", "table", CredentialOperation.READ_WRITE, "s3://b/t"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("initialStorageCredential is required");
   }
@@ -541,7 +545,8 @@ class UCCredentialHadoopConfsTest {
             () ->
                 renewalBuilder("s3")
                     .initialCredentials(s3Creds())
-                    .buildForTable("table-uuid", "catalog", "schema", "table", "s3://b/t"))
+                    .buildForTable(
+                        "catalog", "schema", "table", CredentialOperation.READ_WRITE, "s3://b/t"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("initialStorageCredential is required");
   }
@@ -563,16 +568,56 @@ class UCCredentialHadoopConfsTest {
             () ->
                 renewalBuilder("s3")
                     .initialStorageCredential(deltaS3Credential())
-                    .buildForTable(null, "catalog", "schema", "table", "s3://bucket/table"))
+                    .buildForTable(
+                        null,
+                        "schema",
+                        "table",
+                        CredentialOperation.READ_WRITE,
+                        "s3://bucket/table"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("tableId is required");
+        .hasMessageContaining("catalog is required");
 
     assertThatThrownBy(
             () ->
                 renewalBuilder("s3")
                     .initialStorageCredential(deltaS3Credential())
-                    .buildForTable("table-uuid", null, "schema", "table", "s3://bucket/table"))
+                    .buildForTable(
+                        "catalog",
+                        null,
+                        "table",
+                        CredentialOperation.READ_WRITE,
+                        "s3://bucket/table"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("catalog is required");
+        .hasMessageContaining("schema is required");
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable(
+                        "catalog",
+                        "schema",
+                        null,
+                        CredentialOperation.READ_WRITE,
+                        "s3://bucket/table"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("table is required");
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable("catalog", "schema", "table", null, "s3://bucket/table"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("operation is required");
+
+    assertThatThrownBy(
+            () ->
+                renewalBuilder("s3")
+                    .initialStorageCredential(deltaS3Credential())
+                    .buildForTable(
+                        "catalog", "schema", "table", CredentialOperation.READ_WRITE, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("location is required");
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -1,7 +1,10 @@
 package io.unitycatalog.hadoop.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
@@ -162,6 +165,209 @@ class CredPropsUtilTest {
 
     assertThat(props).doesNotContainKey("fs.s3.impl.original");
     assertThat(props).doesNotContainKey("fs.s3a.impl.original");
+  }
+
+  // For unitycatalog delta table API.
+
+  @Test
+  void s3DeltaTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            tokenProvider(),
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "s3://bucket/tbl",
+            CredentialOperation.READ_WRITE,
+            s3Creds());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
+        .containsEntry(
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "cat")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "sch")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "tbl")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/tbl")
+        .containsEntry(
+            UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, TableOperation.READ_WRITE.getValue())
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, "sk")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, "st")
+        .doesNotContainKey(UCHadoopConfConstants.UC_TABLE_ID_KEY);
+  }
+
+  @Test
+  void gcsDeltaTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            tokenProvider(),
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "gs://bucket/tbl",
+            CredentialOperation.READ,
+            gcsCreds());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "cat")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "sch")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "tbl")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "gs://bucket/tbl")
+        .containsEntry(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, TableOperation.READ.getValue())
+        .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "token")
+        .containsEntry(
+            UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
+            String.valueOf(Long.MAX_VALUE));
+  }
+
+  @Test
+  void abfsDeltaTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "abfss",
+            "http://uc",
+            tokenProvider(),
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "abfss://container@account.dfs.core.windows.net/tbl",
+            CredentialOperation.READ_WRITE,
+            abfsCreds());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "cat")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "sch")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "tbl")
+        .containsEntry(
+            UCHadoopConfConstants.UC_DELTA_LOCATION_KEY,
+            "abfss://container@account.dfs.core.windows.net/tbl")
+        .containsEntry(
+            UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, TableOperation.READ_WRITE.getValue())
+        .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, "sas");
+  }
+
+  @Test
+  void deltaTableStaticCredsEmbedCloudKeysAndOmitDeltaKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            null,
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "s3://bucket/tbl",
+            CredentialOperation.READ_WRITE,
+            s3Creds());
+
+    assertThat(props)
+        .containsEntry("fs.s3a.access.key", "ak")
+        .containsEntry("fs.s3a.secret.key", "sk")
+        .containsEntry("fs.s3a.session.token", "st")
+        .doesNotContainKey(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY)
+        .doesNotContainKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY);
+  }
+
+  @Test
+  void deltaTableUnknownSchemeReturnsEmptyMap() {
+    assertThat(
+            CredPropsUtil.createDeltaTableCredProps(
+                false,
+                false,
+                new Configuration(false),
+                "hdfs",
+                "http://uc",
+                null,
+                UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+                "hdfs://namenode/tbl",
+                CredentialOperation.READ_WRITE,
+                s3Creds()))
+        .isEmpty();
+  }
+
+  @Test
+  void s3DeltaTableOriginalImplPreservedWithCredScopedFs() {
+    Configuration conf = new Configuration(false);
+    conf.set("fs.s3.impl", CUSTOM_S3_IMPL);
+    conf.set("fs.s3a.impl", CUSTOM_S3_IMPL);
+
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            true,
+            true,
+            conf,
+            "s3",
+            "http://uc",
+            tokenProvider(),
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "s3://bucket/tbl",
+            CredentialOperation.READ_WRITE,
+            s3Creds());
+
+    assertThat(props.get("fs.s3.impl.original")).isEqualTo(CUSTOM_S3_IMPL);
+    assertThat(props.get("fs.s3a.impl.original")).isEqualTo(CUSTOM_S3_IMPL);
+  }
+
+  @Test
+  void deltaTableOriginalImplNotSetWhenCredScopedFsDisabled() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            tokenProvider(),
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "s3://bucket/tbl",
+            CredentialOperation.READ_WRITE,
+            s3Creds());
+
+    assertThat(props)
+        .doesNotContainKey("fs.s3.impl.original")
+        .doesNotContainKey("fs.s3a.impl.original");
+  }
+
+  @Test
+  void propsBuilderRejectsTableIdAfterDeltaTableIdentifier() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.ucDeltaTableIdentifier(
+        UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl");
+
+    assertThatThrownBy(() -> builder.tableId("table-id"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tableId cannot be set with UC Delta table identifier");
+  }
+
+  @Test
+  void propsBuilderRejectsDeltaTableIdentifierAfterTableId() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.tableId("table-id");
+
+    assertThatThrownBy(
+            () ->
+                builder.ucDeltaTableIdentifier(
+                    UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UC Delta table identifier cannot be set with tableId");
+  }
+
+  private static TokenProvider tokenProvider() {
+    return TokenProvider.create(Map.of("type", "static", "token", "tok"));
   }
 
   private static TemporaryCredentials s3Creds() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
@@ -2,6 +2,7 @@ package io.unitycatalog.hadoop.internal.fs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
@@ -91,5 +92,95 @@ class CredScopedKeyTest {
   void createReturnsDefaultKeyWhenNoType() {
     assertThat(CredScopedKey.create(URI.create("s3://b"), new Configuration()))
         .isInstanceOf(CredScopedKey.DefaultCredScopedKey.class);
+  }
+
+  @Test
+  void deltaTableKeyEqualWhenSameFields() {
+    UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
+    assertThat(new CredScopedKey.DeltaTableCredScopedKey(id, "READ_WRITE", "s3://b/t"))
+        .isEqualTo(new CredScopedKey.DeltaTableCredScopedKey(id, "READ_WRITE", "s3://b/t"))
+        .hasSameHashCodeAs(new CredScopedKey.DeltaTableCredScopedKey(id, "READ_WRITE", "s3://b/t"));
+  }
+
+  @Test
+  void deltaTableKeyNotEqualWhenDifferentCatalog() {
+    assertThat(
+            new CredScopedKey.DeltaTableCredScopedKey(
+                UCDeltaTableIdentifier.of("cat1", "sch", "tbl"), "READ", "s3://b/t"))
+        .isNotEqualTo(
+            new CredScopedKey.DeltaTableCredScopedKey(
+                UCDeltaTableIdentifier.of("cat2", "sch", "tbl"), "READ", "s3://b/t"));
+  }
+
+  @Test
+  void deltaTableKeyNotEqualWhenDifferentOperation() {
+    UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
+    assertThat(new CredScopedKey.DeltaTableCredScopedKey(id, "READ", "s3://b/t"))
+        .isNotEqualTo(new CredScopedKey.DeltaTableCredScopedKey(id, "READ_WRITE", "s3://b/t"));
+  }
+
+  @Test
+  void deltaTableKeyNotEqualWhenDifferentLocation() {
+    UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
+    assertThat(new CredScopedKey.DeltaTableCredScopedKey(id, "READ", "s3://b/t1"))
+        .isNotEqualTo(new CredScopedKey.DeltaTableCredScopedKey(id, "READ", "s3://b/t2"));
+  }
+
+  @Test
+  void deltaTableKeyIgnoresCredentialUid() {
+    Configuration left = deltaTableConf("s3://b/t", "uid-1");
+    Configuration right = deltaTableConf("s3://b/t", "uid-2");
+
+    assertThat(CredScopedKey.create(URI.create("s3://b"), left))
+        .isEqualTo(CredScopedKey.create(URI.create("s3://b"), right));
+  }
+
+  @Test
+  void createReturnsDeltaTableKeyWhenDeltaApiEnabled() {
+    Configuration conf = new Configuration();
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "cat");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "sch");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "tbl");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://b/tbl");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ_WRITE");
+    conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, "uid-1");
+
+    UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
+    assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
+        .isInstanceOf(CredScopedKey.DeltaTableCredScopedKey.class)
+        .isEqualTo(new CredScopedKey.DeltaTableCredScopedKey(id, "READ_WRITE", "s3://b/tbl"));
+  }
+
+  @Test
+  void createReturnsTableKeyWhenDeltaApiNotEnabled() {
+    Configuration conf = new Configuration();
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+
+    assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
+        .isInstanceOf(CredScopedKey.TableCredScopedKey.class)
+        .isEqualTo(new CredScopedKey.TableCredScopedKey("tid", "READ"));
+  }
+
+  private static Configuration deltaTableConf(String location, String uid) {
+    Configuration conf = new Configuration();
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
+    conf.set(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY, "cat");
+    conf.set(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY, "sch");
+    conf.set(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY, "tbl");
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+    conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, uid);
+    return conf;
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This updates the Hadoop credential configuration API for UC Delta table support, adds a public Delta table builder overload using catalog/schema/table/operation/location, keeps `UCDeltaTableIdentifier` internal, factors Delta table credential property helpers into `CredPropsUtil`, and updates credential-scoped filesystem cache keys so Delta table scopes include the table location instead of the random credential UID. The location in the Delta table scoped key fixes stale credential-cache reuse after drop and recreate while avoiding excess filesystem instances from per-call random UIDs.

Validation:

- `./build/sbt -mem 4096 hadoop/test` passed: 132 tests, 0 failures.

No related issue was identified in the source branch.