### PR TITLE
Auto-default delta.feature.catalogManaged on UC-managed Delta CREATE

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -10,11 +10,8 @@ public class UCTableProperties {
   public static final String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
 
   // This table property should be set in order to enable Delta code to use UC as commit coordinator
-  public static final String DELTA_CATALOG_MANAGED_KEY = "delta.feature.catalogOwned-preview";
+  public static final String DELTA_CATALOG_MANAGED_KEY = "delta.feature.catalogManaged";
   public static final String DELTA_CATALOG_MANAGED_VALUE = "supported";
-  // Eventually Delta will be changed to use this feature name instead. But before that is done, we
-  // can't set it yet.
-  public static final String DELTA_CATALOG_MANAGED_KEY_NEW = "delta.feature.catalogManaged";
 
   // These properties were added by `V1Table.addV2TableProperties` in package spark-catalyst.
   // They are used for constructing the CreateTable rpc.

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -119,16 +119,18 @@ class UCSingleCatalog
 
   /**
    * Returns the properties UC should pass to the Delta catalog delegate for a managed Delta
-   * CREATE / CTAS. When the UC Delta API path is ready, we skip UC's legacy
-   * `createStagingTable` and pass the caller-supplied properties through untouched -- the
-   * Delta catalog stages and finalizes via the UC Delta API. Otherwise we fall back to the
-   * legacy staging path so older Delta builds keep working.
+   * CREATE / CTAS. Runs {@link #validateAndDefaultManagedDeltaCreateProperties} on the input
+   * first. When the UC Delta API path is ready, we skip UC's legacy `createStagingTable` and
+   * pass the validated properties through untouched -- the Delta catalog stages and finalizes
+   * via the UC Delta API. Otherwise we fall back to the legacy staging path so older Delta
+   * builds keep working.
    */
   private def managedDeltaCreatePropsForDelegate(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (shouldUseDeltaAPI) properties
-    else stageManagedDeltaTableAndGetProps(ident, properties)
+    val validated = validateAndDefaultManagedDeltaCreateProperties(properties)
+    if (shouldUseDeltaAPI) validated
+    else stageManagedDeltaTableAndGetProps(ident, validated)
   }
 
   override def name(): String = delegate.name()
@@ -160,7 +162,6 @@ class UCSingleCatalog
     if (UCSingleCatalog.isManagedTable(properties, ident)) {
       if (UCSingleCatalog.hasDeltaProvider(properties)) {
         // Managed Delta table
-        validateManagedDeltaCreateProperties(properties)
         val newProps = managedDeltaCreatePropsForDelegate(ident, properties)
         delegate.createTable(ident, columns, partitions, newProps)
       } else {
@@ -215,28 +216,29 @@ class UCSingleCatalog
   }
 
   /**
-   * Checks that the user-supplied table properties are valid for creating a new UC-managed Delta
-   * table.
+   * Validates and normalizes the user-supplied table properties for creating a new UC-managed
+   * Delta table, returning the properties to pass downstream.
    *
    * In this path, UC expects the caller to provide only user-controlled properties. It rejects
    * properties that UC itself assigns during staging, such as the UC table ID and the
-   * managed-location marker. It also requires the catalog-managed Delta feature flag to be present
-   * and set to the supported value, because that flag determines whether the new table is created
-   * with the coordinated-commit behavior expected for UC-managed Delta tables.
+   * managed-location marker. The catalog-managed Delta feature flag is automatically turned on.
    */
-  private def validateManagedDeltaCreateProperties(properties: util.Map[String, String]): Unit = {
+  private def validateAndDefaultManagedDeltaCreateProperties(
+      properties: util.Map[String, String]): util.Map[String, String] = {
     rejectSystemManagedProperties(properties)
-    if (!properties.containsKey(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW)) {
-      throw new ApiException(
-        s"Managed table creation requires table property " +
-          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'=" +
-          s"'${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'" +
-          s" to be set.")
+    Option(properties.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY)) match {
+      case None =>
+        val augmented = new util.HashMap[String, String](properties)
+        augmented.put(
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
+        augmented
+      case Some(v) if v == UCTableProperties.DELTA_CATALOG_MANAGED_VALUE =>
+        properties
+      case Some(v) =>
+        throw new ApiException(
+          s"Invalid property value '$v' for '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY}'.")
     }
-    Option(properties.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
-      .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
-      .foreach(v => throw new ApiException(
-        s"Invalid property value '$v' for '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'."))
   }
 
   /**
@@ -256,12 +258,11 @@ class UCSingleCatalog
       operation: String): util.Map[String, String] = {
     val fullTableName = UCSingleCatalog.fullTableNameForApi(name(), ident)
 
-    // First, ensure the caller is not trying to override system-managed properties.
+    // First, ensure the caller is not trying to override system-managed properties. Called
+    // explicitly here (and again inside validateAndDefault below) so a system-managed override on
+    // a REPLACE against a non-managed-Delta table still surfaces the precise error rather than
+    // tripping the more generic "only supported for catalog-managed UC Delta tables" gate.
     rejectSystemManagedProperties(properties)
-    Option(properties.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
-      .filter(_ != UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
-      .foreach(_ => throw new ApiException(
-        s"Cannot override property '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW}'."))
     if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
       throw new ApiException(
         s"$operation cannot specify property '${TableCatalog.PROP_LOCATION}' " +
@@ -292,13 +293,13 @@ class UCSingleCatalog
           s"USING DELTA. Cannot change table format from " +
           s"${existingProvider.toUpperCase(Locale.ROOT)} to " +
           s"${provider.toUpperCase(Locale.ROOT)} for $fullTableName."))
+    // Deferred to here so the existing-table gate above can short-circuit for non-managed-Delta
+    // REPLACE without paying the validate-default cost (and without auto-adding a Delta-only
+    // property to a non-Delta property map).
+    val validated = validateAndDefaultManagedDeltaCreateProperties(properties)
     val newProps = new util.HashMap[String, String]
-    newProps.putAll(properties)
+    newProps.putAll(validated)
     newProps.put(TableCatalog.PROP_PROVIDER, existingProvider)
-    // Preserve the catalog-managed marker on the properties passed to Delta for replace.
-    newProps.put(
-      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
-      UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
     // Location intentionally omitted; Delta resolves it from the existing table snapshot.
     newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
 
@@ -328,7 +329,7 @@ class UCSingleCatalog
     tableInfo.getTableType == TableType.MANAGED &&
     tableInfo.getDataSourceFormat == DataSourceFormat.DELTA &&
     tableProperties.exists(
-      _.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW) ==
+      _.get(UCTableProperties.DELTA_CATALOG_MANAGED_KEY) ==
         UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)
   }
 
@@ -442,7 +443,6 @@ class UCSingleCatalog
     }.getOrElse {
       // Creating a new table -- route through the same gate as `createTable` so a fresh
       // CREATE OR REPLACE picks up the UC Delta API path when it's available.
-      validateManagedDeltaCreateProperties(properties)
       managedDeltaCreatePropsForDelegate(ident, properties)
     }
     UCSingleCatalog.requireProviderSpecified("CREATE OR REPLACE TABLE", newProps)

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -237,7 +237,8 @@ class UCSingleCatalog
         properties
       case Some(v) =>
         throw new ApiException(
-          s"Invalid property value '$v' for '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY}'.")
+          s"Invalid property value '$v' for '${UCTableProperties.DELTA_CATALOG_MANAGED_KEY}'. " +
+            s"Must be '${UCTableProperties.DELTA_CATALOG_MANAGED_VALUE}'.")
     }
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseTableReadWriteTest.java
@@ -70,11 +70,6 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   protected static final String ANOTHER_TEST_TABLE = "test_table_another";
-  protected static final String TBLPROPERTIES_CATALOG_OWNED_CLAUSE =
-      String.format(
-          "TBLPROPERTIES ('%s'='%s')",
-          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
-          UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
 
   /**
    * This class is used for control various options for table creation during test. The tableFormat
@@ -164,7 +159,7 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
 
     public String createManagedTableSql() {
       return String.format(
-          "%s TABLE %s.%s.%s %s USING %s %s %s %s %s",
+          "%s TABLE %s.%s.%s %s USING %s %s %s %s",
           ddlCommand(),
           catalogName,
           schemaName,
@@ -172,7 +167,6 @@ public abstract class BaseTableReadWriteTest extends BaseSparkIntegrationTest {
           columnsClause(),
           tableFormat(),
           partitionClause(),
-          TBLPROPERTIES_CATALOG_OWNED_CLAUSE,
           commentClause(),
           asSelectClause());
     }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -70,24 +70,24 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
 
   @Test
   public void testCreateManagedTableErrors() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    // Include SPARK_CATALOG so the explicit-`supported` success path below can finish creating the
+    // table via Delta -- DeltaLog.checkRequiredConfigurations requires spark_catalog to be set to a
+    // UC/Delta catalog. The other assertions in this method short-circuit in UCSingleCatalog before
+    // Delta is reached, so they don't care, but the success path actually invokes Delta.
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
     ensureSparkCatalogSchemaExists();
     String fullTableName = CATALOG_NAME + "." + SCHEMA_NAME + "." + DELTA_TABLE;
-    assertThatThrownBy(
-            () ->
-                sql(
-                    "CREATE TABLE %s(name STRING) USING parquet %s",
-                    fullTableName, TBLPROPERTIES_CATALOG_OWNED_CLAUSE))
+    assertThatThrownBy(() -> sql("CREATE TABLE %s(name STRING) USING parquet", fullTableName))
         .hasMessageContaining("not support non-Delta managed table");
     assertThatThrownBy(
             () ->
                 sql(
                     "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'disabled')",
-                    fullTableName, UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW))
+                    fullTableName, UCTableProperties.DELTA_CATALOG_MANAGED_KEY))
         .hasMessageContaining(
             String.format(
                 "Invalid property value 'disabled' for '%s'",
-                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW));
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY));
     assertThatThrownBy(
             () ->
                 sql(
@@ -100,12 +100,15 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
                     "CREATE TABLE %s(name STRING) USING delta " + "TBLPROPERTIES ('%s' = 'false')",
                     fullTableName, TableCatalog.PROP_IS_MANAGED_LOCATION))
         .hasMessageContaining("is_managed_location");
-    assertThatThrownBy(() -> sql("CREATE TABLE %s(name STRING) USING delta", fullTableName))
-        .hasMessageContaining(
-            String.format(
-                "Managed table creation requires table property '%s'='%s' to be set",
-                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
-                UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
+
+    // Explicit catalog-managed=supported is accepted (the no-property path is implicitly
+    // covered by every other managed-Delta test via `createManagedTableSql()`).
+    sql(
+        "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = '%s')",
+        fullTableName,
+        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+        UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+    sql("DROP TABLE IF EXISTS %s", fullTableName);
   }
 
   @ParameterizedTest
@@ -169,7 +172,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
               .contains(
                   String.format(
                       "%s=%s",
-                      UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                      UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
                       UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
           // Check schema of table
           validateTableSchema(
@@ -189,7 +192,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
           assertThat(tablePropertiesFromServer)
               .containsEntry(UCTableProperties.UC_TABLE_ID_KEY, tableInfo.getTableId())
               .containsEntry(
-                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                  UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
                   UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
         }
       }
@@ -282,7 +285,7 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
     assertThat(tablePropertiesFromServer).containsKey(UCTableProperties.UC_TABLE_ID_KEY);
     assertThat(tablePropertiesFromServer)
         .containsEntry(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -86,8 +86,9 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
                     fullTableName, UCTableProperties.DELTA_CATALOG_MANAGED_KEY))
         .hasMessageContaining(
             String.format(
-                "Invalid property value 'disabled' for '%s'",
-                UCTableProperties.DELTA_CATALOG_MANAGED_KEY));
+                "Invalid property value 'disabled' for '%s'. Must be '%s'.",
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+                UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
     assertThatThrownBy(
             () ->
                 sql(

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -52,13 +52,13 @@ public class UCSingleCatalogStagingTableTest {
       Map.of(
           TableCatalog.PROP_PROVIDER,
           "delta",
-          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
           UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
   private static final Map<String, String> MANAGED_DELTA_REPLACE_OVERRIDE_PROPS =
       Map.of(
           TableCatalog.PROP_PROVIDER,
           "delta",
-          UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+          UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
           "disabled");
   private static final Map<String, String> REPLACE_DELTA_PROPS =
       Map.of(TableCatalog.PROP_PROVIDER, "delta");
@@ -187,7 +187,42 @@ public class UCSingleCatalogStagingTableTest {
   }
 
   @Test
-  public void testStageCreateOrReplaceMissingManagedTableRequiresCatalogManagedFeature()
+  public void testStageCreateOrReplaceMissingManagedTableAutoDefaultsCatalogManagedFeature()
+      throws Exception {
+    GenericCredentialFetcher mockCredApi = mock(GenericCredentialFetcher.class);
+    when(mockCredApi.createCredential())
+        .thenReturn(
+            new GenericCredential(
+                new TemporaryCredentials()
+                    .gcpOauthToken(new GcpOauthToken().oauthToken("token"))
+                    .expirationTime(Long.MAX_VALUE)));
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, conf) -> mockCredApi;
+
+    ManagedReplaceMocks mocks = new ManagedReplaceMocks();
+    mockMissingTableLookup(mocks.tablesApi);
+    when(mockDelegate.stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any()))
+        .thenReturn(mocks.staged);
+    when(mocks.tablesApi.createStagingTable(any(CreateStagingTable.class)))
+        .thenReturn(
+            new StagingTableInfo().id("staging-id").stagingLocation("gs://uc-staging/table"));
+
+    StagedTable result =
+        catalog.stageCreateOrReplace(
+            IDENT, SCHEMA, PARTITIONS, Map.of(TableCatalog.PROP_PROVIDER, "delta"));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+    verify(mockDelegate).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    // catalog-managed is auto-defaulted when the caller omits it (new behavior).
+    assertThat(propsCaptor.getValue())
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+    assertThat(result).isSameAs(mocks.staged);
+  }
+
+  @Test
+  public void testStageCreateOrReplaceMissingManagedTableRejectsInvalidCatalogManagedValue()
       throws Exception {
     TablesApi mockTablesApi = mock(TablesApi.class);
     mockMissingTableLookup(mockTablesApi);
@@ -195,12 +230,77 @@ public class UCSingleCatalogStagingTableTest {
     assertThatThrownBy(
             () ->
                 catalog.stageCreateOrReplace(
-                    IDENT, SCHEMA, PARTITIONS, Map.of(TableCatalog.PROP_PROVIDER, "delta")))
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER, "delta",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY, "bogus")))
         .isInstanceOf(ApiException.class)
-        .hasMessageContaining("Managed table creation requires table property");
+        .hasMessageContaining("Invalid property value 'bogus'");
 
     verify(mockTablesApi, never()).createStagingTable(any(CreateStagingTable.class));
     verify(mockDelegate, never()).stageCreateOrReplace(eq(IDENT), eq(SCHEMA), any(), any());
+  }
+
+  /**
+   * The {@code stageCreate} path (used by SQL {@code CREATE TABLE ... USING delta} and CTAS) must
+   * apply the same auto-default behavior as {@code createTable} / {@code stageCreateOrReplace}.
+   * Pinned with a unit test so a regression here is caught fast, not only by the slow end-to-end
+   * {@code DeltaManagedTableReadWriteTest} suites.
+   */
+  @Test
+  public void testStageCreateMissingManagedTableAutoDefaultsCatalogManagedFeature()
+      throws Exception {
+    GenericCredentialFetcher mockCredApi = mock(GenericCredentialFetcher.class);
+    when(mockCredApi.createCredential())
+        .thenReturn(
+            new GenericCredential(
+                new TemporaryCredentials()
+                    .gcpOauthToken(new GcpOauthToken().oauthToken("token"))
+                    .expirationTime(Long.MAX_VALUE)));
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, conf) -> mockCredApi;
+
+    ManagedReplaceMocks mocks = new ManagedReplaceMocks();
+    // Inject the mocked TablesApi onto the catalog so stageManagedDeltaTableAndGetProps can call
+    // createStagingTable. The getTable mock that mockMissingTableLookup also installs is harmless
+    // here (stageCreate doesn't probe existence).
+    mockMissingTableLookup(mocks.tablesApi);
+    when(mockDelegate.stageCreate(eq(IDENT), eq(SCHEMA), any(), any())).thenReturn(mocks.staged);
+    when(mocks.tablesApi.createStagingTable(any(CreateStagingTable.class)))
+        .thenReturn(
+            new StagingTableInfo().id("staging-id").stagingLocation("gs://uc-staging/table"));
+
+    StagedTable result =
+        catalog.stageCreate(IDENT, SCHEMA, PARTITIONS, Map.of(TableCatalog.PROP_PROVIDER, "delta"));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass((Class) Map.class);
+    verify(mockDelegate).stageCreate(eq(IDENT), eq(SCHEMA), any(), propsCaptor.capture());
+    // catalog-managed is auto-defaulted when the caller omits it (new behavior).
+    assertThat(propsCaptor.getValue())
+        .containsEntry(
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
+            UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
+    assertThat(result).isSameAs(mocks.staged);
+  }
+
+  @Test
+  public void testStageCreateMissingManagedTableRejectsInvalidCatalogManagedValue()
+      throws Exception {
+    assertThatThrownBy(
+            () ->
+                catalog.stageCreate(
+                    IDENT,
+                    SCHEMA,
+                    PARTITIONS,
+                    Map.of(
+                        TableCatalog.PROP_PROVIDER, "delta",
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY, "bogus")))
+        .isInstanceOf(ApiException.class)
+        .hasMessageContaining("Invalid property value 'bogus'");
+
+    verify(mockDelegate, never()).stageCreate(eq(IDENT), eq(SCHEMA), any(), any());
   }
 
   @Test
@@ -264,7 +364,7 @@ public class UCSingleCatalogStagingTableTest {
         SCHEMA,
         PARTITIONS,
         Map.of(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
 
     @SuppressWarnings("unchecked")
@@ -274,7 +374,7 @@ public class UCSingleCatalogStagingTableTest {
     assertThat(propsCaptor.getValue())
         .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
         .containsEntry(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
   }
 
@@ -291,7 +391,7 @@ public class UCSingleCatalogStagingTableTest {
                     Map.of(
                         TableCatalog.PROP_PROVIDER,
                         "parquet",
-                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
                         UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)))
         .isInstanceOf(ApiException.class)
         .hasMessageContaining("requires USING DELTA")
@@ -310,7 +410,7 @@ public class UCSingleCatalogStagingTableTest {
         SCHEMA,
         PARTITIONS,
         Map.of(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
 
     @SuppressWarnings("unchecked")
@@ -320,7 +420,7 @@ public class UCSingleCatalogStagingTableTest {
     assertThat(propsCaptor.getValue())
         .containsEntry(TableCatalog.PROP_PROVIDER, "delta")
         .containsEntry(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
   }
 
@@ -337,7 +437,7 @@ public class UCSingleCatalogStagingTableTest {
                     Map.of(
                         TableCatalog.PROP_PROVIDER,
                         "parquet",
-                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                        UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
                         UCTableProperties.DELTA_CATALOG_MANAGED_VALUE)))
         .isInstanceOf(ApiException.class)
         .hasMessageContaining("requires USING DELTA")
@@ -371,7 +471,7 @@ public class UCSingleCatalogStagingTableTest {
         .containsEntry(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
         .doesNotContainKey(UCTableProperties.UC_TABLE_ID_KEY)
         .containsEntry(
-            UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+            UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
             UCTableProperties.DELTA_CATALOG_MANAGED_VALUE);
     assertThat(result).isSameAs(mocks.staged);
   }
@@ -396,7 +496,7 @@ public class UCSingleCatalogStagingTableTest {
         .tableId("table-id")
         .properties(
             Map.of(
-                UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW,
+                UCTableProperties.DELTA_CATALOG_MANAGED_KEY,
                 UCTableProperties.DELTA_CATALOG_MANAGED_VALUE));
   }
 
@@ -410,8 +510,7 @@ public class UCSingleCatalogStagingTableTest {
                 catalog.stageReplace(
                     IDENT, SCHEMA, PARTITIONS, MANAGED_DELTA_REPLACE_OVERRIDE_PROPS))
         .isInstanceOf(ApiException.class)
-        .hasMessageContaining(
-            "Cannot override property '" + UCTableProperties.DELTA_CATALOG_MANAGED_KEY_NEW + "'");
+        .hasMessageContaining("Invalid property value 'disabled'");
 
     verify(mockDelegate, never()).stageReplace(eq(IDENT), eq(SCHEMA), any(), any());
   }

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkCredentialRenewalTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkCredentialRenewalTest.java
@@ -124,13 +124,9 @@ public class SparkCredentialRenewalTest {
     sql("DROP TABLE IF EXISTS %s", dstTable(tableType));
     if (MANAGED_TABLE_TYPE.equals(tableType)) {
       sql(
-          "CREATE TABLE %s (id INT) USING delta PARTITIONED BY (partition INT)"
-              + " TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')",
+          "CREATE TABLE %s (id INT) USING delta PARTITIONED BY (partition INT)",
           srcTable(tableType));
-      sql(
-          "CREATE TABLE %s (id INT) USING delta"
-              + " TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')",
-          dstTable(tableType));
+      sql("CREATE TABLE %s (id INT) USING delta", dstTable(tableType));
     } else {
       sql(
           "CREATE TABLE %s (id INT) USING delta LOCATION '%s/%s' PARTITIONED BY (partition INT)",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1587/files) to review incremental changes.
- [**stack/catalog_managed_default**](https://github.com/unitycatalog/unitycatalog/pull/1587) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1587/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Auto-default delta.feature.catalogManaged on UC-managed Delta CREATE

Changes:
- `UCSingleCatalog.validateAndDefaultManagedDeltaCreateProperties` (renamed from `validate...`): now returns the properties map, auto-defaulting `delta.feature.catalogManaged=supported` when absent. Set to `supported` is accepted; set to anything else is rejected.
- CREATE and CREATE OR REPLACE call sites consume the returned (possibly augmented) map.
- `UCTableProperties`: drop the dead `DELTA_CATALOG_MANAGED_KEY_NEW` and the unused legacy value `"delta.feature.catalogOwned-preview"`; `DELTA_CATALOG_MANAGED_KEY` now holds the value that production code already used (`"delta.feature.catalogManaged"`). Pure rename, no runtime behavior change. Test references updated.
- `BaseTableReadWriteTest.createManagedTableSql()`: drop the now-redundant `TBLPROPERTIES` clause; helper-built integration tests implicitly exercise the auto-default path.
- `DeltaManagedTableReadWriteTest.testCreateManagedTableErrors`: remove the missing-property failure assertion; add one inline success `sql(...)` pinning the explicit-`supported` path.

Why:
- Most callers want catalog-managed behavior on UC-managed Delta tables; requiring them to set the flag explicitly is friction with no upside.
- The three-case contract is now: absent → auto-default, supported → accepted, other → rejected.
