### PR TITLE
Advance table updatedAt only on metadata changes in the Delta update endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -279,8 +279,9 @@ public class TableRepository {
    * diff-flush at the end applies only the keys that actually changed. Request classification runs
    * before opening the transaction (see {@link DeltaUpdateTableMapper#collectRequest}); inside,
    * requirement checks run first so a stale-snapshot conflict short-circuits before any write is
-   * persisted. The DAO's {@code updatedAt}/{@code updatedBy} advance once at the end; the resulting
-   * etag naturally rolls.
+   * persisted. The DAO's {@code updatedAt}/{@code updatedBy} advance at the end only when the
+   * request changes catalog-visible metadata; data-only commits and backfill notifications leave
+   * them untouched.
    */
   public DeltaLoadTableResponse updateTableForDelta(
       String catalog, String schema, String table, DeltaUpdateTableRequest request) {
@@ -307,8 +308,13 @@ public class TableRepository {
                               d.uniformFields(),
                               d.latestBackfilledVersion()));
           properties.flush(session, dao.getId());
-          dao.setUpdatedAt(new Date());
-          dao.setUpdatedBy(callerId);
+          // updatedAt/updatedBy track the last change to the table's catalog-visible metadata.
+          // Data-only add-commit and backfill-only requests change no metadata, so they must
+          // not advance these fields.
+          if (collected.updates().changesTableMetadata()) {
+            dao.setUpdatedAt(new Date());
+            dao.setUpdatedBy(callerId);
+          }
           session.merge(dao);
           session.flush();
           return buildLoadTableResponse(

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -186,6 +186,13 @@ public final class DeltaUpdateTableMapper {
      * the auto-stamping of {@code delta.lastUpdateVersion} / {@code delta.lastCommitTimestamp} on
      * a MANAGED {@code add-commit}. {@code update-metadata-snapshot-version} is intentionally
      * omitted: it is EXTERNAL-only and so can never co-occur with {@code add-commit}.
+     *
+     * <p>A {@code set-domain-metadata} that touches only the {@code delta.rowTracking} domain does
+     * not count: the Delta protocol requires writers to advance the row-tracking high-water mark in
+     * every commit that assigns fresh row IDs, so clients mirror it alongside otherwise data-only
+     * {@code add-commit}s. It is per-commit snapshot bookkeeping, not a metadata change; counting
+     * it would advance {@code updatedAt} and the {@code delta.lastUpdateVersion} stamp on every
+     * data commit of a row-tracking table. The high-water-mark property itself is still persisted.
      */
     boolean hasManagedTableMetadataChange() {
       return setProperties.isPresent()
@@ -194,8 +201,31 @@ public final class DeltaUpdateTableMapper {
           || setSchema.isPresent()
           || setPartitionColumns.isPresent()
           || setTableComment.isPresent()
-          || setDomainMetadata.isPresent()
+          || setsDomainMetadataBeyondRowTracking()
           || removeDomainMetadata.isPresent();
+    }
+
+    /**
+     * True if {@code set-domain-metadata} is present and sets any domain other than {@code
+     * delta.rowTracking}. Extend this check when new domains are added to {@link
+     * DeltaDomainMetadataUpdates}.
+     */
+    private boolean setsDomainMetadataBeyondRowTracking() {
+      if (setDomainMetadata.isEmpty()) {
+        return false;
+      }
+      DeltaDomainMetadataUpdates updates = setDomainMetadata.get().getUpdates();
+      return updates != null && updates.getDeltaClustering() != null;
+    }
+
+    /**
+     * True if this request changes catalog-visible table metadata: any MANAGED-applicable
+     * metadata action ({@link #hasManagedTableMetadataChange()}) or the EXTERNAL-only {@code
+     * update-metadata-snapshot-version}. Data-only {@code add-commit} and backfill-only
+     * requests carry no metadata change and return false.
+     */
+    public boolean changesTableMetadata() {
+      return hasManagedTableMetadataChange() || updateSnapshotVersion.isPresent();
     }
 
     void putOnce(DeltaTableUpdate update) {

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -88,6 +88,11 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       Handle h =
           createDeltaManaged(
               "tbl_umbrella", Map.of("keep", "v1", "update_me", "v_old", "drop_me", "v3"));
+      Long t0 =
+          deltaTablesApi
+              .loadTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, h.name())
+              .getMetadata()
+              .getUpdatedTime();
 
       // Must keep the managed-contract required features; adding CLUSTERING proves features are
       // replaced (not merged) by what the request carries.
@@ -130,6 +135,8 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(props1)
           .containsEntry(TableProperties.CLUSTERING_COLUMNS, "[[\"id\"]]")
           .containsKey(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK);
+      // A metadata change advances updated-time, and with it the etag.
+      assertThat(r1.getMetadata().getUpdatedTime()).isGreaterThan(t0);
       assertThat(r1.getMetadata().getEtag()).isNotEqualTo(h.etag());
 
       // Phase 2: remove-domain-metadata alone -- now the rowTracking entry must disappear.
@@ -140,6 +147,25 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(r2.getMetadata().getProperties())
           .doesNotContainKey(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK)
           .containsKey(TableProperties.CLUSTERING_COLUMNS);
+
+      // Phase 3: a set-domain-metadata touching clustering is a metadata change and rolls the
+      // etag, even when the exempt rowTracking high-water mark rides in the same action --
+      // contrast with the HWM-only case in the tbl_commit_meta_stamp section.
+      DeltaLoadTableResponse r3 =
+          updateTable(
+              h.withEtag(r2.getMetadata().getEtag()),
+              new DeltaSetDomainMetadataUpdate()
+                  .updates(
+                      new DeltaDomainMetadataUpdates()
+                          .deltaClustering(
+                              new DeltaClusteringDomainMetadata()
+                                  .clusteringColumns(List.of(List.of("name"))))
+                          .deltaRowTracking(
+                              new DeltaRowTrackingDomainMetadata().rowIdHighWaterMark(123L))));
+      assertThat(r3.getMetadata().getProperties())
+          .containsEntry(TableProperties.CLUSTERING_COLUMNS, "[[\"name\"]]")
+          .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "123");
+      assertThat(r3.getMetadata().getEtag()).isNotEqualTo(r2.getMetadata().getEtag());
     }
 
     // -------- set-protocol-drops-feature + sibling remove-DM in same RPC succeeds (post-apply
@@ -554,6 +580,11 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
     // -------- add-commit on managed Delta (+ version conflict) --------
     {
       Handle h = createDeltaManaged("tbl_commit", Map.of());
+      Long t0 =
+          deltaTablesApi
+              .loadTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, h.name())
+              .getMetadata()
+              .getUpdatedTime();
       DeltaLoadTableResponse r1 =
           updateTable(
               h,
@@ -568,6 +599,11 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(r1.getCommits()).hasSize(1);
       assertThat(r1.getCommits().get(0).getVersion()).isEqualTo(1L);
       assertThat(r1.getLatestTableVersion()).isEqualTo(1L);
+      // A data-only commit changes no metadata, so it must not advance updated-time (and hence
+      // must not roll the etag). The conflict calls below reuse this etag in assert-etag and
+      // fail on the version check, which also proves the pre-commit etag remains valid.
+      assertThat(r1.getMetadata().getUpdatedTime()).isEqualTo(t0);
+      assertThat(r1.getMetadata().getEtag()).isEqualTo(h.etag());
 
       // Replaying v1 should surface as a CommitVersionConflict (409). Pin assert-etag against
       // the post-r1 etag so the conflict comes from the version check, not from assert-etag.
@@ -639,6 +675,8 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(r2.getLatestTableVersion()).isEqualTo(2L);
       assertThat(r2.getCommits()).hasSize(1);
       assertThat(r2.getCommits().get(0).getVersion()).isEqualTo(2L);
+      // The combined commit+backfill request is still data-only: updated-time must not advance.
+      assertThat(r2.getMetadata().getUpdatedTime()).isEqualTo(r1.getMetadata().getUpdatedTime());
     }
 
     // -------- MANAGED add-commit + metadata change stamps lastUpdateVersion/timestamp --------
@@ -679,6 +717,34 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                           .fileModificationTimestamp(1700000002L)));
       assertThat(r2.getMetadata().getLastCommitVersion()).isEqualTo(1L);
       assertThat(r2.getMetadata().getLastCommitTimestampMs()).isEqualTo(1700000001L);
+
+      // v3: add-commit + set-domain-metadata touching only delta.rowTracking. The Delta protocol
+      // makes writers mirror the row-tracking high-water mark on every fresh-row commit, so this
+      // is data-stream bookkeeping: the HWM property must persist, but lastUpdateVersion,
+      // updated-time, and the etag must all stay where the last real metadata change (v1) left
+      // them.
+      DeltaLoadTableResponse r3 =
+          updateTable(
+              h.withEtag(r2.getMetadata().getEtag()),
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(3L)
+                          .timestamp(1700000003L)
+                          .fileName("00000003.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000003L)),
+              new DeltaSetDomainMetadataUpdate()
+                  .updates(
+                      new DeltaDomainMetadataUpdates()
+                          .deltaRowTracking(
+                              new DeltaRowTrackingDomainMetadata().rowIdHighWaterMark(150L))));
+      assertThat(r3.getMetadata().getProperties())
+          .containsEntry(TableProperties.ROW_TRACKING_ROW_ID_HIGH_WATER_MARK, "150");
+      assertThat(r3.getMetadata().getLastCommitVersion()).isEqualTo(1L);
+      assertThat(r3.getMetadata().getLastCommitTimestampMs()).isEqualTo(1700000001L);
+      assertThat(r3.getMetadata().getUpdatedTime()).isEqualTo(r1.getMetadata().getUpdatedTime());
+      assertThat(r3.getMetadata().getEtag()).isEqualTo(r1.getMetadata().getEtag());
     }
 
     // -------- add-commit with no commit block is rejected --------
@@ -769,7 +835,10 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
               h.withEtag(r1.getMetadata().getEtag()),
               new DeltaSetLatestBackfilledVersionUpdate().latestPublishedVersion(1L));
       assertThat(r2.getLatestTableVersion()).isEqualTo(1L);
-      assertThat(r2.getMetadata().getEtag()).isNotEqualTo(r1.getMetadata().getEtag());
+      // A backfill notification is not a metadata change, so it must not advance updated-time
+      // (and hence must not roll the etag).
+      assertThat(r2.getMetadata().getUpdatedTime()).isEqualTo(r1.getMetadata().getUpdatedTime());
+      assertThat(r2.getMetadata().getEtag()).isEqualTo(r1.getMetadata().getEtag());
     }
 
     // -------- set-latest-backfilled-version on a table with no prior commits rejected --------

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapperTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.service.delta;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -10,10 +11,12 @@ import io.unitycatalog.server.delta.model.DeltaDomainMetadataUpdates;
 import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.DeltaRemoveDomainMetadataUpdate;
 import io.unitycatalog.server.delta.model.DeltaRemovePropertiesUpdate;
+import io.unitycatalog.server.delta.model.DeltaRowTrackingDomainMetadata;
 import io.unitycatalog.server.delta.model.DeltaSetDomainMetadataUpdate;
 import io.unitycatalog.server.delta.model.DeltaSetPropertiesUpdate;
 import io.unitycatalog.server.delta.model.DeltaSetProtocolUpdate;
 import io.unitycatalog.server.delta.model.DeltaTableRequirement;
+import io.unitycatalog.server.delta.model.DeltaTableUpdate;
 import io.unitycatalog.server.delta.model.DeltaUpdateTableRequest;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.persist.MutablePropertyMap;
@@ -337,7 +340,65 @@ public class DeltaUpdateTableMapperTest {
         .hasMessageContaining(TableFeature.DELETION_VECTORS.specName());
   }
 
+  @Test
+  public void changesTableMetadataExemptsRowTrackingOnlyDomainMetadata() {
+    // The Delta protocol requires writers to advance the rowTracking high-water mark on every
+    // fresh-row commit, so an HWM-only set-domain-metadata rides along with data commits and
+    // must not classify the request as a metadata change.
+    DeltaSetDomainMetadataUpdate hwmOnly =
+        new DeltaSetDomainMetadataUpdate()
+            .updates(
+                new DeltaDomainMetadataUpdates()
+                    .deltaRowTracking(new DeltaRowTrackingDomainMetadata().rowIdHighWaterMark(7L)))
+            .action("set-domain-metadata");
+    assertThat(collectUpdatesRequest(hwmOnly).updates().changesTableMetadata()).isFalse();
+
+    // A set-domain-metadata with no updates body sets nothing and is likewise not a change.
+    assertThat(
+            collectUpdatesRequest(new DeltaSetDomainMetadataUpdate().action("set-domain-metadata"))
+                .updates()
+                .changesTableMetadata())
+        .isFalse();
+
+    // Touching any other domain in the same action still counts...
+    assertThat(
+            collectUpdatesRequest(
+                    new DeltaSetDomainMetadataUpdate()
+                        .updates(
+                            new DeltaDomainMetadataUpdates()
+                                .deltaRowTracking(
+                                    new DeltaRowTrackingDomainMetadata().rowIdHighWaterMark(7L))
+                                .deltaClustering(
+                                    new DeltaClusteringDomainMetadata()
+                                        .clusteringColumns(List.of(List.of("id")))))
+                        .action("set-domain-metadata"))
+                .updates()
+                .changesTableMetadata())
+        .isTrue();
+
+    // ... as does any sibling metadata action alongside the HWM.
+    assertThat(
+            collectUpdatesRequest(
+                    hwmOnly,
+                    new DeltaSetPropertiesUpdate()
+                        .updates(Map.of("k", "v"))
+                        .action("set-properties"))
+                .updates()
+                .changesTableMetadata())
+        .isTrue();
+  }
+
   // --- fixtures ---
+
+  /** Build a {@link CollectedRequest} with the canonical requirement and the given updates. */
+  private static CollectedRequest collectUpdatesRequest(DeltaTableUpdate... updates) {
+    return DeltaUpdateTableMapper.collectRequest(
+        new DeltaUpdateTableRequest()
+            .requirements(
+                List.of(
+                    new DeltaAssertTableUUID().uuid(UUID.randomUUID()).type("assert-table-uuid")))
+            .updates(List.of(updates)));
+  }
 
   /** Build a {@link CollectedRequest} with the supplied requirements and a no-op update. */
   private static CollectedRequest collectRequestFor(DeltaTableRequirement... requirements) {
@@ -352,28 +413,15 @@ public class DeltaUpdateTableMapperTest {
   }
 
   private static CollectedRequest collectSetProtocolRequest(DeltaProtocol protocol) {
-    return DeltaUpdateTableMapper.collectRequest(
-        new DeltaUpdateTableRequest()
-            .requirements(
-                List.of(
-                    new DeltaAssertTableUUID().uuid(UUID.randomUUID()).type("assert-table-uuid")))
-            .updates(
-                List.of(new DeltaSetProtocolUpdate().protocol(protocol).action("set-protocol"))));
+    return collectUpdatesRequest(
+        new DeltaSetProtocolUpdate().protocol(protocol).action("set-protocol"));
   }
 
   private static CollectedRequest collectSetProtocolAndSetPropertiesRequest(
       DeltaProtocol protocol, Map<String, String> extraProperties) {
-    return DeltaUpdateTableMapper.collectRequest(
-        new DeltaUpdateTableRequest()
-            .requirements(
-                List.of(
-                    new DeltaAssertTableUUID().uuid(UUID.randomUUID()).type("assert-table-uuid")))
-            .updates(
-                List.of(
-                    new DeltaSetProtocolUpdate().protocol(protocol).action("set-protocol"),
-                    new DeltaSetPropertiesUpdate()
-                        .updates(extraProperties)
-                        .action("set-properties"))));
+    return collectUpdatesRequest(
+        new DeltaSetProtocolUpdate().protocol(protocol).action("set-protocol"),
+        new DeltaSetPropertiesUpdate().updates(extraProperties).action("set-properties"));
   }
 
   private static TableInfoDAO managedDao() {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

updateTable advanced updatedAt on every request. updatedAt tracks metadata changes, so the etag (derived from it) must stay stable under data ingest, per the managed tables spec.

- Gate the updatedAt/updatedBy roll on the request carrying a metadata action; data-only add-commit and backfill-only requests no longer advance it.
- Exempt set-domain-metadata touching only the delta.rowTracking high-water mark: the Delta protocol makes writers mirror the HWM on every fresh-row commit, so it is data-stream bookkeeping, not a metadata change. The HWM property is still persisted; any other domain or sibling action still counts.
- Tests piggyback on existing blocks: metadata changes advance updated-time and etag; data-only, backfill-only, and HWM-only requests leave them (and the lastUpdateVersion stamp) unchanged; mixed requests still roll.
