### PR TITLE
[Spark] Route managed Delta REPLACE / CREATE OR REPLACE through the UC Delta API

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -400,9 +400,12 @@ class UCSingleCatalog
       properties: util.Map[String, String]): StagedTable = {
     val stagingCatalog = requireStagingCatalog("REPLACE TABLE")
     if (shouldDelegateReplaceToDeltaApi(properties)) {
-      // Defer load + augment to the Delta-side `buildReplaceProps`.
+      // Defer load + augment to the Delta-side `buildReplaceProps`. UCSingleCatalog no longer
+      // loads the existing table and prepare the properties for replace as this will be done by
+      // Delta instead.
       return stagingCatalog.stageReplace(ident, schema, partitions, properties)
     }
+    // The following becomes dead code when Delta API is turned on
     val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = false)
     val newProps = loadExistingManagedTablePropsForReplace(
       ident,
@@ -422,8 +425,12 @@ class UCSingleCatalog
     val stagingCatalog = requireStagingCatalog("CREATE OR REPLACE TABLE")
     if (shouldDelegateReplaceToDeltaApi(properties)) {
       // Defer existence-probe + branch (create-staging vs replace) to the Delta catalog.
+      // UCSingleCatalog no longer loads the existing table and prepare the properties for replace,
+      // or create a staging table if table doesn't exist yet, as this will be done by Delta catalog
+      // instead.
       return stagingCatalog.stageCreateOrReplace(ident, schema, partitions, properties)
     }
+    // The following becomes dead code when Delta API is turned on
     val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = true)
     val newProps = existingTable.map { tableInfo =>
       // Replacing existing table.

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -106,6 +106,18 @@ class UCSingleCatalog
     DeltaVersionUtils.isDeltaRestApiReady(deltaCatalogLoaded, deltaRestApiEnabled)
 
   /**
+   * REPLACE / CREATE OR REPLACE delegation gate.
+   *
+   *   - Delegate when: UC Delta API is wired in AND request specifies Delta provider.
+   *   - Existing-table validation (MANAGED, Delta, catalog-managed) is enforced by the
+   *     Delta-side `buildReplaceProps` after loading; we do not pre-check it here.
+   *   - Non-Delta REPLACE stays on the legacy path; its rejection error is unchanged.
+   */
+  private def shouldDelegateReplaceToDeltaApi(properties: util.Map[String, String]): Boolean = {
+    shouldUseDeltaAPI && UCSingleCatalog.hasDeltaProvider(properties)
+  }
+
+  /**
    * Returns the properties UC should pass to the Delta catalog delegate for a managed Delta
    * CREATE / CTAS. When the UC Delta API path is ready, we skip UC's legacy
    * `createStagingTable` and pass the caller-supplied properties through untouched -- the
@@ -387,6 +399,10 @@ class UCSingleCatalog
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
     val stagingCatalog = requireStagingCatalog("REPLACE TABLE")
+    if (shouldDelegateReplaceToDeltaApi(properties)) {
+      // Defer load + augment to the Delta-side `buildReplaceProps`.
+      return stagingCatalog.stageReplace(ident, schema, partitions, properties)
+    }
     val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = false)
     val newProps = loadExistingManagedTablePropsForReplace(
       ident,
@@ -404,6 +420,10 @@ class UCSingleCatalog
       partitions: Array[Transform],
       properties: util.Map[String, String]): StagedTable = {
     val stagingCatalog = requireStagingCatalog("CREATE OR REPLACE TABLE")
+    if (shouldDelegateReplaceToDeltaApi(properties)) {
+      // Defer existence-probe + branch (create-staging vs replace) to the Delta catalog.
+      return stagingCatalog.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
     val existingTable = resolveExistingTableForReplace(ident, allowMissingTable = true)
     val newProps = existingTable.map { tableInfo =>
       // Replacing existing table.


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
[Spark] Route managed Delta REPLACE / CREATE OR REPLACE through the UC Delta API

When the UC Delta API path is wired in and the request specifies the Delta provider, defer to the Delta catalog instead of UC's legacy REPLACE flow:

- `stageReplace` and `stageCreateOrReplace` short-circuit to the staging catalog.
- The Delta-side `buildReplaceProps` loads + validates the existing table (MANAGED, Delta, catalog-managed) in one round trip.
- Non-Delta REPLACE stays on the legacy path; rejection error unchanged.
