### PR TITLE
[Spark] Delegate ALTER TABLE through UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -310,7 +310,7 @@ class UCSingleCatalog
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    throw new UnsupportedOperationException("Altering a table is not supported yet")
+    delegate.alterTable(ident, changes: _*)
   }
 
   override def dropTable(ident: Identifier): Boolean = delegate.dropTable(ident)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -28,7 +28,9 @@ import java.util.Map;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.StagingTableCatalog;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -98,6 +100,18 @@ public class UCSingleCatalogStagingTableTest {
 
     verify(mockDelegate).stageCreate(eq(IDENT), eq(SCHEMA), any(), any());
     assertThat(result).isSameAs(staged);
+  }
+
+  @Test
+  public void testAlterTableDelegatesToUnderlyingCatalog() throws Exception {
+    Table table = mock(Table.class);
+    TableChange change = TableChange.setProperty("custom.key", "custom.value");
+    when(mockDelegate.alterTable(IDENT, change)).thenReturn(table);
+
+    Table result = catalog.alterTable(IDENT, new TableChange[] {change});
+
+    verify(mockDelegate).alterTable(IDENT, change);
+    assertThat(result).isSameAs(table);
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Why: Delta-side ALTER TABLE support needs the Spark catalog to delegate ALTER operations to the underlying Delta catalog instead of stopping in `UCSingleCatalog`.

How: `UCSingleCatalog.alterTable` now forwards to the delegate catalog, with a unit test covering the delegation.