### PR TITLE
[Release] Prepare Unity Catalog 0.5.0: remove Spark 4.2 preview, set release version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,10 +47,6 @@ jobs:
             # Cross-version testing with Delta master is informational; failures
             # indicate upcoming incompatibilities but should not block PRs.
             non-blocking: true
-          - spark-version: "4.2.0-preview5"
-            delta-version: "master-SNAPSHOT"
-            validation-mode: "spark-tests"
-            non-blocking: true
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/project/spark-versions.json
+++ b/project/spark-versions.json
@@ -2,7 +2,6 @@
   "default": "4.1.0",
   "versions": [
     {"version": "4.0.0", "sourceDir": "scala-shims/spark-4.0"},
-    {"version": "4.1.0", "sourceDir": "scala-shims/spark-4.1"},
-    {"version": "4.2.0-preview5", "sourceDir": "scala-shims/spark-4.2"}
+    {"version": "4.1.0", "sourceDir": "scala-shims/spark-4.1"}
   ]
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.0-SNAPSHOT"
+ThisBuild / version := "0.5.0"


### PR DESCRIPTION
## Summary

Prepares the `branch-0.5` release branch for the Unity Catalog 0.5.0 release:

- **Set version to `0.5.0`** in `version.sbt` (was `0.5.0-SNAPSHOT`)
- **Remove Spark 4.2 preview** (`4.2.0-preview5`) from `project/spark-versions.json` — Spark 4.2 is not yet GA and should not be included in the release build matrix

After this change, the release will publish Spark connector artifacts for Spark 4.0 and 4.1 only:
- `unitycatalog-spark_4.0_2.13:0.5.0`
- `unitycatalog-spark_4.1_2.13:0.5.0`

Plus the Spark-independent artifacts:
- `unitycatalog-client:0.5.0`
- `unitycatalog-server:0.5.0`

## Test plan

- [x] Verify `build/sbt compile` succeeds with only Spark 4.0/4.1 in spark-versions.json
- [x] Verify cross-build loop produces correct artifacts for 4.0 and 4.1