### PR TITLE
Add S3-compatible storage endpoint support

### DIFF
--- a/api/Models/TemporaryCredentials.md
+++ b/api/Models/TemporaryCredentials.md
@@ -6,6 +6,7 @@
 | **aws\_temp\_credentials** | [**AwsCredentials**](AwsCredentials.md) |  | [optional] [default to null] |
 | **azure\_user\_delegation\_sas** | [**AzureUserDelegationSAS**](AzureUserDelegationSAS.md) |  | [optional] [default to null] |
 | **gcp\_oauth\_token** | [**GcpOauthToken**](GcpOauthToken.md) |  | [optional] [default to null] |
+| **endpoint\_url** | **String** | Optional S3 compatible endpoint URL | [optional] [default to null] |
 | **expiration\_time** | **Long** | Server time when the credential will expire, in epoch milliseconds. The API client is advised to cache the credential given this expiration time.  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -2651,6 +2651,9 @@ components:
           $ref: '#/components/schemas/AzureUserDelegationSAS'
         gcp_oauth_token:
           $ref: '#/components/schemas/GcpOauthToken'
+        endpoint_url:
+          description: Optional S3 compatible endpoint URL
+          type: string
         expiration_time:
           description: |
             Server time when the credential will expire, in epoch milliseconds.

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -293,11 +293,17 @@ public class CredPropsUtil {
   private static Map<String, String> s3FixedCredProps(
       boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
-    return new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set("fs.s3a.access.key", awsCred.getAccessKeyId())
-        .set("fs.s3a.secret.key", awsCred.getSecretAccessKey())
-        .set("fs.s3a.session.token", awsCred.getSessionToken())
-        .build();
+    S3PropsBuilder builder =
+        new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
+            .set("fs.s3a.access.key", awsCred.getAccessKeyId())
+            .set("fs.s3a.secret.key", awsCred.getSecretAccessKey())
+            .set("fs.s3a.session.token", awsCred.getSessionToken());
+    if (tempCreds.getEndpointUrl() != null && !tempCreds.getEndpointUrl().isEmpty()) {
+      builder
+          .set("fs.s3a.endpoint", tempCreds.getEndpointUrl())
+          .set(UCHadoopConfConstants.S3A_INIT_ENDPOINT_URL, tempCreds.getEndpointUrl());
+    }
+    return builder.build();
   }
 
   private static S3PropsBuilder s3TempCredPropsBuilder(
@@ -322,6 +328,12 @@ public class CredPropsUtil {
       builder.set(
           UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME,
           String.valueOf(tempCreds.getExpirationTime()));
+    }
+
+    if (tempCreds.getEndpointUrl() != null && !tempCreds.getEndpointUrl().isEmpty()) {
+      builder
+          .set("fs.s3a.endpoint", tempCreds.getEndpointUrl())
+          .set(UCHadoopConfConstants.S3A_INIT_ENDPOINT_URL, tempCreds.getEndpointUrl());
     }
 
     return builder;

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -17,6 +17,7 @@ public class UCHadoopConfConstants {
   public static final String S3A_INIT_SESSION_TOKEN = "fs.s3a.init.session.token";
   // Expired time in milliseconds.
   public static final String S3A_INIT_CRED_EXPIRED_TIME = "fs.s3a.init.credential.expired.time";
+  public static final String S3A_INIT_ENDPOINT_URL = "fs.s3a.init.endpoint";
 
   // Keys for the initialized Azure Blob Storage token.
   public static final String AZURE_INIT_SAS_TOKEN = "fs.azure.init.sas.token";

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -1022,6 +1022,29 @@ class CredPropsUtilTest {
     return TokenProvider.create(Map.of("type", "static", "token", "tok"));
   }
 
+  @Test
+  void s3EndpointUrlAppliedFromTemporaryCredentials() {
+    TemporaryCredentials creds =
+        s3Creds().endpointUrl("http://localhost:9000").expirationTime(Long.MAX_VALUE);
+
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            false,
+            true,
+            new Configuration(false),
+            "s3",
+            "http://uc",
+            null,
+            "tid",
+            TableOperation.READ_WRITE,
+            creds,
+            Map.of());
+
+    assertThat(props.get("fs.s3a.endpoint")).isEqualTo("http://localhost:9000");
+    assertThat(props.get(UCHadoopConfConstants.S3A_INIT_ENDPOINT_URL))
+        .isEqualTo("http://localhost:9000");
+  }
+
   private static TemporaryCredentials s3Creds() {
     return new TemporaryCredentials()
         .awsTempCredentials(

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -47,6 +47,8 @@ aws.accessKey=
 aws.secretKey=
 # The region of AWS. If running on-premises, pick the nearest region.
 aws.region=
+# Optional custom S3-compatible STS endpoint (e.g. for MinIO)
+aws.endpointUrl=
 
 #### The following "s3.*" configs are legacy per-bucket hardcoded credential config
 
@@ -54,6 +56,8 @@ aws.region=
 s3.bucketPath.0=
 s3.region.0=
 s3.awsRoleArn.0=
+# Optional custom S3-compatible endpoint (e.g. for MinIO)
+s3.endpointUrl.0=
 # Optional (If blank, it will use DefaultCredentialsProviderChain)
 s3.accessKey.0=
 s3.secretKey.0=

--- a/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelUtils.java
@@ -168,6 +168,11 @@ public class DeltaKernelUtils {
       conf.set("fs.s3a.session.token", awsTempCredentials.getSessionToken());
       conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
       conf.set("fs.s3a.path.style.access", "true");
+
+      if (temporaryCredentials.getEndpointUrl() != null
+          && !temporaryCredentials.getEndpointUrl().isEmpty()) {
+        conf.set("fs.s3a.endpoint", temporaryCredentials.getEndpointUrl());
+      }
     } else if (scheme.equals(Constants.URI_SCHEME_FILE)) {
       conf.set("fs.file.impl", "org.apache.hadoop.fs.LocalFileSystem");
     } else {

--- a/server/src/main/java/io/unitycatalog/server/service/credential/CloudCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/CloudCredentialVendor.java
@@ -73,6 +73,7 @@ public class CloudCredentialVendor {
     if (awsSessionCredentials.expiration() != null) {
       temporaryCredentials.expirationTime(awsSessionCredentials.expiration().toEpochMilli());
     }
+    awsCredentialVendor.resolveS3EndpointUrl(context).ifPresent(temporaryCredentials::endpointUrl);
     return temporaryCredentials;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.service.credential.aws;
 import io.unitycatalog.server.model.AwsIamRoleResponse;
 import io.unitycatalog.server.persist.dao.CredentialDAO;
 import io.unitycatalog.server.service.credential.CredentialContext;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -85,7 +86,11 @@ public interface AwsCredentialGenerator {
         credentialsProvider = DefaultCredentialsProvider.create();
       }
 
-      this.stsClient = builder.region(region).credentialsProvider(credentialsProvider).build();
+      StsClientBuilder stsBuilder = builder.region(region).credentialsProvider(credentialsProvider);
+      if (config.getEndpointUrl() != null && !config.getEndpointUrl().isEmpty()) {
+        stsBuilder.endpointOverride(URI.create(config.getEndpointUrl()));
+      }
+      this.stsClient = stsBuilder.build();
       this.staticAwsRoleArn = config.getAwsRoleArn();
     }
 

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialVendor.java
@@ -8,6 +8,7 @@ import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import lombok.Getter;
@@ -141,5 +142,19 @@ public class AwsCredentialVendor {
               context.getStorageBase(), storageBase -> createPerBucketCredentialGenerator(config));
     }
     return generator.generate(context);
+  }
+
+  public Optional<String> resolveS3EndpointUrl(CredentialContext context) {
+    if (context.getStorageBase() != null) {
+      S3StorageConfig config = perBucketS3Configs.get(context.getStorageBase());
+      if (config != null && config.getEndpointUrl() != null && !config.getEndpointUrl().isEmpty()) {
+        return Optional.of(config.getEndpointUrl());
+      }
+    }
+    if (awsS3MasterRoleConfig.getEndpointUrl() != null
+        && !awsS3MasterRoleConfig.getEndpointUrl().isEmpty()) {
+      return Optional.of(awsS3MasterRoleConfig.getEndpointUrl());
+    }
+    return Optional.empty();
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/S3StorageConfig.java
@@ -14,5 +14,6 @@ public class S3StorageConfig {
   private final String accessKey;
   private final String secretKey;
   private final String sessionToken;
+  private final String endpointUrl;
   private final String credentialGenerator;
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
@@ -24,7 +24,9 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
@@ -86,20 +88,29 @@ public class FileIOFactory {
     S3StorageConfig s3StorageConfig = s3Configurations.get(location.getStorageBase());
 
     S3FileIO s3FileIO =
-        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location),
-            s3StorageConfig.getRegion()));
+        new S3FileIO(
+            () ->
+                getS3Client(
+                    getAwsCredentialsProvider(location),
+                    s3StorageConfig.getRegion(),
+                    s3StorageConfig.getEndpointUrl()));
 
     s3FileIO.initialize(Map.of());
 
     return s3FileIO;
   }
 
-  protected S3Client getS3Client(AwsCredentialsProvider awsCredentialsProvider, String region) {
-    return S3Client.builder()
-        .region(Region.of(region))
-        .credentialsProvider(awsCredentialsProvider)
-        .forcePathStyle(false)
-        .build();
+  protected S3Client getS3Client(
+      AwsCredentialsProvider awsCredentialsProvider, String region, String endpointUrl) {
+    S3ClientBuilder s3ClientBuilder =
+        S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(awsCredentialsProvider)
+            .forcePathStyle(false);
+    if (endpointUrl != null && !endpointUrl.isEmpty()) {
+      s3ClientBuilder.endpointOverride(URI.create(endpointUrl));
+    }
+    return s3ClientBuilder.build();
   }
 
   private AwsCredentialsProvider getAwsCredentialsProvider(NormalizedURL location) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -210,6 +210,8 @@ public class ServerProperties {
     AWS_SECRET_KEY("aws.secretKey"),
     AWS_SESSION_TOKEN("aws.sessionToken"),
     AWS_REGION("aws.region"),
+    AWS_ENDPOINT_URL("aws.endpointUrl"),
+    AWS_S3_ENDPOINT_URL("aws.s3.endpointUrl"),
     INCLUDE_STACK_TRACE_IN_ERROR("server.include-stacktrace-in-error", "false", BOOLEAN_VALIDATOR);
     // The is not an exhaustive list. Some property keys like s3.bucketPath.0 with a numbering
     // suffix is not included. They are only accessed internally from functions like
@@ -304,6 +306,7 @@ public class ServerProperties {
         .region(get(Property.AWS_REGION))
         .accessKey(get(Property.AWS_ACCESS_KEY))
         .secretKey(get(Property.AWS_SECRET_KEY))
+        .endpointUrl(get(Property.AWS_ENDPOINT_URL))
         // Does not take AWS_SESSION_TOKEN as it's only part of a temporary credential.
         .build();
   }
@@ -318,6 +321,7 @@ public class ServerProperties {
       String accessKey = getProperty("s3.accessKey." + i);
       String secretKey = getProperty("s3.secretKey." + i);
       String sessionToken = getProperty("s3.sessionToken." + i);
+      String endpointUrl = getProperty("s3.endpointUrl." + i);
       String credentialGenerator = getProperty("s3.credentialGenerator." + i);
       if ((bucketPath == null || region == null || awsRoleArn == null)
           && (accessKey == null || secretKey == null || sessionToken == null)) {
@@ -331,6 +335,7 @@ public class ServerProperties {
               .accessKey(accessKey)
               .secretKey(secretKey)
               .sessionToken(sessionToken)
+              .endpointUrl(endpointUrl)
               .credentialGenerator(credentialGenerator)
               .build();
       s3BucketConfigMap.put(NormalizedURL.from(bucketPath), s3StorageConfig);

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -114,6 +114,35 @@ public class CloudCredentialVendorTest {
   }
 
   @Test
+  public void testGenerateS3TemporaryCredentialsIncludeEndpointUrl() {
+    final String ACCESS_KEY = "accessKey";
+    final String SECRET_KEY = "secretKey";
+    final String SESSION_TOKEN = "sessionToken";
+    final String ENDPOINT_URL = "http://localhost:9000";
+    when(serverProperties.getS3Configurations())
+        .thenReturn(
+            Map.of(
+                NormalizedURL.from("s3://storageBase"),
+                S3StorageConfig.builder()
+                    .accessKey(ACCESS_KEY)
+                    .secretKey(SECRET_KEY)
+                    .sessionToken(SESSION_TOKEN)
+                    .endpointUrl(ENDPOINT_URL)
+                    .build()));
+    AwsCredentialVendor awsCredentialVendor = new AwsCredentialVendor(serverProperties);
+    credentialsOperations = new CloudCredentialVendor(awsCredentialVendor, null, null);
+    TemporaryCredentials s3TemporaryCredentials =
+        vendCredential("s3://storageBase/abc", Set.of(CredentialContext.Privilege.SELECT));
+    assertThat(s3TemporaryCredentials.getAwsTempCredentials())
+        .isEqualTo(
+            new AwsCredentials()
+                .accessKeyId(ACCESS_KEY)
+                .secretAccessKey(SECRET_KEY)
+                .sessionToken(SESSION_TOKEN));
+    assertThat(s3TemporaryCredentials.getEndpointUrl()).isEqualTo(ENDPOINT_URL);
+  }
+
+  @Test
   public void testGenerateAzureTemporaryCredentials() {
     final String CLIENT_ID = "clientId";
     final String CLIENT_SECRET = "clientSecret";


### PR DESCRIPTION
## Summary
- Add `endpoint_url` to `TemporaryCredentials` and propagate it from server config (`s3.endpointUrl.*`, `aws.endpointUrl`) through credential vending.
- Apply endpoint settings in the Hadoop connector (`fs.s3a.endpoint`, `fs.s3a.init.endpoint`), Iceberg `FileIOFactory`, and Delta CLI.
- Add unit tests for server and Hadoop credential plumbing.

## Test plan
- [x] `hadoop/testOnly -- *s3EndpointUrlAppliedFromTemporaryCredentials*`
- [x] `server/testOnly -- *testGenerateS3TemporaryCredentialsIncludeEndpointUrl*`


Made with [Cursor](https://cursor.com)