### PR TITLE
Fix file-size-histogram.file-counts to be int64

### DIFF
--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -1450,6 +1450,7 @@ components:
                       type: array
                       items:
                         type: integer
+                        format: int64
                       description: Count of files in each bin
                     total-bytes:
                       type: array


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1597/files) to review incremental changes.
- [**stack/metric_int64**](https://github.com/unitycatalog/unitycatalog/pull/1597) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1597/files)]

---------
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
