### PR TITLE
New experimental flag: server.managed-table.use-delta-api-only (default off)

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -192,7 +192,8 @@ public class UnityCatalogServer {
     MetastoreService metastoreService = new MetastoreService(repositories);
     // TODO: combine these into a single service in a follow-up PR
     TemporaryTableCredentialsService temporaryTableCredentialsService =
-        new TemporaryTableCredentialsService(storageCredentialVendor, repositories);
+        new TemporaryTableCredentialsService(
+            storageCredentialVendor, repositories, serverProperties);
     TemporaryVolumeCredentialsService temporaryVolumeCredentialsService =
         new TemporaryVolumeCredentialsService(storageCredentialVendor, repositories);
     TemporaryModelVersionCredentialsService temporaryModelVersionCredentialsService =

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -76,32 +76,45 @@ public class TableRepository {
   }
 
   /**
-   * Retrieves the storage location for a table or staging table by its ID. First attempts to find a
-   * regular table with the given ID, then falls back to searching for a staging table if no regular
-   * table is found. NOTE: This function is specially needed by generateTemporaryTableCredential
-   * during the short window when a staging table is just created and the initial data is being
-   * written but before the actual table is already created. Reading of a staging table is not a
-   * common supplemental of an actual table but only a special case.
+   * Returned by {@link #getStorageLocationForTableOrStagingTable} so callers (today the temp-creds
+   * service) can vend and gate from a single DB read. Staging rows project as MANAGED because they
+   * always finalize to MANAGED Delta.
+   */
+  public record TableStorageLocationInfo(NormalizedURL url, TableType tableType) {}
+
+  /**
+   * Retrieves the storage location for a table or staging table by its ID, plus the table type.
+   * Staging tables are counted as Managed tables too. First attempts to find a regular table with
+   * the given ID, then falls back to searching for a staging table if no regular table is found.
+   * NOTE: This function is specially needed by generateTemporaryTableCredential during the short
+   * window when a staging table is just created and the initial data is being written but before
+   * the actual table is already created. Reading of a staging table is not a common supplemental of
+   * an actual table but only a special case.
    *
    * @param tableId the ID of the table or staging table
-   * @return the normalized URL of the storage location
+   * @return the normalized URL of the storage location, plus table type. Both in
+   *     TableStorageLocationInfo
    * @throws BaseException with ErrorCode.TABLE_NOT_FOUND if neither a table nor staging table is
    *     found with the given ID
    */
-  public NormalizedURL getStorageLocationForTableOrStagingTable(UUID tableId) {
+  public TableStorageLocationInfo getStorageLocationForTableOrStagingTable(UUID tableId) {
     return TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
           LOGGER.debug("Getting storage location of table by id: {}", tableId);
           TableInfoDAO tableInfoDAO = session.get(TableInfoDAO.class, tableId);
           if (tableInfoDAO != null) {
-            return NormalizedURL.from(tableInfoDAO.getUrl());
+            return new TableStorageLocationInfo(
+                NormalizedURL.from(tableInfoDAO.getUrl()),
+                TableType.fromValue(tableInfoDAO.getType()));
           }
 
           LOGGER.debug("Getting storage location of staging table by id: {}", tableId);
           StagingTableDAO stagingTableDAO = session.get(StagingTableDAO.class, tableId);
           if (stagingTableDAO != null) {
-            return NormalizedURL.from(stagingTableDAO.getStagingLocation());
+            // Staging rows always become MANAGED Delta on finalize, so project them as MANAGED.
+            return new TableStorageLocationInfo(
+                NormalizedURL.from(stagingTableDAO.getStagingLocation()), TableType.MANAGED);
           }
           throw new BaseException(
               ErrorCode.TABLE_NOT_FOUND,

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
@@ -43,6 +43,10 @@ public class DeltaCommitsService extends AuthorizedService {
   public HttpResponse postCommit(
       @AuthorizeResourceKey(value = TABLE, key = "table_id")
       DeltaCommit commit) {
+    // The UC REST commit endpoint only accepts MANAGED Delta tables (enforced downstream by
+    // validateTableForCommit), so the gate applies unconditionally here.
+    serverProperties.checkDeltaApiOnlyEnabled(
+        "POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} with action add-commit");
     deltaCommitRepository.postCommit(commit);
     return HttpResponse.of(HttpStatus.OK);
   }
@@ -57,6 +61,9 @@ public class DeltaCommitsService extends AuthorizedService {
   public HttpResponse getCommits(
     @AuthorizeResourceKey(value = TABLE, key = "table_id")
     DeltaGetCommits rpc) {
+    // Same as postCommit above -- managed-Delta-only by contract; gate unconditionally.
+    serverProperties.checkDeltaApiOnlyEnabled(
+        "GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} (commits[])");
     return HttpResponse.ofJson(deltaCommitRepository.getCommits(rpc));
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
@@ -51,6 +51,10 @@ public class StagingTableService extends AuthorizedService {
       })
       CreateStagingTable createStagingTable) {
     assert createStagingTable != null;
+    // A staging table can only ever finalize into a MANAGED Delta table, so the
+    // managed-tables-use-delta-api-only gate applies unconditionally here.
+    serverProperties.checkDeltaApiOnlyEnabled(
+        "POST /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables");
     StagingTableInfo createdStagingTable =
         stagingTableRepository.createStagingTable(createStagingTable);
     String catalog = createdStagingTable.getCatalogName();

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -87,6 +87,9 @@ public class TableService extends AuthorizedService {
       @AuthorizeKey(key = "table_type")
       CreateTable createTable) {
     assert createTable != null;
+    serverProperties.checkDeltaApiOnlyForManagedTable(
+        createTable.getTableType(),
+        "POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables");
     TableInfo tableInfo = tableRepository.createTable(createTable);
 
     SchemaInfo schemaInfo =

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
@@ -12,9 +12,10 @@ import io.unitycatalog.server.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.server.model.TableOperation;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.TableRepository.TableStorageLocationInfo;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
-import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
 
 import java.util.Collections;
 import java.util.Set;
@@ -28,11 +29,14 @@ import static io.unitycatalog.server.service.credential.CredentialContext.Privil
 public class TemporaryTableCredentialsService {
   private final TableRepository tableRepository;
   private final StorageCredentialVendor storageCredentialVendor;
+  private final ServerProperties serverProperties;
 
   public TemporaryTableCredentialsService(StorageCredentialVendor storageCredentialVendor,
-                                          Repositories repositories) {
+                                          Repositories repositories,
+                                          ServerProperties serverProperties) {
     this.storageCredentialVendor = storageCredentialVendor;
     this.tableRepository = repositories.getTableRepository();
+    this.serverProperties = serverProperties;
   }
 
   @Post("")
@@ -42,9 +46,13 @@ public class TemporaryTableCredentialsService {
       @AuthorizeKey(key = "operation")
       GenerateTemporaryTableCredential generateTemporaryTableCredential) {
     String tableId = generateTemporaryTableCredential.getTableId();
-    NormalizedURL storageLocation = tableRepository.getStorageLocationForTableOrStagingTable(
-        UUID.fromString(tableId));
-    return HttpResponse.ofJson(storageCredentialVendor.vendCredential(storageLocation,
+    TableStorageLocationInfo info =
+        tableRepository.getStorageLocationForTableOrStagingTable(UUID.fromString(tableId));
+    serverProperties.checkDeltaApiOnlyForManagedTable(
+        info.tableType(),
+        "GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials"
+            + " (or /delta/v1/staging-tables/{table_id}/credentials for unfinalized staging)");
+    return HttpResponse.ofJson(storageCredentialVendor.vendCredential(info.url(),
             tableOperationToPrivileges(generateTemporaryTableCredential.getOperation())));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -2,6 +2,7 @@ package io.unitycatalog.server.utils;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.service.credential.aws.S3StorageConfig;
 import io.unitycatalog.server.service.credential.azure.ADLSStorageConfig;
 import io.unitycatalog.server.service.credential.gcp.GcsStorageConfig;
@@ -197,6 +198,8 @@ public class ServerProperties {
     REDIRECT_PORT("server.redirect-port", POSITIVE_INTEGER_VALIDATOR),
     COOKIE_TIMEOUT("server.cookie-timeout", "P5D", DURATION_VALIDATOR),
     MANAGED_TABLE_ENABLED("server.managed-table.enabled", "false", BOOLEAN_VALIDATOR),
+    MANAGED_TABLE_USE_DELTA_API_ONLY(
+        "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
     // `storage-root.*` are replaced by managed storage locations of catalog and schema.
     MODEL_STORAGE_ROOT("storage-root.models", STORAGE_PATH_VALIDATOR), // Deprecated
     TABLE_STORAGE_ROOT("storage-root.tables", STORAGE_PATH_VALIDATOR), // Deprecated
@@ -450,6 +453,49 @@ public class ServerProperties {
           ErrorCode.INVALID_ARGUMENT,
           "MANAGED table is an experimental feature and is currently disabled. "
               + "To enable it, set 'server.managed-table.enabled=true' in server.properties");
+    }
+  }
+
+  /**
+   * Reject the UC request when MANAGED_TABLES_USE_DELTA_API_ONLY is on and the targeted table is
+   * MANAGED. Call from UC endpoints whose Delta equivalent should be used instead. Any non-MANAGED
+   * table would continue to work: EXTERNAL, METRIC_VIEW etc.
+   *
+   * @param tableType the table type to check; only {@link TableType#MANAGED} triggers the gate.
+   * @param deltaEndpoint full Delta endpoint to suggest in the error, e.g. {@code "POST
+   *     /delta/v1/catalogs/{catalog}/schemas/{schema}/tables"}.
+   */
+  public void checkDeltaApiOnlyForManagedTable(TableType tableType, String deltaEndpoint) {
+    if (tableType == TableType.MANAGED
+        && isTrueOrEnable(get(Property.MANAGED_TABLE_USE_DELTA_API_ONLY))) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "This Unity Catalog endpoint is disabled for MANAGED Delta tables when "
+              + Property.MANAGED_TABLE_USE_DELTA_API_ONLY.getKey()
+              + "=true. Use the Delta endpoint "
+              + deltaEndpoint
+              + " instead.");
+    }
+  }
+
+  /**
+   * Similar to checkDeltaApiOnlyForManagedTable, reject the UC request when
+   * MANAGED_TABLES_USE_DELTA_API_ONLY is on and the target endpoint is for MANAGED tables only. In
+   * this case it doesn't need to check table type. Call from UC endpoints whose Delta equivalent
+   * should be used instead.
+   *
+   * @param deltaEndpoint full Delta endpoint to suggest in the error, e.g. {@code "POST
+   *     /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables"}.
+   */
+  public void checkDeltaApiOnlyEnabled(String deltaEndpoint) {
+    if (isTrueOrEnable(get(Property.MANAGED_TABLE_USE_DELTA_API_ONLY))) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "This Unity Catalog endpoint is disabled when "
+              + Property.MANAGED_TABLE_USE_DELTA_API_ONLY.getKey()
+              + "=true. Use the Delta endpoint "
+              + deltaEndpoint
+              + " instead.");
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
+++ b/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
@@ -77,13 +77,23 @@ public abstract class DeltaBaseTableCRUDTestEnv extends BaseTableCRUDTestEnv {
   }
 
   /**
-   * Stage and finalize a MANAGED Delta table via Delta REST. Always seeds a {@code
-   * deltaRowTracking} domain so update-side tests can exercise remove-domain-metadata against a
-   * non-empty state; callers that don't care are unaffected.
+   * Stage and finalize a MANAGED Delta table via Delta REST. Stages internally; use {@link
+   * #createDeltaManaged(String, StagingTableResponse, Map)} if the test needs to retain or
+   * inspect the staging response between staging and finalize (e.g. to assert intermediate state
+   * against the staging row).
+   *
+   * <p>Always seeds a {@code deltaRowTracking} domain so update-side tests can exercise
+   * remove-domain-metadata against a non-empty state; callers that don't care are unaffected.
    */
   protected Handle createDeltaManaged(String tableName, Map<String, String> extraProperties)
       throws ApiException {
-    StagingTableResponse staging = createDeltaStaging(tableName);
+    return createDeltaManaged(tableName, createDeltaStaging(tableName), extraProperties);
+  }
+
+  /** Finalize a MANAGED Delta table against an already-created {@code staging} response. */
+  protected Handle createDeltaManaged(
+      String tableName, StagingTableResponse staging, Map<String, String> extraProperties)
+      throws ApiException {
     Map<String, String> properties =
         new HashMap<>(managedContractProperties(staging.getTableId().toString()));
     properties.putAll(extraProperties);

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUseDeltaApiOnlyFlagTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUseDeltaApiOnlyFlagTest.java
@@ -1,0 +1,174 @@
+package io.unitycatalog.server.sdk.delta;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.DeltaCommitsApi;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.StagingTableResponse;
+import io.unitycatalog.client.model.CreateStagingTable;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.DeltaCommit;
+import io.unitycatalog.client.model.DeltaGetCommits;
+import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableOperation;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.delta.DeltaBaseTableCRUDTestEnv;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * End-to-end narrative for {@code server.managed-table.use-delta-api-only=true}: walk the full
+ * MANAGED Delta lifecycle through the gated UC REST endpoints (each must reject) while their Delta
+ * REST counterparts succeed, then prove the gate doesn't over-block by exercising the same UC
+ * endpoints against an EXTERNAL table.
+ *
+ * <p>The flag-OFF default-path is not asserted here -- it is covered by every other UC REST CRUD /
+ * commits test in this module, all of which run with the flag at its default ({@code false}).
+ */
+public class SdkUseDeltaApiOnlyFlagTest extends DeltaBaseTableCRUDTestEnv {
+
+  private TablesApi ucTablesApi;
+  private TemporaryCredentialsApi ucCredsApi;
+  private DeltaCommitsApi ucCommitsApi;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig serverConfig) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected TableOperations createTableOperations(ServerConfig serverConfig) {
+    // The flag test exercises UC's createTable on EXTERNAL Delta via the inherited
+    // BaseTableCRUDTestEnv.createTestingTable helper, which goes through TableOperations.
+    return new SdkTableOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    serverProperties.setProperty(
+        ServerProperties.Property.MANAGED_TABLE_USE_DELTA_API_ONLY.getKey(), "true");
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    ApiClient apiClient = TestUtils.createApiClient(serverConfig);
+    ucTablesApi = new TablesApi(apiClient);
+    ucCredsApi = new TemporaryCredentialsApi(apiClient);
+    ucCommitsApi = new DeltaCommitsApi(apiClient);
+  }
+
+  @Test
+  public void testManagedTablesUseDeltaApiOnlyFlag() throws ApiException {
+    String tableName = "tbl_managed";
+
+    // 1. UC createStagingTable -- blocked: staging tables always become MANAGED Delta.
+    assertGateBlocks(
+        () ->
+            ucTablesApi.createStagingTable(
+                new CreateStagingTable()
+                    .name(tableName)
+                    .catalogName(TestUtils.CATALOG_NAME)
+                    .schemaName(TestUtils.SCHEMA_NAME)));
+
+    // 2. Delta createStagingTable -- the only path that works under this flag.
+    StagingTableResponse staging = createDeltaStaging(tableName);
+
+    // 2b. UC generateTemporaryTableCredentials against the unfinalized staging row -- blocked.
+    // Exercises the staging-row branch of getStorageLocationForTableOrStagingTable, which
+    // projects staging rows as MANAGED so the gate catches them too.
+    assertGateBlocks(
+        () ->
+            ucCredsApi.generateTemporaryTableCredentials(
+                new GenerateTemporaryTableCredential()
+                    .tableId(staging.getTableId().toString())
+                    .operation(TableOperation.READ_WRITE)));
+
+    // 3. UC createTable against that staging location -- blocked because the request is MANAGED.
+    assertGateBlocks(
+        () ->
+            ucTablesApi.createTable(
+                new CreateTable()
+                    .name(tableName)
+                    .catalogName(TestUtils.CATALOG_NAME)
+                    .schemaName(TestUtils.SCHEMA_NAME)
+                    .tableType(TableType.MANAGED)
+                    .dataSourceFormat(DataSourceFormat.DELTA)
+                    .storageLocation(staging.getLocation())));
+
+    // 4. Delta createTable finalizes the staging table into a MANAGED Delta table.
+    Handle managed = createDeltaManaged(tableName, staging, Map.of());
+
+    // 5. UC getTable on the MANAGED Delta table -- allowed for now as non-Delta clients and
+    // older clients supporting only EXTERNAL tables still needs to gracefully recognize MANAGED
+    // Delta tables by loading them.
+    ucTablesApi.getTable(fullName(tableName), null, null);
+
+    // 6. UC generateTemporaryTableCredentials on the MANAGED Delta table -- blocked.
+    assertGateBlocks(
+        () ->
+            ucCredsApi.generateTemporaryTableCredentials(
+                new GenerateTemporaryTableCredential()
+                    .tableId(managed.tableId().toString())
+                    .operation(TableOperation.READ_WRITE)));
+
+    // 7. UC postCommit -- blocked unconditionally (endpoint is MANAGED-Delta-only by contract).
+    assertGateBlocks(
+        () -> ucCommitsApi.commit(new DeltaCommit().tableId(managed.tableId().toString())));
+
+    // 8. UC getCommits -- blocked unconditionally for the same reason.
+    assertGateBlocks(
+        () -> ucCommitsApi.getCommits(new DeltaGetCommits().tableId(managed.tableId().toString())));
+
+    // 9. UC createTable EXTERNAL Delta -- allowed: the gate is precise to MANAGED. Goes through
+    // BaseTableCRUDTestEnv.createTestingTable which uses the inherited UC TableOperations.
+    TableInfo external =
+        createTestingTable(
+            "tbl_external",
+            TableType.EXTERNAL,
+            Optional.of(testDirectoryRoot.toString()),
+            tableOperations);
+
+    // 10. UC getTable on the EXTERNAL table -- allowed.
+    ucTablesApi.getTable(fullName(external.getName()), null, null);
+
+    // 11. UC generateTemporaryTableCredentials on the EXTERNAL table -- allowed.
+    ucCredsApi.generateTemporaryTableCredentials(
+        new GenerateTemporaryTableCredential()
+            .tableId(external.getTableId())
+            .operation(TableOperation.READ_WRITE));
+  }
+
+  /** Assert the request fails with INVALID_ARGUMENT and the gate's distinctive error wording. */
+  private static void assertGateBlocks(Executable executable) {
+    TestUtils.assertApiException(
+        executable, ErrorCode.INVALID_ARGUMENT, "server.managed-table.use-delta-api-only=true");
+  }
+
+  private static String fullName(String tableName) {
+    return TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + tableName;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.utils.ServerProperties.Property;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -217,5 +218,29 @@ public class ServerPropertiesTest {
           .as("Property %s from etc/conf/server.properties should match default", property.getKey())
           .isEqualTo(serverProperties.get(property));
     }
+  }
+
+  @Test
+  public void testCheckDeltaApiOnlyForManagedTable() {
+    ServerProperties serverProperties1 = new ServerProperties();
+    serverProperties1.checkDeltaApiOnlyForManagedTable(TableType.MANAGED, "endpoint_name");
+    serverProperties1.checkDeltaApiOnlyForManagedTable(TableType.EXTERNAL, "endpoint_name");
+    serverProperties1.checkDeltaApiOnlyForManagedTable(TableType.METRIC_VIEW, "endpoint_name");
+    serverProperties1.checkDeltaApiOnlyEnabled("endpoint_name");
+
+    Properties props = new Properties();
+    props.setProperty(Property.MANAGED_TABLE_USE_DELTA_API_ONLY.getKey(), "true");
+    ServerProperties serverProperties2 = new ServerProperties(props);
+    serverProperties2.checkDeltaApiOnlyForManagedTable(TableType.EXTERNAL, "endpoint_name");
+    serverProperties2.checkDeltaApiOnlyForManagedTable(TableType.METRIC_VIEW, "endpoint_name");
+    assertThatThrownBy(
+            () ->
+                serverProperties2.checkDeltaApiOnlyForManagedTable(
+                    TableType.MANAGED, "endpoint_name"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("endpoint is disabled for MANAGED Delta tables when");
+    assertThatThrownBy(() -> serverProperties2.checkDeltaApiOnlyEnabled("endpoint_name"))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("endpoint is disabled when");
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1555/files) to review incremental changes.
- [**stack/phaseout**](https://github.com/unitycatalog/unitycatalog/pull/1555) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1555/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
New experimental flag: server.managed-table.use-delta-api-only (default off).

When on, UC endpoints that have a Delta equivalent reject MANAGED tables so clients are forced through the Delta surface. Wired at following entry points and with the gate shared on ServerProperties.checkDeltaApiOnlyForManagedTable and checkDeltaApiOnlyEnabled:
- StagingTableService.createStagingTable (always blocked)
- TableService.createTable (request-typed)
- TemporaryTableCredentialsService.generateTemporaryTableCredential (request-typed)
- DeltaCommitsService.getCommits (always blocked)
- DeltaCommitsService.postCommit (always blocked)
