### PR TITLE
[Build] Use GCS Maven Central mirror unconditionally to avoid HTTP 429s

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -75,12 +75,12 @@ if [[ -n "$MAVEN_PROXY_URL" ]]; then
   maven-proxy: $MAVEN_PROXY_URL
   maven-proxy-ivy: $MAVEN_PROXY_URL, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
 EOF
-  export SBT_OPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=$SBT_REPOSITORIES_CONFIG"
-elif [[ "$JENKINS_URL" != "" ]]; then
-  # Make Jenkins use Google Mirror first as Maven Central may ban us
+else
+  # Default: use sbt-config/repositories which lists GCS Maven Central mirror before maven-central,
+  # avoiding HTTP 429 rate-limiting from repo1.maven.org on CI runners.
   SBT_REPOSITORIES_CONFIG="$(dirname "$(realpath "$0")")/sbt-config/repositories"
-  export SBT_OPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=$SBT_REPOSITORIES_CONFIG"
 fi
+export SBT_OPTS="${SBT_OPTS:-} -Dsbt.override.build.repos=true -Dsbt.repository.config=$SBT_REPOSITORIES_CONFIG"
 
 . "$(dirname "$(realpath "$0")")"/sbt-launch-lib.bash
 

--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -1,8 +1,9 @@
 [repositories]
   local
+  maven-local: file://${user.home}/.m2/repository
   local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
-  gcs-maven-central-mirror: https://maven-central.storage-download.googleapis.com/repos/central/data/
+  gcs-maven-central-mirror: https://maven-central.storage-download.googleapis.com/maven2/
   maven-central
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -45,8 +45,9 @@ acquire_sbt_jar () {
   elif [[ "${SBT_VERSION}" == "1.5.5" ]] && [[ -n "${SBT_1_5_5_MIRROR_JAR_URL}" ]]; then
     URL1="${SBT_1_5_5_MIRROR_JAR_URL}"
   else
-    URL1=${DEFAULT_ARTIFACT_REPOSITORY:-${MAVEN_PROXY_URL:-https://repo1.maven.org/maven2}}/org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
+    URL1=${DEFAULT_ARTIFACT_REPOSITORY:-${MAVEN_PROXY_URL:-https://maven-central.storage-download.googleapis.com/maven2}}/org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
   fi
+  BACKUP_URL="https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar"
 
   JAR=build/sbt-launch-${SBT_VERSION}.jar
   sbt_jar=$JAR
@@ -69,7 +70,19 @@ acquire_sbt_jar () {
     fi
     fi
     if [ ! -f "${JAR}" ]; then
-    # We failed to download
+    # Primary download failed, retry from Maven Central directly
+    printf 'Download from %s failed. Retrying from %s\n' "${URL1}" "${BACKUP_URL}"
+    JAR_DL="${JAR}.part"
+    if [ $(command -v curl) ]; then
+      curl --fail --location --silent ${BACKUP_URL} > "${JAR_DL}" &&\
+        mv "${JAR_DL}" "${JAR}"
+    elif [ $(command -v wget) ]; then
+      wget --quiet ${BACKUP_URL} -O "${JAR_DL}" &&\
+        mv "${JAR_DL}" "${JAR}"
+    fi
+    fi
+    if [ ! -f "${JAR}" ]; then
+    # Both downloads failed
     printf "Our attempt to download sbt locally to ${JAR} failed. Please install sbt manually from https://www.scala-sbt.org/\n"
     exit -1
     fi


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

GitHub Actions CI runners are getting HTTP 429 (Too Many Requests) responses from `repo1.maven.org` during dependency resolution, causing build failures. The GCS Maven Central mirror (`maven-central.storage-download.googleapis.com`) is already configured in `build/sbt-config/repositories`, but it is never activated because `build/sbt` only applies it when `JENKINS_URL` is set — which is not the case on GitHub Actions.

Changes:
- `build/sbt`: Always activate the `sbt-config/repositories` config instead of gating on `JENKINS_URL`. Appends to `SBT_OPTS` rather than overwriting, so callers can pass additional JVM flags via the environment.
- `build/sbt-config/repositories`: Fix stale GCS mirror URL (`/repos/central/data/` → `/maven2/`).
- `build/sbt-launch-lib.bash`: Default the sbt-launch.jar download to the GCS mirror, with automatic fallback to `repo1.maven.org` if the mirror is unavailable.

See #1550 for CI evidence of 429 failures without this fix.