### PR TITLE
[Feat] Add DELETE table endpoint for Delta REST Catalog

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
@@ -89,6 +89,20 @@ public final class AuthorizeExpressions {
       """;
 
   /**
+   * Authorization policy for deleting a table, shared by the UC REST and Delta REST Catalog
+   * delete endpoints. Metastore admin alone is intentionally not sufficient -- the caller must
+   * hold {@code OWNER} somewhere in the catalog / schema / table hierarchy.
+   */
+  public static final String DELETE_TABLE =
+      """
+      #authorize(#principal, #catalog, OWNER) ||
+      (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
+      (#authorize(#principal, #schema, USE_SCHEMA) &&
+          #authorize(#principal, #catalog, USE_CATALOG) &&
+          #authorize(#principal, #table, OWNER))
+      """;
+
+  /**
    * Authorization policy for vending table credentials. Admin-above-the-table privileges on
    * their own are not sufficient; the caller must have an explicit table-level privilege
    * matching the requested operation. {@code READ} needs OWNER or SELECT; {@code READ_WRITE}

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -865,6 +865,23 @@ public class TableRepository {
         /* readOnly = */ false);
   }
 
+  /**
+   * Deletes a table from a DAO the caller already holds (e.g. from {@link #findTableOrThrow}),
+   * sparing callers the dotted-name round-trip and schema lookup of {@link #deleteTable(String)}.
+   *
+   * @throws BaseException with ErrorCode.TABLE_NOT_FOUND if the table no longer exists.
+   */
+  public void deleteTable(TableInfoDAO dao) {
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          deleteTable(session, dao.getSchemaId(), dao.getName());
+          return null;
+        },
+        "Failed to delete table " + dao.getName(),
+        /* readOnly = */ false);
+  }
+
   public void deleteTable(Session session, UUID schemaId, String tableName) {
     TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, tableName);
     if (tableInfoDAO == null) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -867,15 +867,13 @@ public class TableRepository {
 
   /**
    * Deletes a table from a DAO the caller already holds (e.g. from {@link #findTableOrThrow}),
-   * sparing callers the dotted-name round-trip and schema lookup of {@link #deleteTable(String)}.
-   *
-   * @throws BaseException with ErrorCode.TABLE_NOT_FOUND if the table no longer exists.
+   * sparing callers the dotted-name round-trip and lookups of {@link #deleteTable(String)}.
    */
   public void deleteTable(TableInfoDAO dao) {
     TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
-          deleteTable(session, dao.getSchemaId(), dao.getName());
+          deleteTable(session, dao);
           return null;
         },
         "Failed to delete table " + dao.getName(),
@@ -887,6 +885,10 @@ public class TableRepository {
     if (tableInfoDAO == null) {
       throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableName);
     }
+    deleteTable(session, tableInfoDAO);
+  }
+
+  private void deleteTable(Session session, TableInfoDAO tableInfoDAO) {
     if (TableType.MANAGED.getValue().equals(tableInfoDAO.getType())) {
       try {
         FileOperations.deleteDirectory(NormalizedURL.from(tableInfoDAO.getUrl()));

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -141,13 +141,7 @@ public class TableService extends AuthorizedService {
   }
 
   @Delete("/{full_name}")
-  @AuthorizeExpression("""
-      #authorize(#principal, #catalog, OWNER) ||
-      (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
-      (#authorize(#principal, #schema, USE_SCHEMA) &&
-          #authorize(#principal, #catalog, USE_CATALOG) &&
-          #authorize(#principal, #table, OWNER))
-      """)
+  @AuthorizeExpression(AuthorizeExpressions.DELETE_TABLE)
   public HttpResponse deleteTable(
       @Param("full_name") @AuthorizeResourceKey(TABLE) String fullName) {
     TableInfo tableInfo = tableRepository.getTable(fullName);

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -8,6 +8,7 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
@@ -137,6 +138,24 @@ public class DeltaApiService extends AuthorizedService {
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
     tableRepository.findTableOrThrow(catalog, schema, table);
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+
+  // ==================== Delete Table API ====================
+
+  /**
+   * Delete a table by three-part name. Delta REST counterpart of {@link
+   * io.unitycatalog.server.service.TableService#deleteTable}, but returns 204 No Content per
+   * {@code delta.yaml} (the UC counterpart returns 200).
+   */
+  @Delete("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+  @AuthorizeExpression(AuthorizeExpressions.DELETE_TABLE)
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse deleteTable(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table) {
+    tableRepository.deleteTable(String.join(".", catalog, schema, table));
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -40,6 +40,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.service.AuthorizedService;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
@@ -144,7 +145,7 @@ public class DeltaApiService extends AuthorizedService {
   // ==================== Delete Table API ====================
 
   /**
-   * Delete a table by three-part name. Delta REST counterpart of {@link
+   * Delete a table by three-part name. Mirrors {@link
    * io.unitycatalog.server.service.TableService#deleteTable}, but returns 204 No Content per
    * {@code delta.yaml} (the UC counterpart returns 200).
    */
@@ -155,7 +156,10 @@ public class DeltaApiService extends AuthorizedService {
       @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
+    TableInfoDAO tableInfo = tableRepository.findTableOrThrow(catalog, schema, table);
     tableRepository.deleteTable(String.join(".", catalog, schema, table));
+    removeHierarchicalAuthorizations(
+        tableInfo.getId().toString(), tableInfo.getSchemaId().toString());
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -157,7 +157,7 @@ public class DeltaApiService extends AuthorizedService {
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
     TableInfoDAO tableInfo = tableRepository.findTableOrThrow(catalog, schema, table);
-    tableRepository.deleteTable(String.join(".", catalog, schema, table));
+    tableRepository.deleteTable(tableInfo);
     removeHierarchicalAuthorizations(
         tableInfo.getId().toString(), tableInfo.getSchemaId().toString());
     return HttpResponse.of(HttpStatus.NO_CONTENT);

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeleteTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeleteTableTest.java
@@ -1,0 +1,102 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.ApiResponse;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaErrorType;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.BaseTableCRUDTestEnv;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * E2E tests for the Delta REST Catalog {@code DELETE table} endpoint (204 on success, 404 on
+ * missing).
+ */
+public class SdkDeleteTableTest extends BaseServerTest {
+
+  private CatalogOperations catalogOps;
+  private SchemaOperations schemaOps;
+  private TableOperations tableOps;
+  private DeltaTablesApi deltaTablesApi;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    var apiClient = TestUtils.createApiClient(serverConfig);
+    catalogOps = new SdkCatalogOperations(apiClient);
+    schemaOps = new SdkSchemaOperations(apiClient);
+    tableOps = new SdkTableOperations(apiClient);
+    deltaTablesApi = new DeltaTablesApi(apiClient);
+    cleanUp();
+    createCatalogAndSchema();
+  }
+
+  private void cleanUp() {
+    try {
+      catalogOps.deleteCatalog(TestUtils.CATALOG_NAME, Optional.of(true));
+    } catch (Exception e) {
+      // Ignore
+    }
+  }
+
+  private void createCatalogAndSchema() {
+    try {
+      catalogOps.createCatalog(new CreateCatalog().name(TestUtils.CATALOG_NAME).comment("test"));
+      schemaOps.createSchema(
+          new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testDeleteTableEndpoint() throws Exception {
+    createAndAssertDeleteThenNotFound(
+        "tbl_delete_external",
+        TableType.EXTERNAL,
+        Optional.of("file:///tmp/uc_test/tbl_delete_external"));
+
+    createAndAssertDeleteThenNotFound("tbl_delete_managed", TableType.MANAGED, Optional.empty());
+
+    // -------- Not-found: deleting a missing table returns 404 NoSuchTableException --------
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.deleteTable(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "nonexistent"),
+        DeltaErrorType.NO_SUCH_TABLE_EXCEPTION,
+        "Table not found");
+  }
+
+  /**
+   * Creates a table, deletes it via the Delta REST endpoint, and asserts the delete returns 204 and
+   * the table is no longer loadable.
+   */
+  private void createAndAssertDeleteThenNotFound(
+      String tableName, TableType tableType, Optional<String> storageLocation) throws Exception {
+    BaseTableCRUDTestEnv.createTestingTable(tableName, tableType, storageLocation, tableOps);
+
+    ApiResponse<Void> response =
+        deltaTablesApi.deleteTableWithHttpInfo(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, tableName);
+    assertThat(response.getStatusCode()).isEqualTo(204);
+
+    TestUtils.assertDeltaApiException(
+        () -> deltaTablesApi.loadTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, tableName),
+        DeltaErrorType.NO_SUCH_TABLE_EXCEPTION,
+        "Table not found");
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1607/files) to review incremental changes.
- [stack/delta-api-table-exists-head-endpoint](https://github.com/unitycatalog/unitycatalog/pull/1606) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1606/files)] [MERGED]
  - [**stack/delta-api-table-delete-endpoint**](https://github.com/unitycatalog/unitycatalog/pull/1607) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1607/files)]

---------
**Description of changes**

Adds a delete table endpoint to the Delta REST Catalog so Delta clients can delete UC-managed or external Delta tables through the Delta REST API.

```
Endpoint: DELETE /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}
Operation ID: deleteTable
Auth: same as UC table delete (AuthorizeExpressions.DELETE_TABLE).
Responses: 204 No Content if the table is deleted, 404 Not Found if it doesn't exist.
```

Supersedes #1559, recreated on current main to resolve merge conflicts.

**Testing**

The new DELETE endpoint was tested against both managed and external tables to return status 204 and make the table no longer loadable. The non-existent 404 error code was also tested.
