### PR TITLE
chore: make tarball/dist launch relocatable; stage jars per component

### DIFF
--- a/bin/start-uc-server
+++ b/bin/start-uc-server
@@ -41,8 +41,10 @@ run_in_source_code() {
 
 # This function runs the server using the tarball
 run_in_tarball() {
-  SERVER_CLASSPATH_FILE=$(find "$TARBALL_JAR_DIR" -name "classpath" | head -n 1)
-  run_uc_server_java_command "$SERVER_CLASSPATH_FILE" "$@"
+  # Relocatable classpath: a wildcard over the server jars dir (server and cli
+  # jars are staged separately; see project/Tarball.scala). Quote the glob so the
+  # shell leaves it for the JVM to expand.
+  java -cp "$TARBALL_JAR_DIR/server/*" io.unitycatalog.server.UnityCatalogServer "$@" || exit
 }
 
 # Check if TARBALL_JAR_DIR exists, then we are running in the tarball

--- a/bin/uc
+++ b/bin/uc
@@ -44,9 +44,10 @@ run_in_source_code() {
 
 # This function runs the CLI using the tarball
 run_in_tarball() {
-  CLI_CLASSPATH_FILE=$(find "$TARBALL_JAR_DIR" -name "classpath" | head -n 1)
-
-  run_cli_java_command "$CLI_CLASSPATH_FILE" "$@"
+  # Relocatable classpath: a wildcard over the cli jars dir (server and cli jars
+  # are staged separately; see project/Tarball.scala). Quote the glob so the
+  # shell leaves it for the JVM to expand.
+  java -cp "$TARBALL_JAR_DIR/cli/*" io.unitycatalog.cli.UnityCatalogCli "$@" || exit
 }
 
 # Check if TARBALL_JAR_DIR exists, then we are running in the tarball

--- a/project/Tarball.scala
+++ b/project/Tarball.scala
@@ -1,48 +1,62 @@
 import sbt.Keys.*
 import sbt.*
 
-import java.nio.file.Files
 import scala.sys.process.*
 import scala.util.{Failure, Success, Try}
 object Tarball {
   lazy val createTarball = taskKey[Unit]("Create a tarball for the project")
+  lazy val stageDist =
+    taskKey[File]("Stage the distribution tree (jars/ bin/ etc/) without tarring; returns the staged dir")
+
+  // Stage the distribution layout into `outputDir`:
+  //
+  //   jars/server/*   server jar + its resolved runtime classpath
+  //   jars/cli/*      cli jar    + its resolved runtime classpath
+  //   bin/  etc/
+  //
+  // The server and CLI classpaths are kept in SEPARATE directories on purpose:
+  // the CLI drags in old ANTLR (antlr4-4.5.1, via hadoop-client) while the server
+  // needs antlr4-runtime-4.13.x (via Hibernate). sbt resolves each module's
+  // classpath with correct eviction, so each directory is internally consistent.
+  // The launchers use a JVM wildcard (`-cp jars/<component>/*`) over its own dir,
+  // which is relocatable AND collision-free (no merged, order-dependent classpath).
+  private def copyJarsInto(jars: Seq[File], dir: File): Unit =
+    jars.distinct.foreach(j => IO.copyFile(j, dir / j.getName))
 
   def createTarballSettings(): Def.SettingsDefinition = {
     Seq(
-      createTarball := {
+      stageDist := {
         val log = streams.value.log
-
-        // Output directory for the tarball
         val outputDir = target.value / "dist"
-        val projectJarFiles = Seq(
-          (LocalProject("server") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("cli") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("client") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("controlApi") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("serverModels") / Compile / packageBin).value.getAbsoluteFile
-        )
-        val scriptsDir = baseDirectory.value / "bin"
-        val etcDir = baseDirectory.value / "etc"
 
-        // All JAR files in the classpath
-        val allJars = (LocalProject("server") / Compile / managedClasspath).value.files ++
-          (LocalProject("cli") / Compile / managedClasspath).value.files ++
-          projectJarFiles
+        val serverJar = (LocalProject("server") / Compile / packageBin).value.getAbsoluteFile
+        val serverModelsJar = (LocalProject("serverModels") / Compile / packageBin).value.getAbsoluteFile
+        val serverClasspath = (LocalProject("server") / Compile / managedClasspath).value.files
 
-        // Clean and create the output directory
+        val cliJar = (LocalProject("cli") / Compile / packageBin).value.getAbsoluteFile
+        val clientJar = (LocalProject("client") / Compile / packageBin).value.getAbsoluteFile
+        val controlApiJar = (LocalProject("controlApi") / Compile / packageBin).value.getAbsoluteFile
+        val cliClasspath = (LocalProject("cli") / Compile / managedClasspath).value.files
+
         IO.delete(outputDir)
         IO.createDirectory(outputDir)
 
-        // Copy the JAR file to the output directory
-        allJars.foreach { jarFile =>
-          IO.copyFile(jarFile, outputDir / "jars" / jarFile.getName)
-        }
-        val classpathFile = outputDir / "jars" / "classpath"
-        Files.write(classpathFile.toPath, allJars.mkString(":").getBytes)
-        // Copy the script files to the output directory
-        IO.copyDirectory(scriptsDir, outputDir / "bin")
-        // Copy the etc files to the output directory
-        IO.copyDirectory(etcDir, outputDir / "etc")
+        copyJarsInto(serverClasspath :+ serverJar :+ serverModelsJar, outputDir / "jars" / "server")
+        copyJarsInto(
+          cliClasspath :+ cliJar :+ clientJar :+ controlApiJar :+ serverJar :+ serverModelsJar,
+          outputDir / "jars" / "cli")
+
+        IO.copyDirectory(baseDirectory.value / "bin", outputDir / "bin")
+        IO.copyDirectory(baseDirectory.value / "etc", outputDir / "etc")
+
+        log.info(s"Staged distribution at $outputDir")
+        outputDir
+      },
+      createTarball := {
+        val log = streams.value.log
+
+        // Reuse the staged dist tree
+        val outputDir = stageDist.value
 
         // Create the tarball
         val tarballFile = target.value / s"${name.value}-${version.value}.tar.gz"


### PR DESCRIPTION
This PR prepares improvements to our docker build. The naive approach to generating the tarball inside docker lead to errors due to ordering of classpath and then got dirty doing sorting during build etc.

@tdas @yili-db - it looks like the test failures are due to upstream delta? Also there seems to be a disabled tarball build test. The invoked script is gone. There seem to be no credentials in the workflow though. Should we try and re-enable this?

in #1581 (based on this) we enable tarball tarball tests in the CI again.

There are some other improvements, so here is AI to tell you what happened :):

## Summary

First of a 4-PR stack that reworks the Docker build. This PR is standalone (no Docker changes yet) and de-risks the rest.

The tarball launch path in `bin/start-uc-server` and `bin/uc` previously read a generated `classpath` file containing **absolute host paths** into the Coursier cache. That forced any consumer (notably the Docker image) to reproduce those exact paths — the root cause of the current image shipping the entire dependency cache.

This PR launches the server/CLI with a JVM classpath wildcard over a **per-component** jars directory (`-cp jars/server/*`, `-cp jars/cli/*`). The JVM expands the glob at startup, so the layout is fully relocatable and no classpath file is needed.

Server and CLI classpaths are staged into **separate** directories on purpose: the server needs `antlr4-runtime` 4.13.x (via Hibernate) while the CLI pulls in old ANTLR 4.5.1 (via `hadoop-client`). A single merged dir let the wildcard pick the wrong ANTLR and crash server startup (`InvalidClassException: Could not deserialize ATN`). Per-module dirs are each internally consistent.

`Tarball.scala` gains a `stageDist` task producing the relocatable `jars/{server,cli}/ bin/ etc/` tree without tarring (so the Docker build can `COPY` it directly); `createTarball` reuses it and no longer writes the absolute-path classpath file.

## Stack
1. **This PR** — relocatable launchers + tarball staging
2. Rebuild server Dockerfile (glibc multi-stage)
3. CI: publish to ghcr.io keylessly + cosign
4. Distroless production image

Validated end-to-end in a fork (build, multi-arch publish, server boots and serves).

AI-assisted by: Isaac