### PR TITLE
Extract additional scoped credentials from the UC Delta response

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -7,6 +7,9 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.auth.ScopedCredential;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Internal utility for UC Delta storage credentials. */
@@ -34,6 +37,35 @@ public final class DeltaStorageCredentialUtil {
               .oauthToken(field(config.getGcsOauthToken(), cred, "GCS OAuth token")));
     }
     return out;
+  }
+
+  /** Cloud schemes the connector can translate into Hadoop credential properties. */
+  private static boolean isSupportedCloudScheme(String scheme) {
+    return scheme != null
+        && (scheme.startsWith("s3")
+            || scheme.equals("gs")
+            || scheme.equals("abfs")
+            || scheme.equals("abfss"));
+  }
+
+  /**
+   * Converts every credential in {@code creds} other than {@code primary} into a {@link
+   * ScopedCredential}, skipping prefixes the connector cannot translate.
+   */
+  public static List<ScopedCredential> toAdditionalScopedCredentials(
+      DeltaStorageCredential primary, List<DeltaStorageCredential> creds) {
+    List<ScopedCredential> scoped = new ArrayList<>();
+    for (DeltaStorageCredential cred : creds) {
+      if (cred == null || cred == primary || cred.getPrefix() == null) {
+        continue;
+      }
+      if (!isSupportedCloudScheme(URI.create(cred.getPrefix()).getScheme())) {
+        continue;
+      }
+      String operation = cred.getOperation() == null ? "READ" : cred.getOperation().getValue();
+      scoped.add(new ScopedCredential(cred.getPrefix(), operation, toTemporaryCredentials(cred)));
+    }
+    return scoped;
   }
 
   /** Selects the credential whose prefix covers the requested location. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
@@ -5,18 +5,31 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Internal credential wrapper used by Hadoop token providers.
  *
- * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values.
+ * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values. A
+ * vend may also carry {@link #additionalScopedCredentials()} for other locations a table's reads
+ * span.
  */
 public class GenericCredential {
   private final TemporaryCredentials tempCred;
+  private final List<ScopedCredential> additionalScopedCredentials;
 
   public GenericCredential(TemporaryCredentials tempCred) {
+    this(tempCred, Collections.emptyList());
+  }
+
+  public GenericCredential(
+      TemporaryCredentials tempCred, List<ScopedCredential> additionalScopedCredentials) {
     this.tempCred = tempCred;
+    this.additionalScopedCredentials =
+        Collections.unmodifiableList(new ArrayList<>(additionalScopedCredentials));
   }
 
   public static GenericCredential forAws(
@@ -59,6 +72,14 @@ public class GenericCredential {
 
   public TemporaryCredentials temporaryCredentials() {
     return tempCred;
+  }
+
+  /**
+   * Credentials vended alongside the primary one for other location prefixes. Empty unless the
+   * backing API returned multiple scoped credentials.
+   */
+  public List<ScopedCredential> additionalScopedCredentials() {
+    return additionalScopedCredentials;
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
@@ -1,0 +1,30 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.model.TemporaryCredentials;
+
+/** A vended credential scoped to a storage location prefix other than the table's own. */
+public final class ScopedCredential {
+  private final String prefix;
+  private final String operation;
+  private final TemporaryCredentials credentials;
+
+  public ScopedCredential(String prefix, String operation, TemporaryCredentials credentials) {
+    this.prefix = prefix;
+    this.operation = operation;
+    this.credentials = credentials;
+  }
+
+  /** The location prefix this credential covers. */
+  public String prefix() {
+    return prefix;
+  }
+
+  /** The wire value of the operation this credential is scoped to (e.g. {@code READ}). */
+  public String operation() {
+    return operation;
+  }
+
+  public TemporaryCredentials credentials() {
+    return credentials;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
@@ -4,10 +4,12 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.api.DeltaTemporaryCredentialsApi;
 import io.unitycatalog.client.delta.model.DeltaCredentialOperation;
 import io.unitycatalog.client.delta.model.DeltaCredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+import java.util.List;
 
 /** Adapts the UC Delta temporary credentials SDK API for Hadoop token providers. */
 final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher {
@@ -39,9 +41,13 @@ final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher 
         id.catalog(),
         id.schema(),
         id.table());
+    DeltaStorageCredential primary =
+        DeltaStorageCredentialUtil.selectForLocation(
+            credId.location(), response.getStorageCredentials());
+    List<ScopedCredential> additionalScopedCredentials =
+        DeltaStorageCredentialUtil.toAdditionalScopedCredentials(
+            primary, response.getStorageCredentials());
     return new GenericCredential(
-        DeltaStorageCredentialUtil.toTemporaryCredentials(
-            DeltaStorageCredentialUtil.selectForLocation(
-                credId.location(), response.getStorageCredentials())));
+        DeltaStorageCredentialUtil.toTemporaryCredentials(primary), additionalScopedCredentials);
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1633/files) to review incremental changes.
- [**stack/hadoop-cred-scopes-extract**](https://github.com/unitycatalog/unitycatalog/pull/1633) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1633/files)] ← _this PR_
  - [stack/hadoop-cred-scopes-overlay](https://github.com/unitycatalog/unitycatalog/pull/1634) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1634/files/d696d40fd9b56df3db85dada833afed8bc1fb3d2..8f16cd2ef54183bf67f7d3662944e2bd5298da2e)]
    - [stack/hadoop-cred-scopes-emit](https://github.com/unitycatalog/unitycatalog/pull/1635) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1635/files/8f16cd2ef54183bf67f7d3662944e2bd5298da2e..461be13f9b828b142affc5ca910105020052dc06)]

---------

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Lets the Hadoop connector use every credential the UC Delta temporary-credentials API vends, not just the one matching the table's own location.

This is the producer half: it extracts the additional credentials but does not yet apply them, so on its own it is behavior-preserving.

- Add `ScopedCredential` — a value object pairing a location prefix with its operation and temporary credentials.
- Add `DeltaStorageCredentialUtil.toAdditionalScopedCredentials(primary, all)`, returning every non-primary credential on a supported cloud scheme (`s3`/`s3a`/`s3n`, `gs`, `abfs`/`abfss`); it skips null, prefix-less, and unsupported entries and defaults a missing operation to `READ`.
- `GenericCredential` now carries these extras alongside the primary (empty by default), so a single-credential vend is unchanged.
- `UCDeltaGenericCredentialFetcher` populates them from the vend response.

A single-credential response behaves exactly as before.
