### PR TITLE
[Feat] Add HEAD table exists endpoint for Delta REST Catalog

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -145,6 +145,23 @@ public class TableRepository {
   }
 
   /**
+   * Checks that a regular table exists at the given three-part name, without reading any of its
+   * data.
+   *
+   * @throws BaseException with ErrorCode.TABLE_NOT_FOUND if no table exists at the given name.
+   */
+  public void checkTableExists(String catalog, String schema, String table) {
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          findTableOrThrow(session, catalog, schema, table);
+          return null;
+        },
+        "Failed to check existence of table " + catalog + "." + schema + "." + table,
+        /* readOnly = */ true);
+  }
+
+  /**
    * Looks up the storage location for a staging table by ID. Unlike {@link
    * #getStorageLocationForTableOrStagingTable}, this rejects regular table UUIDs so endpoints
    * scoped to staging tables don't silently accept regular-table inputs.

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -145,19 +145,17 @@ public class TableRepository {
   }
 
   /**
-   * Checks that a regular table exists at the given three-part name, without reading any of its
-   * data.
+   * Looks up a regular table by its three-part name and returns its DAO, without hydrating the full
+   * {@link TableInfo} with columns and properties. The DAO is detached (the read-only transaction
+   * closes before returning), so callers must not touch lazy associations.
    *
    * @throws BaseException with ErrorCode.TABLE_NOT_FOUND if no table exists at the given name.
    */
-  public void checkTableExists(String catalog, String schema, String table) {
-    TransactionManager.executeWithTransaction(
+  public TableInfoDAO findTableOrThrow(String catalog, String schema, String table) {
+    return TransactionManager.executeWithTransaction(
         sessionFactory,
-        session -> {
-          findTableOrThrow(session, catalog, schema, table);
-          return null;
-        },
-        "Failed to check existence of table " + catalog + "." + schema + "." + table,
+        session -> findTableOrThrow(session, catalog, schema, table),
+        "Failed to find table " + catalog + "." + schema + "." + table,
         /* readOnly = */ true);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -6,8 +6,11 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.TABLE;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
@@ -124,6 +127,17 @@ public class DeltaApiService extends AuthorizedService {
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
     return tableRepository.loadTableForDelta(catalog, schema, table);
+  }
+
+  @Head("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_TABLE)
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse tableExists(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table) {
+    tableRepository.checkTableExists(catalog, schema, table);
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   // ==================== Staging Table API ====================

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -136,7 +136,7 @@ public class DeltaApiService extends AuthorizedService {
       @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
-    tableRepository.checkTableExists(catalog, schema, table);
+    tableRepository.findTableOrThrow(catalog, schema, table);
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.sdk.access;
 
+import static io.unitycatalog.server.utils.TestUtils.assertApiExceptionStatusOnly;
 import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -171,6 +172,22 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
 
     // loadTable (regular-2) -> use schema, use catalog, select -> allowed
     assertThat(regular2DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1")).isNotNull();
+
+    // tableExists (admin) -> metastore admin -> allowed (204)
+    assertThat(
+            adminDeltaApi.tableExistsWithHttpInfo("cat_pr1", "sch_pr1", "tbl_pr1").getStatusCode())
+        .isEqualTo(204);
+
+    // tableExists (regular-1) -> use catalog, use schema, but no SELECT -> denied (403).
+    assertApiExceptionStatusOnly(
+        () -> regular1DeltaApi.tableExists("cat_pr1", "sch_pr1", "tbl_pr1"), 403);
+
+    // tableExists (regular-2) -> use schema, use catalog, select -> allowed (204)
+    assertThat(
+            regular2DeltaApi
+                .tableExistsWithHttpInfo("cat_pr1", "sch_pr1", "tbl_pr1")
+                .getStatusCode())
+        .isEqualTo(204);
 
     // Delta getTableCredentials authz: READ requires SELECT, READ_WRITE requires MODIFY
     // getTableCredentials READ (regular-1) -> use catalog, use schema, but no SELECT -> denied

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkLoadTableTest.java
@@ -1,9 +1,11 @@
 package io.unitycatalog.server.sdk.delta;
 
+import static io.unitycatalog.server.utils.TestUtils.assertApiExceptionStatusOnly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.ApiResponse;
 import io.unitycatalog.client.api.DeltaCommitsApi;
 import io.unitycatalog.client.delta.api.DeltaTablesApi;
 import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
@@ -119,6 +121,8 @@ public class SdkLoadTableTest extends BaseServerTest {
                           .position(1)
                           .nullable(true))));
 
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
+
       DeltaLoadTableResponse response = loadTable(tableName);
       DeltaTableMetadata metadata = response.getMetadata();
 
@@ -154,6 +158,8 @@ public class SdkLoadTableTest extends BaseServerTest {
               tableName, TableType.MANAGED, Optional.empty(), tableOps);
       String tableId = tableInfo.getTableId();
       String tableUri = tableInfo.getStorageLocation();
+
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
 
       // Load before any commits: version 0, empty list
       DeltaLoadTableResponse r1 = loadTable(tableName);
@@ -216,6 +222,9 @@ public class SdkLoadTableTest extends BaseServerTest {
       ApiException ex = assertThrows(ApiException.class, () -> loadTable("nonexistent"));
       assertThat(ex.getMessage()).contains("Table not found");
       assertThat(ex.getCode()).isEqualTo(404);
+
+      // HEAD responses carry no body, so assert only the status code.
+      assertApiExceptionStatusOnly(() -> tableExists("nonexistent"), 404);
     }
 
     // -------- Full metadata: partition columns + property-derived fields + uniform Iceberg
@@ -276,6 +285,8 @@ public class SdkLoadTableTest extends BaseServerTest {
           icebergLocation,
           icebergVersion,
           new Date(icebergTimestampMs));
+
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
 
       DeltaLoadTableResponse response = loadTable(tableName);
       DeltaTableMetadata metadata = response.getMetadata();
@@ -342,6 +353,8 @@ public class SdkLoadTableTest extends BaseServerTest {
                           .partitionIndex(2)
                           .nullable(true))));
 
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
+
       assertThat(loadTable(tableName).getMetadata().getPartitionColumns()).isEmpty();
     }
 
@@ -367,6 +380,8 @@ public class SdkLoadTableTest extends BaseServerTest {
                                   + "\"nullable\":false,\"metadata\":{}}")
                           .position(0)
                           .nullable(false))));
+
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
 
       DeltaLoadTableResponse response = loadTable(tableName);
       assertThat(response.getMetadata()).isNotNull();
@@ -397,6 +412,8 @@ public class SdkLoadTableTest extends BaseServerTest {
                               .nullable(false))));
       corruptFirstColumnTypeJson(UUID.fromString(tableInfo.getTableId()), "not json at all");
 
+      assertThat(tableExists(tableName).getStatusCode()).isEqualTo(204);
+
       DeltaLoadTableResponse response = loadTable(tableName);
       assertThat(response.getMetadata()).isNotNull();
       assertThat(response.getMetadata().getColumns().getFields()).isEmpty();
@@ -405,6 +422,11 @@ public class SdkLoadTableTest extends BaseServerTest {
 
   private DeltaLoadTableResponse loadTable(String tableName) throws ApiException {
     return deltaTablesApi.loadTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, tableName);
+  }
+
+  private ApiResponse<Void> tableExists(String tableName) throws ApiException {
+    return deltaTablesApi.tableExistsWithHttpInfo(
+        TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, tableName);
   }
 
   private void corruptFirstColumnTypeJson(UUID tableId, String typeJson) {

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -84,6 +84,16 @@ public class TestUtils {
     assertThat(ex.getCode()).isEqualTo(errorCode.getHttpStatus().code());
   }
 
+  /**
+   * Asserts the call fails by checking the HTTP status code is {@code expectedStatus}. Use for
+   * body-less responses; otherwise use {@link #assertApiException} / {@link
+   * #assertDeltaApiException}.
+   */
+  public static void assertApiExceptionStatusOnly(Executable executable, int expectedStatus) {
+    ApiException ex = assertThrows(ApiException.class, executable);
+    assertThat(ex.getCode()).isEqualTo(expectedStatus);
+  }
+
   public static void assertDeltaApiException(
       Executable executable, DeltaErrorType expectedType, String expectedMessageSubstring) {
     int expectedCode = ErrorCode.getDeltaHttpStatus(expectedType.getValue()).code();


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1606/files) to review incremental changes.
- [**stack/delta-api-table-exists-head-endpoint**](https://github.com/unitycatalog/unitycatalog/pull/1606) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1606/files)]
  - [stack/delta-api-table-delete-endpoint](https://github.com/unitycatalog/unitycatalog/pull/1607) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1607/files/698fe12a84f1f76b4ef2054d636ddba59ce533d5..e2cf8146bcaa72b80af6d632754767b7273f96cd)]

---------
**Description of changes**

Adds a tableExists endpoint to the Delta REST Catalog so Delta clients can cheaply check whether a UC-managed or external Delta table exists.

```
Endpoint: HEAD /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}
Operation ID: tableExists
Auth: same as loadTable (AuthorizeExpressions.GET_TABLE).
Responses: 204 No Content if the table exists, 404 Not Found if it doesn't.
```

Note that while the `delta.yaml` file describes an error body, the HTTP standard was implemented instead as any response body is removed automatically for the HEAD endpoint (see RFC 9110 §9.3.2).

Supersedes #1552, recreated on current main to resolve merge conflicts.

**Testing**

The new HEAD endpoint was tested against both managed and external tables to return status 204. The non-existent 404 error code was also tested.
