### PR TITLE
[Build] Pin Spark 4.2 cross-build to 4.2.0-preview5

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Build a human-readable job name from the matrix entry, e.g.:
     #   "All tests (Spark 4.0.0, Delta 4.1.0)"
-    #   "[Non Blocking] Spark tests (Spark 4.2.0-SNAPSHOT, Delta master-SNAPSHOT)"
+    #   "[Non Blocking] Spark tests (Spark 4.2.0-preview5, Delta master-SNAPSHOT)"
     name: >-
       ${{ matrix.non-blocking && '[Non Blocking]' || '' }}
       ${{ matrix.validation-mode == 'spark-tests' && 'Spark tests' || 'All tests' }}
@@ -47,7 +47,7 @@ jobs:
             # Cross-version testing with Delta master is informational; failures
             # indicate upcoming incompatibilities but should not block PRs.
             non-blocking: true
-          - spark-version: "4.2.0-SNAPSHOT"
+          - spark-version: "4.2.0-preview5"
             delta-version: "master-SNAPSHOT"
             validation-mode: "spark-tests"
             non-blocking: true

--- a/project/spark-versions.json
+++ b/project/spark-versions.json
@@ -3,6 +3,6 @@
   "versions": [
     {"version": "4.0.0", "sourceDir": "scala-shims/spark-4.0"},
     {"version": "4.1.0", "sourceDir": "scala-shims/spark-4.1"},
-    {"version": "4.2.0-SNAPSHOT", "sourceDir": "scala-shims/spark-4.2"}
+    {"version": "4.2.0-preview5", "sourceDir": "scala-shims/spark-4.2"}
   ]
 }

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -118,10 +118,17 @@ class CrossSparkPublishTest:
         return found_jars
 
     def run_sbt_command(self, description: str, command: List[str]) -> bool:
+        # The Test-scoped delta-spark dependency is only required for running tests,
+        # not for publishing. Some Spark versions (e.g. previews) have no matching
+        # Delta release yet, which would otherwise fail `update` during `publishM2`.
+        # `publishM2` doesn't include Test deps in the POM, so skipping is safe here.
+        augmented = list(command)
+        if augmented and augmented[0].endswith("sbt"):
+            augmented.insert(1, "-DskipDeltaSpark=true")
         print(f"  {description}")
         try:
             subprocess.run(
-                command,
+                augmented,
                 cwd=self.uc_root,
                 check=True,
                 stdout=subprocess.DEVNULL,
@@ -129,7 +136,7 @@ class CrossSparkPublishTest:
             )
             return True
         except subprocess.CalledProcessError:
-            print(f"  FAIL: Command failed: {' '.join(command)}")
+            print(f"  FAIL: Command failed: {' '.join(augmented)}")
             return False
 
     def validate_jars(self, expected: Set[str], test_name: str) -> bool:


### PR DESCRIPTION
## Summary

- Replace the `4.2.0-SNAPSHOT` entry in `project/spark-versions.json` with the published `4.2.0-preview5` release so the spark-4.2 cross-build resolves against a stable Maven Central artifact instead of relying on an upstream nightly SNAPSHOT.
- Update the matching CI matrix entry (and its comment) in `.github/workflows/unit-tests.yml`.

The Spark 4.2 entry remains marked `non-blocking: true` in CI, consistent with how it was configured before.

## Test plan

- [x] Local sanity check: `build/sbt -DsparkVersion=4.2.0-preview5 -DskipDeltaSpark=true spark/compile` succeeds.
- [ ] GitHub Actions: the new `[Non Blocking] Spark tests (Spark 4.2.0-preview5, Delta master-SNAPSHOT)` matrix entry runs.
- [ ] All other matrix entries (Spark 4.0.0 / 4.1.0) remain green.