### PR TITLE
[Build] Bump version to 0.6.0-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.0-SNAPSHOT"
+ThisBuild / version := "0.6.0-SNAPSHOT"


### PR DESCRIPTION
## Description

Now that `branch-0.5` has been cut for the 0.5.0 release, bump the `main` branch version to `0.6.0-SNAPSHOT` for the next development cycle.

## Changes

- `version.sbt`: `0.5.0-SNAPSHOT` → `0.6.0-SNAPSHOT`

## How was this patch tested?

Version-only change, no functional impact.