### PR TITLE
[DO NOT MERGE][CI-TEST] Trigger build to demonstrate Maven Central 429 rate-limiting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import Checkstyle._
-
+// Trigger CI to demonstrate Maven Central 429 rate-limiting on GitHub Actions
 import java.nio.file.Files
 import java.io.File
 import Tarball.createTarballSettings

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -1,5 +1,5 @@
 package io.unitycatalog.server;
-
+// CI trigger: no-op comment to exercise full build without GCS mirror
 import static io.unitycatalog.server.security.SecurityContext.Issuers.INTERNAL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;


### PR DESCRIPTION
No-op change to trigger CI and demonstrate that GitHub Actions runners get HTTP 429 rate-limited by `repo1.maven.org` during dependency resolution.

The GCS mirror config in `build/sbt-config/repositories` is never activated because `build/sbt` guards it behind `JENKINS_URL` which is not set on GitHub Actions.

This PR exists solely to capture CI logs showing the 429 failures. Will close after capturing evidence.