### PR TITLE
[Build] Support Spark commit-based builds

### DIFF
--- a/.github/workflows/spark_commit_tests.yml
+++ b/.github/workflows/spark_commit_tests.yml
@@ -1,4 +1,4 @@
-name: "UC Spark Source Ref"
+name: "Spark Source Artifact Cache"
 
 on:
   workflow_dispatch:
@@ -11,25 +11,15 @@ on:
       spark-version:
         description: "Spark compatibility line used for UC and Delta shims"
         required: true
-        default: "4.2"
-        type: string
-      delta-repo:
-        description: "Delta repository to build for the UC test"
-        required: true
-        default: "https://github.com/delta-io/delta.git"
-        type: string
-      delta-ref:
-        description: "Delta ref to build for the UC test"
-        required: true
-        default: "master"
+        default: "4.2.0-preview5"
         type: string
 
 permissions:
   contents: read
 
 jobs:
-  test:
-    name: "UC against Spark ${{ inputs['spark-source-ref'] }}"
+  build-cache:
+    name: "Cache Spark ${{ inputs['spark-source-ref'] }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -41,39 +31,36 @@ jobs:
           distribution: "zulu"
           cache: "sbt"
 
+      - name: Resolve Spark source ref
+        id: spark-ref
+        env:
+          SPARK_SOURCE_REF: ${{ inputs['spark-source-ref'] }}
+        run: |
+          git init /tmp/spark
+          git -C /tmp/spark remote add origin https://github.com/apache/spark.git
+          git -C /tmp/spark fetch --depth 1 origin "$SPARK_SOURCE_REF"
+          SPARK_SHA="$(git -C /tmp/spark rev-parse FETCH_HEAD)"
+          echo "spark_sha=$SPARK_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved Spark source ref $SPARK_SOURCE_REF to $SPARK_SHA"
+
+      - name: Restore Spark Maven cache
+        id: spark-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository/org/apache/spark
+          key: spark-m2-ubuntu-latest-scala-2.13-${{ inputs['spark-version'] }}-${{ steps.spark-ref.outputs.spark_sha }}-${{ hashFiles('project/scripts/build_spark_from_source.sh') }}
+
       - name: Build Spark source ref locally
+        if: steps.spark-cache.outputs.cache-hit != 'true'
         id: spark-build
         env:
           SPARK_SOURCE_REF: ${{ inputs['spark-source-ref'] }}
           SPARK_VERSION: ${{ inputs['spark-version'] }}
         run: bash project/scripts/build_spark_from_source.sh
 
-      - name: Build, package, and publish UC locally
-        run: |
-          build/sbt \
-            -DsparkVersion=${{ inputs['spark-version'] }} \
-            -DsparkCommit=${{ steps.spark-build.outputs.SPARK_SHA }} \
-            -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
-            -DskipDeltaSpark=true \
-            -J-Xmx2G \
-            package publishLocal publishM2
-
-      - name: Build Delta from source against Spark source ref
-        id: delta-build
-        env:
-          DELTA_REPO: ${{ inputs['delta-repo'] }}
-          DELTA_REF: ${{ inputs['delta-ref'] }}
-          SPARK_VERSION: ${{ inputs['spark-version'] }}
-          SPARK_COMMIT: ${{ steps.spark-build.outputs.SPARK_SHA }}
-          SPARK_ARTIFACT_VERSION: ${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }}
-        run: bash project/scripts/build_delta_from_source.sh
-
-      - name: Run UC Spark tests
-        run: |
-          build/sbt \
-            -DsparkVersion=${{ inputs['spark-version'] }} \
-            -DsparkCommit=${{ steps.spark-build.outputs.SPARK_SHA }} \
-            -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
-            -DdeltaVersion=${{ steps.delta-build.outputs.DELTA_VERSION }} \
-            -J-Xmx2G \
-            spark/jacoco
+      - name: Save Spark Maven cache
+        if: steps.spark-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository/org/apache/spark
+          key: spark-m2-ubuntu-latest-scala-2.13-${{ inputs['spark-version'] }}-${{ steps.spark-ref.outputs.spark_sha }}-${{ hashFiles('project/scripts/build_spark_from_source.sh') }}

--- a/.github/workflows/spark_commit_tests.yml
+++ b/.github/workflows/spark_commit_tests.yml
@@ -1,11 +1,12 @@
-name: "UC Spark Commit"
+name: "UC Spark Source Ref"
 
 on:
   workflow_dispatch:
     inputs:
-      spark-commit:
-        description: "Apache Spark commit SHA to build locally"
+      spark-source-ref:
+        description: "Apache Spark source ref to build locally"
         required: true
+        default: "b6bd005ac7549411ec4e7dc944d7a0e19fd56561"
         type: string
       spark-version:
         description: "Spark compatibility line used for UC and Delta shims"
@@ -28,7 +29,7 @@ permissions:
 
 jobs:
   test:
-    name: "UC against Spark ${{ inputs.spark-commit }}"
+    name: "UC against Spark ${{ inputs['spark-source-ref'] }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -40,38 +41,38 @@ jobs:
           distribution: "zulu"
           cache: "sbt"
 
-      - name: Build Spark commit locally
+      - name: Build Spark source ref locally
         id: spark-build
         env:
-          SPARK_COMMIT: ${{ inputs.spark-commit }}
-          SPARK_VERSION: ${{ inputs.spark-version }}
+          SPARK_SOURCE_REF: ${{ inputs['spark-source-ref'] }}
+          SPARK_VERSION: ${{ inputs['spark-version'] }}
         run: bash project/scripts/build_spark_from_source.sh
 
       - name: Build, package, and publish UC locally
         run: |
           build/sbt \
-            -DsparkVersion=${{ inputs.spark-version }} \
-            -DsparkCommit=${{ inputs.spark-commit }} \
+            -DsparkVersion=${{ inputs['spark-version'] }} \
+            -DsparkCommit=${{ steps.spark-build.outputs.SPARK_SHA }} \
             -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
             -DskipDeltaSpark=true \
             -J-Xmx2G \
             package publishLocal publishM2
 
-      - name: Build Delta from source against Spark commit
+      - name: Build Delta from source against Spark source ref
         id: delta-build
         env:
-          DELTA_REPO: ${{ inputs.delta-repo }}
-          DELTA_REF: ${{ inputs.delta-ref }}
-          SPARK_VERSION: ${{ inputs.spark-version }}
-          SPARK_COMMIT: ${{ inputs.spark-commit }}
+          DELTA_REPO: ${{ inputs['delta-repo'] }}
+          DELTA_REF: ${{ inputs['delta-ref'] }}
+          SPARK_VERSION: ${{ inputs['spark-version'] }}
+          SPARK_COMMIT: ${{ steps.spark-build.outputs.SPARK_SHA }}
           SPARK_ARTIFACT_VERSION: ${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }}
         run: bash project/scripts/build_delta_from_source.sh
 
       - name: Run UC Spark tests
         run: |
           build/sbt \
-            -DsparkVersion=${{ inputs.spark-version }} \
-            -DsparkCommit=${{ inputs.spark-commit }} \
+            -DsparkVersion=${{ inputs['spark-version'] }} \
+            -DsparkCommit=${{ steps.spark-build.outputs.SPARK_SHA }} \
             -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
             -DdeltaVersion=${{ steps.delta-build.outputs.DELTA_VERSION }} \
             -J-Xmx2G \

--- a/.github/workflows/spark_commit_tests.yml
+++ b/.github/workflows/spark_commit_tests.yml
@@ -1,0 +1,78 @@
+name: "UC Spark Commit"
+
+on:
+  workflow_dispatch:
+    inputs:
+      spark-commit:
+        description: "Apache Spark commit SHA to build locally"
+        required: true
+        type: string
+      spark-version:
+        description: "Spark compatibility line used for UC and Delta shims"
+        required: true
+        default: "4.2"
+        type: string
+      delta-repo:
+        description: "Delta repository to build for the UC test"
+        required: true
+        default: "https://github.com/delta-io/delta.git"
+        type: string
+      delta-ref:
+        description: "Delta ref to build for the UC test"
+        required: true
+        default: "master"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: "UC against Spark ${{ inputs.spark-commit }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          java-version: "17"
+          distribution: "zulu"
+          cache: "sbt"
+
+      - name: Build Spark commit locally
+        id: spark-build
+        env:
+          SPARK_COMMIT: ${{ inputs.spark-commit }}
+          SPARK_VERSION: ${{ inputs.spark-version }}
+        run: bash project/scripts/build_spark_from_source.sh
+
+      - name: Build, package, and publish UC locally
+        run: |
+          build/sbt \
+            -DsparkVersion=${{ inputs.spark-version }} \
+            -DsparkCommit=${{ inputs.spark-commit }} \
+            -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
+            -DskipDeltaSpark=true \
+            -J-Xmx2G \
+            package publishLocal publishM2
+
+      - name: Build Delta from source against Spark commit
+        id: delta-build
+        env:
+          DELTA_REPO: ${{ inputs.delta-repo }}
+          DELTA_REF: ${{ inputs.delta-ref }}
+          SPARK_VERSION: ${{ inputs.spark-version }}
+          SPARK_COMMIT: ${{ inputs.spark-commit }}
+          SPARK_ARTIFACT_VERSION: ${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }}
+        run: bash project/scripts/build_delta_from_source.sh
+
+      - name: Run UC Spark tests
+        run: |
+          build/sbt \
+            -DsparkVersion=${{ inputs.spark-version }} \
+            -DsparkCommit=${{ inputs.spark-commit }} \
+            -DsparkArtifactVersion=${{ steps.spark-build.outputs.SPARK_ARTIFACT_VERSION }} \
+            -DdeltaVersion=${{ steps.delta-build.outputs.DELTA_VERSION }} \
+            -J-Xmx2G \
+            spark/jacoco

--- a/.github/workflows/spark_commit_tests.yml
+++ b/.github/workflows/spark_commit_tests.yml
@@ -11,7 +11,7 @@ on:
       spark-version:
         description: "Spark compatibility line used for UC and Delta shims"
         required: true
-        default: "4.2.0-preview5"
+        default: "4.2.0-SNAPSHOT"
         type: string
 
 permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,8 @@ jobs:
       ${{ matrix.validation-mode == 'spark-tests' && 'Spark tests' || 'All tests' }}
       (Spark ${{ matrix.spark-version }}${{ matrix.delta-version != '' && format(', Delta {0}', matrix.delta-version) || '' }})
     continue-on-error: ${{ matrix.non-blocking || false }}
+    env:
+      SPARK_SOURCE_REF: "b6bd005ac7549411ec4e7dc944d7a0e19fd56561"
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +62,74 @@ jobs:
         java-version: '17'
         distribution: 'zulu'
         cache: 'sbt'
+
+    - name: Resolve Spark source ref
+      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      id: spark-source
+      run: |
+        git init /tmp/spark
+        git -C /tmp/spark remote add origin https://github.com/apache/spark.git
+        git -C /tmp/spark fetch --depth 1 origin "$SPARK_SOURCE_REF"
+        git -C /tmp/spark checkout --detach FETCH_HEAD
+        SPARK_SHA="$(git -C /tmp/spark rev-parse HEAD)"
+        SPARK_SHORT_SHA="${SPARK_SHA:0:12}"
+        if SPARK_BASE_VERSION="$(python3 - <<'PY'
+        import re
+        from pathlib import Path
+
+        version_file = Path("/tmp/spark/version.sbt")
+        if not version_file.exists():
+            raise SystemExit(1)
+
+        match = re.search(r'\bversion\s*:?=\s*"([^"]+)"', version_file.read_text())
+        if not match:
+            raise SystemExit(1)
+
+        print(match.group(1).removesuffix("-SNAPSHOT"))
+        PY
+        )"; then
+          :
+        else
+          SPARK_BASE_VERSION="${{ matrix.spark-version }}"
+        fi
+        SPARK_ARTIFACT_VERSION="${SPARK_BASE_VERSION}-${SPARK_SHORT_SHA}-SNAPSHOT"
+        echo "spark_sha=$SPARK_SHA" >> "$GITHUB_OUTPUT"
+        echo "spark_artifact_version=$SPARK_ARTIFACT_VERSION" >> "$GITHUB_OUTPUT"
+        echo "Resolved Spark source ref $SPARK_SOURCE_REF to $SPARK_SHA"
+
+    - name: Restore Spark Maven cache
+      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      id: spark-source-cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.m2/repository/org/apache/spark
+        key: spark-m2-ubuntu-latest-scala-2.13-${{ matrix.spark-version }}-${{ steps.spark-source.outputs.spark_sha }}-${{ hashFiles('project/scripts/build_spark_from_source.sh') }}
+
+    - name: Fail on Spark source cache miss
+      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT' && steps.spark-source-cache.outputs.cache-hit != 'true'
+      run: |
+        echo "::error::Spark Maven artifacts were not found in the GitHub Actions cache. Run the Spark Source Artifact Cache workflow for $SPARK_SOURCE_REF first."
+        exit 1
+
+    - name: Verify restored Spark Maven artifacts
+      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      env:
+        SPARK_ARTIFACT_VERSION: ${{ steps.spark-source.outputs.spark_artifact_version }}
+      run: |
+        missing=0
+        for module in spark-sql_2.13 spark-core_2.13 spark-catalyst_2.13 spark-hive_2.13; do
+          pom="$HOME/.m2/repository/org/apache/spark/$module/$SPARK_ARTIFACT_VERSION/$module-$SPARK_ARTIFACT_VERSION.pom"
+          if [[ ! -f "$pom" ]]; then
+            echo "::error::Missing restored Spark Maven artifact: $pom"
+            missing=1
+          fi
+        done
+        if [[ "$missing" != "0" ]]; then
+          echo "The Spark cache was restored, but it does not contain the expected Maven artifacts. Re-run the Spark Source Artifact Cache workflow for $SPARK_SOURCE_REF."
+          exit 1
+        fi
+        echo "SPARK_COMMIT=${{ steps.spark-source.outputs.spark_sha }}" >> "$GITHUB_ENV"
+        echo "SPARK_ARTIFACT_VERSION=$SPARK_ARTIFACT_VERSION" >> "$GITHUB_ENV"
 
     # Publish UC to local caches BEFORE building Delta — Delta's build resolves
     # UC artifacts from ~/.ivy2/local via -DunityCatalogVersion.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
             # Cross-version testing with Delta master is informational; failures
             # indicate upcoming incompatibilities but should not block PRs.
             non-blocking: true
-          - spark-version: "4.2.0-preview5"
+          - spark-version: "4.2.0-SNAPSHOT"
             delta-version: "master-SNAPSHOT"
             validation-mode: "spark-tests"
             non-blocking: true
@@ -64,7 +64,7 @@ jobs:
         cache: 'sbt'
 
     - name: Resolve Spark source ref
-      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      if: matrix.spark-version == '4.2.0-SNAPSHOT' && matrix.delta-version == 'master-SNAPSHOT'
       id: spark-source
       run: |
         git init /tmp/spark
@@ -98,7 +98,7 @@ jobs:
         echo "Resolved Spark source ref $SPARK_SOURCE_REF to $SPARK_SHA"
 
     - name: Restore Spark Maven cache
-      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      if: matrix.spark-version == '4.2.0-SNAPSHOT' && matrix.delta-version == 'master-SNAPSHOT'
       id: spark-source-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -106,13 +106,13 @@ jobs:
         key: spark-m2-ubuntu-latest-scala-2.13-${{ matrix.spark-version }}-${{ steps.spark-source.outputs.spark_sha }}-${{ hashFiles('project/scripts/build_spark_from_source.sh') }}
 
     - name: Fail on Spark source cache miss
-      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT' && steps.spark-source-cache.outputs.cache-hit != 'true'
+      if: matrix.spark-version == '4.2.0-SNAPSHOT' && matrix.delta-version == 'master-SNAPSHOT' && steps.spark-source-cache.outputs.cache-hit != 'true'
       run: |
         echo "::error::Spark Maven artifacts were not found in the GitHub Actions cache. Run the Spark Source Artifact Cache workflow for $SPARK_SOURCE_REF first."
         exit 1
 
     - name: Verify restored Spark Maven artifacts
-      if: matrix.spark-version == '4.2.0-preview5' && matrix.delta-version == 'master-SNAPSHOT'
+      if: matrix.spark-version == '4.2.0-SNAPSHOT' && matrix.delta-version == 'master-SNAPSHOT'
       env:
         SPARK_ARTIFACT_VERSION: ${{ steps.spark-source.outputs.spark_artifact_version }}
       run: |

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val deltaVersion = sys.props.getOrElse("deltaVersion", "4.1.0")
 // Intentionally shadows CrossSparkVersions.autoImport.sparkVersion (SettingKey).
 // This String val is used for libraryDependencies coordinates; the SettingKey is
 // queryable in SBT via `show spark/sparkVersion`.
-lazy val sparkVersion = CrossSparkVersions.getSparkVersionSpec().fullVersion
+lazy val sparkVersion = CrossSparkVersions.getSparkArtifactVersion()
 lazy val sparkMajorMinorVersion = CrossSparkVersions.getSparkVersionSpec().shortVersion
 
 // delta-spark is only needed for tests. When UC is published to local Maven before

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -15,14 +15,17 @@ import scala.util.parsing.json.JSON
  *   - DEFAULT: latest stable Spark version (used when -DsparkVersion is not set)
  *   - sparkVersionedModuleName: appends _X.Y suffix to artifact names
  *   - sparkSourceDirSettings: wires per-version shim source dirs
+ *   - sparkCommit: optional exact Spark commit built locally for source-built profiles
  */
 
 case class SparkVersionSpec(
   fullVersion: String,
-  additionalSourceDir: String
+  additionalSourceDir: String,
+  requiresSparkCommit: Boolean = false
 ) {
   def shortVersion: String = fullVersion.split("\\.").take(2).mkString(".")
   def isSnapshot: Boolean = fullVersion.contains("SNAPSHOT")
+  def artifactBaseVersion: String = fullVersion.stripSuffix("-SNAPSHOT")
 }
 
 object SparkVersionSpec {
@@ -37,7 +40,8 @@ object SparkVersionSpec {
           val versions = map("versions").asInstanceOf[List[Map[String, Any]]].map { v =>
             SparkVersionSpec(
               v("version").asInstanceOf[String],
-              v("sourceDir").asInstanceOf[String]
+              v("sourceDir").asInstanceOf[String],
+              v.get("requiresSparkCommit").exists(_.asInstanceOf[Boolean])
             )
           }
           (default, versions)
@@ -69,13 +73,62 @@ object CrossSparkVersions extends AutoPlugin {
   /** Resolves the active SparkVersionSpec from `-DsparkVersion` (full or short form). */
   def getSparkVersionSpec(): SparkVersionSpec = {
     val input = sys.props.getOrElse("sparkVersion", SparkVersionSpec.DEFAULT.fullVersion)
-    SparkVersionSpec.ALL_SPECS.find { spec =>
-      spec.fullVersion == input || spec.shortVersion == input
-    }.getOrElse {
+    val candidates =
+      if (input == "master") SparkVersionSpec.ALL_SPECS.filter(_.requiresSparkCommit)
+      else SparkVersionSpec.ALL_SPECS.filter { spec =>
+        spec.fullVersion == input || spec.shortVersion == input
+      }
+
+    val spec = if (getSparkCommit().isDefined || getSparkArtifactVersionOverride().isDefined) {
+      candidates.find(_.requiresSparkCommit).orElse(candidates.headOption)
+    } else {
+      candidates.find(!_.requiresSparkCommit).orElse(candidates.headOption)
+    }
+
+    spec.getOrElse {
       val valid = SparkVersionSpec.ALL_SPECS.flatMap(s => Seq(s.fullVersion, s.shortVersion))
       throw new IllegalArgumentException(
-        s"Invalid sparkVersion: $input. Valid values: ${valid.mkString(", ")}"
+        s"Invalid sparkVersion: $input. Valid values: ${(valid :+ "master").mkString(", ")}"
       )
+    }
+  }
+
+  private def getSparkCommit(): Option[String] = {
+    sys.props.get("sparkCommit").orElse(sys.env.get("SPARK_COMMIT")).filter(_.nonEmpty)
+  }
+
+  private def getSparkArtifactVersionOverride(): Option[String] = {
+    sys.props.get("sparkArtifactVersion")
+      .orElse(sys.env.get("SPARK_ARTIFACT_VERSION"))
+      .filter(_.nonEmpty)
+  }
+
+  private def shortCommit(commit: String): String = {
+    val trimmed = commit.trim.toLowerCase
+    if (!trimmed.matches("[0-9a-f]{7,40}")) {
+      throw new IllegalArgumentException(
+        s"Invalid sparkCommit '$commit'. Expected a 7 to 40 character git SHA."
+      )
+    }
+    trimmed.take(12)
+  }
+
+  def sparkArtifactVersionForCommit(spec: SparkVersionSpec, commit: String): String = {
+    s"${spec.artifactBaseVersion}-${shortCommit(commit)}-SNAPSHOT"
+  }
+
+  def getSparkArtifactVersion(): String = {
+    val spec = getSparkVersionSpec()
+    getSparkArtifactVersionOverride().getOrElse {
+      getSparkCommit() match {
+        case Some(commit) => sparkArtifactVersionForCommit(spec, commit)
+        case None if spec.requiresSparkCommit =>
+          throw new IllegalArgumentException(
+            s"Spark ${spec.fullVersion} requires -DsparkCommit=<sha> " +
+              "or -DsparkArtifactVersion=<local-maven-version>."
+          )
+        case None => spec.fullVersion
+      }
     }
   }
 

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -93,15 +93,15 @@ object CrossSparkVersions extends AutoPlugin {
     }
   }
 
-  private def getSparkCommit(): Option[String] = {
-    sys.props.get("sparkCommit").orElse(sys.env.get("SPARK_COMMIT")).filter(_.nonEmpty)
+  private def propertyOrEnv(propertyName: String, envName: String): Option[String] = {
+    sys.props.get(propertyName).orElse(sys.env.get(envName)).filter(_.nonEmpty)
   }
 
-  private def getSparkArtifactVersionOverride(): Option[String] = {
-    sys.props.get("sparkArtifactVersion")
-      .orElse(sys.env.get("SPARK_ARTIFACT_VERSION"))
-      .filter(_.nonEmpty)
-  }
+  private def getSparkCommit(): Option[String] =
+    propertyOrEnv("sparkCommit", "SPARK_COMMIT")
+
+  private def getSparkArtifactVersionOverride(): Option[String] =
+    propertyOrEnv("sparkArtifactVersion", "SPARK_ARTIFACT_VERSION")
 
   private def shortCommit(commit: String): String = {
     val trimmed = commit.trim.toLowerCase

--- a/project/scripts/build_delta_from_source.sh
+++ b/project/scripts/build_delta_from_source.sh
@@ -3,6 +3,8 @@
 # to local Maven (~/.m2). Designed for CI but works locally too.
 set -euo pipefail
 
+DELTA_REPO="${DELTA_REPO:-https://github.com/delta-io/delta.git}"
+DELTA_REF="${DELTA_REF:-master}"
 DELTA_DIR="${DELTA_DIR:-/tmp/delta}"
 META_ONLY=false
 
@@ -22,11 +24,14 @@ done
 
 # ── Clone ────────────────────────────────────────────────────────────────────
 if [ -d "$DELTA_DIR/.git" ]; then
-  echo "Delta already cloned at $DELTA_DIR -- skipping clone."
+  echo "Delta already cloned at $DELTA_DIR -- fetching $DELTA_REF."
+  git -C "$DELTA_DIR" fetch "$DELTA_REPO" "$DELTA_REF"
 else
-  echo "Cloning delta-io/delta into $DELTA_DIR ..."
-  git clone --depth=1 --branch=master "https://github.com/delta-io/delta.git" "$DELTA_DIR"
+  echo "Cloning Delta from $DELTA_REPO into $DELTA_DIR ..."
+  git clone "$DELTA_REPO" "$DELTA_DIR"
+  git -C "$DELTA_DIR" fetch "$DELTA_REPO" "$DELTA_REF"
 fi
+git -C "$DELTA_DIR" checkout --detach FETCH_HEAD
 
 # ── Resolve metadata ────────────────────────────────────────────────────────
 DELTA_SHA=$(git -C "$DELTA_DIR" rev-parse HEAD)
@@ -52,7 +57,15 @@ if $META_ONLY; then
 fi
 
 # ── Build & publish to local Maven ───────────────────────────────────────────
-SPARK_MAJOR_MINOR="${SPARK_MAJOR_MINOR:?SPARK_MAJOR_MINOR is required for build (e.g. 4.1)}"
+SPARK_VERSION="${SPARK_VERSION:-${SPARK_MAJOR_MINOR:-}}"
+SPARK_VERSION="${SPARK_VERSION:?SPARK_VERSION or SPARK_MAJOR_MINOR is required for build (e.g. 4.1)}"
+SPARK_COMMIT_ARGS=()
+if [[ -n "${SPARK_COMMIT:-}" ]]; then
+  SPARK_COMMIT_ARGS+=("-DsparkCommit=$SPARK_COMMIT")
+fi
+if [[ -n "${SPARK_ARTIFACT_VERSION:-}" ]]; then
+  SPARK_COMMIT_ARGS+=("-DsparkArtifactVersion=$SPARK_ARTIFACT_VERSION")
+fi
 cd "$DELTA_DIR"
 
 # UC jars are already in ~/.m2 from the workflow's pre-Delta publishM2 step.
@@ -62,7 +75,8 @@ cd "$DELTA_DIR"
 # (delta-spark-v1, delta-spark-v2) that aren't published separately. The M2 POM
 # filters them via pomPostProcess. UC's build/sbt forces maven-local in the
 # resolver chain, so ~/.m2 artifacts are found.
-build/sbt -DsparkVersion="$SPARK_MAJOR_MINOR" \
+build/sbt -DsparkVersion="$SPARK_VERSION" \
+  "${SPARK_COMMIT_ARGS[@]}" \
   -Ddelta.autoBuildPinnedUnityCatalog=false \
   -DunityCatalogVersion="$UC_VERSION" \
   storage/publishM2 \

--- a/project/scripts/build_spark_from_source.sh
+++ b/project/scripts/build_spark_from_source.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #
-# Build a specific Apache Spark commit and publish it to local Maven for UC tests.
+# Build a specific Apache Spark source ref and publish it to local Maven for UC tests.
 #
 # Required:
-#   SPARK_COMMIT=<git-sha>
+#   SPARK_SOURCE_REF=<git-ref-or-sha>
 #
 # Optional:
+#   SPARK_COMMIT=<git-sha> compatibility alias for SPARK_SOURCE_REF
 #   SPARK_VERSION=<compatibility line, default: 4.2>
-#   SPARK_BASE_VERSION=<artifact base version, default: ${SPARK_VERSION}.0>
+#   SPARK_BASE_VERSION=<artifact base version; default read from Spark version.sbt>
 #   SPARK_ARTIFACT_VERSION=<exact local Maven version to publish>
 #   SPARK_REPO=<git URL, default: https://github.com/apache/spark.git>
 #   SPARK_DIR=<checkout dir, default: /tmp/spark>
@@ -17,52 +18,79 @@
 #
 set -euo pipefail
 
-SPARK_COMMIT="${SPARK_COMMIT:?SPARK_COMMIT is required}"
+SPARK_SOURCE_REF="${SPARK_SOURCE_REF:-${SPARK_COMMIT:-}}"
+SPARK_SOURCE_REF="${SPARK_SOURCE_REF:?SPARK_SOURCE_REF is required}"
 SPARK_REPO="${SPARK_REPO:-https://github.com/apache/spark.git}"
 SPARK_DIR="${SPARK_DIR:-/tmp/spark}"
 SPARK_VERSION="${SPARK_VERSION:-4.2}"
+SPARK_MVN_PROFILES="${SPARK_MVN_PROFILES:--Pscala-2.13 -Phive -Phive-thriftserver -Pconnect}"
+SPARK_MVN_GOALS="${SPARK_MVN_GOALS:-install}"
+SPARK_MVN_EXTRA_ARGS="${SPARK_MVN_EXTRA_ARGS:-}"
+
+if [[ -d "$SPARK_DIR/.git" ]]; then
+  echo "Using existing Spark checkout at $SPARK_DIR"
+else
+  echo "Initializing Spark checkout at $SPARK_DIR"
+  mkdir -p "$SPARK_DIR"
+  git -C "$SPARK_DIR" init
+fi
+
+if ! git -C "$SPARK_DIR" remote get-url origin > /dev/null 2>&1; then
+  git -C "$SPARK_DIR" remote add origin "$SPARK_REPO"
+else
+  git -C "$SPARK_DIR" remote set-url origin "$SPARK_REPO"
+fi
+
+git -C "$SPARK_DIR" fetch --depth 1 origin "$SPARK_SOURCE_REF"
+git -C "$SPARK_DIR" checkout --detach FETCH_HEAD
+ACTUAL_SHA="$(git -C "$SPARK_DIR" rev-parse HEAD)"
+SPARK_SHORT_SHA="$(echo "$ACTUAL_SHA" | cut -c1-12)"
+
+cd "$SPARK_DIR"
+
+read_spark_base_version() {
+  python3 - <<'PY'
+import re
+from pathlib import Path
+
+version_file = Path("version.sbt")
+if not version_file.exists():
+    raise SystemExit(1)
+
+match = re.search(r'\bversion\s*:?=\s*"([^"]+)"', version_file.read_text())
+if not match:
+    raise SystemExit(1)
+
+print(match.group(1).removesuffix("-SNAPSHOT"))
+PY
+}
+
 if [[ -z "${SPARK_BASE_VERSION:-}" ]]; then
-  if [[ "$SPARK_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  if SPARK_BASE_VERSION="$(read_spark_base_version)"; then
+    :
+  elif [[ "$SPARK_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
     SPARK_BASE_VERSION="${SPARK_VERSION}.0"
   else
     SPARK_BASE_VERSION="${SPARK_VERSION%-SNAPSHOT}"
   fi
 fi
-SPARK_SHORT_SHA="$(echo "$SPARK_COMMIT" | tr '[:upper:]' '[:lower:]' | cut -c1-12)"
+
 SPARK_ARTIFACT_VERSION="${SPARK_ARTIFACT_VERSION:-${SPARK_BASE_VERSION}-${SPARK_SHORT_SHA}-SNAPSHOT}"
-SPARK_MVN_PROFILES="${SPARK_MVN_PROFILES:--Pscala-2.13 -Phive -Phive-thriftserver -Pconnect}"
-SPARK_MVN_GOALS="${SPARK_MVN_GOALS:-install}"
-SPARK_MVN_EXTRA_ARGS="${SPARK_MVN_EXTRA_ARGS:-}"
 
-if [[ ! "$SPARK_COMMIT" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-  echo "SPARK_COMMIT must be a 7 to 40 character git SHA: $SPARK_COMMIT" >&2
-  exit 1
-fi
+echo "Building Spark ref $SPARK_SOURCE_REF ($ACTUAL_SHA) as Maven version $SPARK_ARTIFACT_VERSION"
 
-if [[ -d "$SPARK_DIR/.git" ]]; then
-  echo "Using existing Spark checkout at $SPARK_DIR"
-  git -C "$SPARK_DIR" fetch "$SPARK_REPO" "$SPARK_COMMIT"
-else
-  echo "Cloning Spark from $SPARK_REPO into $SPARK_DIR"
-  git clone "$SPARK_REPO" "$SPARK_DIR"
-  git -C "$SPARK_DIR" fetch "$SPARK_REPO" "$SPARK_COMMIT"
-fi
+# Spark's Maven build does not use the `revision` property for its own module
+# versions, so update the checked-out POMs before publishing the local artifacts.
+# shellcheck disable=SC2086
+./build/mvn \
+  $SPARK_MVN_EXTRA_ARGS \
+  versions:set \
+  -DnewVersion="$SPARK_ARTIFACT_VERSION" \
+  -DgenerateBackupPoms=false
 
-git -C "$SPARK_DIR" checkout --detach "$SPARK_COMMIT"
-ACTUAL_SHA="$(git -C "$SPARK_DIR" rev-parse HEAD)"
-if [[ "$ACTUAL_SHA" != "$(git -C "$SPARK_DIR" rev-parse "$SPARK_COMMIT^{commit}")" ]]; then
-  echo "Checked out $ACTUAL_SHA, expected $SPARK_COMMIT" >&2
-  exit 1
-fi
-
-echo "Building Spark commit $ACTUAL_SHA as Maven version $SPARK_ARTIFACT_VERSION"
-cd "$SPARK_DIR"
-
-# Spark's Maven build uses the revision property for artifact versions.
 # shellcheck disable=SC2086
 ./build/mvn \
   -DskipTests \
-  -Drevision="$SPARK_ARTIFACT_VERSION" \
   -Dscala.version=2.13.17 \
   $SPARK_MVN_PROFILES \
   $SPARK_MVN_EXTRA_ARGS \
@@ -76,6 +104,8 @@ emit_output() {
   echo "$key=$value"
 }
 
+emit_output "SPARK_SOURCE_REF" "$SPARK_SOURCE_REF"
 emit_output "SPARK_SHA" "$ACTUAL_SHA"
 emit_output "SPARK_VERSION" "$SPARK_VERSION"
+emit_output "SPARK_BASE_VERSION" "$SPARK_BASE_VERSION"
 emit_output "SPARK_ARTIFACT_VERSION" "$SPARK_ARTIFACT_VERSION"

--- a/project/scripts/build_spark_from_source.sh
+++ b/project/scripts/build_spark_from_source.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Build a specific Apache Spark commit and publish it to local Maven for UC tests.
+#
+# Required:
+#   SPARK_COMMIT=<git-sha>
+#
+# Optional:
+#   SPARK_VERSION=<compatibility line, default: 4.2>
+#   SPARK_BASE_VERSION=<artifact base version, default: ${SPARK_VERSION}.0>
+#   SPARK_ARTIFACT_VERSION=<exact local Maven version to publish>
+#   SPARK_REPO=<git URL, default: https://github.com/apache/spark.git>
+#   SPARK_DIR=<checkout dir, default: /tmp/spark>
+#   SPARK_MVN_PROFILES=<profiles, default: -Pscala-2.13 -Phive -Phive-thriftserver -Pconnect>
+#   SPARK_MVN_GOALS=<maven goals, default: install>
+#   SPARK_MVN_EXTRA_ARGS=<additional args>
+#
+set -euo pipefail
+
+SPARK_COMMIT="${SPARK_COMMIT:?SPARK_COMMIT is required}"
+SPARK_REPO="${SPARK_REPO:-https://github.com/apache/spark.git}"
+SPARK_DIR="${SPARK_DIR:-/tmp/spark}"
+SPARK_VERSION="${SPARK_VERSION:-4.2}"
+if [[ -z "${SPARK_BASE_VERSION:-}" ]]; then
+  if [[ "$SPARK_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    SPARK_BASE_VERSION="${SPARK_VERSION}.0"
+  else
+    SPARK_BASE_VERSION="${SPARK_VERSION%-SNAPSHOT}"
+  fi
+fi
+SPARK_SHORT_SHA="$(echo "$SPARK_COMMIT" | tr '[:upper:]' '[:lower:]' | cut -c1-12)"
+SPARK_ARTIFACT_VERSION="${SPARK_ARTIFACT_VERSION:-${SPARK_BASE_VERSION}-${SPARK_SHORT_SHA}-SNAPSHOT}"
+SPARK_MVN_PROFILES="${SPARK_MVN_PROFILES:--Pscala-2.13 -Phive -Phive-thriftserver -Pconnect}"
+SPARK_MVN_GOALS="${SPARK_MVN_GOALS:-install}"
+SPARK_MVN_EXTRA_ARGS="${SPARK_MVN_EXTRA_ARGS:-}"
+
+if [[ ! "$SPARK_COMMIT" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+  echo "SPARK_COMMIT must be a 7 to 40 character git SHA: $SPARK_COMMIT" >&2
+  exit 1
+fi
+
+if [[ -d "$SPARK_DIR/.git" ]]; then
+  echo "Using existing Spark checkout at $SPARK_DIR"
+  git -C "$SPARK_DIR" fetch "$SPARK_REPO" "$SPARK_COMMIT"
+else
+  echo "Cloning Spark from $SPARK_REPO into $SPARK_DIR"
+  git clone "$SPARK_REPO" "$SPARK_DIR"
+  git -C "$SPARK_DIR" fetch "$SPARK_REPO" "$SPARK_COMMIT"
+fi
+
+git -C "$SPARK_DIR" checkout --detach "$SPARK_COMMIT"
+ACTUAL_SHA="$(git -C "$SPARK_DIR" rev-parse HEAD)"
+if [[ "$ACTUAL_SHA" != "$(git -C "$SPARK_DIR" rev-parse "$SPARK_COMMIT^{commit}")" ]]; then
+  echo "Checked out $ACTUAL_SHA, expected $SPARK_COMMIT" >&2
+  exit 1
+fi
+
+echo "Building Spark commit $ACTUAL_SHA as Maven version $SPARK_ARTIFACT_VERSION"
+cd "$SPARK_DIR"
+
+# Spark's Maven build uses the revision property for artifact versions.
+# shellcheck disable=SC2086
+./build/mvn \
+  -DskipTests \
+  -Drevision="$SPARK_ARTIFACT_VERSION" \
+  -Dscala.version=2.13.17 \
+  $SPARK_MVN_PROFILES \
+  $SPARK_MVN_EXTRA_ARGS \
+  $SPARK_MVN_GOALS
+
+emit_output() {
+  local key="$1" value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "$key=$value" >> "$GITHUB_OUTPUT"
+  fi
+  echo "$key=$value"
+}
+
+emit_output "SPARK_SHA" "$ACTUAL_SHA"
+emit_output "SPARK_VERSION" "$SPARK_VERSION"
+emit_output "SPARK_ARTIFACT_VERSION" "$SPARK_ARTIFACT_VERSION"

--- a/project/spark-versions.json
+++ b/project/spark-versions.json
@@ -4,6 +4,6 @@
     {"version": "4.0.0", "sourceDir": "scala-shims/spark-4.0"},
     {"version": "4.1.0", "sourceDir": "scala-shims/spark-4.1"},
     {"version": "4.2.0-preview5", "sourceDir": "scala-shims/spark-4.2"},
-    {"version": "4.2.0", "sourceDir": "scala-shims/spark-4.2", "requiresSparkCommit": true}
+    {"version": "4.2.0-SNAPSHOT", "sourceDir": "scala-shims/spark-4.2", "requiresSparkCommit": true}
   ]
 }

--- a/project/spark-versions.json
+++ b/project/spark-versions.json
@@ -3,6 +3,7 @@
   "versions": [
     {"version": "4.0.0", "sourceDir": "scala-shims/spark-4.0"},
     {"version": "4.1.0", "sourceDir": "scala-shims/spark-4.1"},
-    {"version": "4.2.0-preview5", "sourceDir": "scala-shims/spark-4.2"}
+    {"version": "4.2.0-preview5", "sourceDir": "scala-shims/spark-4.2"},
+    {"version": "4.2.0", "sourceDir": "scala-shims/spark-4.2", "requiresSparkCommit": true}
   ]
 }

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -44,8 +44,9 @@ NON_SPARK_RELATED_JAR_TEMPLATES = [
 class SparkVersionSpec(object):
     """Configuration for a specific Spark version."""
 
-    def __init__(self, suffix):
+    def __init__(self, suffix, requires_spark_commit=False):
         self.suffix = suffix
+        self.requires_spark_commit = requires_spark_commit
         self.spark_related_jars = [
             jar.format(suffix=self.suffix, version="{version}")
             for jar in SPARK_RELATED_JAR_TEMPLATES
@@ -66,7 +67,10 @@ def _load_spark_versions():
     for entry in data["versions"]:
         ver = entry["version"]
         short = "_" + ".".join(ver.split(".")[:2])
-        versions[ver] = SparkVersionSpec(suffix=short)
+        versions[ver] = SparkVersionSpec(
+            suffix=short,
+            requires_spark_commit=entry.get("requiresSparkCommit", False),
+        )
     return data["default"], versions
 
 
@@ -222,8 +226,8 @@ class CrossSparkPublishTest:
 
         all_passed = True
         for spark_version, spark_spec in SPARK_VERSIONS.items():
-            if "SNAPSHOT" in spark_version:
-                print(f"\n  Skipping snapshot version: {spark_version}")
+            if "SNAPSHOT" in spark_version or spark_spec.requires_spark_commit:
+                print(f"\n  Skipping source-built or snapshot version: {spark_version}")
                 continue
 
             self.clean_maven_cache()
@@ -266,7 +270,7 @@ class CrossSparkPublishTest:
 
         # Step 2: Publish WITH suffix for each non-snapshot version
         for spark_version, spark_spec in SPARK_VERSIONS.items():
-            if "SNAPSHOT" in spark_version:
+            if "SNAPSHOT" in spark_version or spark_spec.requires_spark_commit:
                 continue
             if not self.run_sbt_command(
                 f"Step 2: build/sbt -DsparkVersion={spark_version} spark/publishM2",
@@ -289,7 +293,7 @@ class CrossSparkPublishTest:
 
         # Step 2: With suffix for each non-snapshot
         for spark_version, spark_spec in SPARK_VERSIONS.items():
-            if "SNAPSHOT" in spark_version:
+            if "SNAPSHOT" in spark_version or spark_spec.requires_spark_commit:
                 continue
             expected.update(
                 substitute_version(spark_spec.spark_related_jars, self.uc_version)


### PR DESCRIPTION
## Summary
- Add an opt-in `sparkCommit` hook that resolves UC Spark dependencies from locally built Spark artifacts for an exact SHA.
- Add a manual Spark Source Artifact Cache workflow that defaults to the same Spark source ref used by Delta, while allowing maintainers to pass another Spark branch, tag, or commit.
- Update the existing non-blocking `Delta master-SNAPSHOT + Spark 4.2.0-SNAPSHOT` Unit Tests lane to consume the cached source-built Spark artifacts instead of adding a new Delta-master check.
- Mark the source-built Spark compatibility spec as `4.2.0-SNAPSHOT` so release tooling treats it as pre-release/source-built.

## Test plan
- `bash -n project/scripts/build_spark_from_source.sh`
- `bash -n project/scripts/build_delta_from_source.sh`
- Parsed `.github/workflows/spark_commit_tests.yml` and `.github/workflows/unit-tests.yml` with PyYAML.
- `git diff --check`
- `build/sbt -DsparkVersion=4.2.0-SNAPSHOT -DsparkCommit=b6bd005ac7549411ec4e7dc944d7a0e19fd56561 -DsparkArtifactVersion=4.2.0-b6bd005ac754-SNAPSHOT "show spark/sparkVersion" "show spark/libraryDependencies"` shows `spark/sparkVersion = 4.2.0-SNAPSHOT` and `org.apache.spark:spark-sql:4.2.0-b6bd005ac754-SNAPSHOT:provided`.
- Verified release metadata treats only `4.0.0` and `4.1.0` as release-like versions and skips `4.2.0-SNAPSHOT`.
- Verified changed files contain no internal Maven/proxy references.

Full Spark source build/test was not run locally because it requires building Apache Spark from source.
