### PR TITLE
feat: support trusted-header authentication for proxy deployments

### DIFF
--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -9,6 +9,14 @@ server.env=dev
 # server.allowed-issuers=https://accounts.google.com
 # server.audiences=111122223333-abab1212cdcd3434.apps.googleusercontent.com
 server.authorization=disable
+# How requests are authenticated when authorization is enabled: jwt (default) | trusted-header.
+# In trusted-header mode (for deployments behind a proxy like Envoy that terminates authentication),
+# the authenticated principal is taken from a trusted header instead of a JWT. The header value
+# (an email) must resolve to an ENABLED user.
+# SECURITY: trusted-header mode is only safe when clients cannot reach Unity Catalog directly and
+# the proxy strips/overwrites this header on inbound requests.
+#server.authentication.mode=trusted-header
+#server.authentication.trusted-header.name=X-Forwarded-Email
 server.authorization-url=
 server.token-url=
 server.client-id=

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
@@ -47,6 +48,7 @@ import io.unitycatalog.server.service.TemporaryModelVersionCredentialsService;
 import io.unitycatalog.server.service.TemporaryPathCredentialsService;
 import io.unitycatalog.server.service.TemporaryTableCredentialsService;
 import io.unitycatalog.server.service.TemporaryVolumeCredentialsService;
+import io.unitycatalog.server.service.TrustedHeaderAuthDecorator;
 import io.unitycatalog.server.service.VolumeService;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
@@ -58,6 +60,7 @@ import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.OptionParser;
 import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.ServerProperties.AuthenticationMode;
 import io.unitycatalog.server.utils.VersionUtils;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
@@ -332,7 +335,8 @@ public class UnityCatalogServer {
           .exclude(CONTROL_PATH + "auth/tokens")
           .build(accessDecorator);
 
-      AuthDecorator authDecorator = new AuthDecorator(securityContext, repositories);
+      DecoratingHttpServiceFunction authDecorator =
+          buildAuthDecorator(serverProperties, repositories);
       armeriaServerBuilder.routeDecorator().pathPrefix(BASE_PATH).build(authDecorator);
       armeriaServerBuilder
           .routeDecorator()
@@ -343,6 +347,23 @@ public class UnityCatalogServer {
       ExceptionHandlingDecorator exceptionDecorator =
           new ExceptionHandlingDecorator(new GlobalExceptionHandler());
       armeriaServerBuilder.decorator(exceptionDecorator);
+    }
+  }
+
+  /**
+   * Selects the authentication decorator based on the configured {@link AuthenticationMode}. New
+   * authentication mechanisms should be added here as additional cases.
+   */
+  private DecoratingHttpServiceFunction buildAuthDecorator(
+      ServerProperties serverProperties, Repositories repositories) {
+    AuthenticationMode mode = serverProperties.getAuthenticationMode();
+    LOGGER.info("Using authentication mode: {}", mode.getValue());
+    switch (mode) {
+      case TRUSTED_HEADER:
+        return new TrustedHeaderAuthDecorator(serverProperties, repositories);
+      case JWT:
+      default:
+        return new AuthDecorator(securityContext, repositories);
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/TrustedHeaderAuthDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TrustedHeaderAuthDecorator.java
@@ -1,0 +1,77 @@
+package io.unitycatalog.server.service;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.netty.util.AttributeKey;
+import io.unitycatalog.control.model.User;
+import io.unitycatalog.server.exception.AuthorizationException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.UserRepository;
+import io.unitycatalog.server.utils.ServerProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Trusted-header authentication decorator.
+ *
+ * <p>This decorator is intended for deployments where Unity Catalog sits behind a fronting proxy
+ * (e.g. Envoy) that terminates authentication against the identity provider. Rather than validating
+ * a JWT, it trusts the principal email injected by the proxy in a configured header.
+ *
+ * <p>The header value is looked up against the user database and the request is only allowed if it
+ * resolves to an existing, {@link User.StateEnum#ENABLED ENABLED} user. The resolved principal
+ * email is added to the request attributes so downstream authorization can reference it (see {@code
+ * IdentityUtils}).
+ *
+ * <p>SECURITY: This mode trusts the header unconditionally. It is only safe when clients cannot
+ * reach Unity Catalog directly and the proxy strips/overwrites the header on inbound requests.
+ */
+public class TrustedHeaderAuthDecorator implements DecoratingHttpServiceFunction {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TrustedHeaderAuthDecorator.class);
+
+  public static final AttributeKey<String> PRINCIPAL_ATTR =
+      AttributeKey.valueOf(String.class, "TRUSTED_HEADER_PRINCIPAL_ATTR");
+
+  private final String headerName;
+  private final UserRepository userRepository;
+
+  public TrustedHeaderAuthDecorator(ServerProperties serverProperties, Repositories repositories) {
+    this.headerName = serverProperties.getTrustedHeaderName();
+    this.userRepository = repositories.getUserRepository();
+  }
+
+  @Override
+  public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
+      throws Exception {
+    LOGGER.debug("TrustedHeaderAuthDecorator checking {}", req.path());
+
+    String principal = req.headers().get(headerName);
+    if (principal == null || principal.trim().isEmpty()) {
+      throw new AuthorizationException(
+          ErrorCode.UNAUTHENTICATED, "No trusted identity header found.");
+    }
+
+    User user;
+    try {
+      user = userRepository.getUserByEmail(principal);
+    } catch (Exception e) {
+      LOGGER.debug("User not found: {}", principal);
+      user = null;
+    }
+    if (user == null || user.getState() != User.StateEnum.ENABLED) {
+      throw new AuthorizationException(
+          ErrorCode.PERMISSION_DENIED, "User not allowed: " + principal);
+    }
+
+    LOGGER.debug("Access allowed for subject: {}", principal);
+
+    ctx.setAttr(PRINCIPAL_ATTR, principal);
+
+    return delegate.serve(ctx, req);
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/IdentityUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/IdentityUtils.java
@@ -5,10 +5,18 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.service.AuthDecorator;
+import io.unitycatalog.server.service.TrustedHeaderAuthDecorator;
 
 public class IdentityUtils {
   public static String findPrincipalEmailAddress() {
     ServiceRequestContext ctx = ServiceRequestContext.current();
+
+    // When deployed behind a trusted proxy, identity comes from a trusted header rather than a JWT.
+    String headerPrincipal = ctx.attr(TrustedHeaderAuthDecorator.PRINCIPAL_ATTR);
+    if (headerPrincipal != null) {
+      return headerPrincipal;
+    }
+
     DecodedJWT decodedJWT = ctx.attr(AuthDecorator.DECODED_JWT_ATTR);
     // TODO: if/when authorization becomes mandatory, maybe just throw an exception here?
     if (decodedJWT != null) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -191,6 +191,10 @@ public class ServerProperties {
     SERVER_ENV("server.env", "dev", new EnumValidator(true, "dev", "prod", "test")),
     AUTHORIZATION_ENABLED(
         "server.authorization", "disable", new EnumValidator(true, "enable", "disable")),
+    AUTHENTICATION_MODE(
+        "server.authentication.mode", "jwt", new EnumValidator(true, "jwt", "trusted-header")),
+    TRUSTED_HEADER_AUTH_NAME(
+        "server.authentication.trusted-header.name", "X-Forwarded-Email", NOOP_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),
@@ -231,6 +235,32 @@ public class ServerProperties {
 
     Property(String key) {
       this(key, null, NOOP_VALIDATOR);
+    }
+  }
+
+  /** Mechanism used to authenticate requests. See {@link #getAuthenticationMode()}. */
+  public enum AuthenticationMode {
+    JWT("jwt"),
+    TRUSTED_HEADER("trusted-header");
+
+    private final String value;
+
+    AuthenticationMode(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public static AuthenticationMode fromValue(String value) {
+      for (AuthenticationMode mode : values()) {
+        if (mode.value.equalsIgnoreCase(value)) {
+          return mode;
+        }
+      }
+      throw new BaseException(
+          ErrorCode.INTERNAL, "Unknown " + Property.AUTHENTICATION_MODE.key + ": " + value);
     }
   }
 
@@ -437,6 +467,25 @@ public class ServerProperties {
 
   public boolean isAuthorizationEnabled() {
     return isTrueOrEnable(get(Property.AUTHORIZATION_ENABLED));
+  }
+
+  /**
+   * The mechanism used to authenticate requests and establish the caller's identity. Only consulted
+   * when authorization is enabled.
+   *
+   * <ul>
+   *   <li>{@code JWT} (default): validate a bearer JWT issued by the internal issuer.
+   *   <li>{@code TRUSTED_HEADER}: trust the principal email injected by a fronting proxy (e.g.
+   *       Envoy) in a configured header.
+   * </ul>
+   */
+  public AuthenticationMode getAuthenticationMode() {
+    return AuthenticationMode.fromValue(get(Property.AUTHENTICATION_MODE));
+  }
+
+  /** Name of the trusted header carrying the principal's email (trusted-header mode). */
+  public String getTrustedHeaderName() {
+    return get(Property.TRUSTED_HEADER_AUTH_NAME);
   }
 
   public boolean isIncludeStackTraceInError() {

--- a/server/src/test/java/io/unitycatalog/server/service/TrustedHeaderAuthDecoratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/TrustedHeaderAuthDecoratorTest.java
@@ -1,0 +1,103 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+import io.unitycatalog.control.model.User;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.UserRepository;
+import io.unitycatalog.server.persist.model.CreateUser;
+import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.ServerProperties.Property;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for {@link TrustedHeaderAuthDecorator}: the server is configured with {@code
+ * server.authentication.mode=trusted-header} and requests carry identity in a trusted header rather
+ * than a JWT. Each test drives a real HTTP request through the full decorator chain.
+ */
+public class TrustedHeaderAuthDecoratorTest extends BaseServerTest {
+
+  private static final String TRUSTED_HEADER = "X-Forwarded-Email";
+  private static final String KNOWN_USER_EMAIL = "trusted-user@example.com";
+  // listCatalogs is authenticated and response-filtered, so any authenticated user gets 200 with a
+  // (possibly empty) list. This exercises identity resolution without needing privilege grants.
+  private static final String CATALOGS_ENDPOINT = "/api/2.1/unity-catalog/catalogs";
+
+  private WebClient client;
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    serverProperties.setProperty(Property.AUTHORIZATION_ENABLED.getKey(), "enable");
+    serverProperties.setProperty(Property.AUTHENTICATION_MODE.getKey(), "trusted-header");
+    serverProperties.setProperty(Property.TRUSTED_HEADER_AUTH_NAME.getKey(), TRUSTED_HEADER);
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    client = WebClient.builder(serverConfig.getServerUrl()).build();
+
+    // Seed an ENABLED user directly against the same database the server uses.
+    UserRepository userRepository =
+        new Repositories(
+                hibernateConfigurator.getSessionFactory(), new ServerProperties(serverProperties))
+            .getUserRepository();
+    userRepository.createUser(
+        CreateUser.builder().name("Trusted User").email(KNOWN_USER_EMAIL).build());
+  }
+
+  private AggregatedHttpResponse listCatalogs(String headerEmail) {
+    RequestHeadersBuilder builder =
+        RequestHeaders.builder().method(HttpMethod.GET).path(CATALOGS_ENDPOINT);
+    if (headerEmail != null) {
+      builder.add(TRUSTED_HEADER, headerEmail);
+    }
+    return client.execute(builder.build()).aggregate().join();
+  }
+
+  @Test
+  public void testKnownUserIsAllowed() {
+    AggregatedHttpResponse response = listCatalogs(KNOWN_USER_EMAIL);
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void testUnknownUserIsForbidden() {
+    AggregatedHttpResponse response = listCatalogs("nobody@example.com");
+    assertThat(response.status()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  public void testMissingHeaderIsUnauthorized() {
+    AggregatedHttpResponse response = listCatalogs(null);
+    assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void testDisabledUserIsForbidden() {
+    // Create then disable a user (deleteUser sets state to DISABLED), and verify the header for
+    // that user is rejected.
+    String disabledEmail = "disabled-user@example.com";
+    UserRepository userRepository =
+        new Repositories(
+                hibernateConfigurator.getSessionFactory(), new ServerProperties(serverProperties))
+            .getUserRepository();
+    User created =
+        userRepository.createUser(
+            CreateUser.builder().name("Disabled User").email(disabledEmail).build());
+    userRepository.deleteUser(created.getId());
+
+    AggregatedHttpResponse response = listCatalogs(disabledEmail);
+    assertThat(response.status()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -199,6 +199,33 @@ public class ServerPropertiesTest {
   }
 
   @Test
+  public void testAuthenticationMode() {
+    // JWT by default, with a sensible default header name.
+    ServerProperties defaults = new ServerProperties();
+    assertThat(defaults.getAuthenticationMode()).isEqualTo(ServerProperties.AuthenticationMode.JWT);
+    assertThat(defaults.getTrustedHeaderName()).isEqualTo("X-Forwarded-Email");
+
+    // Mode is an enum: jwt | trusted-header.
+    testValidProperty(Property.AUTHENTICATION_MODE, "jwt");
+    testValidProperty(Property.AUTHENTICATION_MODE, "trusted-header");
+    testInvalidProperty(
+        Property.AUTHENTICATION_MODE,
+        "saml",
+        "Invalid value 'saml'",
+        "server.authentication.mode",
+        "Allowed values: [jwt, trusted-header]");
+
+    // Custom mode/name are read back via the accessors.
+    Properties props = new Properties();
+    props.setProperty(Property.AUTHENTICATION_MODE.getKey(), "trusted-header");
+    props.setProperty(Property.TRUSTED_HEADER_AUTH_NAME.getKey(), "X-Auth-Request-Email");
+    ServerProperties configured = new ServerProperties(props);
+    assertThat(configured.getAuthenticationMode())
+        .isEqualTo(ServerProperties.AuthenticationMode.TRUSTED_HEADER);
+    assertThat(configured.getTrustedHeaderName()).isEqualTo("X-Auth-Request-Email");
+  }
+
+  @Test
   public void testDefaultPropertyValues() {
     // Test that all default values are valid and correctly set. If any of them are invalid, the
     // constructor would throw exception.


### PR DESCRIPTION
## Summary

Adds an authentication-mode setting so Unity Catalog can be deployed behind a fronting proxy (e.g. Envoy) that terminates authentication against the identity provider. In trusted-header mode the server takes the caller's identity from a configured, proxy-injected header instead of validating a JWT, while still authorizing against its own user database.

The change is intentionally minimal and follows the existing Armeria decorator + `ServerProperties` patterns. Downstream authorization code is unchanged.

## Design

- **`server.authorization=enable|disable`** stays as the master switch for whether the authorization layer runs at all (still read by `AuthService` / `AuthorizedService`).
- **`server.authentication.mode=jwt|trusted-header`** (new, default `jwt`) selects *how* a caller is authenticated. Read only by the decorator wiring, so it is the extension point for future mechanisms.
- **`server.authentication.trusted-header.name`** (new, default `X-Forwarded-Email`) names the header carrying the principal's email.

In trusted-header mode, `TrustedHeaderAuthDecorator`:
1. reads the configured header (missing/blank → `401 UNAUTHENTICATED`),
2. requires the value to resolve to an existing, `ENABLED` user — identical DB validation to the JWT path (otherwise `403 PERMISSION_DENIED`),
3. exposes the principal on the request context.

`IdentityUtils.findPrincipalEmailAddress()` reads the trusted-header principal first and falls back to the JWT subject, so `UnityAccessDecorator`, services, and `UserRepository.findPrincipalId()` need no changes. `UnityCatalogServer` selects the decorator by mode in a single `switch`.

## Security

Trusted-header mode trusts the header unconditionally. It is opt-in (default `jwt`), gated behind authorization being enabled, and only safe when clients cannot reach the server directly and the proxy strips/overwrites the header on inbound requests. This is documented in `etc/conf/server.properties`.

## Testing

- `ServerPropertiesTest`: validation and accessors for the new properties (mode enum, header name, defaults).
- `TrustedHeaderAuthDecoratorTest`: end-to-end against a running server in trusted-header mode through the full auth + access decorator chain — known ENABLED user → 200, unknown user → 403, missing header → 401, disabled user → 403.
- Existing `AuthServiceTest` (JWT path) unchanged and passing.

All 18 tests across these suites pass; checkstyle and spotless clean.

AI-assisted by: Isaac