### PR TITLE
Implement Iceberg REST catalog write endpoints

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1685,6 +1685,7 @@ components:
       type: string
       enum:
         - DELTA
+        - ICEBERG
         - CSV
         - JSON
         - AVRO

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -292,7 +292,7 @@ public class UnityCatalogServer {
     armeriaServerBuilder.annotatedService(
         BASE_PATH + "iceberg",
         new IcebergRestCatalogService(
-            schemaService, tableConfigService, metadataService, repositories),
+            schemaService, tableService, tableConfigService, metadataService, repositories),
         icebergRequestConverter,
         icebergResponseConverter);
   }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -555,6 +555,48 @@ public class TableRepository {
   }
 
   /**
+   * Assigns a storage location for a new managed Iceberg table (an Iceberg REST createTable request
+   * without an explicit location), mirroring how staging locations are assigned for managed Delta
+   * tables: under the schema's managed storage location when set, else the catalog's, else the
+   * {@code storage-root.tables} server property, with the table UUID as the leaf directory. {@code
+   * createTableImpl} later recovers the UUID from that leaf (see {@link
+   * #extractManagedIcebergTableUuid}).
+   */
+  public NormalizedURL assignManagedIcebergTableLocation(
+      String catalogName, String schemaName, UUID tableUUID) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          RepositoryUtils.CatalogAndSchemaDao catalogAndSchemaDao =
+              RepositoryUtils.getCatalogAndSchemaDaoOrThrow(session, catalogName, schemaName);
+          NormalizedURL parentStorageLocation =
+              ExternalLocationUtils.getManagedStorageLocation(
+                  catalogAndSchemaDao,
+                  () ->
+                      Optional.ofNullable(
+                              serverProperties.get(ServerProperties.Property.TABLE_STORAGE_ROOT))
+                          .map(NormalizedURL::from));
+          return ExternalLocationUtils.getManagedLocationForTable(parentStorageLocation, tableUUID);
+        },
+        "Failed to assign a managed Iceberg table location in " + catalogName + "." + schemaName,
+        /* readOnly = */ true);
+  }
+
+  private static UUID extractManagedIcebergTableUuid(NormalizedURL storageLocation) {
+    String path = storageLocation.toString();
+    String leaf = path.substring(path.lastIndexOf('/') + 1);
+    try {
+      return UUID.fromString(leaf);
+    } catch (IllegalArgumentException e) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Managed Iceberg tables can only be created through the Iceberg REST catalog (the"
+              + " storage location must end in the table UUID): "
+              + path);
+    }
+  }
+
+  /**
    * Compare-and-swap the Iceberg metadata location of a native Iceberg table (created through the
    * Iceberg REST catalog). This is the linearization point of an Iceberg REST commit: the metadata
    * file for {@code newMetadataLocation} is written by the caller before this method runs, and the
@@ -708,24 +750,31 @@ public class TableRepository {
           } else if (tableType == TableType.MANAGED) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             serverProperties.checkManagedTableEnabled();
-            if (createTable.getDataSourceFormat() != DataSourceFormat.DELTA) {
+            if (createTable.getDataSourceFormat() == DataSourceFormat.ICEBERG) {
+              // Managed Iceberg tables are created through the Iceberg REST catalog, which
+              // assigns the storage location under the managed root (see
+              // assignManagedIcebergTableLocation) with the table UUID as the leaf directory.
+              // No Delta staging table is involved.
+              tableUUID = extractManagedIcebergTableUuid(storageLocation);
+            } else if (createTable.getDataSourceFormat() != DataSourceFormat.DELTA) {
               throw new BaseException(
                   ErrorCode.INVALID_ARGUMENT,
-                  "Managed table creation is only supported for Delta format.");
+                  "Managed table creation is only supported for Delta and Iceberg formats.");
+            } else {
+              // Find and commit staging table with the same staging location
+              StagingTableDAO stagingTableDAO =
+                  repositories
+                      .getStagingTableRepository()
+                      .commitStagingTable(session, callerId, storageLocation);
+              tableUUID = stagingTableDAO.getId();
+              // MANAGED tables (created via either UC REST or Delta REST) must carry UC_TABLE_ID
+              // in their properties, matching the staging UUID. UC has the staging UUID as the
+              // source of truth; a request with a missing or mismatched UC_TABLE_ID gets rejected
+              // here instead of producing an internally-inconsistent UC table that subsequent
+              // commits would fail on.
+              UcManagedDeltaContract.validateTableIdProperty(
+                  createTable.getProperties(), tableUUID.toString());
             }
-            // Find and commit staging table with the same staging location
-            StagingTableDAO stagingTableDAO =
-                repositories
-                    .getStagingTableRepository()
-                    .commitStagingTable(session, callerId, storageLocation);
-            tableUUID = stagingTableDAO.getId();
-            // MANAGED tables (created via either UC REST or Delta REST) must carry UC_TABLE_ID in
-            // their properties, matching the staging UUID. UC has the staging UUID as the source of
-            // truth; a request with a missing or mismatched UC_TABLE_ID gets rejected here
-            // instead of producing an internally-inconsistent UC table that subsequent commits
-            // would fail on.
-            UcManagedDeltaContract.validateTableIdProperty(
-                createTable.getProperties(), tableUUID.toString());
           } else if (tableType == TableType.METRIC_VIEW) {
             storageLocation = null;
             validateMetricView(createTable);

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -351,8 +351,10 @@ public class TableRepository {
 
   /**
    * Acquire {@code SELECT ... FOR UPDATE} on the table row and refresh in-memory state, so two
-   * concurrent {@link #updateTableForDelta} calls serialize. Lock-wait timeouts and deadlock
-   * victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
+   * concurrent commits on the same table serialize. Shared by the Delta ({@link
+   * #updateTableForDelta}) and Iceberg REST ({@link #setIcebergMetadataLocation}) commit paths.
+   * Lock-wait timeouts and deadlock victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409)
+   * instead of a generic 500.
    */
   private static void lockTableForUpdate(
       Session session, TableInfoDAO dao, String catalog, String schema, String table) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -566,20 +566,52 @@ public class TableRepository {
       String catalogName, String schemaName, UUID tableUUID) {
     return TransactionManager.executeWithTransaction(
         sessionFactory,
-        session -> {
-          RepositoryUtils.CatalogAndSchemaDao catalogAndSchemaDao =
-              RepositoryUtils.getCatalogAndSchemaDaoOrThrow(session, catalogName, schemaName);
-          NormalizedURL parentStorageLocation =
-              ExternalLocationUtils.getManagedStorageLocation(
-                  catalogAndSchemaDao,
-                  () ->
-                      Optional.ofNullable(
-                              serverProperties.get(ServerProperties.Property.TABLE_STORAGE_ROOT))
-                          .map(NormalizedURL::from));
-          return ExternalLocationUtils.getManagedLocationForTable(parentStorageLocation, tableUUID);
-        },
+        session ->
+            ExternalLocationUtils.getManagedLocationForTable(
+                managedTablesParentLocation(session, catalogName, schemaName), tableUUID),
         "Failed to assign a managed Iceberg table location in " + catalogName + "." + schemaName,
         /* readOnly = */ true);
+  }
+
+  /**
+   * Returns whether {@code location} sits under the managed-tables area that {@link
+   * #assignManagedIcebergTableLocation} assigns from, i.e. {@code <managed-root>/tables/}. The
+   * Iceberg REST commit path uses this to classify a staged create whose location was assigned by
+   * the server (MANAGED) versus supplied by the client (EXTERNAL). Returns false when no managed
+   * root is configured.
+   */
+  public boolean isManagedIcebergTableLocation(
+      String catalogName, String schemaName, String location) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          NormalizedURL parentStorageLocation;
+          try {
+            parentStorageLocation = managedTablesParentLocation(session, catalogName, schemaName);
+          } catch (BaseException e) {
+            if (e.getErrorCode() == ErrorCode.FAILED_PRECONDITION) {
+              // No managed root configured, so nothing can be under it.
+              return false;
+            }
+            throw e;
+          }
+          return NormalizedURL.from(location)
+              .toString()
+              .startsWith(parentStorageLocation + "/tables/");
+        },
+        "Failed to resolve the managed storage root for " + catalogName + "." + schemaName,
+        /* readOnly = */ true);
+  }
+
+  private NormalizedURL managedTablesParentLocation(
+      Session session, String catalogName, String schemaName) {
+    RepositoryUtils.CatalogAndSchemaDao catalogAndSchemaDao =
+        RepositoryUtils.getCatalogAndSchemaDaoOrThrow(session, catalogName, schemaName);
+    return ExternalLocationUtils.getManagedStorageLocation(
+        catalogAndSchemaDao,
+        () ->
+            Optional.ofNullable(serverProperties.get(ServerProperties.Property.TABLE_STORAGE_ROOT))
+                .map(NormalizedURL::from));
   }
 
   private static UUID extractManagedIcebergTableUuid(NormalizedURL storageLocation) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -307,7 +307,7 @@ public class TableRepository {
         session -> {
           TableInfoDAO dao = findTableOrThrow(session, catalog, schema, table);
           requireDeltaTable(dao, catalog, schema, table);
-          lockTableForDeltaUpdate(session, dao, catalog, schema, table);
+          lockTableForUpdate(session, dao, catalog, schema, table);
           DeltaUpdateTableMapper.checkRequirements(dao, collected);
           MutablePropertyMap properties = MutablePropertyMap.load(session, dao.getId());
           DeltaUpdateTableMapper.applyUpdates(session, dao, properties, collected, serverProperties)
@@ -354,7 +354,7 @@ public class TableRepository {
    * concurrent {@link #updateTableForDelta} calls serialize. Lock-wait timeouts and deadlock
    * victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
    */
-  private static void lockTableForDeltaUpdate(
+  private static void lockTableForUpdate(
       Session session, TableInfoDAO dao, String catalog, String schema, String table) {
     try {
       session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
@@ -552,6 +552,59 @@ public class TableRepository {
       Session session, String catalogName, String schemaName, String tableName) {
     TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
     return dao.getUniformIcebergMetadataLocation();
+  }
+
+  /**
+   * Compare-and-swap the Iceberg metadata location of a native Iceberg table (created through the
+   * Iceberg REST catalog). This is the linearization point of an Iceberg REST commit: the metadata
+   * file for {@code newMetadataLocation} is written by the caller before this method runs, and the
+   * swap only succeeds when the stored location still matches {@code expectedMetadataLocation}
+   * ({@code null} for a freshly created table). A mismatch means a concurrent commit won and
+   * surfaces as {@link ErrorCode#UPDATE_REQUIREMENT_CONFLICT} so the caller can translate it into
+   * an Iceberg {@code CommitFailedException}.
+   *
+   * <p>Only tables with {@link DataSourceFormat#ICEBERG} can be committed to: UniForm-enabled Delta
+   * tables also carry a uniform metadata location, but their Iceberg metadata is derived from the
+   * Delta log and stays read-only through this API.
+   */
+  public void setIcebergMetadataLocation(
+      String catalogName,
+      String schemaName,
+      String tableName,
+      String expectedMetadataLocation,
+      String newMetadataLocation) {
+    String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String fullName = catalogName + "." + schemaName + "." + tableName;
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
+          if (!DataSourceFormat.ICEBERG.toString().equals(dao.getDataSourceFormat())) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Table is not a native Iceberg table and cannot be committed to via the Iceberg"
+                    + " REST catalog: "
+                    + fullName);
+          }
+          lockTableForUpdate(session, dao, catalogName, schemaName, tableName);
+          if (!Objects.equals(dao.getUniformIcebergMetadataLocation(), expectedMetadataLocation)) {
+            throw new BaseException(
+                ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+                "Metadata location for "
+                    + fullName
+                    + " changed concurrently: expected "
+                    + expectedMetadataLocation
+                    + " but found "
+                    + dao.getUniformIcebergMetadataLocation());
+          }
+          dao.setUniformIcebergMetadataLocation(newMetadataLocation);
+          dao.setUpdatedAt(new Date());
+          dao.setUpdatedBy(callerId);
+          session.merge(dao);
+          return null;
+        },
+        "Failed to update Iceberg metadata location for " + fullName,
+        /* readOnly = */ false);
   }
 
   private TableInfoDAO findTableOrThrow(

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -425,10 +425,14 @@ public class IcebergRestCatalogService {
     try {
       tableRepository.setIcebergMetadataLocation(
           catalog, namespace, table, metadataLocation, newMetadataLocation);
-    } catch (BaseException e) {
+    } catch (RuntimeException e) {
+      // The metadata file was written before the swap, so any failure (a lost commit race or an
+      // unexpected error) leaves it orphaned unless we clean it up.
       metadataService.deleteTableMetadata(newMetadataLocation);
-      if (e.getErrorCode() == ErrorCode.UPDATE_REQUIREMENT_CONFLICT) {
-        throw new CommitFailedException("Commit conflict on %s: %s", fullName, e.getErrorMessage());
+      if (e instanceof BaseException
+          && ((BaseException) e).getErrorCode() == ErrorCode.UPDATE_REQUIREMENT_CONFLICT) {
+        throw new CommitFailedException(
+            "Commit conflict on %s: %s", fullName, ((BaseException) e).getErrorMessage());
       }
       throw e;
     }

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -420,7 +420,9 @@ public class IcebergRestCatalogService {
     // spec compatibility but does not delete files); MANAGED tables have their storage directory
     // removed by the repository's delete path.
     tableService.deleteTable(fullName);
-    return HttpResponse.of(HttpStatus.NO_CONTENT);
+    // 200 instead of the spec's 204: Armeria stalls body-less 204 responses on HTTP/1.1
+    // connections, and clients accept 200 here (apache/iceberg-rest-fixture also returns 200).
+    return HttpResponse.of(HttpStatus.OK);
   }
 
   /** Looks up the UC table entry, translating UC's not-found error into the Iceberg shape. */

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.service;
 
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.service.credential.CredentialContext.READ_WRITE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.HttpResponse;
@@ -27,7 +28,6 @@ import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
-import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.iceberg.IcebergSchemaConverter;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.MetadataUpdate;
@@ -83,11 +82,6 @@ public class IcebergRestCatalogService {
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
           Endpoint.V1_DELETE_TABLE);
-
-  // All Iceberg REST endpoints currently authorize as metastore owner (see the
-  // @AuthorizeExpression on each route), so write-capable storage credentials are only handed to
-  // principals that could already write through the UC API.
-  private static final Set<CredentialContext.Privilege> READ_WRITE = CredentialContext.READ_WRITE;
 
   private final SchemaService schemaService;
   private final TableService tableService;
@@ -250,7 +244,9 @@ public class IcebergRestCatalogService {
 
     TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
     // Native Iceberg tables are writable through this catalog, so vend write-capable storage
-    // credentials; UniForm-derived metadata stays read-only.
+    // credentials; UniForm-derived metadata stays read-only. All write-capable routes authorize as
+    // metastore owner (see the @AuthorizeExpression on each), so READ_WRITE creds are only handed
+    // to principals that could already write through the UC API.
     Map<String, String> config =
         tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG
             ? tableConfigService.getTableConfig(tableMetadata, READ_WRITE)

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -40,9 +40,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -269,11 +271,6 @@ public class IcebergRestCatalogService {
       @Param("namespace") String namespace,
       CreateTableRequest request) {
     request.validate();
-    if (request.stageCreate()) {
-      throw new BadRequestException(
-          "Staged table creation is not supported yet. Clients should create tables directly,"
-              + " e.g. DuckDB with `STAGE_CREATE_TABLES false` or PyIceberg/Spark createTable.");
-    }
     String location = request.location();
     TableType tableType;
     if (location == null || location.isEmpty()) {
@@ -296,35 +293,72 @@ public class IcebergRestCatalogService {
         request.writeOrder() == null ? SortOrder.unsorted() : request.writeOrder();
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(request.schema(), spec, writeOrder, location, properties);
+
+    if (request.stageCreate()) {
+      // Staged creation is stateless, mirroring Iceberg's reference CatalogHandlers: nothing is
+      // registered and no metadata file is written. The client writes data files against the
+      // returned metadata and the table materializes when it commits with an assert-create
+      // requirement (see commitStagedCreate). The returned metadata carries no metadata-location.
+      if (ucTableExists(catalog, namespace, request.name())) {
+        throw new AlreadyExistsException("Table already exists: %s.%s", namespace, request.name());
+      }
+      metadataService.prepareTableLocation(tableMetadata);
+      return LoadTableResponse.builder()
+          .withTableMetadata(tableMetadata)
+          .addAllConfig(tableConfigService.getTableConfig(tableMetadata, READ_WRITE))
+          .build();
+    }
+
+    return finalizeIcebergTableCreation(
+        catalog, namespace, request.name(), tableType, tableMetadata, properties, false);
+  }
+
+  /**
+   * Registers a new Iceberg table in UC, writes its first metadata file, and links the metadata
+   * location, rolling the UC entry back when a later step fails. Shared by direct creates and
+   * commits of staged creates; {@code fromCommit} only changes the already-exists error shape (409
+   * {@link CommitFailedException} for commits, 409 {@link AlreadyExistsException} for creates).
+   */
+  private LoadTableResponse finalizeIcebergTableCreation(
+      String catalog,
+      String namespace,
+      String name,
+      TableType tableType,
+      TableMetadata tableMetadata,
+      Map<String, String> properties,
+      boolean fromCommit) {
     String metadataLocation = MetadataService.newMetadataLocation(tableMetadata, 0);
 
     CreateTable createTable =
         new CreateTable()
-            .name(request.name())
+            .name(name)
             .catalogName(catalog)
             .schemaName(namespace)
             .tableType(tableType)
             .dataSourceFormat(DataSourceFormat.ICEBERG)
             .columns(IcebergSchemaConverter.toColumnInfos(tableMetadata.schema()))
-            .storageLocation(location)
+            .storageLocation(tableMetadata.location())
             .properties(properties);
     try {
       tableService.createTable(createTable);
     } catch (BaseException e) {
       if (e.getErrorCode() == ErrorCode.TABLE_ALREADY_EXISTS) {
-        throw new AlreadyExistsException("Table already exists: %s.%s", namespace, request.name());
+        if (fromCommit) {
+          throw new CommitFailedException(
+              "Requirement failed: table already exists: %s.%s", namespace, name);
+        }
+        throw new AlreadyExistsException("Table already exists: %s.%s", namespace, name);
       }
       throw e;
     }
     try {
       metadataService.writeTableMetadata(tableMetadata, metadataLocation);
-      tableRepository.setIcebergMetadataLocation(
-          catalog, namespace, request.name(), null, metadataLocation);
+      tableRepository.setIcebergMetadataLocation(catalog, namespace, name, null, metadataLocation);
     } catch (RuntimeException e) {
       // Roll the UC entry back so a failed create doesn't leave behind a table that can never be
       // loaded through this catalog.
       try {
-        tableService.deleteTable(catalog + "." + namespace + "." + request.name());
+        tableService.deleteTable(catalog + "." + namespace + "." + name);
       } catch (RuntimeException cleanupFailure) {
         e.addSuppressed(cleanupFailure);
       }
@@ -349,6 +383,12 @@ public class IcebergRestCatalogService {
       @Param("table") String table,
       UpdateTableRequest request) {
     String fullName = catalog + "." + namespace + "." + table;
+    boolean isCreateCommit =
+        request.requirements().stream()
+            .anyMatch(r -> r instanceof UpdateRequirement.AssertTableDoesNotExist);
+    if (isCreateCommit) {
+      return commitStagedCreate(catalog, namespace, table, request);
+    }
     TableInfo tableInfo = getIcebergTableInfo(catalog, namespace, table);
     String metadataLocation;
     try (Session session = sessionFactory.openSession()) {
@@ -423,6 +463,64 @@ public class IcebergRestCatalogService {
     // 200 instead of the spec's 204: Armeria stalls body-less 204 responses on HTTP/1.1
     // connections, and clients accept 200 here (apache/iceberg-rest-fixture also returns 200).
     return HttpResponse.of(HttpStatus.OK);
+  }
+
+  /**
+   * Materializes a staged create: a commit whose requirements carry {@code assert-create}
+   * (AssertTableDoesNotExist). Mirroring Iceberg's reference CatalogHandlers, the staged metadata
+   * is rebuilt from the commit's updates against an empty base, the first metadata file is written,
+   * and the table is registered in UC. The table is MANAGED when its location sits under the
+   * managed-tables area this service assigns from, EXTERNAL otherwise.
+   */
+  private LoadTableResponse commitStagedCreate(
+      String catalog, String namespace, String table, UpdateTableRequest request) {
+    String fullName = catalog + "." + namespace + "." + table;
+    for (UpdateRequirement requirement : request.requirements()) {
+      if (!(requirement instanceof UpdateRequirement.AssertTableDoesNotExist)) {
+        throw new BadRequestException(
+            "Invalid requirement for a create commit: %s", requirement.getClass().getSimpleName());
+      }
+    }
+    if (ucTableExists(catalog, namespace, table)) {
+      throw new CommitFailedException("Requirement failed: table already exists: %s", fullName);
+    }
+
+    // Pick the format version out of the updates before building, like CatalogHandlers.create:
+    // buildFromEmpty defaults to v2, and applying an upgrade-format-version update for a lower
+    // version would otherwise fail as a downgrade.
+    Optional<Integer> formatVersion =
+        request.updates().stream()
+            .filter(update -> update instanceof MetadataUpdate.UpgradeFormatVersion)
+            .map(update -> ((MetadataUpdate.UpgradeFormatVersion) update).formatVersion())
+            .findFirst();
+    // buildFromEmpty(int) seeds the requested version; the no-arg overload uses the default.
+    TableMetadata.Builder builder =
+        formatVersion.map(TableMetadata::buildFromEmpty).orElseGet(TableMetadata::buildFromEmpty);
+    request.updates().forEach(update -> update.applyTo(builder));
+    TableMetadata tableMetadata = builder.build();
+    if (tableMetadata.location() == null || tableMetadata.location().isEmpty()) {
+      throw new BadRequestException(
+          "Create commit for %s must include a set-location update", fullName);
+    }
+
+    TableType tableType =
+        tableRepository.isManagedIcebergTableLocation(catalog, namespace, tableMetadata.location())
+            ? TableType.MANAGED
+            : TableType.EXTERNAL;
+    return finalizeIcebergTableCreation(
+        catalog, namespace, table, tableType, tableMetadata, tableMetadata.properties(), true);
+  }
+
+  private boolean ucTableExists(String catalog, String namespace, String table) {
+    try {
+      tableRepository.getTable(catalog + "." + namespace + "." + table);
+      return true;
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   /** Looks up the UC table entry, translating UC's not-found error into the Iceberg shape. */

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
@@ -274,12 +275,21 @@ public class IcebergRestCatalogService {
               + " e.g. DuckDB with `STAGE_CREATE_TABLES false` or PyIceberg/Spark createTable.");
     }
     String location = request.location();
+    TableType tableType;
     if (location == null || location.isEmpty()) {
-      throw new BadRequestException(
-          "Table location is required: Unity Catalog does not assign storage locations to"
-              + " Iceberg REST tables yet.");
+      // No client-supplied location: assign one under the managed storage root (schema's, else
+      // catalog's, else the storage-root.tables server property) and create a MANAGED table,
+      // mirroring how staging locations are assigned for managed Delta tables. Clients like
+      // DuckDB rely on server-assigned locations.
+      tableType = TableType.MANAGED;
+      location =
+          tableRepository
+              .assignManagedIcebergTableLocation(catalog, namespace, UUID.randomUUID())
+              .toString();
+    } else {
+      tableType = TableType.EXTERNAL;
+      location = location.replaceAll("/+$", "");
     }
-    location = location.replaceAll("/+$", "");
     Map<String, String> properties = request.properties() == null ? Map.of() : request.properties();
     PartitionSpec spec = request.spec() == null ? PartitionSpec.unpartitioned() : request.spec();
     SortOrder writeOrder =
@@ -293,7 +303,7 @@ public class IcebergRestCatalogService {
             .name(request.name())
             .catalogName(catalog)
             .schemaName(namespace)
-            .tableType(TableType.EXTERNAL)
+            .tableType(tableType)
             .dataSourceFormat(DataSourceFormat.ICEBERG)
             .columns(IcebergSchemaConverter.toColumnInfos(tableMetadata.schema()))
             .storageLocation(location)
@@ -406,8 +416,9 @@ public class IcebergRestCatalogService {
               + " Catalog API instead.",
           fullName);
     }
-    // Tables created through this API are EXTERNAL: data and metadata files are left in place,
-    // so purgeRequested is accepted for spec compatibility but does not delete files.
+    // EXTERNAL tables leave data and metadata files in place (purgeRequested is accepted for
+    // spec compatibility but does not delete files); MANAGED tables have their storage directory
+    // removed by the repository's delete path.
     tableService.deleteTable(fullName);
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -5,6 +5,7 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
@@ -13,12 +14,21 @@ import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
+import io.unitycatalog.server.model.CreateSchema;
+import io.unitycatalog.server.model.CreateTable;
+import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.iceberg.IcebergSchemaConverter;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.JsonUtils;
@@ -27,15 +37,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -56,9 +75,19 @@ public class IcebergRestCatalogService {
           Endpoint.V1_LOAD_TABLE,
           Endpoint.V1_LOAD_VIEW,
           Endpoint.V1_REPORT_METRICS,
-          Endpoint.V1_LIST_TABLES);
+          Endpoint.V1_LIST_TABLES,
+          Endpoint.V1_CREATE_NAMESPACE,
+          Endpoint.V1_CREATE_TABLE,
+          Endpoint.V1_UPDATE_TABLE,
+          Endpoint.V1_DELETE_TABLE);
+
+  // All Iceberg REST endpoints currently authorize as metastore owner (see the
+  // @AuthorizeExpression on each route), so write-capable storage credentials are only handed to
+  // principals that could already write through the UC API.
+  private static final Set<CredentialContext.Privilege> READ_WRITE = CredentialContext.READ_WRITE;
 
   private final SchemaService schemaService;
+  private final TableService tableService;
   private final TableConfigService tableConfigService;
   private final MetadataService metadataService;
   private final TableRepository tableRepository;
@@ -66,10 +95,12 @@ public class IcebergRestCatalogService {
 
   public IcebergRestCatalogService(
       SchemaService schemaService,
+      TableService tableService,
       TableConfigService tableConfigService,
       MetadataService metadataService,
       Repositories repositories) {
     this.schemaService = schemaService;
+    this.tableService = tableService;
     this.tableConfigService = tableConfigService;
     this.metadataService = metadataService;
     this.tableRepository = repositories.getTableRepository();
@@ -142,6 +173,38 @@ public class IcebergRestCatalogService {
         .build();
   }
 
+  @Post("/v1/catalogs/{catalog}/namespaces")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public CreateNamespaceResponse createNamespace(
+      @Param("catalog") String catalog, CreateNamespaceRequest request)
+      throws JsonProcessingException {
+    request.validate();
+    if (request.namespace().levels().length != 1) {
+      throw new BadRequestException("Nested namespaces are not supported: %s", request.namespace());
+    }
+    String schemaName = request.namespace().level(0);
+    CreateSchema createSchema =
+        new CreateSchema().name(schemaName).catalogName(catalog).properties(request.properties());
+    String resp;
+    try {
+      resp = schemaService.createSchema(createSchema).aggregate().join().contentUtf8();
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.SCHEMA_ALREADY_EXISTS) {
+        throw new AlreadyExistsException("Namespace already exists: %s", request.namespace());
+      }
+      throw e;
+    }
+    SchemaInfo schemaInfo = JsonUtils.getInstance().readValue(resp, SchemaInfo.class);
+    Map<String, String> properties =
+        schemaInfo.getProperties() == null ? Map.of() : schemaInfo.getProperties();
+    return CreateNamespaceResponse.builder()
+        .withNamespace(request.namespace())
+        .setProperties(properties)
+        .build();
+  }
+
   // Table APIs
 
   @Head("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
@@ -171,9 +234,9 @@ public class IcebergRestCatalogService {
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       @Param("table") String table) {
+    TableInfo tableInfo = getIcebergTableInfo(catalog, namespace, table);
     String metadataLocation;
     try (Session session = sessionFactory.openSession()) {
-      tableRepository.getTable(catalog + "." + namespace + "." + table);
       metadataLocation =
           tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
     }
@@ -183,12 +246,182 @@ public class IcebergRestCatalogService {
     }
 
     TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
-    Map<String, String> config = tableConfigService.getTableConfig(tableMetadata);
+    // Native Iceberg tables are writable through this catalog, so vend write-capable storage
+    // credentials; UniForm-derived metadata stays read-only.
+    Map<String, String> config =
+        tableInfo.getDataSourceFormat() == DataSourceFormat.ICEBERG
+            ? tableConfigService.getTableConfig(tableMetadata, READ_WRITE)
+            : tableConfigService.getTableConfig(tableMetadata);
 
     return LoadTableResponse.builder()
         .withTableMetadata(tableMetadata)
         .addAllConfig(config)
         .build();
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse createTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      CreateTableRequest request) {
+    request.validate();
+    if (request.stageCreate()) {
+      throw new BadRequestException(
+          "Staged table creation is not supported yet. Clients should create tables directly,"
+              + " e.g. DuckDB with `STAGE_CREATE_TABLES false` or PyIceberg/Spark createTable.");
+    }
+    String location = request.location();
+    if (location == null || location.isEmpty()) {
+      throw new BadRequestException(
+          "Table location is required: Unity Catalog does not assign storage locations to"
+              + " Iceberg REST tables yet.");
+    }
+    location = location.replaceAll("/+$", "");
+    Map<String, String> properties = request.properties() == null ? Map.of() : request.properties();
+    PartitionSpec spec = request.spec() == null ? PartitionSpec.unpartitioned() : request.spec();
+    SortOrder writeOrder =
+        request.writeOrder() == null ? SortOrder.unsorted() : request.writeOrder();
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(request.schema(), spec, writeOrder, location, properties);
+    String metadataLocation = MetadataService.newMetadataLocation(tableMetadata, 0);
+
+    CreateTable createTable =
+        new CreateTable()
+            .name(request.name())
+            .catalogName(catalog)
+            .schemaName(namespace)
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.ICEBERG)
+            .columns(IcebergSchemaConverter.toColumnInfos(tableMetadata.schema()))
+            .storageLocation(location)
+            .properties(properties);
+    try {
+      tableService.createTable(createTable);
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.TABLE_ALREADY_EXISTS) {
+        throw new AlreadyExistsException("Table already exists: %s.%s", namespace, request.name());
+      }
+      throw e;
+    }
+    try {
+      metadataService.writeTableMetadata(tableMetadata, metadataLocation);
+      tableRepository.setIcebergMetadataLocation(
+          catalog, namespace, request.name(), null, metadataLocation);
+    } catch (RuntimeException e) {
+      // Roll the UC entry back so a failed create doesn't leave behind a table that can never be
+      // loaded through this catalog.
+      try {
+        tableService.deleteTable(catalog + "." + namespace + "." + request.name());
+      } catch (RuntimeException cleanupFailure) {
+        e.addSuppressed(cleanupFailure);
+      }
+      metadataService.deleteTableMetadata(metadataLocation);
+      throw e;
+    }
+
+    TableMetadata committed = metadataService.readTableMetadata(metadataLocation);
+    return LoadTableResponse.builder()
+        .withTableMetadata(committed)
+        .addAllConfig(tableConfigService.getTableConfig(committed, READ_WRITE))
+        .build();
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse updateTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table,
+      UpdateTableRequest request) {
+    String fullName = catalog + "." + namespace + "." + table;
+    TableInfo tableInfo = getIcebergTableInfo(catalog, namespace, table);
+    String metadataLocation;
+    try (Session session = sessionFactory.openSession()) {
+      metadataLocation =
+          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
+    }
+    if (metadataLocation == null) {
+      throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
+    }
+    if (tableInfo.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
+      throw new BadRequestException(
+          "Table %s is a UniForm-enabled Delta table; its Iceberg metadata is derived from the"
+              + " Delta log and is read-only through the Iceberg REST catalog.",
+          fullName);
+    }
+
+    TableMetadata base = metadataService.readTableMetadata(metadataLocation);
+    request.requirements().forEach(requirement -> requirement.validate(base));
+
+    TableMetadata.Builder builder = TableMetadata.buildFrom(base);
+    request.updates().forEach(update -> update.applyTo(builder));
+    TableMetadata updated = builder.build();
+    if (updated.changes().isEmpty()) {
+      return LoadTableResponse.builder()
+          .withTableMetadata(base)
+          .addAllConfig(tableConfigService.getTableConfig(base, READ_WRITE))
+          .build();
+    }
+
+    String newMetadataLocation =
+        MetadataService.newMetadataLocation(
+            updated, MetadataService.parseMetadataVersion(metadataLocation) + 1);
+    metadataService.writeTableMetadata(updated, newMetadataLocation);
+    try {
+      tableRepository.setIcebergMetadataLocation(
+          catalog, namespace, table, metadataLocation, newMetadataLocation);
+    } catch (BaseException e) {
+      metadataService.deleteTableMetadata(newMetadataLocation);
+      if (e.getErrorCode() == ErrorCode.UPDATE_REQUIREMENT_CONFLICT) {
+        throw new CommitFailedException("Commit conflict on %s: %s", fullName, e.getErrorMessage());
+      }
+      throw e;
+    }
+
+    TableMetadata committed = metadataService.readTableMetadata(newMetadataLocation);
+    return LoadTableResponse.builder()
+        .withTableMetadata(committed)
+        .addAllConfig(tableConfigService.getTableConfig(committed, READ_WRITE))
+        .build();
+  }
+
+  @Delete("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse dropTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table,
+      @Param("purgeRequested") Optional<Boolean> purgeRequested) {
+    String fullName = catalog + "." + namespace + "." + table;
+    TableInfo tableInfo = getIcebergTableInfo(catalog, namespace, table);
+    if (tableInfo.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
+      throw new BadRequestException(
+          "Table %s was not created through the Iceberg REST catalog; drop it through the Unity"
+              + " Catalog API instead.",
+          fullName);
+    }
+    // Tables created through this API are EXTERNAL: data and metadata files are left in place,
+    // so purgeRequested is accepted for spec compatibility but does not delete files.
+    tableService.deleteTable(fullName);
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+
+  /** Looks up the UC table entry, translating UC's not-found error into the Iceberg shape. */
+  private TableInfo getIcebergTableInfo(String catalog, String namespace, String table) {
+    try {
+      return tableRepository.getTable(catalog + "." + namespace + "." + table);
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND) {
+        throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
+      }
+      throw e;
+    }
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/views/{view}")

--- a/server/src/main/java/io/unitycatalog/server/service/credential/CredentialContext.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/CredentialContext.java
@@ -23,6 +23,11 @@ public class CredentialContext {
     UPDATE
   }
 
+  // Common privilege sets: SELECT alone vends read-only storage credentials, SELECT + UPDATE vends
+  // read/write credentials.
+  public static final Set<Privilege> READ_ONLY = Set.of(Privilege.SELECT);
+  public static final Set<Privilege> READ_WRITE = Set.of(Privilege.SELECT, Privilege.UPDATE);
+
   // The storage scheme (S3, GCS, ABFS) to determine which cloud vendor to use
   private final UriScheme storageScheme;
   // The storage base (e.g., s3://bucket) for looking up per-bucket configurations

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
@@ -32,10 +32,6 @@ public class FileIOFactory {
 
   private final StorageCredentialVendor storageCredentialVendor;
   private final Map<NormalizedURL, S3StorageConfig> s3Configurations;
-  // FIXME!! privileges are defaulted to READ only here for now as Iceberg REST impl doesn't
-  //  support write
-  private final Set<CredentialContext.Privilege> privileges =
-      Set.of(CredentialContext.Privilege.SELECT);
 
   public FileIOFactory(
       StorageCredentialVendor storageCredentialVendor, ServerProperties serverProperties) {
@@ -45,15 +41,20 @@ public class FileIOFactory {
 
   // TODO: Cache fileIOs
   public FileIO getFileIO(NormalizedURL location) {
+    return getFileIO(location, CredentialContext.READ_ONLY);
+  }
+
+  public FileIO getFileIO(NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     return switch (UriScheme.fromURI(location.toUri())) {
-      case ABFS, ABFSS -> getADLSFileIO(location);
-      case GS -> getGCSFileIO(location);
-      case S3 -> getS3FileIO(location);
+      case ABFS, ABFSS -> getADLSFileIO(location, privileges);
+      case GS -> getGCSFileIO(location, privileges);
+      case S3 -> getS3FileIO(location, privileges);
       case FILE, NULL -> new SimpleLocalFileIO();
     };
   }
 
-  protected ADLSFileIO getADLSFileIO(NormalizedURL location) {
+  protected ADLSFileIO getADLSFileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     AzureUserDelegationSAS credential =
         storageCredentialVendor.vendCredential(location, privileges).getAzureUserDelegationSas();
     ADLSLocationUtils.ADLSLocationParts locationParts = ADLSLocationUtils.parseLocation(location);
@@ -69,7 +70,8 @@ public class FileIOFactory {
   }
 
   @SneakyThrows
-  protected GCSFileIO getGCSFileIO(NormalizedURL location) {
+  protected GCSFileIO getGCSFileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     GcpOauthToken gcpToken =
         storageCredentialVendor.vendCredential(location, privileges).getGcpOauthToken();
 
@@ -82,11 +84,12 @@ public class FileIOFactory {
     return result;
   }
 
-  protected S3FileIO getS3FileIO(NormalizedURL location) {
+  protected S3FileIO getS3FileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     S3StorageConfig s3StorageConfig = s3Configurations.get(location.getStorageBase());
 
     S3FileIO s3FileIO =
-        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location),
+        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location, privileges),
             s3StorageConfig.getRegion()));
 
     s3FileIO.initialize(Map.of());
@@ -102,7 +105,8 @@ public class FileIOFactory {
         .build();
   }
 
-  private AwsCredentialsProvider getAwsCredentialsProvider(NormalizedURL location) {
+  private AwsCredentialsProvider getAwsCredentialsProvider(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     try {
       AwsCredentials awsSessionCredentials =
           storageCredentialVendor.vendCredential(location, privileges).getAwsTempCredentials();

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
@@ -1,0 +1,161 @@
+package io.unitycatalog.server.service.iceberg;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.ColumnTypeName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Converts an Iceberg schema into Unity Catalog {@link ColumnInfo}s so tables created through the
+ * Iceberg REST catalog are browsable through the UC API and UI. The Iceberg metadata file remains
+ * the source of truth for Iceberg clients; this conversion only feeds UC's own column listing.
+ *
+ * <p>{@code type_json} is rendered in the Spark StructField JSON shape that UC stores for all
+ * other formats (see {@code ColumnUtils.validateTypeJson}).
+ */
+public final class IcebergSchemaConverter {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private IcebergSchemaConverter() {}
+
+  public static List<ColumnInfo> toColumnInfos(Schema schema) {
+    List<ColumnInfo> columns = new ArrayList<>();
+    List<Types.NestedField> fields = schema.columns();
+    for (int i = 0; i < fields.size(); i++) {
+      Types.NestedField field = fields.get(i);
+      ColumnInfo column =
+          new ColumnInfo()
+              .name(field.name())
+              .typeText(typeText(field.type()))
+              .typeJson(structFieldJson(field).toString())
+              .typeName(typeName(field.type()))
+              .position(i)
+              .nullable(field.isOptional())
+              .comment(field.doc());
+      if (field.type().typeId() == Type.TypeID.DECIMAL) {
+        Types.DecimalType decimal = (Types.DecimalType) field.type();
+        column.typePrecision(decimal.precision()).typeScale(decimal.scale());
+      }
+      columns.add(column);
+    }
+    return columns;
+  }
+
+  private static ObjectNode structFieldJson(Types.NestedField field) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("name", field.name());
+    node.set("type", typeJson(field.type()));
+    node.put("nullable", field.isOptional());
+    node.set("metadata", MAPPER.createObjectNode());
+    return node;
+  }
+
+  private static JsonNode typeJson(Type type) {
+    return switch (type.typeId()) {
+      case STRUCT -> {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "struct");
+        ArrayNode fields = node.putArray("fields");
+        ((Types.StructType) type).fields().forEach(f -> fields.add(structFieldJson(f)));
+        yield node;
+      }
+      case LIST -> {
+        Types.ListType list = (Types.ListType) type;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "array");
+        node.set("elementType", typeJson(list.elementType()));
+        node.put("containsNull", list.isElementOptional());
+        yield node;
+      }
+      case MAP -> {
+        Types.MapType map = (Types.MapType) type;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "map");
+        node.set("keyType", typeJson(map.keyType()));
+        node.set("valueType", typeJson(map.valueType()));
+        node.put("valueContainsNull", map.isValueOptional());
+        yield node;
+      }
+      default -> MAPPER.getNodeFactory().textNode(primitiveTypeName(type));
+    };
+  }
+
+  private static String typeText(Type type) {
+    return switch (type.typeId()) {
+      case STRUCT ->
+          ((Types.StructType) type)
+              .fields().stream()
+                  .map(f -> f.name() + ":" + typeText(f.type()))
+                  .collect(Collectors.joining(",", "struct<", ">"));
+      case LIST -> "array<" + typeText(((Types.ListType) type).elementType()) + ">";
+      case MAP -> {
+        Types.MapType map = (Types.MapType) type;
+        yield "map<" + typeText(map.keyType()) + "," + typeText(map.valueType()) + ">";
+      }
+      case INTEGER -> "int";
+      case LONG -> "bigint";
+      default -> primitiveTypeName(type);
+    };
+  }
+
+  private static String primitiveTypeName(Type type) {
+    return switch (type.typeId()) {
+      case BOOLEAN -> "boolean";
+      case INTEGER -> "integer";
+      case LONG -> "long";
+      case FLOAT -> "float";
+      case DOUBLE -> "double";
+      case DATE -> "date";
+      case TIMESTAMP ->
+          ((Types.TimestampType) type).shouldAdjustToUTC() ? "timestamp" : "timestamp_ntz";
+      case STRING, UUID -> "string";
+      case FIXED, BINARY -> "binary";
+      case DECIMAL -> {
+        Types.DecimalType decimal = (Types.DecimalType) type;
+        yield String.format("decimal(%d,%d)", decimal.precision(), decimal.scale());
+      }
+      case VARIANT -> "variant";
+      default ->
+          throw new BadRequestException(
+              "Iceberg type %s is not supported by Unity Catalog",
+              type.toString().toUpperCase(Locale.ROOT));
+    };
+  }
+
+  private static ColumnTypeName typeName(Type type) {
+    return switch (type.typeId()) {
+      case BOOLEAN -> ColumnTypeName.BOOLEAN;
+      case INTEGER -> ColumnTypeName.INT;
+      case LONG -> ColumnTypeName.LONG;
+      case FLOAT -> ColumnTypeName.FLOAT;
+      case DOUBLE -> ColumnTypeName.DOUBLE;
+      case DATE -> ColumnTypeName.DATE;
+      case TIMESTAMP ->
+          ((Types.TimestampType) type).shouldAdjustToUTC()
+              ? ColumnTypeName.TIMESTAMP
+              : ColumnTypeName.TIMESTAMP_NTZ;
+      case STRING, UUID -> ColumnTypeName.STRING;
+      case FIXED, BINARY -> ColumnTypeName.BINARY;
+      case DECIMAL -> ColumnTypeName.DECIMAL;
+      case VARIANT -> ColumnTypeName.VARIANT;
+      case STRUCT -> ColumnTypeName.STRUCT;
+      case LIST -> ColumnTypeName.ARRAY;
+      case MAP -> ColumnTypeName.MAP;
+      default ->
+          throw new BadRequestException(
+              "Iceberg type %s is not supported by Unity Catalog",
+              type.toString().toUpperCase(Locale.ROOT));
+    };
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -1,12 +1,22 @@
 package io.unitycatalog.server.service.iceberg;
 
+import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.FileIO;
 
 public class MetadataService {
+
+  // Matches the version prefix of metadata file names written by this service and by other
+  // Iceberg catalog implementations, e.g. "00003-<uuid>.metadata.json" or "v3.metadata.json".
+  private static final Pattern METADATA_FILE_VERSION =
+      Pattern.compile("^(?:v)?(\\d+)-?.*\\.metadata\\.json(?:\\.gz)?$");
 
   private final FileIOFactory fileIOFactory;
 
@@ -20,5 +30,53 @@ public class MetadataService {
 
     return CompletableFuture.supplyAsync(() -> TableMetadataParser.read(fileIO, metadataLocation))
         .join();
+  }
+
+  public void writeTableMetadata(TableMetadata tableMetadata, String metadataLocation) {
+    FileIO fileIO =
+        fileIOFactory.getFileIO(NormalizedURL.from(metadataLocation), CredentialContext.READ_WRITE);
+
+    CompletableFuture.runAsync(
+            () -> TableMetadataParser.write(tableMetadata, fileIO.newOutputFile(metadataLocation)))
+        .join();
+  }
+
+  /** Best-effort cleanup of a metadata file that lost a commit race or whose commit failed. */
+  public void deleteTableMetadata(String metadataLocation) {
+    try {
+      FileIO fileIO =
+          fileIOFactory.getFileIO(
+              NormalizedURL.from(metadataLocation), CredentialContext.READ_WRITE);
+      CompletableFuture.runAsync(() -> fileIO.deleteFile(metadataLocation)).join();
+    } catch (Exception e) {
+      // Orphaned metadata files are harmless; the commit outcome is decided by the catalog.
+    }
+  }
+
+  /** Builds the location of the next metadata file, following the common Iceberg naming scheme. */
+  public static String newMetadataLocation(TableMetadata tableMetadata, int version) {
+    String metadataDirectory =
+        tableMetadata
+            .properties()
+            .getOrDefault(
+                TableProperties.WRITE_METADATA_LOCATION, tableMetadata.location() + "/metadata");
+    return String.format("%s/%05d-%s.metadata.json", metadataDirectory, version, UUID.randomUUID());
+  }
+
+  /**
+   * Parses the version number out of a metadata file location, returning -1 when the file name does
+   * not follow a recognized versioning scheme (so the next version becomes 0).
+   */
+  public static int parseMetadataVersion(String metadataLocation) {
+    String fileName = metadataLocation.substring(metadataLocation.lastIndexOf('/') + 1);
+    Matcher matcher = METADATA_FILE_VERSION.matcher(fileName);
+    if (matcher.matches()) {
+      try {
+        return Integer.parseInt(matcher.group(1));
+      } catch (NumberFormatException e) {
+        return -1;
+      }
+    }
+    return -1;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -2,6 +2,9 @@ package io.unitycatalog.server.service.iceberg;
 
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.UriScheme;
+import java.io.File;
+import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
@@ -39,6 +42,23 @@ public class MetadataService {
     CompletableFuture.runAsync(
             () -> TableMetadataParser.write(tableMetadata, fileIO.newOutputFile(metadataLocation)))
         .join();
+  }
+
+  /**
+   * For local file locations, pre-creates the table's directory layout so clients that write data
+   * and manifest files before the first commit (e.g. staged creates) don't fail on missing parent
+   * directories. Object stores have no directories, so this is a no-op for them.
+   */
+  public void prepareTableLocation(TableMetadata tableMetadata) {
+    NormalizedURL location = NormalizedURL.from(tableMetadata.location());
+    UriScheme scheme = UriScheme.fromURI(location.toUri());
+    if (scheme != UriScheme.FILE && scheme != UriScheme.NULL) {
+      return;
+    }
+    String base = tableMetadata.location();
+    File baseDir = base.startsWith("file:") ? new File(URI.create(base).getPath()) : new File(base);
+    new File(baseDir, "metadata").mkdirs();
+    new File(baseDir, "data").mkdirs();
   }
 
   /** Best-effort cleanup of a metadata file that lost a commit race or whose commit failed. */

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/SimpleLocalFileIO.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/SimpleLocalFileIO.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.service.iceberg;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -13,11 +17,29 @@ public class SimpleLocalFileIO implements FileIO {
 
   @Override
   public OutputFile newOutputFile(String path) {
-    throw new UnsupportedOperationException();
+    File file = toLocalFile(path);
+    File parent = file.getParentFile();
+    if (parent != null && !parent.exists() && !parent.mkdirs() && !parent.exists()) {
+      throw new UncheckedIOException(
+          new IOException("Failed to create parent directories for: " + path));
+    }
+    return Files.localOutput(file);
   }
 
   @Override
   public void deleteFile(String path) {
-    throw new UnsupportedOperationException();
+    File file = toLocalFile(path);
+    if (file.exists() && !file.delete()) {
+      throw new UncheckedIOException(new IOException("Failed to delete: " + path));
+    }
+  }
+
+  // Locations arrive both as plain paths and as file: URIs (matching what
+  // org.apache.iceberg.Files.localInput accepts).
+  private static File toLocalFile(String path) {
+    if (path.startsWith("file:")) {
+      return new File(URI.create(path).getPath());
+    }
+    return new File(path);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -24,10 +24,6 @@ public class TableConfigService {
 
   private final StorageCredentialVendor storageCredentialVendor;
   private final Map<NormalizedURL, S3StorageConfig> s3Configurations;
-  // FIXME!! privileges are defaulted to READ only here for now as Iceberg REST impl doesn't
-  // support write
-  private final Set<CredentialContext.Privilege> privileges =
-      Set.of(CredentialContext.Privilege.SELECT);
 
   public TableConfigService(
       StorageCredentialVendor storageCredentialVendor, ServerProperties serverProperties) {
@@ -36,18 +32,24 @@ public class TableConfigService {
   }
 
   public Map<String, String> getTableConfig(TableMetadata tableMetadata) {
+    return getTableConfig(tableMetadata, CredentialContext.READ_ONLY);
+  }
+
+  public Map<String, String> getTableConfig(
+      TableMetadata tableMetadata, Set<CredentialContext.Privilege> privileges) {
     NormalizedURL location = NormalizedURL.from(tableMetadata.location());
     UriScheme scheme = UriScheme.fromURI(location.toUri());
 
     return switch(scheme) {
-      case ABFS, ABFSS -> getADLSConfig(location);
-      case GS -> getGCSConfig(location);
-      case S3 -> getS3Config(location);
+      case ABFS, ABFSS -> getADLSConfig(location, privileges);
+      case GS -> getGCSConfig(location, privileges);
+      case S3 -> getS3Config(location, privileges);
       case FILE, NULL -> Map.of();
     };
   }
 
-  private Map<String, String> getADLSConfig(NormalizedURL location) {
+  private Map<String, String> getADLSConfig(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     ADLSLocationUtils.ADLSLocationParts locationParts = ADLSLocationUtils.parseLocation(location);
 
     AzureUserDelegationSAS azureCredential =
@@ -58,7 +60,8 @@ public class TableConfigService {
         azureCredential.getSasToken());
   }
 
-  private Map<String, String> getGCSConfig(NormalizedURL location) {
+  private Map<String, String> getGCSConfig(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     TemporaryCredentials credential = storageCredentialVendor.vendCredential(location, privileges);
     GcpOauthToken token = credential.getGcpOauthToken();
 
@@ -68,7 +71,8 @@ public class TableConfigService {
         Long.toString(credential.getExpirationTime()));
   }
 
-  private Map<String, String> getS3Config(NormalizedURL location) {
+  private Map<String, String> getS3Config(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     S3StorageConfig s3StorageConfig = s3Configurations.get(location.getStorageBase());
     AwsCredentials awsCredential =
         storageCredentialVendor.vendCredential(location, privileges).getAwsTempCredentials();

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -201,7 +201,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             ex ->
                 assertThat(ex.getCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
-        .withMessageContaining("Managed table creation is only supported for Delta format");
+        .withMessageContaining(
+            "Managed table creation is only supported for Delta and Iceberg formats");
 
     // Step 3: Create a managed table using the staging location
     CreateTable createTableRequest =

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -407,7 +408,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             Types.NestedField.optional(2, "data", Types.StringType.get()));
     String location = Files.createTempDirectory("iceberg-rest-table").toUri().toString();
 
-    // Staged creation is rejected with a clear error
+    // Staged creation is stateless: it returns metadata without a metadata-location and
+    // registers nothing, so the direct create below still succeeds.
     {
       CreateTableRequest request =
           CreateTableRequest.builder()
@@ -418,7 +420,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .build();
       AggregatedHttpResponse resp =
           postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation()).isNull();
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
     }
 
     // Create the table
@@ -557,6 +563,97 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
       resp = client.delete(managedTablePath).aggregate().join();
       assertThat(resp.status().code()).isEqualTo(200);
+    }
+  }
+
+  @Test
+  public void testStagedCreateAndCommit() throws ApiException, IOException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+    // Stage the create (no location -> server-assigned managed location). Nothing is registered.
+    TableMetadata staged;
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      staged = loadTableResponse.tableMetadata();
+      assertThat(staged.metadataFileLocation()).isNull();
+      assertThat(staged.location()).contains("/tables/");
+
+      // the staged table is not registered: not in UC, not loadable, not listable
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
+    }
+
+    // Commit the staged create: assert-create requirement + updates rebuilding the metadata
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableDoesNotExist()),
+              List.of(
+                  new MetadataUpdate.AssignUUID(staged.uuid()),
+                  new MetadataUpdate.UpgradeFormatVersion(staged.formatVersion()),
+                  new MetadataUpdate.AddSchema(staged.schema()),
+                  new MetadataUpdate.SetCurrentSchema(-1),
+                  new MetadataUpdate.AddPartitionSpec(staged.spec()),
+                  new MetadataUpdate.SetDefaultPartitionSpec(-1),
+                  new MetadataUpdate.AddSortOrder(staged.sortOrder()),
+                  new MetadataUpdate.SetDefaultSortOrder(-1),
+                  new MetadataUpdate.SetLocation(staged.location()),
+                  new MetadataUpdate.SetProperties(Map.of("staged", "true"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00000-");
+      assertThat(loadTableResponse.tableMetadata().uuid()).isEqualTo(staged.uuid());
+      assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("staged", "true");
+
+      // the table is now registered in UC as a managed Iceberg table and loadable
+      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.MANAGED);
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(200);
+
+      // replaying the create commit loses the race: 409 CommitFailedException
+      resp = postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(CommitFailedException.class.getSimpleName());
+    }
+
+    // staging a create for an existing table is a conflict
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.auth.AuthToken;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.CatalogInfo;
@@ -28,20 +31,32 @@ import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +111,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/views/{view}\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\""
+                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\","
+                + "\"POST /v1/{prefix}/namespaces\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
+                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
                 + "]}");
 
     // not setting warehouse param should result in 400 BadRequestException
@@ -329,5 +348,197 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
+
+    // UniForm-derived Iceberg metadata is read-only: commits and drops through the Iceberg REST
+    // catalog must be rejected.
+    {
+      String tablePath =
+          TEST_BASE_PREFIX
+              + "/namespaces/"
+              + TestUtils.SCHEMA_NAME
+              + "/tables/"
+              + TestUtils.TABLE_NAME;
+      UpdateTableRequest commitRequest =
+          new UpdateTableRequest(
+              List.of(), List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(commitRequest));
+      assertThat(resp.status().code()).isEqualTo(400);
+
+      resp = client.delete(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(400);
+    }
+  }
+
+  @Test
+  public void testIcebergTableWriteLifecycle() throws ApiException, IOException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+
+    String namespacesPath = TEST_BASE_PREFIX + "/namespaces";
+    String tablesPath = namespacesPath + "/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+
+    // Create the namespace through the Iceberg REST catalog
+    {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.builder()
+              .withNamespace(Namespace.of(TestUtils.SCHEMA_NAME))
+              .setProperties(TestUtils.PROPERTIES)
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      CreateNamespaceResponse createNamespaceResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), CreateNamespaceResponse.class);
+      assertThat(createNamespaceResponse.namespace())
+          .isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME));
+
+      // creating it again is a conflict
+      resp = postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+    }
+
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    String location = Files.createTempDirectory("iceberg-rest-table").toUri().toString();
+
+    // Staged creation is rejected with a clear error
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .withLocation(location)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(400);
+    }
+
+    // Create the table
+    String initialMetadataLocation;
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .withLocation(location)
+              .setProperty("created-by", "iceberg-rest-test")
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      initialMetadataLocation = loadTableResponse.tableMetadata().metadataFileLocation();
+      assertThat(initialMetadataLocation).contains("/metadata/00000-");
+      assertThat(loadTableResponse.tableMetadata().schema().columns()).hasSize(2);
+      assertThat(loadTableResponse.tableMetadata().properties())
+          .containsEntry("created-by", "iceberg-rest-test");
+
+      // creating it again is a conflict
+      resp = postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+    }
+
+    // The table is registered in UC as a native Iceberg table with converted columns
+    {
+      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.EXTERNAL);
+      assertThat(tableInfo.getColumns())
+          .extracting(ColumnInfo::getName)
+          .containsExactly("id", "data");
+    }
+
+    // The table is loadable and listable through the Iceberg REST catalog
+    String tableUuid;
+    {
+      AggregatedHttpResponse resp = client.head(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .isEqualTo(initialMetadataLocation);
+      tableUuid = loadTableResponse.tableMetadata().uuid();
+
+      resp = client.get(tablesPath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      ListTablesResponse listTablesResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+      assertThat(listTablesResponse.identifiers())
+          .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
+    }
+
+    // Commit an update against the table
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableUUID(tableUuid)),
+              List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00001-");
+      assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("foo", "bar");
+
+      // the new metadata location is what loadTable now returns
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse reloaded =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(reloaded.tableMetadata().metadataFileLocation())
+          .isEqualTo(loadTableResponse.tableMetadata().metadataFileLocation());
+      assertThat(reloaded.tableMetadata().properties()).containsEntry("foo", "bar");
+    }
+
+    // A commit whose requirements no longer hold fails with CommitFailedException
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableUUID(UUID.randomUUID().toString())),
+              List.of(new MetadataUpdate.SetProperties(Map.of("should", "fail"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(CommitFailedException.class.getSimpleName());
+    }
+
+    // Drop the table
+    {
+      AggregatedHttpResponse resp = client.delete(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(204);
+
+      resp = client.head(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(404);
+
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(404);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(NoSuchTableException.class.getSimpleName());
+    }
+  }
+
+  private AggregatedHttpResponse postJson(String path, String body) {
+    return client
+        .execute(
+            RequestHeaders.builder(HttpMethod.POST, path).contentType(MediaType.JSON).build(), body)
+        .aggregate()
+        .join();
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -532,6 +532,32 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(NoSuchTableException.class.getSimpleName());
     }
+
+    // A create request without a location gets a server-assigned managed location
+    {
+      String managedTablePath = tablesPath + "/managed_iceberg_table";
+      CreateTableRequest request =
+          CreateTableRequest.builder().withName("managed_iceberg_table").withSchema(schema).build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().location()).contains("/tables/");
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00000-");
+
+      TableInfo tableInfo =
+          tableOperations.getTable(
+              TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".managed_iceberg_table");
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.MANAGED);
+      assertThat(tableInfo.getStorageLocation())
+          .isEqualTo(loadTableResponse.tableMetadata().location());
+
+      resp = client.delete(managedTablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(204);
+    }
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -522,7 +522,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     // Drop the table
     {
       AggregatedHttpResponse resp = client.delete(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(204);
+      assertThat(resp.status().code()).isEqualTo(200);
 
       resp = client.head(tablePath).aggregate().join();
       assertThat(resp.status().code()).isEqualTo(404);
@@ -556,7 +556,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
           .isEqualTo(loadTableResponse.tableMetadata().location());
 
       resp = client.delete(managedTablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(204);
+      assertThat(resp.status().code()).isEqualTo(200);
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -32,11 +32,19 @@ import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -655,6 +663,94 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(AlreadyExistsException.class.getSimpleName());
     }
+  }
+
+  @Test
+  public void testConcurrentCommitsSerializeWithCompareAndSwap()
+      throws ApiException, IOException, InterruptedException, ExecutionException, TimeoutException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    String location = Files.createTempDirectory("iceberg-rest-concurrent").toUri().toString();
+
+    // Create the table; its current-schema-id is 0.
+    CreateTableRequest createRequest =
+        CreateTableRequest.builder()
+            .withName(TestUtils.TABLE_NAME)
+            .withSchema(schema)
+            .withLocation(location)
+            .build();
+    AggregatedHttpResponse createResp =
+        postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(createRequest));
+    assertThat(createResp.status().code()).isEqualTo(200);
+    LoadTableResponse created =
+        IcebergObjectMapper.mapper().readValue(createResp.contentUtf8(), LoadTableResponse.class);
+    assertThat(created.tableMetadata().metadataFileLocation()).contains("/metadata/00000-");
+
+    // Fire N commits at once. Each asserts the original current-schema-id (0) and bumps the schema
+    // to a new id, so the commits are mutually exclusive: only the first to land can both satisfy
+    // its requirement and win the metadata-location compare-and-swap in
+    // TableRepository#setIcebergMetadataLocation. A loser fails either because it raced and lost
+    // the CAS, or because it read post-winner state where assert-current-schema-id no longer holds;
+    // both surface as 409 CommitFailedException. The CyclicBarrier releases the threads together to
+    // exercise the CAS path when timing allows, but the outcome is deterministic either way.
+    int concurrency = 8;
+    Schema bumpedSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "added", Types.StringType.get()));
+    CyclicBarrier barrier = new CyclicBarrier(concurrency);
+    ExecutorService pool = Executors.newFixedThreadPool(concurrency);
+    List<Future<Integer>> futures = new ArrayList<>();
+    for (int i = 0; i < concurrency; i++) {
+      futures.add(
+          pool.submit(
+              () -> {
+                UpdateTableRequest request =
+                    new UpdateTableRequest(
+                        List.of(new UpdateRequirement.AssertCurrentSchemaID(0)),
+                        List.of(
+                            new MetadataUpdate.AddSchema(bumpedSchema),
+                            new MetadataUpdate.SetCurrentSchema(-1)));
+                String body = IcebergObjectMapper.mapper().writeValueAsString(request);
+                barrier.await();
+                return postJson(tablePath, body).status().code();
+              }));
+    }
+
+    int successes = 0;
+    int conflicts = 0;
+    for (Future<Integer> future : futures) {
+      int code = future.get(30, TimeUnit.SECONDS);
+      // A commit either wins (200) or loses cleanly (409 CommitFailedException); any other status
+      // would mean the contention surfaced as a server error.
+      assertThat(code).isIn(200, 409);
+      if (code == 200) {
+        successes++;
+      } else {
+        conflicts++;
+      }
+    }
+    pool.shutdown();
+    assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+    // Exactly one commit wins and the rest lose cleanly: no lost updates, no double-applies.
+    assertThat(successes).isEqualTo(1);
+    assertThat(conflicts).isEqualTo(concurrency - 1);
+
+    // The single winner advanced the table to version 1 with the bumped schema; losers left no
+    // trace (their metadata files were rolled back), so the table is loadable and consistent.
+    AggregatedHttpResponse loadResp = client.get(tablePath).aggregate().join();
+    assertThat(loadResp.status().code()).isEqualTo(200);
+    LoadTableResponse loaded =
+        IcebergObjectMapper.mapper().readValue(loadResp.contentUtf8(), LoadTableResponse.class);
+    assertThat(loaded.tableMetadata().metadataFileLocation()).contains("/metadata/00001-");
+    assertThat(loaded.tableMetadata().schema().columns()).hasSize(2);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/FileIOFactoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/FileIOFactoryTest.java
@@ -1,0 +1,53 @@
+package io.unitycatalog.server.service.iceberg;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.model.GcpOauthToken;
+import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link FileIOFactory} requests storage credentials with the privileges the caller
+ * asks for: read-only by default, and read/write when the Iceberg REST catalog writes metadata for
+ * a native Iceberg table (the old hard-coded SELECT-only behavior was the removed FIXME). A GCS
+ * location is used because that path vends credentials eagerly while building the FileIO.
+ */
+public class FileIOFactoryTest {
+
+  private static final NormalizedURL GCS_LOCATION = NormalizedURL.from("gs://test-bucket/table");
+
+  private final StorageCredentialVendor mockVendor = mock();
+  private FileIOFactory fileIOFactory;
+
+  @BeforeEach
+  public void setUp() {
+    ServerProperties serverProperties = mock();
+    when(serverProperties.getS3Configurations()).thenReturn(Map.of());
+    when(mockVendor.vendCredential(any(), any()))
+        .thenReturn(
+            new TemporaryCredentials().gcpOauthToken(new GcpOauthToken().oauthToken("token")));
+    fileIOFactory = new FileIOFactory(mockVendor, serverProperties);
+  }
+
+  @Test
+  public void defaultsToReadOnlyCredentials() {
+    fileIOFactory.getFileIO(GCS_LOCATION);
+    verify(mockVendor).vendCredential(eq(GCS_LOCATION), eq(CredentialContext.READ_ONLY));
+  }
+
+  @Test
+  public void passesThroughRequestedPrivileges() {
+    fileIOFactory.getFileIO(GCS_LOCATION, CredentialContext.READ_WRITE);
+    verify(mockVendor).vendCredential(eq(GCS_LOCATION), eq(CredentialContext.READ_WRITE));
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
@@ -1,0 +1,131 @@
+package io.unitycatalog.server.service.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.ColumnTypeName;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class IcebergSchemaConverterTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  public void convertsPrimitivesWithPositionAndNullability() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get(), "the name"));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+
+    assertThat(columns).hasSize(2);
+
+    ColumnInfo id = columns.get(0);
+    assertThat(id.getName()).isEqualTo("id");
+    assertThat(id.getPosition()).isEqualTo(0);
+    assertThat(id.getNullable()).isFalse();
+    assertThat(id.getTypeName()).isEqualTo(ColumnTypeName.LONG);
+    // Spark DDL text renders LONG as "bigint" while the type JSON uses "long".
+    assertThat(id.getTypeText()).isEqualTo("bigint");
+
+    ColumnInfo name = columns.get(1);
+    assertThat(name.getName()).isEqualTo("name");
+    assertThat(name.getPosition()).isEqualTo(1);
+    assertThat(name.getNullable()).isTrue();
+    assertThat(name.getComment()).isEqualTo("the name");
+    assertThat(name.getTypeName()).isEqualTo(ColumnTypeName.STRING);
+  }
+
+  @Test
+  public void rendersStructFieldTypeJsonInSparkShape() throws Exception {
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+
+    ColumnInfo id = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    JsonNode json = MAPPER.readTree(id.getTypeJson());
+
+    assertThat(json.get("name").asText()).isEqualTo("id");
+    assertThat(json.get("type").asText()).isEqualTo("long");
+    assertThat(json.get("nullable").asBoolean()).isFalse();
+    assertThat(json.get("metadata")).isNotNull();
+  }
+
+  @Test
+  public void carriesDecimalPrecisionAndScale() {
+    Schema schema =
+        new Schema(Types.NestedField.required(1, "amount", Types.DecimalType.of(18, 4)));
+
+    ColumnInfo amount = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    assertThat(amount.getTypeName()).isEqualTo(ColumnTypeName.DECIMAL);
+    assertThat(amount.getTypePrecision()).isEqualTo(18);
+    assertThat(amount.getTypeScale()).isEqualTo(4);
+    assertThat(amount.getTypeText()).isEqualTo("decimal(18,4)");
+  }
+
+  @Test
+  public void distinguishesTimestampWithAndWithoutZone() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+            Types.NestedField.required(2, "ts_ntz", Types.TimestampType.withoutZone()));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+    assertThat(columns.get(0).getTypeName()).isEqualTo(ColumnTypeName.TIMESTAMP);
+    assertThat(columns.get(1).getTypeName()).isEqualTo(ColumnTypeName.TIMESTAMP_NTZ);
+  }
+
+  @Test
+  public void mapsUuidToStringLossily() {
+    Schema schema = new Schema(Types.NestedField.required(1, "key", Types.UUIDType.get()));
+
+    ColumnInfo key = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    assertThat(key.getTypeName()).isEqualTo(ColumnTypeName.STRING);
+    assertThat(key.getTypeText()).isEqualTo("string");
+  }
+
+  @Test
+  public void convertsNestedStructListAndMap() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "props",
+                Types.StructType.of(
+                    Types.NestedField.optional(2, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(3, "b", Types.StringType.get()))),
+            Types.NestedField.required(
+                4, "tags", Types.ListType.ofOptional(5, Types.StringType.get())),
+            Types.NestedField.required(
+                6,
+                "scores",
+                Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.DoubleType.get())));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+
+    ColumnInfo props = columns.get(0);
+    assertThat(props.getTypeName()).isEqualTo(ColumnTypeName.STRUCT);
+    assertThat(props.getTypeText()).isEqualTo("struct<a:int,b:string>");
+
+    ColumnInfo tags = columns.get(1);
+    assertThat(tags.getTypeName()).isEqualTo(ColumnTypeName.ARRAY);
+    assertThat(tags.getTypeText()).isEqualTo("array<string>");
+    JsonNode tagsJson = MAPPER.readTree(tags.getTypeJson()).get("type");
+    assertThat(tagsJson.get("type").asText()).isEqualTo("array");
+    assertThat(tagsJson.get("elementType").asText()).isEqualTo("string");
+    assertThat(tagsJson.get("containsNull").asBoolean()).isTrue();
+
+    ColumnInfo scores = columns.get(2);
+    assertThat(scores.getTypeName()).isEqualTo(ColumnTypeName.MAP);
+    assertThat(scores.getTypeText()).isEqualTo("map<string,double>");
+    JsonNode scoresJson = MAPPER.readTree(scores.getTypeJson()).get("type");
+    assertThat(scoresJson.get("type").asText()).isEqualTo("map");
+    assertThat(scoresJson.get("keyType").asText()).isEqualTo("string");
+    assertThat(scoresJson.get("valueType").asText()).isEqualTo("double");
+    assertThat(scoresJson.get("valueContainsNull").asBoolean()).isFalse();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
@@ -1,16 +1,22 @@
 package io.unitycatalog.server.service.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.amazonaws.util.IOUtils;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.SneakyThrows;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,5 +84,33 @@ public class MetadataServiceTest {
             .toString();
     TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
     assertThat(tableMetadata.uuid()).isEqualTo("55d4dc69-5b14-4483-bfc8-f33b80f99f99");
+  }
+
+  @SneakyThrows
+  @Test
+  public void testWriteAndDeleteTableMetadataOnS3() {
+    when(mockFileIOFactory.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileIOFactory.getFileIO(any(), any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    // Dedicated bucket: the S3Mock extension is static and shared across this class's tests.
+    String bucket = "metadata-write-test";
+    mockS3Client.createBucket(builder -> builder.bucket(bucket).build());
+
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    String tableLocation = "s3://" + bucket + "/write-roundtrip";
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), tableLocation, Map.of());
+    String metadataLocation =
+        tableLocation + "/metadata/00000-" + UUID.randomUUID() + ".metadata.json";
+
+    // The metadata is written to S3 through the FileIO and reads back identically.
+    metadataService.writeTableMetadata(tableMetadata, metadataLocation);
+    assertThat(metadataService.readTableMetadata(metadataLocation).uuid())
+        .isEqualTo(tableMetadata.uuid());
+
+    // Delete removes the object, so a subsequent read of that location fails.
+    metadataService.deleteTableMetadata(metadataLocation);
+    assertThatThrownBy(() -> metadataService.readTableMetadata(metadataLocation))
+        .isInstanceOf(RuntimeException.class);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
@@ -1,0 +1,55 @@
+package io.unitycatalog.server.service.iceberg;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.model.GcpOauthToken;
+import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link TableConfigService} vends storage credentials with the privileges the caller
+ * asks for: read-only by default, and read/write when the Iceberg REST catalog requests it for a
+ * native Iceberg table. A GCS location is used because that path returns a plain config map without
+ * constructing any cloud client.
+ */
+public class TableConfigServiceTest {
+
+  private final StorageCredentialVendor mockVendor = mock();
+  private final TableMetadata mockMetadata = mock();
+  private TableConfigService tableConfigService;
+
+  @BeforeEach
+  public void setUp() {
+    ServerProperties serverProperties = mock();
+    when(serverProperties.getS3Configurations()).thenReturn(Map.of());
+    when(mockMetadata.location()).thenReturn("gs://test-bucket/table");
+    when(mockVendor.vendCredential(any(), any()))
+        .thenReturn(
+            new TemporaryCredentials()
+                .gcpOauthToken(new GcpOauthToken().oauthToken("token"))
+                .expirationTime(0L));
+    tableConfigService = new TableConfigService(mockVendor, serverProperties);
+  }
+
+  @Test
+  public void defaultsToReadOnlyCredentials() {
+    tableConfigService.getTableConfig(mockMetadata);
+    verify(mockVendor).vendCredential(any(), eq(CredentialContext.READ_ONLY));
+  }
+
+  @Test
+  public void passesThroughRequestedPrivileges() {
+    tableConfigService.getTableConfig(mockMetadata, CredentialContext.READ_WRITE);
+    verify(mockVendor).vendCredential(any(), eq(CredentialContext.READ_WRITE));
+  }
+}


### PR DESCRIPTION
## Implement Iceberg REST catalog write endpoints

> 🤖 Heads up: this PR was put together with Claude Fable (AI). A human (@dataders) is driving it and will own the review back-and-forth, but the code + this description were AI-generated. Flagging so reviewers know what they're looking at.

### What this does

Adds the write side of the Iceberg REST catalog to OSS Unity Catalog, so spec-compliant clients (PyIceberg, Spark `RESTCatalog`, the DuckDB iceberg extension, etc.) can actually create and commit to Iceberg tables — not just read UniForm. Covers the write-endpoint part of #3.

| Endpoint | Gist |
|---|---|
| `POST …/namespaces` | Create a schema (delegates to `SchemaService`; single-level only, like today). |
| `POST …/tables` | Create a native Iceberg table: build initial `TableMetadata`, write `00000-*.metadata.json` via `FileIO`, register in UC as `EXTERNAL` with a new `ICEBERG` format. `stage-create` supported and stateless (mirrors Iceberg's `CatalogHandlers`). |
| `POST …/tables/{table}` | Commit: check `UpdateRequirement`s, apply `MetadataUpdate`s, write the next `metadata.json`, then CAS the stored location under a row lock. Lost race → 409. `assert-create` commits materialize a staged create atomically. |
| `DELETE …/tables/{table}` | Drop a REST-created table. Returns **200** not 204 (Armeria stalls body-less 204s on HTTP/1.1; clients accept 200). |

New endpoints are advertised in `GET /v1/config` so clients that do capability detection (DuckDB) light up automatically.

A few supporting bits:
- **Server-assigned locations**: clients that don't send a `location` (DuckDB) get a `MANAGED` table at `<managed-root>/tables/<uuid>`, resolved like managed Delta staging. Explicit location → `EXTERNAL`.
- **UniForm stays read-only**: only `ICEBERG`-format tables accept commits, so the Delta log and Iceberg metadata can't diverge.
- **Privilege-aware credential vending**: `FileIOFactory`/`TableConfigService` no longer hardcode `SELECT` (drops the old `FIXME`); write creds are only vended to native Iceberg tables, and all routes still authorize as metastore owner.
- **UC-visible schema**: Iceberg schemas convert to UC `ColumnInfo`s via a new `IcebergSchemaConverter`, so tables show up in the UC API/UI. The metadata file stays source of truth for Iceberg clients.

### Not in scope (follow-ups, still under #3)

`transactions/commit` (multi-table), `X-Iceberg-Access-Delegation` negotiation, register/rename/namespace-properties/views.

### Testing

`IcebergRestCatalogTest` — 5/5 passing, full `server/test` suite green locally (286 tests, 0 failures). New coverage: full write lifecycle (create → commit → drop, plus dup/stale-requirement/UniForm-rejection cases) and staged-create-then-commit.

Also ran it against real clients on a local server:
- **PyIceberg 0.11.1**: create namespace + table (server-assigned location), two appends, scan, properties, drop.
- **DuckDB 1.5.3** (released extension, no patches): both staged-create (`CTAS`) and direct-create paths, plus `INSERT`/`DROP`.
- **Cross-client**: DuckDB inserted into a PyIceberg-created table, PyIceberg read it back, and vice versa.

### PR Checklist

- [x] A description of the changes is added to the description of this PR.
- [ ] Documentation update for the change if required
- [x] Unit test/Integration test added
