### PR TITLE
Block ALTER TABLE RENAME COLUMN in UCSingleCatalog

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -366,7 +366,7 @@ class UCSingleCatalog
     // Spark represents ALTER TABLE ... RENAME COLUMN as a structured TableChange here.
     if (changes.exists(_.isInstanceOf[TableChange.RenameColumn])) {
       throw new UnsupportedOperationException(
-        "ALTER TABLE RENAME COLUMN is not supported for Unity Catalog tables")
+        "ALTER TABLE RENAME COLUMN is not supported for Unity Catalog tables yet")
     }
     delegate.alterTable(ident, changes: _*)
   }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -363,6 +363,11 @@ class UCSingleCatalog
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    // Spark represents ALTER TABLE ... RENAME COLUMN as a structured TableChange here.
+    if (changes.exists(_.isInstanceOf[TableChange.RenameColumn])) {
+      throw new UnsupportedOperationException(
+        "ALTER TABLE RENAME COLUMN is not supported for Unity Catalog tables")
+    }
     delegate.alterTable(ident, changes: _*)
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/DeltaManagedTableReadWriteTest.java
@@ -222,6 +222,17 @@ public abstract class DeltaManagedTableReadWriteTest extends BaseTableReadWriteT
   }
 
   @Test
+  public void testAlterTableRenameColumnIsRejectedFromSql() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    ensureSparkCatalogSchemaExists();
+    String fullTableName =
+        setupTable(new TableSetupOptions().setCatalogName(CATALOG_NAME).setTableName(TEST_TABLE));
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s RENAME COLUMN i TO renamed_i", fullTableName))
+        .hasMessageContaining("ALTER TABLE RENAME COLUMN");
+  }
+
+  @Test
   public void testManagedDeltaReplaceRejectsProviderChangeWithoutDroppingTable()
       throws ApiException {
     session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCSingleCatalogStagingTableTest.java
@@ -115,6 +115,16 @@ public class UCSingleCatalogStagingTableTest {
   }
 
   @Test
+  public void testAlterTableRejectsRenameColumn() throws Exception {
+    TableChange change = TableChange.renameColumn(new String[] {"old_name"}, "new_name");
+
+    assertThatThrownBy(() -> catalog.alterTable(IDENT, new TableChange[] {change}))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("RENAME COLUMN");
+    verify(mockDelegate, never()).alterTable(eq(IDENT), any(TableChange.class));
+  }
+
+  @Test
   public void testStageCreateFailsWhenDelegateIsNotStagingCatalog() {
     UCSingleCatalog nonStagingCatalog = new UCSingleCatalog();
     setDelegate(nonStagingCatalog, mock(TableCatalog.class));


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This blocks `ALTER TABLE RENAME COLUMN` in `UCSingleCatalog.alterTable` before the request is delegated to the underlying Spark catalog. Spark represents that SQL command as `TableChange.RenameColumn`, so the connector now rejects that structured change directly.

This keeps the temporary block in the OSS UC Spark connector instead of changing Delta/DBR-side catalog code. Other `ALTER TABLE` changes still delegate as before.

Added coverage for both paths:

- A unit test that verifies `TableChange.renameColumn(...)` throws `UnsupportedOperationException` and does not call the delegate.
- A managed Delta Spark SQL test that verifies `ALTER TABLE ... RENAME COLUMN` is rejected through SQL.

Testing:

- `./build/sbt -mem 4096 "spark/testOnly io.unitycatalog.spark.UCSingleCatalogStagingTableTest"`
- `./build/sbt -mem 4096 "spark/testOnly io.unitycatalog.spark.LocalDeltaManagedTableReadWriteTest"`