### PR TITLE
Carry credential scopes through the Hadoop config and filesystem

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -7,6 +7,9 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.auth.ScopedCredential;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Internal utility for UC Delta storage credentials. */
@@ -34,6 +37,35 @@ public final class DeltaStorageCredentialUtil {
               .oauthToken(field(config.getGcsOauthToken(), cred, "GCS OAuth token")));
     }
     return out;
+  }
+
+  /** Cloud schemes the connector can translate into Hadoop credential properties. */
+  private static boolean isSupportedCloudScheme(String scheme) {
+    return scheme != null
+        && (scheme.startsWith("s3")
+            || scheme.equals("gs")
+            || scheme.equals("abfs")
+            || scheme.equals("abfss"));
+  }
+
+  /**
+   * Converts every credential in {@code creds} other than {@code primary} into a {@link
+   * ScopedCredential}, skipping prefixes the connector cannot translate.
+   */
+  public static List<ScopedCredential> toAdditionalScopedCredentials(
+      DeltaStorageCredential primary, List<DeltaStorageCredential> creds) {
+    List<ScopedCredential> scoped = new ArrayList<>();
+    for (DeltaStorageCredential cred : creds) {
+      if (cred == null || cred == primary || cred.getPrefix() == null) {
+        continue;
+      }
+      if (!isSupportedCloudScheme(URI.create(cred.getPrefix()).getScheme())) {
+        continue;
+      }
+      String operation = cred.getOperation() == null ? "READ" : cred.getOperation().getValue();
+      scoped.add(new ScopedCredential(cred.getPrefix(), operation, toTemporaryCredentials(cred)));
+    }
+    return scoped;
   }
 
   /** Selects the credential whose prefix covers the requested location. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -96,7 +96,7 @@ public final class DeltaStorageCredentialUtil {
     return best;
   }
 
-  static boolean prefixCovers(String location, String prefix) {
+  public static boolean prefixCovers(String location, String prefix) {
     String l = stripTrailingSlashes(location);
     String p = stripTrailingSlashes(prefix);
     return !p.isEmpty() && (l.equals(p) || (l.startsWith(p) && l.charAt(p.length()) == '/'));

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -85,6 +85,15 @@ public class UCHadoopConfConstants {
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";
   public static final String UC_PATH_OPERATION_KEY = "fs.unitycatalog.path.operation";
 
+  // Multi-location credential scopes. Scope i in [0, count) carries the location prefix it
+  // covers plus a complete set of Hadoop credential properties under its prop. namespace;
+  // CredScopedFileSystem overlays the covering scope's properties for paths the table's own
+  // credential does not cover.
+  public static final String UC_CRED_SCOPE_COUNT_KEY = "fs.unitycatalog.credscope.count";
+  public static final String UC_CRED_SCOPE_PREFIX = "fs.unitycatalog.credscope.";
+  public static final String UC_CRED_SCOPE_PREFIX_SUFFIX = ".prefix";
+  public static final String UC_CRED_SCOPE_PROP_SUFFIX = ".prop.";
+
   // Key indicating the credential request type, table or path.
   public static final String UC_CREDENTIALS_TYPE_KEY = "fs.unitycatalog.credentials.type";
   public static final String UC_CREDENTIALS_TYPE_TABLE_VALUE = "table";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
@@ -5,18 +5,31 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Internal credential wrapper used by Hadoop token providers.
  *
- * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values.
+ * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values. A
+ * vend may also carry {@link #additionalScopedCredentials()} for other locations a table's reads
+ * span.
  */
 public class GenericCredential {
   private final TemporaryCredentials tempCred;
+  private final List<ScopedCredential> additionalScopedCredentials;
 
   public GenericCredential(TemporaryCredentials tempCred) {
+    this(tempCred, Collections.emptyList());
+  }
+
+  public GenericCredential(
+      TemporaryCredentials tempCred, List<ScopedCredential> additionalScopedCredentials) {
     this.tempCred = tempCred;
+    this.additionalScopedCredentials =
+        Collections.unmodifiableList(new ArrayList<>(additionalScopedCredentials));
   }
 
   public static GenericCredential forAws(
@@ -59,6 +72,14 @@ public class GenericCredential {
 
   public TemporaryCredentials temporaryCredentials() {
     return tempCred;
+  }
+
+  /**
+   * Credentials vended alongside the primary one for other location prefixes. Empty unless the
+   * backing API returned multiple scoped credentials.
+   */
+  public List<ScopedCredential> additionalScopedCredentials() {
+    return additionalScopedCredentials;
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
@@ -1,0 +1,30 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.model.TemporaryCredentials;
+
+/** A vended credential scoped to a storage location prefix other than the table's own. */
+public final class ScopedCredential {
+  private final String prefix;
+  private final String operation;
+  private final TemporaryCredentials credentials;
+
+  public ScopedCredential(String prefix, String operation, TemporaryCredentials credentials) {
+    this.prefix = prefix;
+    this.operation = operation;
+    this.credentials = credentials;
+  }
+
+  /** The location prefix this credential covers. */
+  public String prefix() {
+    return prefix;
+  }
+
+  /** The wire value of the operation this credential is scoped to (e.g. {@code READ}). */
+  public String operation() {
+    return operation;
+  }
+
+  public TemporaryCredentials credentials() {
+    return credentials;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
@@ -4,10 +4,12 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.api.DeltaTemporaryCredentialsApi;
 import io.unitycatalog.client.delta.model.DeltaCredentialOperation;
 import io.unitycatalog.client.delta.model.DeltaCredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+import java.util.List;
 
 /** Adapts the UC Delta temporary credentials SDK API for Hadoop token providers. */
 final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher {
@@ -39,9 +41,13 @@ final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher 
         id.catalog(),
         id.schema(),
         id.table());
+    DeltaStorageCredential primary =
+        DeltaStorageCredentialUtil.selectForLocation(
+            credId.location(), response.getStorageCredentials());
+    List<ScopedCredential> additionalScopedCredentials =
+        DeltaStorageCredentialUtil.toAdditionalScopedCredentials(
+            primary, response.getStorageCredentials());
     return new GenericCredential(
-        DeltaStorageCredentialUtil.toTemporaryCredentials(
-            DeltaStorageCredentialUtil.selectForLocation(
-                credId.location(), response.getStorageCredentials())));
+        DeltaStorageCredentialUtil.toTemporaryCredentials(primary), additionalScopedCredentials);
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -84,8 +84,11 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    CredId key = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
+    // Paths covered by another credential scope get that scope's credentials overlaid, yielding a
+    // distinct key and delegate per scope.
+    Configuration effectiveConf = CredentialScopes.selectConf(uri, conf);
+    CredId key = CredId.create(effectiveConf, () -> new DefaultCredId(uri, effectiveConf));
+    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, effectiveConf));
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredentialScopes.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredentialScopes.java
@@ -1,0 +1,72 @@
+package io.unitycatalog.hadoop.internal.fs;
+
+import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.net.URI;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Encodes and applies multi-location credential scopes carried in a Hadoop configuration.
+ *
+ * <p>A table whose reads span locations beyond its own carries one scope per extra vended
+ * credential: the location prefix it covers plus a complete set of credential properties for that
+ * prefix. {@link #selectConf} overlays the covering scope's properties — longest covering prefix
+ * wins — so {@link CredScopedFileSystem} creates the delegate for those paths with that scope's
+ * credentials. The selection is prefix-based, not bucket-based, so scopes that share a bucket are
+ * supported, and the overlaid properties may target any cloud scheme.
+ */
+public final class CredentialScopes {
+
+  private CredentialScopes() {}
+
+  /** Writes scope {@code index} ({@code prefix} plus its credential {@code props}) into a map. */
+  public static void encode(
+      Map<String, String> into, int index, String prefix, Map<String, String> props) {
+    String ns = UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX + index;
+    into.put(ns + UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX_SUFFIX, prefix);
+    for (Map.Entry<String, String> e : props.entrySet()) {
+      into.put(ns + UCHadoopConfConstants.UC_CRED_SCOPE_PROP_SUFFIX + e.getKey(), e.getValue());
+    }
+  }
+
+  /**
+   * Returns {@code conf} with the credential properties of the scope covering {@code uri} overlaid,
+   * or {@code conf} unchanged when no scope covers it (the table's own credentials already apply).
+   */
+  public static Configuration selectConf(URI uri, Configuration conf) {
+    int count = conf.getInt(UCHadoopConfConstants.UC_CRED_SCOPE_COUNT_KEY, 0);
+    if (count <= 0 || uri == null) {
+      return conf;
+    }
+    String path = uri.toString();
+    int best = -1;
+    int bestLength = -1;
+    for (int i = 0; i < count; i++) {
+      String prefix =
+          conf.get(
+              UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX
+                  + i
+                  + UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX_SUFFIX);
+      if (prefix == null || !DeltaStorageCredentialUtil.prefixCovers(path, prefix)) {
+        continue;
+      }
+      if (prefix.length() > bestLength) {
+        best = i;
+        bestLength = prefix.length();
+      }
+    }
+    if (best < 0) {
+      return conf;
+    }
+    String propNamespace =
+        UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX
+            + best
+            + UCHadoopConfConstants.UC_CRED_SCOPE_PROP_SUFFIX;
+    Configuration effective = new Configuration(conf);
+    for (Map.Entry<String, String> entry : conf.getPropsWithPrefix(propNamespace).entrySet()) {
+      effective.set(entry.getKey(), entry.getValue());
+    }
+    return effective;
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1634/files/d696d40fd9b56df3db85dada833afed8bc1fb3d2..8f16cd2ef54183bf67f7d3662944e2bd5298da2e) to review incremental changes.
- [stack/hadoop-cred-scopes-extract](https://github.com/unitycatalog/unitycatalog/pull/1633) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1633/files)]
  - [**stack/hadoop-cred-scopes-overlay**](https://github.com/unitycatalog/unitycatalog/pull/1634) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1634/files/d696d40fd9b56df3db85dada833afed8bc1fb3d2..8f16cd2ef54183bf67f7d3662944e2bd5298da2e)] ← _this PR_
    - [stack/hadoop-cred-scopes-emit](https://github.com/unitycatalog/unitycatalog/pull/1635) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1635/files/8f16cd2ef54183bf67f7d3662944e2bd5298da2e..461be13f9b828b142affc5ca910105020052dc06)]

---------

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Defines how additional-location credentials travel through the Hadoop `Configuration` and how the filesystem applies them per path. Behavior-preserving: nothing writes the new config keys yet, so `selectConf` is a no-op when no scope keys are present.

- Add config keys under `fs.unitycatalog.credscope.*`: a scope `count`, plus per-index `.prefix` and namespaced `.prop.` credential properties.
- Add `CredentialScopes` with `encode(...)` (write one scope into a config map) and `selectConf(uri, conf)` (overlay the longest covering scope's properties onto a copy, or return `conf` unchanged when no scope covers the URI — the input is never mutated).
- `CredScopedFileSystem.initialize` runs the path URI through `selectConf`, so a covered path's delegate filesystem is created and cached with that scope's credentials while uncovered paths keep the unscoped config.
- Make `DeltaStorageCredentialUtil.prefixCovers` public so selection reuses the same segment-aware prefix matching.

Selection is prefix-based, not bucket-based, so scopes sharing a bucket are supported.
