### PR TITLE
[Refactor] Return deleted TableInfoDAO from TableRepository.deleteTable

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -877,7 +877,7 @@ public class TableRepository {
         /* readOnly = */ false);
   }
 
-  public TableInfoDAO deleteTable(Session session, UUID schemaId, String tableName) {
+  TableInfoDAO deleteTable(Session session, UUID schemaId, String tableName) {
     TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, tableName);
     if (tableInfoDAO == null) {
       throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableName);

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -849,29 +849,35 @@ public class TableRepository {
     return new ListTablesResponse().tables(result).nextPageToken(nextPageToken);
   }
 
-  public void deleteTable(String fullName) {
-    TransactionManager.executeWithTransaction(
+  /**
+   * Variant of {@link #deleteTable(String, String, String)} taking the table's three-part name as a
+   * single dotted string.
+   */
+  public TableInfoDAO deleteTable(String fullName) {
+    String[] parts = fullName.split("\\.");
+    if (parts.length != 3) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid table name: " + fullName);
+    }
+    return deleteTable(parts[0], parts[1], parts[2]);
+  }
+
+  /**
+   * Deletes a table and returns the deleted table's DAO. The DAO is detached; do not access its
+   * lazy fields.
+   */
+  public TableInfoDAO deleteTable(String catalog, String schema, String table) {
+    return TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
-          String[] parts = fullName.split("\\.");
-          if (parts.length != 3) {
-            throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid table name: " + fullName);
-          }
-          String catalogName = parts[0];
-          String schemaName = parts[1];
-          String tableName = parts[2];
           UUID schemaId =
-              repositories
-                  .getSchemaRepository()
-                  .getSchemaIdOrThrow(session, catalogName, schemaName);
-          deleteTable(session, schemaId, tableName);
-          return null;
+              repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
+          return deleteTable(session, schemaId, table);
         },
         "Failed to delete table",
         /* readOnly = */ false);
   }
 
-  public void deleteTable(Session session, UUID schemaId, String tableName) {
+  public TableInfoDAO deleteTable(Session session, UUID schemaId, String tableName) {
     TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, tableName);
     if (tableInfoDAO == null) {
       throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableName);
@@ -894,5 +900,6 @@ public class TableRepository {
     PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE)
         .forEach(session::remove);
     session.remove(tableInfoDAO);
+    return tableInfoDAO;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -22,6 +22,7 @@ import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
@@ -150,13 +151,8 @@ public class TableService extends AuthorizedService {
       """)
   public HttpResponse deleteTable(
       @Param("full_name") @AuthorizeResourceKey(TABLE) String fullName) {
-    TableInfo tableInfo = tableRepository.getTable(fullName);
-    tableRepository.deleteTable(fullName);
-
-    SchemaInfo schemaInfo =
-        schemaRepository.getSchema(tableInfo.getCatalogName() + "." + tableInfo.getSchemaName());
-    removeHierarchicalAuthorizations(tableInfo.getTableId(), schemaInfo.getSchemaId());
-
+    TableInfoDAO deleted = tableRepository.deleteTable(fullName);
+    removeHierarchicalAuthorizations(deleted.getId().toString(), deleted.getSchemaId().toString());
     return HttpResponse.of(HttpStatus.OK);
   }
 }


### PR DESCRIPTION
**Description of changes**

Refactors table deletion so `TableRepository.deleteTable(...)` returns the deleted `TableInfoDAO` instead of `void`. The DAO already carries the table and schema UUIDs, so the delete handler can remove the table's hierarchical authorizations from a **single** lookup — dropping the extra `getTable` + `getSchema` reads the UC delete handler previously made, and closing the time-of-check/time-of-use window between a separate lookup and the delete.

- `TableRepository`:
  - `void deleteTable(String fullName)` → `TableInfoDAO deleteTable(String fullName)` (thin wrapper that splits the dotted name, mirroring `getTable(String)`).
  - Adds `TableInfoDAO deleteTable(String catalog, String schema, String table)` for callers that already hold the three name parts separately.
  - The in-transaction `deleteTable(Session, UUID, String)` overload now returns the DAO and is package-private (only the schema cascade delete uses it).
- `TableService.deleteTable` now makes a single `deleteTable(fullName)` call and removes the hierarchical authorizations using the returned DAO.

No change to the UC REST `DELETE /tables/{full_name}` contract.

**Testing**

Pure refactor — covered by the existing suite. Verified locally: `server/Test/compile`, `javafmtCheckAll`, and Checkstyle (main + test) clean; targeted tests pass (`SdkTableCRUDTest`, `SdkTableAccessControlCRUDTest` — delete + auth removal end-to-end, `SdkMetricViewCRUDTest`, `SdkSchemaCRUDTest` — schema cascade delete); full `server/test`: 285/285.
