### PR TITLE
[UC CLI] Make table read honor --output json/jsonPretty

### DIFF
--- a/examples/cli/src/main/java/io/unitycatalog/cli/TableCli.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/TableCli.java
@@ -57,7 +57,7 @@ public class TableCli {
         output = getTable(tablesApi, json);
         break;
       case CliUtils.READ:
-        output = readTable(temporaryCredentialsApi, tablesApi, json);
+        output = readTable(temporaryCredentialsApi, tablesApi, json, cmd);
         break;
       case CliUtils.WRITE:
         output = writeTable(temporaryCredentialsApi, tablesApi, json);
@@ -220,8 +220,11 @@ public class TableCli {
   }
 
   private static String readTable(
-      TemporaryCredentialsApi temporaryCredentialsApi, TablesApi tablesApi, JSONObject json)
-      throws ApiException {
+      TemporaryCredentialsApi temporaryCredentialsApi,
+      TablesApi tablesApi,
+      JSONObject json,
+      CommandLine cmd)
+      throws ApiException, JsonProcessingException {
     String fullTableName = json.getString(CliParams.FULL_NAME.getServerParam());
     TableInfo info =
         tablesApi.getTable(
@@ -242,6 +245,15 @@ public class TableCli {
               new GenerateTemporaryTableCredential()
                   .tableId(tableId)
                   .operation(TableOperation.READ));
+      boolean jsonOutput =
+          cmd.hasOption(CliUtils.OUTPUT)
+              && ("json".equals(cmd.getOptionValue(CliUtils.OUTPUT))
+                  || "jsonPretty".equals(cmd.getOptionValue(CliUtils.OUTPUT)));
+      if (jsonOutput) {
+        return objectWriter.writeValueAsString(
+            DeltaKernelUtils.readDeltaTableAsRecords(
+                info.getStorageLocation(), temporaryCredentials, maxResults));
+      }
       return DeltaKernelUtils.readDeltaTable(
           info.getStorageLocation(), temporaryCredentials, maxResults);
     } catch (Exception e) {

--- a/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
@@ -25,7 +25,9 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -204,6 +206,32 @@ public class DeltaKernelUtils {
         at.addRule();
       }
       return at.render();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to read Delta table", e);
+    }
+  }
+
+  public static List<Map<String, String>> readDeltaTableAsRecords(
+      String tablePath, TemporaryCredentials temporaryCredentials, int maxResults) {
+    Engine engine = getEngine(URI.create(tablePath), temporaryCredentials);
+    try {
+      Table table = Table.forPath(engine, substituteSchemeForS3(tablePath));
+      Snapshot snapshot = table.getLatestSnapshot(engine);
+      StructType readSchema = snapshot.getSchema();
+      ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(readSchema);
+      List<Row> rowData =
+          DeltaKernelReadUtils.readData(engine, readSchema, scanBuilder.build(), maxResults);
+
+      List<Map<String, String>> records = new ArrayList<>();
+      for (Row row : rowData) {
+        Map<String, String> record = new LinkedHashMap<>();
+        for (int colOrdinal = 0; colOrdinal < readSchema.length(); colOrdinal++) {
+          String colName = readSchema.at(colOrdinal).getName();
+          record.put(colName, DeltaKernelReadUtils.getValue(row, colOrdinal));
+        }
+        records.add(record);
+      }
+      return records;
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to read Delta table", e);
     }


### PR DESCRIPTION
## Summary
- Make `uc table read` honor `--output json` and `--output jsonPretty`.
- Keep default non-JSON output behavior unchanged.

## Changes
- `examples/cli/src/main/java/io/unitycatalog/cli/TableCli.java`
  - Route `table read` to JSON records when JSON output is requested.
- `examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java`
  - Add `readDeltaTableAsRecords(...)` to return row records for JSON serialization.

## Validation
- Reproduced issue where `table read` ignored JSON output flag.
- `sbt +clean +package +publishLocal +publishM2` succeeds.
- Smoke test with temp table under `/tmp` returns JSON array for:
  - `uc table read --full_name unity.default.myTableJson --max_results 5 --output json`
