### PR TITLE
fix: make uc_delta_commits Postgres-compatible (UUID columns + DELETE…

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -696,7 +696,9 @@ public class DeltaCommitRepository {
   private static int deleteCommitsUpTo(Session session, UUID tableId, long upToCommitVersion) {
     NativeQuery<?> query =
         session.createNativeQuery(
-            "DELETE FROM uc_delta_commits WHERE table_id = :tableId AND commit_version <= :upToCommitVersion LIMIT :numCommitsPerBatch");
+            "DELETE FROM uc_delta_commits WHERE id IN ("
+                + "SELECT id FROM uc_delta_commits WHERE table_id = :tableId "
+                + "AND commit_version <= :upToCommitVersion LIMIT :numCommitsPerBatch)");
     query.setParameter("tableId", tableId);
     query.setParameter("upToCommitVersion", upToCommitVersion);
     query.setParameter("numCommitsPerBatch", NUM_COMMITS_PER_BATCH);
@@ -717,7 +719,9 @@ public class DeltaCommitRepository {
   private static int deleteCommits(Session session, UUID tableId) {
     NativeQuery<?> query =
         session.createNativeQuery(
-            "DELETE FROM uc_delta_commits WHERE table_id = :tableId LIMIT :numCommitsPerBatch");
+            "DELETE FROM uc_delta_commits WHERE id IN ("
+                + "SELECT id FROM uc_delta_commits WHERE table_id = :tableId "
+                + "LIMIT :numCommitsPerBatch)");
     query.setParameter("tableId", tableId);
     query.setParameter("numCommitsPerBatch", NUM_COMMITS_PER_BATCH);
     return query.executeUpdate();

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DeltaCommitDAO.java
@@ -30,10 +30,10 @@ public class DeltaCommitDAO {
   // optionally commit_version. But this is a required field as a unique ID in the database.
   @Id
   @UuidGenerator
-  @Column(name = "id", columnDefinition = "BINARY(16)")
+  @Column(name = "id")
   private UUID id;
 
-  @Column(name = "table_id", nullable = false, columnDefinition = "BINARY(16)")
+  @Column(name = "table_id", nullable = false)
   private UUID tableId;
 
   @Column(name = "commit_version", nullable = false)


### PR DESCRIPTION
… batch)

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Drop the H2-specific columnDefinition='BINARY(16)' from DeltaCommitDAO's
UUID columns so Hibernate maps them to Postgres 'uuid' (matching the other
working DAOs); without this the CREATE for uc_delta_commits silently fails
under hbm2ddl=update on Postgres and the table is never created.

Rewrite the two DELETE ... LIMIT native queries in DeltaCommitRepository as
portable 'DELETE ... WHERE id IN (SELECT id ... LIMIT n)' subqueries, which
Postgres accepts (it rejects DELETE ... LIMIT). Batch semantics and the
loop-until-zero callers are unchanged.

Co-authored-by: Isaac