### PR TITLE
Support Iceberg REST loading UC SQL views

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1677,6 +1677,7 @@ components:
       enum:
         - MANAGED
         - EXTERNAL
+        - VIEW
         - STREAMING_TABLE # Not yet fully implemented
         - MATERIALIZED_VIEW # Not yet fully implemented
         - METRIC_VIEW

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val deltaVersion = sys.props.getOrElse("deltaVersion", "4.2.0")
 // queryable in SBT via `show spark/sparkVersion`.
 lazy val sparkVersion = CrossSparkVersions.getSparkArtifactVersion()
 lazy val sparkMajorMinorVersion = CrossSparkVersions.getSparkVersionSpec().shortVersion
+lazy val icebergSparkRuntimeVersion = "1.11.0"
 
 // delta-spark is only needed for tests. When UC is published to local Maven before
 // Delta is built (e.g. CI pre-Delta publishM2 step), the matching Delta artifact may
@@ -34,6 +35,17 @@ lazy val sparkMajorMinorVersion = CrossSparkVersions.getSparkVersionSpec().short
 def deltaSparkTestDeps: Seq[ModuleID] =
   if (sys.props.getOrElse("skipDeltaSpark", "false").toBoolean) Seq.empty
   else Seq("io.delta" %% s"delta-spark_$sparkMajorMinorVersion" % deltaVersion % Test)
+
+def icebergSparkRuntimeTestDeps: Seq[ModuleID] =
+  sparkMajorMinorVersion match {
+    case "4.0" | "4.1" =>
+      Seq(
+        "org.apache.iceberg" %
+          s"iceberg-spark-runtime-${sparkMajorMinorVersion}_2.13" %
+          icebergSparkRuntimeVersion %
+          Test)
+    case _ => Seq.empty
+  }
 
 // Apache Snapshots resolver is in build/sbt-config/repositories (global).
 // No per-module sparkResolvers needed.
@@ -667,7 +679,7 @@ lazy val spark = (project in file("connectors/spark"))
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % Test,
       "org.projectlombok" % "lombok" % "1.18.32" % Test,
       "com.google.cloud.bigdataoss" % "gcs-connector" % "3.0.2" % Test classifier "shaded",
-    ) ++ deltaSparkTestDeps,
+    ) ++ deltaSparkTestDeps ++ icebergSparkRuntimeTestDeps,
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.0",

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/IcebergRestCatalogViewE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/IcebergRestCatalogViewE2ETest.java
@@ -1,0 +1,105 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.TableType;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+public class IcebergRestCatalogViewE2ETest extends BaseSparkIntegrationTest {
+
+  private static final String ICEBERG_REST_CATALOG = "iceberg_rest";
+
+  @Test
+  @EnabledIf("hasIcebergSparkRuntime")
+  public void testSparkReadsUcSqlViewThroughIcebergRestCatalog() throws ApiException {
+    String viewName = "constant_view";
+    createSqlView(viewName);
+    session = createIcebergRestSparkSession();
+
+    List<Row> rows =
+        session
+            .sql(
+                String.format(
+                    "SELECT as_int, as_string FROM %s.%s.%s",
+                    ICEBERG_REST_CATALOG, SCHEMA_NAME, viewName))
+            .collectAsList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(42);
+    assertThat(rows.get(0).getString(1)).isEqualTo("ready");
+  }
+
+  private void createSqlView(String viewName) throws ApiException {
+    TablesApi tablesApi = new TablesApi(createApiClient(serverConfig));
+    ColumnInfo intColumn =
+        new ColumnInfo()
+            .name("as_int")
+            .typeText("INTEGER")
+            .typeJson(
+                "{\"name\":\"as_int\",\"type\":\"integer\"," + "\"nullable\":true,\"metadata\":{}}")
+            .typeName(ColumnTypeName.INT)
+            .position(0)
+            .nullable(true);
+    ColumnInfo stringColumn =
+        new ColumnInfo()
+            .name("as_string")
+            .typeText("STRING")
+            .typeJson(
+                "{\"name\":\"as_string\",\"type\":\"string\","
+                    + "\"nullable\":true,\"metadata\":{}}")
+            .typeName(ColumnTypeName.STRING)
+            .position(1)
+            .nullable(true);
+    tablesApi.createTable(
+        new CreateTable()
+            .name(viewName)
+            .catalogName(CATALOG_NAME)
+            .schemaName(SCHEMA_NAME)
+            .columns(List.of(intColumn, stringColumn))
+            .tableType(TableType.fromValue("VIEW"))
+            .viewDefinition("SELECT 42 AS as_int, 'ready' AS as_string"));
+  }
+
+  private SparkSession createIcebergRestSparkSession() {
+    String catalogConf = "spark.sql.catalog." + ICEBERG_REST_CATALOG;
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("iceberg-rest-view-e2e")
+            .master("local[*]")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config(
+                "spark.sql.extensions",
+                "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+            .config(catalogConf, "org.apache.iceberg.spark.SparkCatalog")
+            .config(catalogConf + ".type", "rest")
+            .config(
+                catalogConf + ".uri",
+                serverConfig.getServerUrl() + "/api/2.1/unity-catalog/iceberg")
+            .config(catalogConf + ".warehouse", CATALOG_NAME);
+    if (serverConfig.getAuthToken() != null && !serverConfig.getAuthToken().isEmpty()) {
+      builder.config(catalogConf + ".token", serverConfig.getAuthToken());
+    }
+    return builder.getOrCreate();
+  }
+
+  private boolean hasIcebergSparkRuntime() {
+    try {
+      Class.forName("org.apache.iceberg.spark.SparkCatalog");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -292,7 +292,7 @@ public class UnityCatalogServer {
     armeriaServerBuilder.annotatedService(
         BASE_PATH + "iceberg",
         new IcebergRestCatalogService(
-            schemaService, tableConfigService, metadataService, repositories),
+            schemaService, tableConfigService, metadataService, repositories, serverProperties),
         icebergRequestConverter,
         icebergResponseConverter);
   }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -649,8 +649,8 @@ public class TableRepository {
           }
           TableType tableType = Objects.requireNonNull(createTable.getTableType());
           // `tableUUID` is the table's primary key. The shape is uniform across the three
-          // creatable branches (external, managed, metric view); the only divergence is the
-          // source of the UUID (random for external/metric-view, staging-table id for managed).
+          // creatable branches (external, managed, view-like rows); the only divergence is the
+          // source of the UUID (random for external/views, staging-table id for managed).
           // The string form is generated exactly once below at `tableInfo.tableId(...)`.
           UUID tableUUID;
           NormalizedURL storageLocation;
@@ -682,6 +682,10 @@ public class TableRepository {
           } else if (tableType == TableType.METRIC_VIEW) {
             storageLocation = null;
             validateMetricView(createTable);
+            tableUUID = UUID.randomUUID();
+          } else if (tableType == TableType.VIEW) {
+            storageLocation = null;
+            validateSqlView(createTable, columnInfos);
             tableUUID = UUID.randomUUID();
           } else if (tableType == TableType.STREAMING_TABLE) {
             throw new BaseException(
@@ -764,6 +768,19 @@ public class TableRepository {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
           "view_dependencies must contain at least one entry for metric view");
+    }
+  }
+
+  private static void validateSqlView(CreateTable createTable, List<ColumnInfo> columnInfos) {
+    if (createTable.getViewDefinition() == null || createTable.getViewDefinition().isEmpty()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "view_definition is required for view");
+    }
+    if (columnInfos == null || columnInfos.isEmpty()) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "columns are required for view");
+    }
+    if (createTable.getStorageLocation() != null && !createTable.getStorageLocation().isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "storage_location must not be provided for view");
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -13,15 +13,22 @@ import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
+import io.unitycatalog.server.service.iceberg.ViewMetadataService;
 import io.unitycatalog.server.utils.JsonUtils;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,19 +68,31 @@ public class IcebergRestCatalogService {
   private final SchemaService schemaService;
   private final TableConfigService tableConfigService;
   private final MetadataService metadataService;
+  private final ViewMetadataService viewMetadataService;
   private final TableRepository tableRepository;
   private final SessionFactory sessionFactory;
+  private final String viewStorageRoot;
 
   public IcebergRestCatalogService(
       SchemaService schemaService,
       TableConfigService tableConfigService,
       MetadataService metadataService,
-      Repositories repositories) {
+      Repositories repositories,
+      ServerProperties serverProperties) {
     this.schemaService = schemaService;
     this.tableConfigService = tableConfigService;
     this.metadataService = metadataService;
+    this.viewMetadataService = new ViewMetadataService();
     this.tableRepository = repositories.getTableRepository();
     this.sessionFactory = repositories.getSessionFactory();
+    this.viewStorageRoot =
+        Optional.ofNullable(serverProperties.get(ServerProperties.Property.TABLE_STORAGE_ROOT))
+            .map(NormalizedURL::from)
+            .map(NormalizedURL::toString)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        "storage-root.tables must be configured to load Iceberg views"));
   }
 
   // Config APIs
@@ -196,12 +215,30 @@ public class IcebergRestCatalogService {
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public LoadViewResponse loadView(
-      @Param("namespace") String namespace, @Param("view") String view) {
-    // this is not supported yet, but Iceberg REST client tries to load
-    // a table with given path name and then tries to load a view with that
-    // name if it didn't find a table, so for now, let's just return a 404
-    // as that should be expected since it didn't find a table with the name
-    throw new NoSuchViewException("View does not exist: %s", namespace + "." + view);
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("view") String view) {
+    TableInfo tableInfo = getTableForViewEndpoint(catalog, namespace, view);
+    if (tableInfo.getTableType() != TableType.VIEW) {
+      throw noSuchView(namespace, view);
+    }
+
+    return viewMetadataService.loadView(tableInfo, viewStorageRoot, metadataService);
+  }
+
+  private TableInfo getTableForViewEndpoint(String catalog, String namespace, String view) {
+    try {
+      return tableRepository.getTable(catalog + "." + namespace + "." + view);
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND) {
+        throw noSuchView(namespace, view);
+      }
+      throw e;
+    }
+  }
+
+  private static NoSuchViewException noSuchView(String namespace, String view) {
+    return new NoSuchViewException("View does not exist: %s", namespace + "." + view);
   }
 
   @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}/metrics")

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/FileIOFactory.java
@@ -32,10 +32,6 @@ public class FileIOFactory {
 
   private final StorageCredentialVendor storageCredentialVendor;
   private final Map<NormalizedURL, S3StorageConfig> s3Configurations;
-  // FIXME!! privileges are defaulted to READ only here for now as Iceberg REST impl doesn't
-  //  support write
-  private final Set<CredentialContext.Privilege> privileges =
-      Set.of(CredentialContext.Privilege.SELECT);
 
   public FileIOFactory(
       StorageCredentialVendor storageCredentialVendor, ServerProperties serverProperties) {
@@ -45,15 +41,20 @@ public class FileIOFactory {
 
   // TODO: Cache fileIOs
   public FileIO getFileIO(NormalizedURL location) {
+    return getFileIO(location, Set.of(CredentialContext.Privilege.SELECT));
+  }
+
+  public FileIO getFileIO(NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     return switch (UriScheme.fromURI(location.toUri())) {
-      case ABFS, ABFSS -> getADLSFileIO(location);
-      case GS -> getGCSFileIO(location);
-      case S3 -> getS3FileIO(location);
+      case ABFS, ABFSS -> getADLSFileIO(location, privileges);
+      case GS -> getGCSFileIO(location, privileges);
+      case S3 -> getS3FileIO(location, privileges);
       case FILE, NULL -> new SimpleLocalFileIO();
     };
   }
 
-  protected ADLSFileIO getADLSFileIO(NormalizedURL location) {
+  protected ADLSFileIO getADLSFileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     AzureUserDelegationSAS credential =
         storageCredentialVendor.vendCredential(location, privileges).getAzureUserDelegationSas();
     ADLSLocationUtils.ADLSLocationParts locationParts = ADLSLocationUtils.parseLocation(location);
@@ -69,7 +70,8 @@ public class FileIOFactory {
   }
 
   @SneakyThrows
-  protected GCSFileIO getGCSFileIO(NormalizedURL location) {
+  protected GCSFileIO getGCSFileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     GcpOauthToken gcpToken =
         storageCredentialVendor.vendCredential(location, privileges).getGcpOauthToken();
 
@@ -82,12 +84,15 @@ public class FileIOFactory {
     return result;
   }
 
-  protected S3FileIO getS3FileIO(NormalizedURL location) {
+  protected S3FileIO getS3FileIO(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     S3StorageConfig s3StorageConfig = s3Configurations.get(location.getStorageBase());
 
     S3FileIO s3FileIO =
-        new S3FileIO(() -> getS3Client(getAwsCredentialsProvider(location),
-            s3StorageConfig.getRegion()));
+        new S3FileIO(
+            () ->
+                getS3Client(
+                    getAwsCredentialsProvider(location, privileges), s3StorageConfig.getRegion()));
 
     s3FileIO.initialize(Map.of());
 
@@ -102,7 +107,8 @@ public class FileIOFactory {
         .build();
   }
 
-  private AwsCredentialsProvider getAwsCredentialsProvider(NormalizedURL location) {
+  private AwsCredentialsProvider getAwsCredentialsProvider(
+      NormalizedURL location, Set<CredentialContext.Privilege> privileges) {
     try {
       AwsCredentials awsSessionCredentials =
           storageCredentialVendor.vendCredential(location, privileges).getAwsTempCredentials();

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -1,10 +1,14 @@
 package io.unitycatalog.server.service.iceberg;
 
+import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewMetadataParser;
 
 public class MetadataService {
 
@@ -20,5 +24,20 @@ public class MetadataService {
 
     return CompletableFuture.supplyAsync(() -> TableMetadataParser.read(fileIO, metadataLocation))
         .join();
+  }
+
+  public ViewMetadata readViewMetadata(String metadataLocation) {
+    FileIO fileIO = fileIOFactory.getFileIO(NormalizedURL.from(metadataLocation));
+    return CompletableFuture.supplyAsync(
+            () -> ViewMetadataParser.read(fileIO.newInputFile(metadataLocation)))
+        .join();
+  }
+
+  public void writeViewMetadata(ViewMetadata viewMetadata, String metadataLocation) {
+    FileIO fileIO =
+        fileIOFactory.getFileIO(
+            NormalizedURL.from(metadataLocation),
+            Set.of(CredentialContext.Privilege.SELECT, CredentialContext.Privilege.UPDATE));
+    ViewMetadataParser.overwrite(viewMetadata, fileIO.newOutputFile(metadataLocation));
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/SimpleLocalFileIO.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/SimpleLocalFileIO.java
@@ -1,5 +1,8 @@
 package io.unitycatalog.server.service.iceberg;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -8,16 +11,33 @@ import org.apache.iceberg.io.OutputFile;
 public class SimpleLocalFileIO implements FileIO {
   @Override
   public InputFile newInputFile(String path) {
-    return Files.localInput(path);
+    return Files.localInput(localPath(path));
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    throw new UnsupportedOperationException();
+    try {
+      Path localPath = Path.of(localPath(path));
+      java.nio.file.Files.createDirectories(localPath.getParent());
+      return Files.localOutput(localPath.toString());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create local output file: " + path, e);
+    }
   }
 
   @Override
   public void deleteFile(String path) {
-    throw new UnsupportedOperationException();
+    try {
+      java.nio.file.Files.deleteIfExists(Path.of(localPath(path)));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to delete local file: " + path, e);
+    }
+  }
+
+  private static String localPath(String path) {
+    if (path.startsWith("file:")) {
+      return Path.of(URI.create(path)).toString();
+    }
+    return path;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/ViewMetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/ViewMetadataService.java
@@ -1,0 +1,258 @@
+package io.unitycatalog.server.service.iceberg;
+
+import io.unitycatalog.server.delta.model.DeltaArrayType;
+import io.unitycatalog.server.delta.model.DeltaDataType;
+import io.unitycatalog.server.delta.model.DeltaDecimalType;
+import io.unitycatalog.server.delta.model.DeltaMapType;
+import io.unitycatalog.server.delta.model.DeltaPrimitiveType;
+import io.unitycatalog.server.delta.model.DeltaStructField;
+import io.unitycatalog.server.delta.model.DeltaStructFieldMetadata;
+import io.unitycatalog.server.delta.model.DeltaStructType;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.utils.ColumnUtils;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewVersion;
+
+public class ViewMetadataService {
+
+  private static final String COMMENT_PROPERTY = "comment";
+  private static final String SQL_DIALECT = "spark";
+  private static final int INITIAL_VERSION_ID = 1;
+
+  public LoadViewResponse loadView(
+      TableInfo tableInfo, String viewStorageRoot, MetadataService metadataService) {
+    validateViewInfo(tableInfo);
+
+    long timestampMillis = updatedAtMillis(tableInfo);
+    String viewLocation = viewLocation(viewStorageRoot, tableInfo);
+    String metadataLocation = metadataLocation(viewLocation, timestampMillis);
+    Schema schema = toIcebergSchema(tableInfo.getColumns());
+    ViewVersion version =
+        ImmutableViewVersion.builder()
+            .versionId(INITIAL_VERSION_ID)
+            .timestampMillis(timestampMillis)
+            .schemaId(schema.schemaId())
+            .summary(Map.of())
+            .addRepresentations(
+                ImmutableSQLViewRepresentation.builder()
+                    .sql(tableInfo.getViewDefinition())
+                    .dialect(SQL_DIALECT)
+                    .build())
+            .defaultCatalog(tableInfo.getCatalogName())
+            .defaultNamespace(Namespace.of(tableInfo.getSchemaName()))
+            .build();
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .assignUUID(tableInfo.getTableId())
+            .setLocation(viewLocation)
+            .setProperties(viewProperties(tableInfo))
+            .setCurrentVersion(version, schema)
+            .build();
+
+    metadataService.writeViewMetadata(metadata, metadataLocation);
+
+    return ImmutableLoadViewResponse.builder()
+        .metadataLocation(metadataLocation)
+        .metadata(metadataService.readViewMetadata(metadataLocation))
+        .config(Map.of())
+        .build();
+  }
+
+  private static void validateViewInfo(TableInfo tableInfo) {
+    if (tableInfo.getTableId() == null || tableInfo.getTableId().isEmpty()) {
+      throw new BadRequestException("View table_id is required");
+    }
+    if (tableInfo.getViewDefinition() == null || tableInfo.getViewDefinition().isEmpty()) {
+      throw new BadRequestException("View view_definition is required");
+    }
+    if (tableInfo.getColumns() == null || tableInfo.getColumns().isEmpty()) {
+      throw new BadRequestException("View columns are required");
+    }
+    if (tableInfo.getCatalogName() == null || tableInfo.getCatalogName().isEmpty()) {
+      throw new BadRequestException("View catalog_name is required");
+    }
+    if (tableInfo.getSchemaName() == null || tableInfo.getSchemaName().isEmpty()) {
+      throw new BadRequestException("View schema_name is required");
+    }
+  }
+
+  private static String viewLocation(String viewStorageRoot, TableInfo tableInfo) {
+    return String.join("/", viewStorageRoot, "views", tableInfo.getTableId());
+  }
+
+  private static String metadataLocation(String viewLocation, long timestampMillis) {
+    return viewLocation + "/metadata/" + timestampMillis + ".metadata.json";
+  }
+
+  private static long updatedAtMillis(TableInfo tableInfo) {
+    if (tableInfo.getUpdatedAt() != null) {
+      return tableInfo.getUpdatedAt();
+    }
+    if (tableInfo.getCreatedAt() != null) {
+      return tableInfo.getCreatedAt();
+    }
+    return System.currentTimeMillis();
+  }
+
+  private static Map<String, String> viewProperties(TableInfo tableInfo) {
+    Map<String, String> properties = new LinkedHashMap<>();
+    if (tableInfo.getProperties() != null) {
+      properties.putAll(tableInfo.getProperties());
+    }
+    if (tableInfo.getComment() != null && !tableInfo.getComment().isEmpty()) {
+      properties.put(COMMENT_PROPERTY, tableInfo.getComment());
+    }
+    return properties;
+  }
+
+  private static Schema toIcebergSchema(List<ColumnInfo> columns) {
+    FieldIdAllocator fieldIds = new FieldIdAllocator();
+    List<Types.NestedField> fields =
+        columns.stream()
+            .sorted(
+                Comparator.comparing(
+                    column ->
+                        column.getPosition() == null ? Integer.MAX_VALUE : column.getPosition()))
+            .map(column -> toIcebergField(column, fieldIds))
+            .toList();
+    return new Schema(fields);
+  }
+
+  private static Types.NestedField toIcebergField(
+      ColumnInfo column, FieldIdAllocator fieldIds) {
+    DeltaStructField field;
+    try {
+      field = ColumnUtils.toStructField(column);
+    } catch (IllegalStateException e) {
+      throw new BadRequestException(e, "Invalid type_json for view column %s", column.getName());
+    }
+
+    String name = field.getName() != null ? field.getName() : column.getName();
+    int fieldId = fieldIds.next();
+    Type type = toIcebergType(field.getType(), fieldIds);
+    String comment = column.getComment() != null ? column.getComment() : commentFrom(field);
+    boolean isOptional = field.getNullable() == null || field.getNullable();
+    return nestedField(fieldId, isOptional, name, type, comment);
+  }
+
+  private static Type toIcebergType(DeltaDataType deltaType, FieldIdAllocator fieldIds) {
+    if (deltaType == null) {
+      throw new BadRequestException("Unsupported view column type: null");
+    }
+    if (deltaType instanceof DeltaPrimitiveType primitive) {
+      return toIcebergPrimitiveType(primitive);
+    } else if (deltaType instanceof DeltaDecimalType decimal) {
+      if (decimal.getPrecision() == null || decimal.getScale() == null) {
+        throw new BadRequestException("Invalid decimal view column type: %s", decimal);
+      }
+      return Types.DecimalType.of(decimal.getPrecision(), decimal.getScale());
+    } else if (deltaType instanceof DeltaStructType struct) {
+      return toIcebergStructType(struct, fieldIds);
+    } else if (deltaType instanceof DeltaArrayType array) {
+      return toIcebergListType(array, fieldIds);
+    } else if (deltaType instanceof DeltaMapType map) {
+      return toIcebergMapType(map, fieldIds);
+    }
+    throw new BadRequestException("Unsupported view column type: %s", deltaType.getType());
+  }
+
+  private static Type toIcebergPrimitiveType(DeltaPrimitiveType primitive) {
+    String primitiveType = primitive.getType();
+    if (primitiveType == null) {
+      throw new BadRequestException("Unsupported view column type: null");
+    }
+    return switch (primitiveType) {
+      case "boolean" -> Types.BooleanType.get();
+      case "byte", "short", "integer" -> Types.IntegerType.get();
+      case "long" -> Types.LongType.get();
+      case "float" -> Types.FloatType.get();
+      case "double" -> Types.DoubleType.get();
+      case "date" -> Types.DateType.get();
+      case "timestamp" -> Types.TimestampType.withZone();
+      case "timestamp_ntz" -> Types.TimestampType.withoutZone();
+      case "string" -> Types.StringType.get();
+      case "binary" -> Types.BinaryType.get();
+      default -> throw new BadRequestException("Unsupported view column type: %s", primitiveType);
+    };
+  }
+
+  private static Type toIcebergStructType(DeltaStructType struct, FieldIdAllocator fieldIds) {
+    List<Types.NestedField> fields = new ArrayList<>();
+    if (struct.getFields() != null) {
+      for (DeltaStructField field : struct.getFields()) {
+        fields.add(toIcebergNestedField(field, fieldIds));
+      }
+    }
+    return Types.StructType.of(fields);
+  }
+
+  private static Types.NestedField toIcebergNestedField(
+      DeltaStructField field, FieldIdAllocator fieldIds) {
+    int fieldId = fieldIds.next();
+    Type type = toIcebergType(field.getType(), fieldIds);
+    boolean isOptional = field.getNullable() == null || field.getNullable();
+    return nestedField(fieldId, isOptional, field.getName(), type, commentFrom(field));
+  }
+
+  private static Types.NestedField nestedField(
+      int id, boolean isOptional, String name, Type type, String comment) {
+    Types.NestedField.Builder builder =
+        Types.NestedField.builder().withId(id).isOptional(isOptional).withName(name).ofType(type);
+    if (comment != null) {
+      builder.withDoc(comment);
+    }
+    return builder.build();
+  }
+
+  private static Type toIcebergListType(DeltaArrayType array, FieldIdAllocator fieldIds) {
+    int elementId = fieldIds.next();
+    Type elementType = toIcebergType(array.getElementType(), fieldIds);
+    if (Boolean.FALSE.equals(array.getContainsNull())) {
+      return Types.ListType.ofRequired(elementId, elementType);
+    }
+    return Types.ListType.ofOptional(elementId, elementType);
+  }
+
+  private static Type toIcebergMapType(DeltaMapType map, FieldIdAllocator fieldIds) {
+    int keyId = fieldIds.next();
+    int valueId = fieldIds.next();
+    Type keyType = toIcebergType(map.getKeyType(), fieldIds);
+    Type valueType = toIcebergType(map.getValueType(), fieldIds);
+    if (Boolean.FALSE.equals(map.getValueContainsNull())) {
+      return Types.MapType.ofRequired(keyId, valueId, keyType, valueType);
+    }
+    return Types.MapType.ofOptional(keyId, valueId, keyType, valueType);
+  }
+
+  private static String commentFrom(DeltaStructField field) {
+    DeltaStructFieldMetadata metadata = field.getMetadata();
+    if (metadata == null) {
+      return null;
+    }
+    Object comment = metadata.get(COMMENT_PROPERTY);
+    return comment instanceof String ? (String) comment : null;
+  }
+
+  private static class FieldIdAllocator {
+    private int nextId = 1;
+
+    int next() {
+      return nextId++;
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -126,6 +126,101 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
         "{\"name\":\"bad_column\",\"type\":\"integer\",\"nullable\":true}");
   }
 
+  @Test
+  public void testCreateSqlView() throws Exception {
+    String viewName = "test_sql_view";
+    String viewFullName = TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + viewName;
+    String viewDefinition = "SELECT test_column FROM source_table";
+    CreateTable createViewRequest =
+        new CreateTable()
+            .name(viewName)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(columns)
+            .tableType(TableType.fromValue("VIEW"))
+            .viewDefinition(viewDefinition)
+            .comment("SQL view");
+
+    TableInfo viewInfo = localTablesApi.createTable(createViewRequest);
+
+    assertThat(viewInfo.getName()).isEqualTo(viewName);
+    assertThat(viewInfo.getTableType()).isEqualTo(TableType.fromValue("VIEW"));
+    assertThat(viewInfo.getViewDefinition()).isEqualTo(viewDefinition);
+    assertThat(viewInfo.getStorageLocation()).isNull();
+    assertThat(viewInfo.getTableId()).isNotNull();
+
+    TableInfo fetched = tableOperations.getTable(viewFullName);
+    assertThat(fetched.getTableType()).isEqualTo(TableType.fromValue("VIEW"));
+    assertThat(fetched.getViewDefinition()).isEqualTo(viewDefinition);
+
+    tableOperations.deleteTable(viewFullName);
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> tableOperations.getTable(viewFullName))
+        .satisfies(
+            ex ->
+                assertThat(ex.getCode())
+                    .isEqualTo(ErrorCode.TABLE_NOT_FOUND.getHttpStatus().code()));
+  }
+
+  @Test
+  public void testCreateSqlViewRequiresViewDefinition() throws Exception {
+    CreateTable createViewRequest =
+        new CreateTable()
+            .name("test_sql_view_missing_definition")
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(columns)
+            .tableType(TableType.fromValue("VIEW"));
+
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> localTablesApi.createTable(createViewRequest))
+        .satisfies(
+            ex ->
+                assertThat(ex.getCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
+        .withMessageContaining("view_definition is required for view");
+  }
+
+  @Test
+  public void testCreateSqlViewRequiresColumns() throws Exception {
+    CreateTable createViewRequest =
+        new CreateTable()
+            .name("test_sql_view_missing_columns")
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .tableType(TableType.fromValue("VIEW"))
+            .viewDefinition("SELECT test_column FROM source_table");
+
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> localTablesApi.createTable(createViewRequest))
+        .satisfies(
+            ex ->
+                assertThat(ex.getCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
+        .withMessageContaining("columns are required for view");
+  }
+
+  @Test
+  public void testCreateSqlViewRejectsStorageLocation() throws Exception {
+    CreateTable createViewRequest =
+        new CreateTable()
+            .name("test_sql_view_with_storage")
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(columns)
+            .tableType(TableType.fromValue("VIEW"))
+            .viewDefinition("SELECT test_column FROM source_table")
+            .storageLocation("/tmp/view");
+
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> localTablesApi.createTable(createViewRequest))
+        .satisfies(
+            ex ->
+                assertThat(ex.getCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
+        .withMessageContaining("storage_location must not be provided for view");
+  }
+
   private void assertCreateTableWithInvalidTypeJson(String tableName, String typeJson)
       throws Exception {
     CreateTable createTableRequest =

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -25,10 +25,12 @@ import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import io.unitycatalog.server.service.iceberg.SimpleLocalFileIO;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,12 +38,18 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewMetadataParser;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.junit.jupiter.api.BeforeEach;
@@ -329,5 +337,177 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
+  }
+
+  @Test
+  public void testLoadViewReturnsIcebergMetadata() throws ApiException, IOException {
+    String viewName = "event_agg";
+    String viewSql = "SELECT as_int, as_string FROM source_events";
+    CreateCatalog createCatalog =
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
+    catalogOperations.createCatalog(createCatalog);
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+    ColumnInfo columnInfo1 =
+        new ColumnInfo()
+            .name("as_int")
+            .typeText("INTEGER")
+            .typeJson(
+                "{\"name\":\"as_int\",\"type\":\"integer\","
+                    + "\"nullable\":true,\"metadata\":{\"comment\":\"Integer column\"}}")
+            .typeName(ColumnTypeName.INT)
+            .position(0)
+            .comment("Integer column")
+            .nullable(true);
+    ColumnInfo columnInfo2 =
+        new ColumnInfo()
+            .name("as_string")
+            .typeText("STRING")
+            .typeJson(
+                "{\"name\":\"as_string\",\"type\":\"string\","
+                    + "\"nullable\":true,\"metadata\":{}}")
+            .typeName(ColumnTypeName.STRING)
+            .position(1)
+            .nullable(true);
+    ColumnInfo columnInfo3 =
+        new ColumnInfo()
+            .name("as_struct")
+            .typeText("STRUCT<nested_int: INT>")
+            .typeJson(
+                "{\"name\":\"as_struct\","
+                    + "\"type\":{\"type\":\"struct\","
+                    + "\"fields\":[{\"name\":\"nested_int\",\"type\":\"integer\","
+                    + "\"nullable\":false,\"metadata\":{}}]},"
+                    + "\"nullable\":true,\"metadata\":{}}")
+            .typeName(ColumnTypeName.STRUCT)
+            .position(2)
+            .nullable(true);
+    TableInfo viewInfo =
+        tableOperations.createTable(
+            new CreateTable()
+                .name(viewName)
+                .catalogName(TestUtils.CATALOG_NAME)
+                .schemaName(TestUtils.SCHEMA_NAME)
+                .columns(List.of(columnInfo1, columnInfo2, columnInfo3))
+                .tableType(TableType.fromValue("VIEW"))
+                .viewDefinition(viewSql)
+                .comment("Daily event counts")
+                .properties(Map.of("team", "analytics")));
+
+    AggregatedHttpResponse resp =
+        client
+            .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/views/" + viewName)
+            .aggregate()
+            .join();
+
+    assertThat(resp.status().code()).as(resp.contentUtf8()).isEqualTo(200);
+    LoadViewResponse loadViewResponse =
+        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadViewResponse.class);
+    assertThat(loadViewResponse.metadataLocation())
+        .startsWith(tableStorageRoot + "/views/" + viewInfo.getTableId() + "/metadata/");
+    ViewMetadata persistedMetadata =
+        ViewMetadataParser.read(
+            new SimpleLocalFileIO().newInputFile(loadViewResponse.metadataLocation()));
+    assertThat(persistedMetadata.uuid()).isEqualTo(viewInfo.getTableId());
+    assertThat(loadViewResponse.metadata().uuid()).isEqualTo(viewInfo.getTableId());
+    assertThat(loadViewResponse.metadata().formatVersion()).isEqualTo(1);
+    assertThat(loadViewResponse.metadata().location())
+        .isEqualTo(tableStorageRoot + "/views/" + viewInfo.getTableId());
+    assertThat(loadViewResponse.metadata().currentVersionId()).isEqualTo(1);
+    assertThat(loadViewResponse.metadata().history()).hasSize(1);
+    assertThat(loadViewResponse.metadata().properties())
+        .containsEntry("comment", "Daily event counts")
+        .containsEntry("team", "analytics");
+    assertThat(loadViewResponse.metadata().schema().schemaId()).isEqualTo(0);
+    assertThat(loadViewResponse.metadata().schema().columns()).hasSize(3);
+    assertThat(loadViewResponse.metadata().schema().findField("as_int").fieldId()).isEqualTo(1);
+    assertThat(loadViewResponse.metadata().schema().findField("as_int").type())
+        .isEqualTo(Types.IntegerType.get());
+    assertThat(loadViewResponse.metadata().schema().findField("as_int").doc())
+        .isEqualTo("Integer column");
+    assertThat(loadViewResponse.metadata().schema().findField("as_string").fieldId()).isEqualTo(2);
+    assertThat(loadViewResponse.metadata().schema().findField("as_string").type())
+        .isEqualTo(Types.StringType.get());
+    assertThat(loadViewResponse.metadata().schema().findField("as_struct").fieldId()).isEqualTo(3);
+    assertThat(
+            loadViewResponse
+                .metadata()
+                .schema()
+                .findField("as_struct")
+                .type()
+                .asStructType()
+                .field("nested_int")
+                .fieldId())
+        .isEqualTo(4);
+    assertThat(loadViewResponse.metadata().currentVersion().defaultCatalog())
+        .isEqualTo(TestUtils.CATALOG_NAME);
+    assertThat(loadViewResponse.metadata().currentVersion().defaultNamespace())
+        .isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME));
+    SQLViewRepresentation representation =
+        (SQLViewRepresentation)
+            loadViewResponse.metadata().currentVersion().representations().get(0);
+    assertThat(representation.sql()).isEqualTo(viewSql);
+    assertThat(representation.dialect()).isEqualTo("spark");
+  }
+
+  @Test
+  public void testLoadMissingViewReturnsNoSuchView() throws ApiException, IOException {
+    CreateCatalog createCatalog =
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
+    catalogOperations.createCatalog(createCatalog);
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    AggregatedHttpResponse resp =
+        client
+            .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/views/missing_view")
+            .aggregate()
+            .join();
+
+    assertThat(resp.status().code()).isEqualTo(404);
+    ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(errorResponse.type()).isEqualTo(NoSuchViewException.class.getSimpleName());
+  }
+
+  @Test
+  public void testLoadViewRejectsTableObjectAsNoSuchView() throws ApiException, IOException {
+    CreateCatalog createCatalog =
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
+    catalogOperations.createCatalog(createCatalog);
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+    ColumnInfo columnInfo =
+        new ColumnInfo()
+            .name("as_int")
+            .typeText("INTEGER")
+            .typeJson(
+                "{\"name\":\"as_int\",\"type\":\"integer\"," + "\"nullable\":true,\"metadata\":{}}")
+            .typeName(ColumnTypeName.INT)
+            .position(0)
+            .nullable(true);
+    tableOperations.createTable(
+        new CreateTable()
+            .name(TestUtils.TABLE_NAME)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(List.of(columnInfo))
+            .storageLocation("/tmp/stagingLocation")
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.DELTA));
+
+    AggregatedHttpResponse resp =
+        client
+            .get(
+                TEST_BASE_PREFIX
+                    + "/namespaces/"
+                    + TestUtils.SCHEMA_NAME
+                    + "/views/"
+                    + TestUtils.TABLE_NAME)
+            .aggregate()
+            .join();
+
+    assertThat(resp.status().code()).isEqualTo(404);
+    ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(errorResponse.type()).isEqualTo(NoSuchViewException.class.getSimpleName());
   }
 }


### PR DESCRIPTION
## Summary
- add VIEW as a public UC table type and allow native SQL view rows with view_definition and columns
- implement Iceberg REST loadView for UC SQL views using Iceberg ViewMetadata
- materialize a real Iceberg view metadata JSON file under the configured UC storage root and return that file as metadata-location
- return Iceberg NoSuchViewException for missing views and non-view table objects
- add Spark E2E coverage that reads a UC SQL view through the Apache Iceberg REST catalog

## Testing
- build/sbt generate
- build/sbt -J-Xmx3G "spark/testOnly io.unitycatalog.spark.IcebergRestCatalogViewE2ETest"
- build/sbt -J-Xmx2G "server/testOnly io.unitycatalog.server.sdk.tables.SdkTableCRUDTest io.unitycatalog.server.service.IcebergRestCatalogTest"
- git diff --check