### PR TITLE
build: rebuild server Dockerfile as glibc multi-stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Build output (the single biggest context-bloat item) -- regenerated in the image
+**/target/
+
+# sbt / Scala / IDE state
+.bloop/
+.metals/
+.bsp/
+project/project/
+project/boot/
+lib_managed/
+src_managed/
+.idea/
+*.iml
+.vscode/
+
+# VCS & CI (not needed inside the build context)
+.git/
+.github/
+
+# Secrets / local env -- must never leak into an image
+*.env
+.env
+entra-id.env
+examples/credential-vending/.certs/
+
+# Node / Python build artifacts (UI builds from its own context)
+ui/node_modules/
+web/node_modules/
+**/__pycache__/
+*.pyc
+
+# Docs & site (not part of the server image)
+docs/
+site/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,67 @@
-# syntax=docker.io/docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
-ARG HOME="/home/unitycatalog"
+# syntax=docker/dockerfile:1.7
 
-# Build stage, using Amazon Corretto jdk 17 on alpine with arm64 support
-FROM amazoncorretto:17-alpine3.20-jdk@sha256:c045f0537bc890f9e61924f33f35e9667f696b4f372dad4a73861a9396b5d0b5 as base
+# ---------------------------------------------------------------------------
+# Build stage: full JDK (glibc) + sbt. The Coursier/ivy/sbt caches live only in
+# BuildKit cache mounts and are never written into an image layer.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:17-jdk-jammy@sha256:beabb759e6f9653c843958d1d1f5cecb881dfb85aa6081e2bef099ab1260344e AS build
 
-# Dependencies are installed in $HOME/.cache by sbt
-ARG HOME
-ENV HOME=$HOME
+WORKDIR /workspace
+
+# Copy only what sbt needs to resolve dependencies and compile the server + CLI.
+# Each directory keeps its name under /workspace (so build.sbt's module paths resolve).
+COPY version.sbt build.sbt ./
+COPY dev/ ./dev/
+COPY build/ ./build/
+COPY project/ ./project/
+COPY examples/ ./examples/
+COPY server/ ./server/
+COPY api/ ./api/
+COPY clients/ ./clients/
+COPY bin/ ./bin/
+COPY etc/ ./etc/
+
+# Stage the relocatable distribution tree (jars/ bin/ etc/) into target/dist.
+# The dependency caches are mounted, so they accelerate the build without being
+# baked into any layer. `sharing=locked` serialises concurrent (multi-arch) builds
+# that share the cache to avoid corruption.
+RUN --mount=type=cache,target=/root/.cache/coursier,sharing=locked \
+    --mount=type=cache,target=/root/.sbt,sharing=locked \
+    --mount=type=cache,target=/root/.ivy2,sharing=locked \
+    bash ./build/sbt -info clean stageDist
+
+# ---------------------------------------------------------------------------
+# Runtime stage (default): JRE (glibc, has a shell so the bash launchers work).
+# Ships only the relocatable dist tree -- no JDK, no sbt, no dependency cache.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:17-jre-jammy@sha256:47c73dc23524b031bed0a5030410c722af6a8b49d4b25898ea8f4615895065f0 AS runtime
+
+ARG USER=unitycatalog
+ARG HOME=/home/unitycatalog
+
+LABEL org.opencontainers.image.title="Unity Catalog Server" \
+      org.opencontainers.image.description="Unity Catalog server" \
+      org.opencontainers.image.source="https://github.com/unitycatalog/unitycatalog" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Service account: numeric-friendly system user, no login shell.
+RUN groupadd -r "$USER" \
+ && useradd -r -g "$USER" -d "$HOME" -s /usr/sbin/nologin "$USER"
 
 WORKDIR $HOME
 
-COPY --parents dev/ build/ project/ examples/ server/ api/ clients/ version.sbt build.sbt ./
-
-RUN apk add --no-cache bash && ./build/sbt -info clean package
-
-# Small runtime image
-FROM alpine:3.20@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805 as runtime
-
-# Specific JAVA_HOME from Amazon Corretto
-ARG JAVA_HOME="/usr/lib/jvm/default-jvm"
-ARG USER="unitycatalog"
-ARG HOME
-
-# Copy Java from base
-COPY --from=base $JAVA_HOME $JAVA_HOME
-
-ENV HOME=$HOME \
-    JAVA_HOME=$JAVA_HOME \
-    PATH="${JAVA_HOME}/bin:${PATH}"
-
-# Copy build artifacts from base stage
-COPY --from=base --parents \
-    $HOME/examples/ \
-    $HOME/server/ \
-    $HOME/api/ \
-    $HOME/clients/ \
-    $HOME/target/ \
-    $HOME/.cache/ \
-    /
-
-# Create a service user with read and execute permissions and write permissions of the ./etc directory
-RUN <<EOF
-apk add --no-cache bash
-addgroup -S $USER
-adduser -S -G $USER $USER
-chmod -R 550 $HOME
-mkdir -p $HOME/etc/
-chmod -R 770 $HOME/etc/
-chown -R $USER:$USER $HOME
-EOF
+# Copy only the relocatable distribution: flat jars + launchers + config.
+COPY --from=build --chown=$USER:$USER /workspace/target/dist/jars ./jars
+COPY --from=build --chown=$USER:$USER /workspace/target/dist/bin  ./bin
+COPY --from=build --chown=$USER:$USER /workspace/target/dist/etc  ./etc
 
 USER $USER
 
-# Copy remaining directories here for caching optimization
-COPY --chown=$USER:$USER --parents bin/ etc/ $HOME/
+EXPOSE 8080
 
-WORKDIR $HOME
+# No dedicated health endpoint exists; check that the server is accepting TCP
+# connections on 8080. The JRE base ships bash, so /dev/tcp is available.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/8080' || exit 1
 
-CMD ["./bin/start-uc-server"]
+ENTRYPOINT ["./bin/start-uc-server"]

--- a/bin/start-uc-server
+++ b/bin/start-uc-server
@@ -41,8 +41,10 @@ run_in_source_code() {
 
 # This function runs the server using the tarball
 run_in_tarball() {
-  SERVER_CLASSPATH_FILE=$(find "$TARBALL_JAR_DIR" -name "classpath" | head -n 1)
-  run_uc_server_java_command "$SERVER_CLASSPATH_FILE" "$@"
+  # Relocatable classpath: a wildcard over the server jars dir (server and cli
+  # jars are staged separately; see project/Tarball.scala). Quote the glob so the
+  # shell leaves it for the JVM to expand.
+  java -cp "$TARBALL_JAR_DIR/server/*" io.unitycatalog.server.UnityCatalogServer "$@" || exit
 }
 
 # Check if TARBALL_JAR_DIR exists, then we are running in the tarball

--- a/bin/uc
+++ b/bin/uc
@@ -44,9 +44,10 @@ run_in_source_code() {
 
 # This function runs the CLI using the tarball
 run_in_tarball() {
-  CLI_CLASSPATH_FILE=$(find "$TARBALL_JAR_DIR" -name "classpath" | head -n 1)
-
-  run_cli_java_command "$CLI_CLASSPATH_FILE" "$@"
+  # Relocatable classpath: a wildcard over the cli jars dir (server and cli jars
+  # are staged separately; see project/Tarball.scala). Quote the glob so the
+  # shell leaves it for the JVM to expand.
+  java -cp "$TARBALL_JAR_DIR/cli/*" io.unitycatalog.cli.UnityCatalogCli "$@" || exit
 }
 
 # Check if TARBALL_JAR_DIR exists, then we are running in the tarball

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,15 +4,19 @@ services:
 
   server:
     image: unitycatalog/unitycatalog:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
     ports:
       - "8080:8080"
     volumes:
       - type: bind
         source: ./etc/conf
-        target: /opt/unitycatalog/etc/conf
+        target: /home/unitycatalog/etc/conf
       - type: volume
         source: unitycatalog_data
-        target: /opt/unitycatalog/etc/data
+        target: /home/unitycatalog/etc/data
   ui:
     build:
       context: ui/

--- a/project/Tarball.scala
+++ b/project/Tarball.scala
@@ -1,48 +1,62 @@
 import sbt.Keys.*
 import sbt.*
 
-import java.nio.file.Files
 import scala.sys.process.*
 import scala.util.{Failure, Success, Try}
 object Tarball {
   lazy val createTarball = taskKey[Unit]("Create a tarball for the project")
+  lazy val stageDist =
+    taskKey[File]("Stage the distribution tree (jars/ bin/ etc/) without tarring; returns the staged dir")
+
+  // Stage the distribution layout into `outputDir`:
+  //
+  //   jars/server/*   server jar + its resolved runtime classpath
+  //   jars/cli/*      cli jar    + its resolved runtime classpath
+  //   bin/  etc/
+  //
+  // The server and CLI classpaths are kept in SEPARATE directories on purpose:
+  // the CLI drags in old ANTLR (antlr4-4.5.1, via hadoop-client) while the server
+  // needs antlr4-runtime-4.13.x (via Hibernate). sbt resolves each module's
+  // classpath with correct eviction, so each directory is internally consistent.
+  // The launchers use a JVM wildcard (`-cp jars/<component>/*`) over its own dir,
+  // which is relocatable AND collision-free (no merged, order-dependent classpath).
+  private def copyJarsInto(jars: Seq[File], dir: File): Unit =
+    jars.distinct.foreach(j => IO.copyFile(j, dir / j.getName))
 
   def createTarballSettings(): Def.SettingsDefinition = {
     Seq(
-      createTarball := {
+      stageDist := {
         val log = streams.value.log
-
-        // Output directory for the tarball
         val outputDir = target.value / "dist"
-        val projectJarFiles = Seq(
-          (LocalProject("server") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("cli") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("client") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("controlApi") / Compile / packageBin).value.getAbsoluteFile,
-          (LocalProject("serverModels") / Compile / packageBin).value.getAbsoluteFile
-        )
-        val scriptsDir = baseDirectory.value / "bin"
-        val etcDir = baseDirectory.value / "etc"
 
-        // All JAR files in the classpath
-        val allJars = (LocalProject("server") / Compile / managedClasspath).value.files ++
-          (LocalProject("cli") / Compile / managedClasspath).value.files ++
-          projectJarFiles
+        val serverJar = (LocalProject("server") / Compile / packageBin).value.getAbsoluteFile
+        val serverModelsJar = (LocalProject("serverModels") / Compile / packageBin).value.getAbsoluteFile
+        val serverClasspath = (LocalProject("server") / Compile / managedClasspath).value.files
 
-        // Clean and create the output directory
+        val cliJar = (LocalProject("cli") / Compile / packageBin).value.getAbsoluteFile
+        val clientJar = (LocalProject("client") / Compile / packageBin).value.getAbsoluteFile
+        val controlApiJar = (LocalProject("controlApi") / Compile / packageBin).value.getAbsoluteFile
+        val cliClasspath = (LocalProject("cli") / Compile / managedClasspath).value.files
+
         IO.delete(outputDir)
         IO.createDirectory(outputDir)
 
-        // Copy the JAR file to the output directory
-        allJars.foreach { jarFile =>
-          IO.copyFile(jarFile, outputDir / "jars" / jarFile.getName)
-        }
-        val classpathFile = outputDir / "jars" / "classpath"
-        Files.write(classpathFile.toPath, allJars.mkString(":").getBytes)
-        // Copy the script files to the output directory
-        IO.copyDirectory(scriptsDir, outputDir / "bin")
-        // Copy the etc files to the output directory
-        IO.copyDirectory(etcDir, outputDir / "etc")
+        copyJarsInto(serverClasspath :+ serverJar :+ serverModelsJar, outputDir / "jars" / "server")
+        copyJarsInto(
+          cliClasspath :+ cliJar :+ clientJar :+ controlApiJar :+ serverJar :+ serverModelsJar,
+          outputDir / "jars" / "cli")
+
+        IO.copyDirectory(baseDirectory.value / "bin", outputDir / "bin")
+        IO.copyDirectory(baseDirectory.value / "etc", outputDir / "etc")
+
+        log.info(s"Staged distribution at $outputDir")
+        outputDir
+      },
+      createTarball := {
+        val log = streams.value.log
+
+        // Reuse the staged dist tree
+        val outputDir = stageDist.value
 
         // Create the tarball
         val tarballFile = target.value / s"${name.value}-${version.value}.tar.gz"


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

* Based on #1580

Review isolated changes [here](https://github.com/unitycatalog/unitycatalog/pull/1582/changes/e7b772406ebd224bd41d11d2d1a751176db07dde).

Rewrite the server image so the dependency cache is no longer baked into the runtime layer (it was, because the old classpath used absolute cache paths; fixed in #1580).

* **Build stage** (`eclipse-temurin:17-jdk-jammy`, glibc): mounts the Coursier/ivy/sbt caches via BuildKit cache mounts so they speed up builds but never land in an image layer; runs `sbt stageDist` to produce the relocatable `jars/{server,cli}/ bin/ etc/` tree.
* **Runtime stage** (`eclipse-temurin:17-jre-jammy`, glibc): copies only the staged dist — no JDK, no sbt, no dependency cache. Moves off Alpine/musl to glibc to avoid native-lib (netty-tcnative) risk. Runs as a non-root user, pins both bases by digest, adds OCI labels and a TCP healthcheck.
* Adds `.dockerignore` (excludes `**/target/`, IDE/sbt state, secrets, docs) and updates `compose.yaml` to build the server from this Dockerfile and align bind-mount targets with the new `/home/unitycatalog` WORKDIR.

Part of a stack: #1580 (launchers) → **this** → CI publish → distroless image.

AI-assisted by: Isaac
