### PR TITLE
Make deltaRestApiEnabled true by default

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/DeltaVersionUtils.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/DeltaVersionUtils.java
@@ -53,10 +53,10 @@ public class DeltaVersionUtils {
 
   /**
    * Returns true when all the following are true: 1. Delta is loaded as the catalog delegate
-   * (otherwise nothing on the other side would stage the managed-Delta create); 2. the catalog
-   * opted in via the `deltaRestApi.enabled` option; 3. the Delta library on the classpath is at
-   * least [[MIN_DELTA_VERSION_FOR_REST_API]] (older versions silently skip staging if we hand the
-   * request to them).
+   * (otherwise nothing on the other side would stage the managed-Delta create); 2. the catalog is
+   * not opted out via the `deltaRestApi.enabled=false` option; 3. the Delta library on the
+   * classpath is at least [[MIN_DELTA_VERSION_FOR_REST_API]] (older versions silently skip staging
+   * if we hand the request to them).
    */
   public static boolean isDeltaRestApiReady(
       boolean deltaCatalogLoaded, boolean deltaRestApiEnabled) {

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -15,5 +15,5 @@ public class OptionsUtil {
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
   public static final String DELTA_API_ENABLED = "deltaRestApi.enabled";
-  public static final boolean DEFAULT_DELTA_API_ENABLED = false;
+  public static final boolean DEFAULT_DELTA_API_ENABLED = true;
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -57,10 +57,6 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
             .master("local[*]")
             .config("spark.sql.shuffle.partitions", "4")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension");
-    // Opt this test process into the UC Delta API path for managed Delta creates via
-    // `-Duc.test.deltaRestApi.enabled=true`. Off by default so existing tests keep their
-    // legacy behavior.
-    boolean deltaRestApiEnabled = Boolean.getBoolean("uc.test.deltaRestApi.enabled");
     for (String catalog : catalogs) {
       String catalogConf = "spark.sql.catalog." + catalog;
       builder =
@@ -70,8 +66,7 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
               .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
               .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog)
               .config(catalogConf + "." + OptionsUtil.RENEW_CREDENTIAL_ENABLED, renewCred)
-              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled)
-              .config(catalogConf + ".deltaRestApi.enabled", deltaRestApiEnabled);
+              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled);
       if (!List.of(SPARK_CATALOG, CATALOG_NAME).contains(catalog)) {
         createTestCatalog(catalog);
       }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1596/files) to review incremental changes.
- [**stack/delta_api_default**](https://github.com/unitycatalog/unitycatalog/pull/1596) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1596/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
 Make deltaRestApiEnabled true by default.

It will only be enabled when working with Delta 0.4.3 or newer.
