### PR TITLE
Enable managed tables by default: server.managed-table.enabled=true

### DIFF
--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -29,10 +29,9 @@ server.audiences=
 # D-Days H-Hours M-Minutes S-Seconds (P5D = 5 days,PT5H = 5 hours, PT5M = 5 minutes, PT5S = 5 seconds)
 server.cookie-timeout=P5D
 
-## Experimental Feature Flags
-# Enable MANAGED table (experimental feature)
-# Default: false (disabled)
-server.managed-table.enabled=false
+# Enable MANAGED table
+# Default: true (enabled)
+# server.managed-table.enabled=true
 
 #### AWS credential configs
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
@@ -634,7 +634,8 @@ public class ExternalLocationUtils {
               () ->
                   new BaseException(
                       ErrorCode.FAILED_PRECONDITION,
-                      "Neither catalog nor schema has managed location configured."));
+                      "None of catalog, schema or storage-root.tables server property has managed "
+                        + "location configured."));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -197,7 +197,7 @@ public class ServerProperties {
     CLIENT_SECRET("server.client-secret"),
     REDIRECT_PORT("server.redirect-port", POSITIVE_INTEGER_VALIDATOR),
     COOKIE_TIMEOUT("server.cookie-timeout", "P5D", DURATION_VALIDATOR),
-    MANAGED_TABLE_ENABLED("server.managed-table.enabled", "false", BOOLEAN_VALIDATOR),
+    MANAGED_TABLE_ENABLED("server.managed-table.enabled", "true", BOOLEAN_VALIDATOR),
     MANAGED_TABLE_USE_DELTA_API_ONLY(
         "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
     // `storage-root.*` are replaced by managed storage locations of catalog and schema.
@@ -451,8 +451,8 @@ public class ServerProperties {
     if (!isTrueOrEnable(get(Property.MANAGED_TABLE_ENABLED))) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
-          "MANAGED table is an experimental feature and is currently disabled. "
-              + "To enable it, set 'server.managed-table.enabled=true' in server.properties");
+          "MANAGED table is an is currently disabled. To enable it, set "
+              + "'server.managed-table.enabled=true' in server.properties");
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -57,8 +57,6 @@ public abstract class BaseServerTest {
     serverProperties = new Properties();
     serverProperties.setProperty(Property.SERVER_ENV.getKey(), "test");
     serverProperties.setProperty(Property.INCLUDE_STACK_TRACE_IN_ERROR.getKey(), "true");
-    // Enable managed table creation for tests
-    serverProperties.setProperty(Property.MANAGED_TABLE_ENABLED.getKey(), "true");
     tableStorageRoot = getManagedStorageCloudPath(testDirectoryRoot);
     serverProperties.setProperty(Property.TABLE_STORAGE_ROOT.getKey(), tableStorageRoot);
   }

--- a/server/src/test/java/io/unitycatalog/server/base/managedlocation/BaseManagedLocationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/managedlocation/BaseManagedLocationTest.java
@@ -237,7 +237,7 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> volumeOperations.createVolume(createManagedVolume),
           ErrorCode.FAILED_PRECONDITION,
-          "Neither catalog nor schema has managed location configured");
+          "None of catalog, schema or storage-root.tables server property has managed location configured.");
     }
 
     // Managed volume must not specify a location
@@ -306,7 +306,7 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> tableOperations.createTable(createManagedTable),
           ErrorCode.FAILED_PRECONDITION,
-          "Neither catalog nor schema has managed location configured");
+          "None of catalog, schema or storage-root.tables server property has managed location configured.");
     }
 
     // Testing failure cases of external table creation
@@ -384,7 +384,7 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> modelOperations.createRegisteredModel(createModel),
           ErrorCode.FAILED_PRECONDITION,
-          "Neither catalog nor schema has managed location configured");
+          "None of catalog, schema or storage-root.tables server property has managed location configured.");
     }
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1594/files) to review incremental changes.
- [**stack/managed_table_enable_by_default**](https://github.com/unitycatalog/unitycatalog/pull/1594) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1594/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Enable managed tables by default: server.managed-table.enabled=true
