### PR TITLE
[Hadoop] Add buildForStagingTable to UCCredentialHadoopConfs

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -71,7 +71,7 @@ public final class UCCredentialHadoopConfs {
 
   /**
    * Collects credential settings and produces Hadoop configuration properties via {@link
-   * #buildForTable} or {@link #buildForPath}.
+   * #buildForTable}, {@link #buildForStagingTable}, or {@link #buildForPath}.
    */
   public static final class Builder {
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -217,6 +217,37 @@ public final class UCCredentialHadoopConfs {
     }
 
     /**
+     * Builds Hadoop properties for a <em>Delta staging table</em> using the UC Delta staging table
+     * credentials API ({@code GET /delta/v1/staging-tables/{table_id}/credentials}).
+     *
+     * @param stagingTableId the staging table UUID
+     * @param location the staging table storage location, used to select the matching storage
+     *     credential from the response
+     * @return unmodifiable map; empty if the scheme is unrecognized
+     * @throws IllegalArgumentException if {@code stagingTableId}, {@code location}, or {@code
+     *     tokenProvider} is missing
+     * @throws ApiException if the credential fetch from the UC Delta API fails
+     */
+    public Map<String, String> buildForStagingTable(String stagingTableId, String location)
+        throws ApiException {
+      Preconditions.checkArgument(
+          stagingTableId != null && !stagingTableId.isEmpty(), "stagingTableId is required");
+      Preconditions.checkArgument(location != null && !location.isEmpty(), "location is required");
+      Preconditions.checkArgument(tokenProvider != null, "tokenProvider is required");
+      return CredPropsUtil.fetchDeltaStagingTableCredProps(
+          credentialRenewalEnabled,
+          credentialScopedFsEnabled,
+          hadoopConf,
+          scheme,
+          apiClient,
+          catalogUri,
+          tokenProvider,
+          stagingTableId,
+          location,
+          appVersions);
+    }
+
+    /**
      * Builds Hadoop properties for an <em>external path</em> using the UC REST credentials API.
      *
      * @return unmodifiable map; empty if the scheme is unrecognized

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -98,16 +98,18 @@ public class CredPropsUtil {
 
     public T tableId(String tableId) {
       Preconditions.checkState(
-          !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
-          "tableId cannot be set with UC Delta table identifier");
+          !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY)
+              && !builder.containsKey(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY),
+          "tableId cannot be set with UC Delta table or staging table identifier");
       builder.put(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
       return self();
     }
 
     public T ucDeltaTableIdentifier(UCDeltaTableIdentifier identifier, String location) {
       Preconditions.checkState(
-          !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY),
-          "UC Delta table identifier cannot be set with tableId");
+          !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
+              && !builder.containsKey(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY),
+          "UC Delta table identifier cannot be set with tableId or staging table identifier");
       builder.put(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
       builder.put(
           UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -126,6 +126,7 @@ public class CredPropsUtil {
           !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
               && !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
           "deltaStagingTableId cannot be set with tableId or UC Delta table identifier");
+      builder.put(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
       builder.put(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
       builder.put(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
       return self();

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -860,6 +860,7 @@ public class CredPropsUtil {
       Map<String, String> appVersions)
       throws ApiException {
     Configuration reqConf = new Configuration(false);
+    reqConf.set(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true");
     reqConf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
     reqConf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
     TemporaryCredentials creds =

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -121,13 +121,13 @@ public class CredPropsUtil {
       return self();
     }
 
-    public T deltaStagingTableId(String stagingTableId, String location) {
+    public T ucDeltaStagingTableId(String stagingTableId, String location) {
       Preconditions.checkState(
           !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
               && !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
           "deltaStagingTableId cannot be set with tableId or UC Delta table identifier");
       builder.put(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
-      builder.put(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+      builder.put(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
       return self();
     }
 
@@ -590,7 +590,7 @@ public class CredPropsUtil {
         if (renewCredEnabled) {
           return s3TempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-              .deltaStagingTableId(stagingTableId, location)
+              .ucDeltaStagingTableId(stagingTableId, location)
               .appVersions(appVersions)
               .build();
         } else {
@@ -600,7 +600,7 @@ public class CredPropsUtil {
         if (renewCredEnabled) {
           return gcsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-              .deltaStagingTableId(stagingTableId, location)
+              .ucDeltaStagingTableId(stagingTableId, location)
               .appVersions(appVersions)
               .build();
         } else {
@@ -611,7 +611,7 @@ public class CredPropsUtil {
         if (renewCredEnabled) {
           return abfsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
-              .deltaStagingTableId(stagingTableId, location)
+              .ucDeltaStagingTableId(stagingTableId, location)
               .appVersions(appVersions)
               .build();
         } else {
@@ -860,7 +860,7 @@ public class CredPropsUtil {
       throws ApiException {
     Configuration reqConf = new Configuration(false);
     reqConf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
-    reqConf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+    reqConf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
     TemporaryCredentials creds =
         fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, reqConf);
     return createDeltaStagingTableCredProps(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -119,6 +119,16 @@ public class CredPropsUtil {
       return self();
     }
 
+    public T deltaStagingTableId(String stagingTableId, String location) {
+      Preconditions.checkState(
+          !builder.containsKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
+              && !builder.containsKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
+          "deltaStagingTableId cannot be set with tableId or UC Delta table identifier");
+      builder.put(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
+      builder.put(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+      return self();
+    }
+
     public T tableOperation(TableOperation tableOp) {
       builder.put(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, tableOp.getValue());
       return self();
@@ -550,6 +560,67 @@ public class CredPropsUtil {
   }
 
   /**
+   * Builds the Hadoop configuration properties needed to access a Delta staging table's storage.
+   *
+   * @param renewCredEnabled when {@code true}, configures a vended-token provider that
+   *     automatically refreshes credentials before expiry; when {@code false}, embeds the initial
+   *     credentials as static keys.
+   * @param credScopedFsEnabled when {@code true}, overrides {@code fs.<scheme>.impl} with
+   *     CredScopedFileSystem so that filesystem instances are reused per credential scope rather
+   *     than created anew for every file access.
+   * @param hadoopConf the engine's existing Hadoop configuration, used to read any previously
+   *     configured {@code fs.<scheme>.impl} values before they are overridden by
+   *     CredScopedFileSystem.
+   */
+  public static Map<String, String> createDeltaStagingTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      String uri,
+      TokenProvider tokenProvider,
+      String stagingTableId,
+      String location,
+      TemporaryCredentials tempCreds,
+      Map<String, String> appVersions) {
+    switch (scheme) {
+      case "s3":
+        if (renewCredEnabled) {
+          return s3TempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .deltaStagingTableId(stagingTableId, location)
+              .appVersions(appVersions)
+              .build();
+        } else {
+          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      case "gs":
+        if (renewCredEnabled) {
+          return gcsTempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .deltaStagingTableId(stagingTableId, location)
+              .appVersions(appVersions)
+              .build();
+        } else {
+          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      case "abfss":
+      case "abfs":
+        if (renewCredEnabled) {
+          return abfsTempCredPropsBuilder(
+                  credScopedFsEnabled, hadoopConf, uri, tokenProvider, tempCreds)
+              .deltaStagingTableId(stagingTableId, location)
+              .appVersions(appVersions)
+              .build();
+        } else {
+          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+        }
+      default:
+        return Collections.emptyMap();
+    }
+  }
+
+  /**
    * Builds the Hadoop configuration properties needed to access a table's storage location.
    *
    * @param renewCredEnabled when {@code true}, configures a vended-token provider that
@@ -765,6 +836,40 @@ public class CredPropsUtil {
         identifier,
         location,
         CredentialOperation.fromValue(tableOp.value()),
+        creds,
+        appVersions);
+  }
+
+  /**
+   * Fetches Delta staging table credentials from the UC Delta API and builds Hadoop configuration
+   * properties.
+   */
+  public static Map<String, String> fetchDeltaStagingTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      String stagingTableId,
+      String location,
+      Map<String, String> appVersions)
+      throws ApiException {
+    Configuration reqConf = new Configuration(false);
+    reqConf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId);
+    reqConf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, location);
+    TemporaryCredentials creds =
+        fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, reqConf);
+    return createDeltaStagingTableCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        catalogUri,
+        tokenProvider,
+        stagingTableId,
+        location,
         creds,
         appVersions);
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -83,6 +83,8 @@ public class UCHadoopConfConstants {
   // Key for UC Delta staging table credential requests.
   public static final String UC_DELTA_STAGING_TABLE_ID_KEY =
       "fs.unitycatalog.delta.staging.table.id";
+  public static final String UC_DELTA_STAGING_TABLE_LOCATION_KEY =
+      "fs.unitycatalog.delta.staging.table.location";
 
   // Keys for path based temporary credential requests.
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -80,6 +80,10 @@ public class UCHadoopConfConstants {
   public static final String UC_DELTA_TABLE_NAME_KEY = "fs.unitycatalog.delta.table.name";
   public static final String UC_DELTA_LOCATION_KEY = "fs.unitycatalog.delta.location";
 
+  // Key for UC Delta staging table credential requests.
+  public static final String UC_DELTA_STAGING_TABLE_ID_KEY =
+      "fs.unitycatalog.delta.staging.table.id";
+
   // Keys for path based temporary credential requests.
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";
   public static final String UC_PATH_OPERATION_KEY = "fs.unitycatalog.path.operation";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -31,6 +31,12 @@ public interface GenericCredentialFetcher {
     return new UCDeltaGenericCredentialFetcher(conf, api);
   }
 
+  /** Creates a fetcher backed by the UC Delta staging table credentials API. */
+  static GenericCredentialFetcher forUcDeltaStagingTable(
+      Configuration conf, io.unitycatalog.client.delta.api.TemporaryCredentialsApi api) {
+    return new UCDeltaStagingTableCredentialFetcher(conf, api);
+  }
+
   /**
    * Creates a {@link GenericCredentialFetcher} from an already-built {@link ApiClient} and a Hadoop
    * configuration containing only the credential-request keys (type, table/path id, operation, and
@@ -38,6 +44,11 @@ public interface GenericCredentialFetcher {
    * apiClient} already carries authentication.
    */
   static GenericCredentialFetcher create(ApiClient apiClient, Configuration conf) {
+    String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+    if (stagingTableId != null) {
+      return forUcDeltaStagingTable(
+          conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+    }
     boolean useDeltaCredentialsApi =
         conf.getBoolean(
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -50,7 +50,7 @@ public interface GenericCredentialFetcher {
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
     if (useDeltaCredentialsApi) {
       String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
-      if (stagingTableId != null) {
+      if (stagingTableId != null && !stagingTableId.isEmpty()) {
         // Get the credential for the staging table, via UC Delta API.
         return forUcDeltaStagingTable(
             conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -44,19 +44,23 @@ public interface GenericCredentialFetcher {
    * apiClient} already carries authentication.
    */
   static GenericCredentialFetcher create(ApiClient apiClient, Configuration conf) {
-    String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
-    if (stagingTableId != null) {
-      return forUcDeltaStagingTable(
-          conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
-    }
     boolean useDeltaCredentialsApi =
         conf.getBoolean(
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
     if (useDeltaCredentialsApi) {
-      return forUcDelta(
-          conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+      String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+      if (stagingTableId != null) {
+        // Get the credential for the staging table, via UC Delta API.
+        return forUcDeltaStagingTable(
+            conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+      } else {
+        // Get the credentials for the normal table, via UC Delta API.
+        return forUcDelta(
+            conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+      }
     } else {
+      // Get the credentials for either path or table, via legacy UC API.
       return forUc(conf, new io.unitycatalog.client.api.TemporaryCredentialsApi(apiClient));
     }
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -49,18 +49,15 @@ public interface GenericCredentialFetcher {
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
             UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
     if (useDeltaCredentialsApi) {
+      io.unitycatalog.client.delta.api.TemporaryCredentialsApi deltaApi =
+          new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient);
       String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
       if (stagingTableId != null && !stagingTableId.isEmpty()) {
-        // Get the credential for the staging table, via UC Delta API.
-        return forUcDeltaStagingTable(
-            conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+        return forUcDeltaStagingTable(conf, deltaApi);
       } else {
-        // Get the credentials for the normal table, via UC Delta API.
-        return forUcDelta(
-            conf, new io.unitycatalog.client.delta.api.TemporaryCredentialsApi(apiClient));
+        return forUcDelta(conf, deltaApi);
       }
     } else {
-      // Get the credentials for either path or table, via legacy UC API.
       return forUc(conf, new io.unitycatalog.client.api.TemporaryCredentialsApi(apiClient));
     }
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
@@ -11,16 +11,23 @@ import org.apache.hadoop.conf.Configuration;
 
 /** Adapts the UC Delta staging table credentials SDK API for Hadoop token providers. */
 final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFetcher {
+
   private final TemporaryCredentialsApi api;
   private final UUID stagingTableId;
-  private final String location;
+  private final String stagingTableLocation;
 
   UCDeltaStagingTableCredentialFetcher(Configuration conf, TemporaryCredentialsApi api) {
-    Preconditions.checkNotNull(api, "api is required");
+    // Initial the temporary credentials API.
+    Preconditions.checkNotNull(api, "Temporary credentials API is required");
     this.api = api;
+
+    // Initial the staging table id.
     String rawId = require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
     this.stagingTableId = UUID.fromString(rawId);
-    this.location = require(conf, UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+
+    // Initial the staging table location.
+    this.stagingTableLocation =
+        require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
   }
 
   @Override
@@ -30,16 +37,19 @@ final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFet
         response != null,
         "UC Delta API returned no credentials response for staging table '%s'.",
         stagingTableId);
+
     return new GenericCredential(
         DeltaStorageCredentialUtil.toTemporaryCredentials(
             DeltaStorageCredentialUtil.selectForLocation(
-                location, response.getStorageCredentials())));
+                stagingTableLocation, response.getStorageCredentials())));
   }
 
   private static String require(Configuration conf, String key) {
     String value = conf.get(key);
     Preconditions.checkArgument(
-        value != null && !value.isEmpty(), "'%s' is not set in hadoop configuration", key);
+        value != null && !value.isEmpty(),
+        "The required '%s' is not set in hadoop configuration",
+        key);
     return value;
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
@@ -1,0 +1,45 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+
+/** Adapts the UC Delta staging table credentials SDK API for Hadoop token providers. */
+final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFetcher {
+  private final TemporaryCredentialsApi api;
+  private final UUID stagingTableId;
+  private final String location;
+
+  UCDeltaStagingTableCredentialFetcher(Configuration conf, TemporaryCredentialsApi api) {
+    Preconditions.checkNotNull(api, "api is required");
+    this.api = api;
+    String rawId = require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+    this.stagingTableId = UUID.fromString(rawId);
+    this.location = require(conf, UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+  }
+
+  @Override
+  public GenericCredential createCredential() throws ApiException {
+    CredentialsResponse response = api.getStagingTableCredentials(stagingTableId);
+    Preconditions.checkArgument(
+        response != null,
+        "UC Delta API returned no credentials response for staging table '%s'.",
+        stagingTableId);
+    return new GenericCredential(
+        DeltaStorageCredentialUtil.toTemporaryCredentials(
+            DeltaStorageCredentialUtil.selectForLocation(
+                location, response.getStorageCredentials())));
+  }
+
+  private static String require(Configuration conf, String key) {
+    String value = conf.get(key);
+    Preconditions.checkArgument(
+        value != null && !value.isEmpty(), "'%s' is not set in hadoop configuration", key);
+    return value;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
@@ -17,15 +17,10 @@ final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFet
   private final String stagingTableLocation;
 
   UCDeltaStagingTableCredentialFetcher(Configuration conf, TemporaryCredentialsApi api) {
-    // Initial the temporary credentials API.
     Preconditions.checkNotNull(api, "Temporary credentials API is required");
     this.api = api;
-
-    // Initial the staging table id.
-    String rawId = require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
-    this.stagingTableId = UUID.fromString(rawId);
-
-    // Initial the staging table location.
+    this.stagingTableId =
+        UUID.fromString(require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY));
     this.stagingTableLocation =
         require(conf, UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -43,19 +43,18 @@ import org.apache.hadoop.fs.FileSystem;
 public interface CredScopedKey {
 
   static CredScopedKey create(URI uri, Configuration conf) {
-    // Case 1: Delta staging table — keyed by staging table UUID + location.
-    String stagingTableId = conf.get(UC_DELTA_STAGING_TABLE_ID_KEY);
-    if (stagingTableId != null && !stagingTableId.isEmpty()) {
-      String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
-      return new DeltaStagingTableCredScopedKey(stagingTableId, location);
-    }
-
     String type = conf.get(UC_CREDENTIALS_TYPE_KEY);
     boolean isDeltaApi =
         conf.getBoolean(
             UC_DELTA_CREDENTIALS_API_ENABLED_KEY, UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
+    String stagingTableId = conf.get(UC_DELTA_STAGING_TABLE_ID_KEY);
 
-    if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
+    if (stagingTableId != null && !stagingTableId.isEmpty()) {
+      // Case 1: Delta staging table — keyed by staging table UUID + location.
+      String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
+      return new DeltaStagingTableCredScopedKey(stagingTableId, location);
+
+    } else if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
       // Case 2: Path-based credentials — keyed by path + operation.
       String path = conf.get(UC_PATH_KEY);
       String pathOp = conf.get(UC_PATH_OPERATION_KEY);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 public interface CredScopedKey {
 
   static CredScopedKey create(URI uri, Configuration conf) {
+    // Case 1: Delta staging table — keyed by staging table UUID + location.
     String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
     if (stagingTableId != null && !stagingTableId.isEmpty()) {
       String location = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
@@ -35,27 +36,38 @@ public interface CredScopedKey {
     }
 
     String type = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
-    if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
-      String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
-      String pathOperation = conf.get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY);
-      return new PathCredScopedKey(path, pathOperation);
-    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
-      String tableOperation = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
-      if (conf.getBoolean(
-          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
-          UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE)) {
-        String catalog = conf.get(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY);
-        String schema = conf.get(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY);
-        String tableName = conf.get(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY);
-        String location = conf.get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
-        UCDeltaTableIdentifier identifier = UCDeltaTableIdentifier.of(catalog, schema, tableName);
-        return new DeltaTableCredScopedKey(identifier, tableOperation, location);
-      }
-      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
-      return new TableCredScopedKey(tableId, tableOperation);
-    }
+    boolean isDeltaApi =
+        conf.getBoolean(
+            UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
+            UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
 
-    return new DefaultCredScopedKey(uri, conf);
+    if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
+      // Case 2: Path-based credentials — keyed by path + operation.
+      String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
+      String pathOp = conf.get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY);
+      return new PathCredScopedKey(path, pathOp);
+
+    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && isDeltaApi) {
+      // Case 3: Delta table — keyed by catalog.schema.table + operation + location.
+      String tableOp = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
+      UCDeltaTableIdentifier identifier =
+          UCDeltaTableIdentifier.of(
+              conf.get(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
+              conf.get(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY),
+              conf.get(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY));
+      String location = conf.get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+      return new DeltaTableCredScopedKey(identifier, tableOp, location);
+
+    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
+      // Case 4: UC table (legacy API) — keyed by table ID + operation.
+      String tableOp = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
+      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
+      return new TableCredScopedKey(tableId, tableOp);
+
+    } else {
+      // Case 5: Fallback — keyed by URI scheme + authority.
+      return new DefaultCredScopedKey(uri, conf);
+    }
   }
 
   class PathCredScopedKey implements CredScopedKey {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -1,7 +1,22 @@
 package io.unitycatalog.hadoop.internal.fs;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CATALOG_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_LOCATION_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_OPERATION_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
+
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
-import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
@@ -29,39 +44,38 @@ public interface CredScopedKey {
 
   static CredScopedKey create(URI uri, Configuration conf) {
     // Case 1: Delta staging table — keyed by staging table UUID + location.
-    String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+    String stagingTableId = conf.get(UC_DELTA_STAGING_TABLE_ID_KEY);
     if (stagingTableId != null && !stagingTableId.isEmpty()) {
-      String location = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
+      String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
       return new DeltaStagingTableCredScopedKey(stagingTableId, location);
     }
 
-    String type = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
+    String type = conf.get(UC_CREDENTIALS_TYPE_KEY);
     boolean isDeltaApi =
         conf.getBoolean(
-            UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
-            UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
+            UC_DELTA_CREDENTIALS_API_ENABLED_KEY, UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE);
 
-    if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
+    if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
       // Case 2: Path-based credentials — keyed by path + operation.
-      String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
-      String pathOp = conf.get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY);
+      String path = conf.get(UC_PATH_KEY);
+      String pathOp = conf.get(UC_PATH_OPERATION_KEY);
       return new PathCredScopedKey(path, pathOp);
 
-    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && isDeltaApi) {
+    } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && isDeltaApi) {
       // Case 3: Delta table — keyed by catalog.schema.table + operation + location.
-      String tableOp = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
+      String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       UCDeltaTableIdentifier identifier =
           UCDeltaTableIdentifier.of(
-              conf.get(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY),
-              conf.get(UCHadoopConfConstants.UC_DELTA_SCHEMA_KEY),
-              conf.get(UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY));
-      String location = conf.get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+              conf.get(UC_DELTA_CATALOG_KEY),
+              conf.get(UC_DELTA_SCHEMA_KEY),
+              conf.get(UC_DELTA_TABLE_NAME_KEY));
+      String location = conf.get(UC_DELTA_LOCATION_KEY);
       return new DeltaTableCredScopedKey(identifier, tableOp, location);
 
-    } else if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
+    } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)) {
       // Case 4: UC table (legacy API) — keyed by table ID + operation.
-      String tableOp = conf.get(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY);
-      String tableId = conf.get(UCHadoopConfConstants.UC_TABLE_ID_KEY);
+      String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
+      String tableId = conf.get(UC_TABLE_ID_KEY);
       return new TableCredScopedKey(tableId, tableOp);
 
     } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedKey.java
@@ -10,13 +10,15 @@ import org.apache.hadoop.fs.FileSystem;
 /**
  * Cache key that identifies a credential scope for {@link CredScopedFileSystem}.
  *
- * <p>There are four implementations:
+ * <p>There are five implementations:
  *
  * <ul>
  *   <li>{@link TableCredScopedKey} — keyed by table ID and operation; used for table-level
  *       temporary credentials via the UC credentials API.
  *   <li>{@link DeltaTableCredScopedKey} — keyed by table identity, operation, and location; used
  *       for table-level temporary credentials via the UC Delta credentials API.
+ *   <li>{@link DeltaStagingTableCredScopedKey} — keyed by staging table ID and location; used for
+ *       staging-table-level temporary credentials via the UC Delta credentials API.
  *   <li>{@link PathCredScopedKey} — keyed by path and operation; used for path-level temporary
  *       credentials.
  *   <li>{@link DefaultCredScopedKey} — keyed by URI scheme and authority; used as a fallback when
@@ -26,6 +28,12 @@ import org.apache.hadoop.fs.FileSystem;
 public interface CredScopedKey {
 
   static CredScopedKey create(URI uri, Configuration conf) {
+    String stagingTableId = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+    if (stagingTableId != null && !stagingTableId.isEmpty()) {
+      String location = conf.get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
+      return new DeltaStagingTableCredScopedKey(stagingTableId, location);
+    }
+
     String type = conf.get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY);
     if (UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)) {
       String path = conf.get(UCHadoopConfConstants.UC_PATH_KEY);
@@ -140,6 +148,39 @@ public interface CredScopedKey {
           + identifier
           + ", op="
           + tableOperation
+          + ", location="
+          + location
+          + "}";
+    }
+  }
+
+  class DeltaStagingTableCredScopedKey implements CredScopedKey {
+    private final String stagingTableId;
+    private final String location;
+
+    public DeltaStagingTableCredScopedKey(String stagingTableId, String location) {
+      this.stagingTableId = stagingTableId;
+      this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof DeltaStagingTableCredScopedKey)) return false;
+      DeltaStagingTableCredScopedKey that = (DeltaStagingTableCredScopedKey) o;
+      return Objects.equals(stagingTableId, that.stagingTableId)
+          && Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(stagingTableId, location);
+    }
+
+    @Override
+    public String toString() {
+      return "DeltaStagingTableCredScopedKey{stagingTableId="
+          + stagingTableId
           + ", location="
           + location
           + "}";

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
@@ -108,6 +108,53 @@ class UCCredentialHadoopConfsTest {
   }
 
   @Test
+  void missingTokenProviderThrowsForStagingTable() throws Exception {
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .buildForStagingTable("staging-id", "s3://bucket/staging"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tokenProvider");
+  }
+
+  @Test
+  void stagingTableBuildRejectsMissingFields() {
+    TokenProvider tp = TokenProvider.create(Map.of("type", "static", "token", "tok"));
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForStagingTable(null, "s3://bucket/staging"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("stagingTableId is required");
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForStagingTable("", "s3://bucket/staging"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("stagingTableId is required");
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForStagingTable("staging-id", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("location is required");
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForStagingTable("staging-id", ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("location is required");
+  }
+
+  @Test
   void pathOperationValuesRoundTripThroughSdkEnum() {
     // Hadoop enum strings must match SDK enum strings exactly — otherwise the UC
     // server rejects the request at runtime and no other test catches it.

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -382,6 +382,7 @@ class CredPropsUtilTest {
         .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
         .containsEntry(
             UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://bucket/staging")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, "sk")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, "st")
@@ -408,6 +409,7 @@ class CredPropsUtilTest {
         .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
         .containsEntry(
             UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "gs://bucket/staging")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
         .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "token");
   }
 
@@ -431,6 +433,7 @@ class CredPropsUtilTest {
         .containsEntry(
             UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY,
             "abfss://container@account.dfs.core.windows.net/staging")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true")
         .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, "sas");
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -380,7 +380,8 @@ class CredPropsUtilTest {
 
     assertThat(props)
         .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
-        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/staging")
+        .containsEntry(
+            UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://bucket/staging")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, "sk")
         .containsEntry(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, "st")
@@ -405,7 +406,8 @@ class CredPropsUtilTest {
 
     assertThat(props)
         .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
-        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "gs://bucket/staging")
+        .containsEntry(
+            UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "gs://bucket/staging")
         .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "token");
   }
 
@@ -427,7 +429,7 @@ class CredPropsUtilTest {
     assertThat(props)
         .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
         .containsEntry(
-            UCHadoopConfConstants.UC_DELTA_LOCATION_KEY,
+            UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY,
             "abfss://container@account.dfs.core.windows.net/staging")
         .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, "sas");
   }
@@ -524,7 +526,7 @@ class CredPropsUtilTest {
   void propsBuilderRejectsTableIdAfterStagingTableId() {
     CredPropsUtil.S3PropsBuilder builder =
         new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
-    builder.deltaStagingTableId("staging-id", "s3://bucket/staging");
+    builder.ucDeltaStagingTableId("staging-id", "s3://bucket/staging");
 
     assertThatThrownBy(() -> builder.tableId("table-id"))
         .isInstanceOf(IllegalStateException.class)
@@ -535,7 +537,7 @@ class CredPropsUtilTest {
   void propsBuilderRejectsDeltaTableIdentifierAfterStagingTableId() {
     CredPropsUtil.S3PropsBuilder builder =
         new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
-    builder.deltaStagingTableId("staging-id", "s3://bucket/staging");
+    builder.ucDeltaStagingTableId("staging-id", "s3://bucket/staging");
 
     assertThatThrownBy(
             () ->
@@ -551,7 +553,7 @@ class CredPropsUtilTest {
         new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
     builder.tableId("table-id");
 
-    assertThatThrownBy(() -> builder.deltaStagingTableId("staging-id", "s3://bucket/staging"))
+    assertThatThrownBy(() -> builder.ucDeltaStagingTableId("staging-id", "s3://bucket/staging"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("deltaStagingTableId cannot be set");
   }
@@ -563,7 +565,7 @@ class CredPropsUtilTest {
     builder.ucDeltaTableIdentifier(
         UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl");
 
-    assertThatThrownBy(() -> builder.deltaStagingTableId("staging-id", "s3://bucket/staging"))
+    assertThatThrownBy(() -> builder.ucDeltaStagingTableId("staging-id", "s3://bucket/staging"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("deltaStagingTableId cannot be set");
   }
@@ -876,7 +878,7 @@ class CredPropsUtilTest {
 
     assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY))
         .isEqualTo("staging-uuid");
-    assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY))
+    assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY))
         .isEqualTo("s3://bucket/staging");
     assertThat(props).containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak");
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -503,7 +503,7 @@ class CredPropsUtilTest {
 
     assertThatThrownBy(() -> builder.tableId("table-id"))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("tableId cannot be set with UC Delta table identifier");
+        .hasMessageContaining("tableId cannot be set");
   }
 
   @Test
@@ -517,7 +517,32 @@ class CredPropsUtilTest {
                 builder.ucDeltaTableIdentifier(
                     UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl"))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("UC Delta table identifier cannot be set with tableId");
+        .hasMessageContaining("UC Delta table identifier cannot be set");
+  }
+
+  @Test
+  void propsBuilderRejectsTableIdAfterStagingTableId() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.deltaStagingTableId("staging-id", "s3://bucket/staging");
+
+    assertThatThrownBy(() -> builder.tableId("table-id"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tableId cannot be set");
+  }
+
+  @Test
+  void propsBuilderRejectsDeltaTableIdentifierAfterStagingTableId() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.deltaStagingTableId("staging-id", "s3://bucket/staging");
+
+    assertThatThrownBy(
+            () ->
+                builder.ucDeltaTableIdentifier(
+                    UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UC Delta table identifier cannot be set");
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -879,6 +879,8 @@ class CredPropsUtilTest {
             "s3://bucket/staging",
             Map.of());
 
+    assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY))
+        .isEqualTo("true");
     assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY))
         .isEqualTo("staging-uuid");
     assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY))

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -361,6 +361,139 @@ class CredPropsUtilTest {
         .doesNotContainKey("fs.s3a.impl.original");
   }
 
+  // For Delta staging table API.
+
+  @Test
+  void s3DeltaStagingTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaStagingTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            tokenProvider(),
+            "staging-uuid",
+            "s3://bucket/staging",
+            s3Creds(),
+            Map.of());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/staging")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, "sk")
+        .containsEntry(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, "st")
+        .doesNotContainKey(UCHadoopConfConstants.UC_TABLE_ID_KEY)
+        .doesNotContainKey(UCHadoopConfConstants.UC_DELTA_CATALOG_KEY);
+  }
+
+  @Test
+  void gcsDeltaStagingTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaStagingTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            tokenProvider(),
+            "staging-uuid",
+            "gs://bucket/staging",
+            gcsCreds(),
+            Map.of());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "gs://bucket/staging")
+        .containsEntry(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, "token");
+  }
+
+  @Test
+  void abfsDeltaStagingTableCredsHaveExpectedKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaStagingTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "abfss",
+            "http://uc",
+            tokenProvider(),
+            "staging-uuid",
+            "abfss://container@account.dfs.core.windows.net/staging",
+            abfsCreds(),
+            Map.of());
+
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "staging-uuid")
+        .containsEntry(
+            UCHadoopConfConstants.UC_DELTA_LOCATION_KEY,
+            "abfss://container@account.dfs.core.windows.net/staging")
+        .containsEntry(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, "sas");
+  }
+
+  @Test
+  void deltaStagingTableStaticCredsEmbedCloudKeysAndOmitStagingKeys() {
+    Map<String, String> props =
+        CredPropsUtil.createDeltaStagingTableCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            null,
+            "staging-uuid",
+            "s3://bucket/staging",
+            s3Creds(),
+            Map.of());
+
+    assertThat(props)
+        .containsEntry("fs.s3a.access.key", "ak")
+        .containsEntry("fs.s3a.secret.key", "sk")
+        .containsEntry("fs.s3a.session.token", "st")
+        .doesNotContainKey(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+  }
+
+  @Test
+  void deltaStagingTableUnknownSchemeReturnsEmptyMap() {
+    assertThat(
+            CredPropsUtil.createDeltaStagingTableCredProps(
+                false,
+                false,
+                new Configuration(false),
+                "hdfs",
+                "http://uc",
+                null,
+                "staging-uuid",
+                "hdfs://namenode/staging",
+                s3Creds(),
+                Map.of()))
+        .isEmpty();
+  }
+
+  @Test
+  void s3DeltaStagingTableOriginalImplPreservedWithCredScopedFs() {
+    Configuration conf = new Configuration(false);
+    conf.set("fs.s3.impl", CUSTOM_S3_IMPL);
+    conf.set("fs.s3a.impl", CUSTOM_S3_IMPL);
+
+    Map<String, String> props =
+        CredPropsUtil.createDeltaStagingTableCredProps(
+            true,
+            true,
+            conf,
+            "s3",
+            "http://uc",
+            tokenProvider(),
+            "staging-uuid",
+            "s3://bucket/staging",
+            s3Creds(),
+            Map.of());
+
+    assertThat(props.get("fs.s3.impl.original")).isEqualTo(CUSTOM_S3_IMPL);
+    assertThat(props.get("fs.s3a.impl.original")).isEqualTo(CUSTOM_S3_IMPL);
+  }
+
   @Test
   void propsBuilderRejectsTableIdAfterDeltaTableIdentifier() {
     CredPropsUtil.S3PropsBuilder builder =
@@ -385,6 +518,29 @@ class CredPropsUtilTest {
                     UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("UC Delta table identifier cannot be set with tableId");
+  }
+
+  @Test
+  void propsBuilderRejectsStagingTableIdAfterTableId() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.tableId("table-id");
+
+    assertThatThrownBy(() -> builder.deltaStagingTableId("staging-id", "s3://bucket/staging"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("deltaStagingTableId cannot be set");
+  }
+
+  @Test
+  void propsBuilderRejectsStagingTableIdAfterDeltaTableIdentifier() {
+    CredPropsUtil.S3PropsBuilder builder =
+        new CredPropsUtil.S3PropsBuilder(false, new Configuration(false));
+    builder.ucDeltaTableIdentifier(
+        UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "s3://bucket/tbl");
+
+    assertThatThrownBy(() -> builder.deltaStagingTableId("staging-id", "s3://bucket/staging"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("deltaStagingTableId cannot be set");
   }
 
   // UC REST table and path credential props.
@@ -668,6 +824,35 @@ class CredPropsUtilTest {
     assertThat(captured.get().get(UCHadoopConfConstants.UC_PATH_KEY)).isEqualTo("s3://bucket/key");
     assertThat(captured.get().get(UCHadoopConfConstants.UC_PATH_OPERATION_KEY))
         .isEqualTo("PATH_CREATE_TABLE");
+    assertThat(props).containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak");
+  }
+
+  @Test
+  void fetchDeltaStagingTableCredPropsAssemblesReqConfAndReturnsCredProps() throws Exception {
+    AtomicReference<Configuration> captured = new AtomicReference<>();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, conf) -> {
+          captured.set(conf);
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    Map<String, String> props =
+        CredPropsUtil.fetchDeltaStagingTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            null,
+            "http://uc",
+            tokenProvider(),
+            "staging-uuid",
+            "s3://bucket/staging",
+            Map.of());
+
+    assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY))
+        .isEqualTo("staging-uuid");
+    assertThat(captured.get().get(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY))
+        .isEqualTo("s3://bucket/staging");
     assertThat(props).containsEntry(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, "ak");
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
@@ -52,7 +52,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
     GenericCredentialFetcher fetcher = GenericCredentialFetcher.forUcDeltaStagingTable(conf, api);
 
     conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, UUID.randomUUID().toString());
-    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/mutated");
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://bucket/mutated");
 
     fetcher.createCredential();
 
@@ -75,7 +75,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
   @Test
   void factoryThrowsWhenConfMissingStagingTableId() {
     Configuration conf = new Configuration(false);
-    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, LOCATION);
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, LOCATION);
 
     TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
     assertThatThrownBy(() -> GenericCredentialFetcher.forUcDeltaStagingTable(conf, api))
@@ -91,13 +91,13 @@ class UCDeltaStagingTableCredentialFetcherTest {
     TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
     assertThatThrownBy(() -> GenericCredentialFetcher.forUcDeltaStagingTable(conf, api))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+        .hasMessageContaining(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY);
   }
 
   private static Configuration stagingConf() {
     Configuration conf = new Configuration(false);
     conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, STAGING_ID.toString());
-    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, LOCATION);
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, LOCATION);
     return conf;
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
@@ -1,0 +1,117 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.delta.model.StorageCredential;
+import io.unitycatalog.client.delta.model.StorageCredentialConfig;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+class UCDeltaStagingTableCredentialFetcherTest {
+
+  private static final UUID STAGING_ID = UUID.randomUUID();
+  private static final String LOCATION = "s3://bucket/staging-table";
+
+  @Test
+  void createCredentialCallsDeltaStagingApiAndReturnsCredential() throws Exception {
+    Configuration conf = stagingConf();
+    CredentialsResponse response = s3StagingResponse();
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(response);
+
+    GenericCredential cred =
+        GenericCredentialFetcher.forUcDeltaStagingTable(conf, api).createCredential();
+
+    assertThat(cred).isNotNull();
+    TemporaryCredentials out = cred.temporaryCredentials();
+    assertThat(out.getAwsTempCredentials().getAccessKeyId()).isEqualTo("ak");
+    assertThat(out.getAwsTempCredentials().getSecretAccessKey()).isEqualTo("sk");
+    assertThat(out.getAwsTempCredentials().getSessionToken()).isEqualTo("st");
+    assertThat(out.getExpirationTime()).isEqualTo(1234L);
+    verify(api).getStagingTableCredentials(STAGING_ID);
+  }
+
+  @Test
+  void createCredentialUsesFieldsParsedAtConstruction() throws Exception {
+    Configuration conf = stagingConf();
+    CredentialsResponse response = s3StagingResponse();
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(response);
+    GenericCredentialFetcher fetcher = GenericCredentialFetcher.forUcDeltaStagingTable(conf, api);
+
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, UUID.randomUUID().toString());
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, "s3://bucket/mutated");
+
+    fetcher.createCredential();
+
+    verify(api).getStagingTableCredentials(STAGING_ID);
+  }
+
+  @Test
+  void createCredentialRejectsNullResponse() throws Exception {
+    Configuration conf = stagingConf();
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(null);
+
+    assertThatThrownBy(
+            () -> GenericCredentialFetcher.forUcDeltaStagingTable(conf, api).createCredential())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("returned no credentials response");
+  }
+
+  @Test
+  void factoryThrowsWhenConfMissingStagingTableId() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, LOCATION);
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    assertThatThrownBy(() -> GenericCredentialFetcher.forUcDeltaStagingTable(conf, api))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY);
+  }
+
+  @Test
+  void factoryThrowsWhenConfMissingLocation() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, STAGING_ID.toString());
+
+    TemporaryCredentialsApi api = mock(TemporaryCredentialsApi.class);
+    assertThatThrownBy(() -> GenericCredentialFetcher.forUcDeltaStagingTable(conf, api))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY);
+  }
+
+  private static Configuration stagingConf() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, STAGING_ID.toString());
+    conf.set(UCHadoopConfConstants.UC_DELTA_LOCATION_KEY, LOCATION);
+    return conf;
+  }
+
+  private static CredentialsResponse s3StagingResponse() {
+    StorageCredential sc =
+        new StorageCredential()
+            .prefix(LOCATION)
+            .operation(CredentialOperation.READ_WRITE)
+            .expirationTimeMs(1234L)
+            .config(
+                new StorageCredentialConfig()
+                    .s3AccessKeyId("ak")
+                    .s3SecretAccessKey("sk")
+                    .s3SessionToken("st"));
+    return new CredentialsResponse().addStorageCredentialsItem(sc);
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedKeyTest.java
@@ -169,6 +169,52 @@ class CredScopedKeyTest {
         .isEqualTo(new CredScopedKey.TableCredScopedKey("tid", "READ"));
   }
 
+  @Test
+  void deltaStagingTableKeyEqualWhenSameFields() {
+    assertThat(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/staging"))
+        .isEqualTo(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/staging"))
+        .hasSameHashCodeAs(
+            new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/staging"));
+  }
+
+  @Test
+  void deltaStagingTableKeyNotEqualWhenDifferentId() {
+    assertThat(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/staging"))
+        .isNotEqualTo(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-2", "s3://b/staging"));
+  }
+
+  @Test
+  void deltaStagingTableKeyNotEqualWhenDifferentLocation() {
+    assertThat(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/loc1"))
+        .isNotEqualTo(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/loc2"));
+  }
+
+  @Test
+  void createReturnsDeltaStagingTableKey() {
+    Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "stid-1");
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://b/staging");
+
+    assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
+        .isInstanceOf(CredScopedKey.DeltaStagingTableCredScopedKey.class)
+        .isEqualTo(new CredScopedKey.DeltaStagingTableCredScopedKey("stid-1", "s3://b/staging"));
+  }
+
+  @Test
+  void stagingTableKeyTakesPriorityOverTableType() {
+    Configuration conf = new Configuration();
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "stid-1");
+    conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://b/staging");
+
+    assertThat(CredScopedKey.create(URI.create("s3://b"), conf))
+        .isInstanceOf(CredScopedKey.DeltaStagingTableCredScopedKey.class);
+  }
+
   private static Configuration deltaTableConf(String location, String uid) {
     Configuration conf = new Configuration();
     conf.set(


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Wire the Delta REST `getStagingTableCredentials` endpoint
(`GET /delta/v1/staging-tables/{table_id}/credentials`) into the Hadoop
credential-vending layer so connectors (Spark, Flink, Trino, etc.) can obtain
staging-table credentials through the same `UCCredentialHadoopConfs` builder API.

### New public API

```java
Map<String, String> props = UCCredentialHadoopConfs.builder(uri, "s3")
    .tokenProvider(tokenProvider)
    .enableCredentialRenewal(true)
    .enableCredentialScopedFs(true)
    .hadoopConf(hadoopConf)
    .buildForStagingTable(stagingTableId, location);
```

### Changes

| File | What |
|------|------|
| `UCHadoopConfConstants` | New `UC_DELTA_STAGING_TABLE_ID_KEY` config key |
| `CredPropsUtil.PropsBuilder` | New `deltaStagingTableId()` method |
| `CredPropsUtil` | New `createDeltaStagingTableCredProps` + `fetchDeltaStagingTableCredProps` |
| `GenericCredentialFetcher` | New `forUcDeltaStagingTable()` factory + routing in `create()` |
| `UCDeltaStagingTableCredentialFetcher` | New fetcher that calls `getStagingTableCredentials` |
| `UCCredentialHadoopConfs.Builder` | New `buildForStagingTable(stagingTableId, location)` |

### Tests

- `UCCredentialHadoopConfsTest`: builder validation for `buildForStagingTable` (missing fields, missing token provider)
- `CredPropsUtilTest`: `createDeltaStagingTableCredProps` for S3/GCS/ABFS, static creds, unknown scheme, cred-scoped FS, `PropsBuilder` conflict guards, `fetchDeltaStagingTableCredProps` orchestration
- `UCDeltaStagingTableCredentialFetcherTest`: happy path, immutable-after-construction, null response, missing config keys

All 133 hadoop module tests pass locally.

### Note

`UCSingleCatalog` is **not** changed — it continues using the existing `buildForTable(stagingTableId, READ_WRITE)` path via the UC REST API. The new `buildForStagingTable` is intended for future Delta REST API integration.