### PR TITLE
Fix derive table properties and make deletionVectors not required

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaConsts.java
@@ -98,7 +98,7 @@ public final class DeltaConsts {
      * of segment names, so nested columns stay as arrays rather than collapsing to dotted strings).
      * Mirrors the {@code delta.clustering} domain-metadata entry.
      */
-    public static final String CLUSTERING_COLUMNS = "delta.clusteringColumns";
+    public static final String CLUSTERING_COLUMNS = "clusteringColumns";
 
     /**
      * Row-tracking high water mark, mirroring the {@code delta.rowTracking.rowIdHighWaterMark} from
@@ -113,6 +113,12 @@ public final class DeltaConsts {
      * name as it appears in {@code protocol.reader-features} / {@code protocol.writer-features}.
      */
     public static final String FEATURE_PREFIX = "delta.feature.";
+
+    /** Derived property from {@code protocol.min-reader-version}. */
+    public static final String MIN_READER_VERSION = "delta.minReaderVersion";
+
+    /** Derived property from {@code protocol.min-writer-version}. */
+    public static final String MIN_WRITER_VERSION = "delta.minWriterVersion";
 
     /**
      * UniForm enabled-formats property: a comma-separated list naming the additional formats to

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -21,7 +21,7 @@ import java.util.Optional;
  * the DELTA-only format rule apply to all tables. The full UC catalog-managed contract ({@link
  * UcManagedDeltaContract}) applies only to MANAGED tables; EXTERNAL tables skip contract validation
  * but still go through the same {@link DeltaPropertyMapper} projection, so derived
- * {@code delta.feature.*} and {@code delta.clusteringColumns} entries override any client-supplied
+ * {@code delta.feature.*} and {@code clusteringColumns} entries override any client-supplied
  * values under those keys.
  */
 public final class DeltaCreateTableMapper {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaPropertyMapper.java
@@ -72,6 +72,8 @@ public final class DeltaPropertyMapper {
       merged.put(
           TableProperties.LAST_COMMIT_TIMESTAMP, String.valueOf(req.getLastCommitTimestampMs()));
     }
+    // For createTable it's always the 0 commit
+    merged.put(TableProperties.LAST_UPDATE_VERSION, "0");
     return merged;
   }
 
@@ -85,6 +87,8 @@ public final class DeltaPropertyMapper {
    */
   public static void deriveFromProtocol(Map<String, String> props, DeltaProtocol protocol) {
     if (protocol == null) return;
+    props.put(TableProperties.MIN_READER_VERSION, protocol.getMinReaderVersion().toString());
+    props.put(TableProperties.MIN_WRITER_VERSION, protocol.getMinWriterVersion().toString());
     addFeatureProperties(props, protocol.getReaderFeatures());
     addFeatureProperties(props, protocol.getWriterFeatures());
   }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/UcManagedDeltaContract.java
@@ -39,17 +39,22 @@ public final class UcManagedDeltaContract {
   public static final List<TableFeature> REQUIRED_FEATURES =
       List.of(
           TableFeature.CATALOG_MANAGED,
-          TableFeature.DELETION_VECTORS,
           TableFeature.V2_CHECKPOINT,
           TableFeature.VACUUM_PROTOCOL_CHECK,
           TableFeature.IN_COMMIT_TIMESTAMP);
 
   /**
    * Suggested features. {@code domainMetadata} is conditionally required with {@code rowTracking}
-   * but is advertised as suggested so clients that enable row tracking enable it too.
+   * but is advertised as suggested so clients that enable row tracking enable it too. {@code
+   * deletionVectors} is suggested rather than required because Iceberg V2 export is not compatible
+   * with it; clients that enable Iceberg uniform must opt out.
    */
   public static final List<TableFeature> SUGGESTED_FEATURES =
-      List.of(TableFeature.COLUMN_MAPPING, TableFeature.DOMAIN_METADATA, TableFeature.ROW_TRACKING);
+      List.of(
+          TableFeature.COLUMN_MAPPING,
+          TableFeature.DELETION_VECTORS,
+          TableFeature.DOMAIN_METADATA,
+          TableFeature.ROW_TRACKING);
 
   // Wire-format spec-name lists, computed once from the typed feature lists above.
   public static final List<String> REQUIRED_READER_FEATURES = readerFeaturesOf(REQUIRED_FEATURES);
@@ -64,7 +69,6 @@ public final class UcManagedDeltaContract {
   public static final Map<String, String> REQUIRED_FIXED_PROPERTIES =
       Map.of(
           TableProperties.CHECKPOINT_POLICY, "v2",
-          TableProperties.ENABLE_DELETION_VECTORS, "true",
           TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true");
 
   /**
@@ -83,6 +87,7 @@ public final class UcManagedDeltaContract {
 
   private static Map<String, String> buildSuggestedProperties() {
     Map<String, String> props = new HashMap<>();
+    props.put(TableProperties.ENABLE_DELETION_VECTORS, "true");
     props.put(TableProperties.ENABLE_ROW_TRACKING, "true");
     props.put(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_ID_COLUMN_NAME, null);
     props.put(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME, null);

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
@@ -82,36 +82,37 @@ public class SdkCreateStagingTableTest extends BaseCRUDTestWithMockCredentials {
     assertThat(resp.getRequiredProtocol().getReaderFeatures())
         .containsExactlyInAnyOrder(
             TableFeature.CATALOG_MANAGED.specName(),
-            TableFeature.DELETION_VECTORS.specName(),
             TableFeature.V2_CHECKPOINT.specName(),
             TableFeature.VACUUM_PROTOCOL_CHECK.specName());
     assertThat(resp.getRequiredProtocol().getWriterFeatures())
         .containsExactlyInAnyOrder(
             TableFeature.CATALOG_MANAGED.specName(),
-            TableFeature.DELETION_VECTORS.specName(),
             TableFeature.IN_COMMIT_TIMESTAMP.specName(),
             TableFeature.V2_CHECKPOINT.specName(),
             TableFeature.VACUUM_PROTOCOL_CHECK.specName());
     assertThat(resp.getSuggestedProtocol().getReaderFeatures())
-        .containsExactlyInAnyOrder(TableFeature.COLUMN_MAPPING.specName());
+        .containsExactlyInAnyOrder(
+            TableFeature.COLUMN_MAPPING.specName(), TableFeature.DELETION_VECTORS.specName());
     assertThat(resp.getSuggestedProtocol().getWriterFeatures())
         .containsExactlyInAnyOrder(
             TableFeature.COLUMN_MAPPING.specName(),
+            TableFeature.DELETION_VECTORS.specName(),
             TableFeature.DOMAIN_METADATA.specName(),
             TableFeature.ROW_TRACKING.specName());
 
     assertThat(resp.getRequiredProperties())
         .containsEntry(TableProperties.CHECKPOINT_POLICY, "v2")
-        .containsEntry(TableProperties.ENABLE_DELETION_VECTORS, "true")
         .containsEntry(TableProperties.ENABLE_IN_COMMIT_TIMESTAMPS, "true")
         // The rule-based property binds the Delta table to the UC-allocated tableId.
         .containsEntry(TableProperties.UC_TABLE_ID, resp.getTableId().toString())
+        .doesNotContainKey(TableProperties.ENABLE_DELETION_VECTORS)
         // ICT enablement version/timestamp are not advertised: catalog-managed tables enable
         // inCommitTimestamp at version 0, and per the Delta protocol the enablement
         // properties only apply when ICT was enabled mid-table.
         .doesNotContainKey(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION)
         .doesNotContainKey(TableProperties.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
     assertThat(resp.getSuggestedProperties())
+        .containsEntry(TableProperties.ENABLE_DELETION_VECTORS, "true")
         .containsEntry(TableProperties.ENABLE_ROW_TRACKING, "true")
         // Null value = client generates a UUID-suffixed column name when enabling row tracking.
         .containsEntry(TableProperties.ROW_TRACKING_MATERIALIZED_ROW_ID_COLUMN_NAME, null)

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaPropertyMapperTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.service.delta;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,6 +50,8 @@ public class DeltaPropertyMapperTest {
     Map<String, String> props = new HashMap<>();
     DeltaPropertyMapper.deriveFromProtocol(props, protocol);
     assertThat(props)
+        .containsEntry(TableProperties.MIN_READER_VERSION, "3")
+        .containsEntry(TableProperties.MIN_WRITER_VERSION, "7")
         .containsEntry(featureKey(TableFeature.CATALOG_MANAGED.specName()), "supported")
         .containsEntry(featureKey(TableFeature.DELETION_VECTORS.specName()), "supported")
         .containsEntry(featureKey(TableFeature.V2_CHECKPOINT.specName()), "supported")
@@ -63,11 +66,14 @@ public class DeltaPropertyMapperTest {
   }
 
   @Test
-  public void deriveFromProtocolEmptyFeatureListsIsNoop() {
+  public void deriveFromProtocolEmptyFeatureListsStillEmitsVersionProps() {
     DeltaProtocol protocol = new DeltaProtocol().minReaderVersion(3).minWriterVersion(7);
     Map<String, String> props = new HashMap<>();
     DeltaPropertyMapper.deriveFromProtocol(props, protocol);
-    assertThat(props).isEmpty();
+    assertThat(props)
+        .containsOnly(
+            entry(TableProperties.MIN_READER_VERSION, "3"),
+            entry(TableProperties.MIN_WRITER_VERSION, "7"));
   }
 
   // ---------- deriveFromDomainMetadata ----------
@@ -141,8 +147,10 @@ public class DeltaPropertyMapperTest {
 
   @Test
   public void mergeTolerantOfAllNulls() {
-    // Empty request: no protocol, no domain-metadata, no properties, no timestamp.
-    assertThat(DeltaPropertyMapper.buildStoredProperties(new CreateTableRequest())).isEmpty();
+    // Empty request: no protocol, no domain-metadata, no properties, no timestamp. The only
+    // entry produced is the unconditional delta.lastUpdateVersion=0 from buildStoredProperties.
+    assertThat(DeltaPropertyMapper.buildStoredProperties(new CreateTableRequest()))
+        .containsOnly(entry(TableProperties.LAST_UPDATE_VERSION, "0"));
   }
 
   @Test
@@ -164,7 +172,8 @@ public class DeltaPropertyMapperTest {
         .containsEntry(featureKey(TableFeature.ROW_TRACKING.specName()), "supported")
         .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "100")
         .containsEntry("custom.key", "custom.value")
-        .containsEntry(TableProperties.LAST_COMMIT_TIMESTAMP, "1700000000000");
+        .containsEntry(TableProperties.LAST_COMMIT_TIMESTAMP, "1700000000000")
+        .containsEntry(TableProperties.LAST_UPDATE_VERSION, "0");
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Fix derive table properties and make deletionVectors not required:
- Derive table properties delta.minReaderVersion, delta.minWriterVersion, delta.lastUpdateVersion
- Fix delta.clusteringColumns to clusteringColumns
- Change feature deletionVectors from required to recommended because it's not compatible with IcebergV2