### PR TITLE
Stop requiring inCommitTimestampEnablement{Version,Timestamp}

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -70,12 +70,9 @@ public final class UcManagedDeltaContract {
   /**
    * Required properties whose value the engine must compute at commit time. The staging response
    * sends them with {@code null} values; the createTable request must echo them back with non-null
-   * values the engine substituted.
+   * values the engine substituted. Currently empty.
    */
-  public static final List<String> ENGINE_GENERATED_PROPERTY_KEYS =
-      List.of(
-          TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
-          TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
+  public static final List<String> ENGINE_GENERATED_PROPERTY_KEYS = List.of();
 
   /**
    * Suggested properties. Null values mean the client generates the value at commit time (required
@@ -102,7 +99,8 @@ public final class UcManagedDeltaContract {
    *   <li>every declared domain-metadata entry is backed by the matching writer feature;
    *   <li>every fixed-value required property equals the expected value;
    *   <li>the UC table-id property is set;
-   *   <li>the engine-generated required properties are present with non-null values.
+   *   <li>every entry in {@link #ENGINE_GENERATED_PROPERTY_KEYS} (if any) is present with a
+   *       non-null value.
    * </ul>
    *
    * <p>Apply only when the table is UC catalog-managed (i.e. MANAGED). EXTERNAL tables don't go

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
@@ -106,9 +106,11 @@ public class SdkCreateStagingTableTest extends BaseCRUDTestWithMockCredentials {
         .containsEntry(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true")
         // The rule-based property binds the Delta table to the UC-allocated tableId.
         .containsEntry(TableProperties.UC_TABLE_ID, resp.getTableId().toString())
-        // Engine-managed (tied to inCommitTimestamp); null value = engine computes at commit time.
-        .containsEntry(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, null)
-        .containsEntry(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, null);
+        // ICT enablement version/timestamp are not advertised: catalog-managed tables enable
+        // inCommitTimestamp at version 0, and per the Delta protocol the enablement
+        // properties only apply when ICT was enabled mid-table.
+        .doesNotContainKey(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION)
+        .doesNotContainKey(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
     assertThat(resp.getSuggestedProperties())
         .containsEntry(TableProperties.ENABLE_ROW_TRACKING, "true")
         // Null value = client generates a UUID-suffixed column name when enabling row tracking.

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateTableTest.java
@@ -459,8 +459,6 @@ public class SdkCreateTableTest extends BaseCRUDTestWithMockCredentials {
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, tableId);
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
     // User-specified properties under server-derived keys are overridden by the structured
     // protocol/domain-metadata blocks. End-to-end override is pinned by the assertions on
     // featureKey(CATALOG_MANAGED) and CLUSTERING_COLUMNS in testCreateTableEndpoint.

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapperTest.java
@@ -146,9 +146,6 @@ public class DeltaCreateTableMapperTest {
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, tableId);
-    // Engine-generated values: any non-null placeholder satisfies the contract.
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
     return props;
   }
 

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaStagingTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaStagingTableMapperTest.java
@@ -71,8 +71,6 @@ public class DeltaStagingTableMapperTest {
 
     // 1. Serialization: the null values must appear as explicit "key": null in the JSON.
     assertThat(json)
-        .contains("\"" + TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION + "\":null")
-        .contains("\"" + TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP + "\":null")
         .contains("\"" + TableProperties.ROW_TRACKING_MATERIALIZED_ROW_ID_COLUMN_NAME + "\":null")
         .contains(
             "\""
@@ -82,9 +80,6 @@ public class DeltaStagingTableMapperTest {
     // 2. Deserialization: reading it back must give maps that still have the keys with null.
     StagingTableResponse roundTripped =
         DeltaRestCatalogMappers.MAPPER.readValue(json, StagingTableResponse.class);
-    assertThat(roundTripped.getRequiredProperties())
-        .containsEntry(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, null)
-        .containsEntry(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, null);
     assertThat(roundTripped.getSuggestedProperties())
         .containsEntry(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_ID_COLUMN_NAME, null)
         .containsEntry(

--- a/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/UcManagedDeltaContractTest.java
@@ -235,17 +235,6 @@ public class UcManagedDeltaContractTest {
         .hasMessageContaining(TableProperties.UC_TABLE_ID);
   }
 
-  @Test
-  public void validateRejectsNullEngineGeneratedProperty() {
-    // The staging response delivers IN_COMMIT_TIMESTAMP_ENABLEMENT_* with null values; the client
-    // must compute and substitute. Echoing the null back is a contract violation.
-    Map<String, String> props = fullProperties();
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, null);
-    assertThatThrownBy(() -> UcManagedDeltaContract.validate(fullProtocol(), null, props))
-        .isInstanceOf(BaseException.class)
-        .hasMessageContaining(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
-  }
-
   // ---------- validateTableIdProperty ----------
 
   @Test
@@ -332,8 +321,6 @@ public class UcManagedDeltaContractTest {
     props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
     props.put(TableProperties.UC_TABLE_ID, UUID.randomUUID().toString());
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "0");
-    props.put(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1700000000000");
     return props;
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Stop requiring inCommitTimestampEnablement{Version,Timestamp}

Per Delta PROTOCOL.md §4 these properties only apply when ICT was enabled mid-table. UC catalog-managed Delta tables enable ICT at v0, so the values are inapplicable.
