### PR TITLE
[Hadoop] Default GCS conflict check to false for downscoped token compatibility

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -57,6 +57,7 @@ public class CredPropsUtil {
   private static final String GCS_ACCESS_TOKEN_KEY = "fs.gs.auth.access.token.credential";
   private static final String GCS_ACCESS_TOKEN_EXPIRATION_KEY =
       "fs.gs.auth.access.token.expiration";
+  private static final String GCS_CONFLICT_CHECK_KEY = "fs.gs.create.items.conflict.check.enable";
   private static final String ABFS_FIXED_SAS_TOKEN_KEY = "fs.azure.sas.fixed.token";
 
   private abstract static class PropsBuilder<T extends PropsBuilder<T>> {
@@ -211,8 +212,11 @@ public class CredPropsUtil {
   private static class GcsPropsBuilder extends PropsBuilder<GcsPropsBuilder> {
 
     GcsPropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
-      // Common properties for GCS.
-      set("fs.gs.create.items.conflict.check.enable", "true");
+      // The upstream GCS connector defaults this to true which causes the connector to
+      // stat every ancestor directory on file creation. With UC-vended downscoped tokens
+      // (scoped to a table's path prefix) these ancestor stats return 403. Default to
+      // false; users with broader credentials can opt back in via Hadoop/Spark config.
+      set(GCS_CONFLICT_CHECK_KEY, hadoopConf.get(GCS_CONFLICT_CHECK_KEY, "false"));
       set("fs.gs.impl.disable.cache", "true");
 
       if (credScopedFsEnabled) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -697,6 +697,99 @@ class CredPropsUtilTest {
     assertThatThrownBy(() -> props.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
   }
 
+  // GCS conflict-check setting propagation.
+
+  @Test
+  void gcsConflictCheckDefaultsFalse() {
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            null,
+            "tid",
+            TableOperation.READ_WRITE,
+            gcsCreds(),
+            Map.of());
+
+    assertThat(props).containsEntry("fs.gs.create.items.conflict.check.enable", "false");
+  }
+
+  @Test
+  void gcsConflictCheckRespectsUserOverrideToTrue() {
+    Configuration conf = new Configuration(false);
+    conf.set("fs.gs.create.items.conflict.check.enable", "true");
+
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            false,
+            false,
+            conf,
+            "gs",
+            "http://uc",
+            null,
+            "tid",
+            TableOperation.READ_WRITE,
+            gcsCreds(),
+            Map.of());
+
+    assertThat(props).containsEntry("fs.gs.create.items.conflict.check.enable", "true");
+  }
+
+  @Test
+  void gcsConflictCheckDefaultWithRenewalEnabled() {
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            tokenProvider(),
+            "tid",
+            TableOperation.READ_WRITE,
+            gcsCreds(),
+            Map.of());
+
+    assertThat(props).containsEntry("fs.gs.create.items.conflict.check.enable", "false");
+  }
+
+  @Test
+  void gcsConflictCheckDefaultPathAndDeltaCredProps() {
+    Map<String, String> pathProps =
+        CredPropsUtil.createPathCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            null,
+            "gs://bucket/key",
+            io.unitycatalog.client.model.PathOperation.PATH_READ,
+            gcsCreds(),
+            Map.of());
+
+    assertThat(pathProps).containsEntry("fs.gs.create.items.conflict.check.enable", "false");
+
+    Map<String, String> deltaProps =
+        CredPropsUtil.createDeltaTableCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "gs",
+            "http://uc",
+            null,
+            UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+            "gs://bucket/tbl",
+            CredentialOperation.READ_WRITE,
+            gcsCreds(),
+            Map.of());
+
+    assertThat(deltaProps).containsEntry("fs.gs.create.items.conflict.check.enable", "false");
+  }
+
   private static GenericCredentialFetcher mockGenericCredentialFetcher(TemporaryCredentials creds) {
     GenericCredentialFetcher api = mock(GenericCredentialFetcher.class);
     try {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

## Problem

When using Unity Catalog with a GCP workspace, UC vends **downscoped GCS OAuth tokens** scoped to a specific table's storage path prefix (e.g., `gs://bucket/.../tables/<uuid>/`). The GCS connector's `create()` method calls `checkNoFilesConflictingWithDirs()`, which stats every ancestor directory. These ancestor paths fall outside the token's scope, so each stat returns **403 Forbidden**, breaking all Delta writes.

The root cause: `CredPropsUtil.GcsPropsBuilder` hardcoded `fs.gs.create.items.conflict.check.enable=true` as a per-table property, ignoring any user-provided Hadoop/Spark configuration.

## Fix

Read the user's Hadoop configuration for `fs.gs.create.items.conflict.check.enable` instead of hardcoding `true`, and default to `false`. This makes downscoped tokens work out of the box. Users with broader GCS credentials who want the conflict check can opt back in by setting the key to `true` in their Hadoop/Spark config.

This is safe because Delta and Iceberg handle file/directory conflicts at the commit protocol layer, making the filesystem-level check redundant for table formats that UC supports.

## Changes

- **`CredPropsUtil.java`**: Extracted `GCS_CONFLICT_CHECK_KEY` constant; changed `GcsPropsBuilder` to read from `hadoopConf` (default `"false"`) instead of hardcoding `"true"`.
- **`CredPropsUtilTest.java`**: Added 4 test methods covering:
  - Default is `"false"` with an empty config
  - User-set `"true"` is respected (opt-in)
  - `createPathCredProps` and `createDeltaTableCredProps` honor the default
  - `renewCredEnabled=true` (renewal code path) also defaults to `"false"`

## How was this tested

- **Unit tests:** `sbt "hadoop/testOnly io.unitycatalog.hadoop.internal.CredPropsUtilTest"` — 32 tests pass (28 existing + 4 new)
- **Manual end-to-end:** Spark 4.1.0 + Delta 4.2.0 + patched UC 0.5.0-SNAPSHOT against a GCP workspace with downscoped GCS tokens. Verified `INSERT INTO` succeeds where it previously failed with 403.