### PR TITLE
Emit per-scope credential properties from CredPropsUtil

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -13,6 +13,8 @@ import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import io.unitycatalog.hadoop.internal.auth.ScopedCredential;
+import io.unitycatalog.hadoop.internal.fs.CredentialScopes;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
@@ -22,8 +24,11 @@ import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Internal utility that builds cloud-provider specific Hadoop configuration properties for Unity
@@ -34,6 +39,8 @@ import org.apache.hadoop.conf.Configuration;
  */
 public class CredPropsUtil {
   private CredPropsUtil() {}
+
+  private static final Logger LOG = LoggerFactory.getLogger(CredPropsUtil.class);
 
   /**
    * Factory seam for {@link GenericCredentialFetcher#create(ApiClient, CredId)}, swappable from
@@ -380,16 +387,62 @@ public class CredPropsUtil {
       UCCredentialHadoopConfs.TableOperation tableOp,
       Map<String, String> appVersions)
       throws ApiException {
-    return createCredProps(
-        renewCredEnabled,
-        credScopedFsEnabled,
-        hadoopConf,
-        scheme,
-        apiClient,
-        catalogUri,
-        tokenProvider,
-        appVersions,
-        new DeltaTableCredId(identifier, tableOp.value(), location));
+    // Fetch once through the (optionally cached) credential path; additional scopes ride along on
+    // the returned credential, so a cache hit still exposes the whole vend.
+    DeltaTableCredId credId = new DeltaTableCredId(identifier, tableOp.value(), location);
+    GenericCredential cred =
+        fetchGenericCredential(
+            hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
+    Map<String, String> props =
+        buildSchemeProps(
+            renewCredEnabled,
+            credScopedFsEnabled,
+            hadoopConf,
+            scheme,
+            catalogUri,
+            tokenProvider,
+            appVersions,
+            credId,
+            cred);
+
+    // Every vended scope must be usable at once, alongside the table's own credential.
+    List<ScopedCredential> additionalScopes = cred.additionalScopedCredentials();
+    if (additionalScopes.isEmpty()) {
+      return props;
+    }
+    if (!credScopedFsEnabled) {
+      LOG.warn(
+          "Table {}.{}.{} has {} additional credential scope(s) but credScopedFs.enabled is"
+              + " false; reads outside the table's own location will fail. Enable the"
+              + " credential-scoped FileSystem to use all vended credentials.",
+          identifier.catalog(),
+          identifier.schema(),
+          identifier.table(),
+          additionalScopes.size());
+    }
+    Map<String, String> merged = new HashMap<>(props);
+    // Key each scope's props by its own prefix so that, in renewal mode, its refresh re-selects
+    // this scope's entry from the table's vend and it renews like the table's own credential.
+    int index = 0;
+    for (ScopedCredential scope : additionalScopes) {
+      DeltaTableCredId scopeCredId =
+          new DeltaTableCredId(identifier, scope.operation(), scope.prefix());
+      Map<String, String> scopeProps =
+          buildSchemeProps(
+              renewCredEnabled,
+              /* credScopedFsEnabled= */ false,
+              hadoopConf,
+              URI.create(scope.prefix()).getScheme(),
+              catalogUri,
+              tokenProvider,
+              appVersions,
+              scopeCredId,
+              new GenericCredential(scope.credentials()));
+      CredentialScopes.encode(merged, index, scope.prefix(), scopeProps);
+      index++;
+    }
+    merged.put(UCHadoopConfConstants.UC_CRED_SCOPE_COUNT_KEY, String.valueOf(index));
+    return Collections.unmodifiableMap(merged);
   }
 
   /**
@@ -464,6 +517,34 @@ public class CredPropsUtil {
     GenericCredential cred =
         fetchGenericCredential(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
+    return buildSchemeProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        catalogUri,
+        tokenProvider,
+        appVersions,
+        credId,
+        cred);
+  }
+
+  /**
+   * Builds the cloud-provider specific Hadoop configuration properties for {@code scheme} from an
+   * already-fetched {@code cred}. Split out of {@link #createCredProps} so callers that need the
+   * fetched credential (e.g. to also emit its additional scopes) can fetch once and build here
+   * without a second round-trip.
+   */
+  private static Map<String, String> buildSchemeProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions,
+      CredId credId,
+      GenericCredential cred) {
     switch (scheme) {
       case "s3":
         if (renewCredEnabled) {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -7,6 +7,9 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.auth.ScopedCredential;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Internal utility for UC Delta storage credentials. */
@@ -34,6 +37,35 @@ public final class DeltaStorageCredentialUtil {
               .oauthToken(field(config.getGcsOauthToken(), cred, "GCS OAuth token")));
     }
     return out;
+  }
+
+  /** Cloud schemes the connector can translate into Hadoop credential properties. */
+  private static boolean isSupportedCloudScheme(String scheme) {
+    return scheme != null
+        && (scheme.startsWith("s3")
+            || scheme.equals("gs")
+            || scheme.equals("abfs")
+            || scheme.equals("abfss"));
+  }
+
+  /**
+   * Converts every credential in {@code creds} other than {@code primary} into a {@link
+   * ScopedCredential}, skipping prefixes the connector cannot translate.
+   */
+  public static List<ScopedCredential> toAdditionalScopedCredentials(
+      DeltaStorageCredential primary, List<DeltaStorageCredential> creds) {
+    List<ScopedCredential> scoped = new ArrayList<>();
+    for (DeltaStorageCredential cred : creds) {
+      if (cred == null || cred == primary || cred.getPrefix() == null) {
+        continue;
+      }
+      if (!isSupportedCloudScheme(URI.create(cred.getPrefix()).getScheme())) {
+        continue;
+      }
+      String operation = cred.getOperation() == null ? "READ" : cred.getOperation().getValue();
+      scoped.add(new ScopedCredential(cred.getPrefix(), operation, toTemporaryCredentials(cred)));
+    }
+    return scoped;
   }
 
   /** Selects the credential whose prefix covers the requested location. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -96,7 +96,7 @@ public final class DeltaStorageCredentialUtil {
     return best;
   }
 
-  static boolean prefixCovers(String location, String prefix) {
+  public static boolean prefixCovers(String location, String prefix) {
     String l = stripTrailingSlashes(location);
     String p = stripTrailingSlashes(prefix);
     return !p.isEmpty() && (l.equals(p) || (l.startsWith(p) && l.charAt(p.length()) == '/'));

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -85,6 +85,15 @@ public class UCHadoopConfConstants {
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";
   public static final String UC_PATH_OPERATION_KEY = "fs.unitycatalog.path.operation";
 
+  // Multi-location credential scopes. Scope i in [0, count) carries the location prefix it
+  // covers plus a complete set of Hadoop credential properties under its prop. namespace;
+  // CredScopedFileSystem overlays the covering scope's properties for paths the table's own
+  // credential does not cover.
+  public static final String UC_CRED_SCOPE_COUNT_KEY = "fs.unitycatalog.credscope.count";
+  public static final String UC_CRED_SCOPE_PREFIX = "fs.unitycatalog.credscope.";
+  public static final String UC_CRED_SCOPE_PREFIX_SUFFIX = ".prefix";
+  public static final String UC_CRED_SCOPE_PROP_SUFFIX = ".prop.";
+
   // Key indicating the credential request type, table or path.
   public static final String UC_CREDENTIALS_TYPE_KEY = "fs.unitycatalog.credentials.type";
   public static final String UC_CREDENTIALS_TYPE_TABLE_VALUE = "table";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
@@ -5,18 +5,31 @@ import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Internal credential wrapper used by Hadoop token providers.
  *
- * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values.
+ * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values. A
+ * vend may also carry {@link #additionalScopedCredentials()} for other locations a table's reads
+ * span.
  */
 public class GenericCredential {
   private final TemporaryCredentials tempCred;
+  private final List<ScopedCredential> additionalScopedCredentials;
 
   public GenericCredential(TemporaryCredentials tempCred) {
+    this(tempCred, Collections.emptyList());
+  }
+
+  public GenericCredential(
+      TemporaryCredentials tempCred, List<ScopedCredential> additionalScopedCredentials) {
     this.tempCred = tempCred;
+    this.additionalScopedCredentials =
+        Collections.unmodifiableList(new ArrayList<>(additionalScopedCredentials));
   }
 
   public static GenericCredential forAws(
@@ -59,6 +72,14 @@ public class GenericCredential {
 
   public TemporaryCredentials temporaryCredentials() {
     return tempCred;
+  }
+
+  /**
+   * Credentials vended alongside the primary one for other location prefixes. Empty unless the
+   * backing API returned multiple scoped credentials.
+   */
+  public List<ScopedCredential> additionalScopedCredentials() {
+    return additionalScopedCredentials;
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/ScopedCredential.java
@@ -1,0 +1,30 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.model.TemporaryCredentials;
+
+/** A vended credential scoped to a storage location prefix other than the table's own. */
+public final class ScopedCredential {
+  private final String prefix;
+  private final String operation;
+  private final TemporaryCredentials credentials;
+
+  public ScopedCredential(String prefix, String operation, TemporaryCredentials credentials) {
+    this.prefix = prefix;
+    this.operation = operation;
+    this.credentials = credentials;
+  }
+
+  /** The location prefix this credential covers. */
+  public String prefix() {
+    return prefix;
+  }
+
+  /** The wire value of the operation this credential is scoped to (e.g. {@code READ}). */
+  public String operation() {
+    return operation;
+  }
+
+  public TemporaryCredentials credentials() {
+    return credentials;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
@@ -4,10 +4,12 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.api.DeltaTemporaryCredentialsApi;
 import io.unitycatalog.client.delta.model.DeltaCredentialOperation;
 import io.unitycatalog.client.delta.model.DeltaCredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+import java.util.List;
 
 /** Adapts the UC Delta temporary credentials SDK API for Hadoop token providers. */
 final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher {
@@ -39,9 +41,13 @@ final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher 
         id.catalog(),
         id.schema(),
         id.table());
+    DeltaStorageCredential primary =
+        DeltaStorageCredentialUtil.selectForLocation(
+            credId.location(), response.getStorageCredentials());
+    List<ScopedCredential> additionalScopedCredentials =
+        DeltaStorageCredentialUtil.toAdditionalScopedCredentials(
+            primary, response.getStorageCredentials());
     return new GenericCredential(
-        DeltaStorageCredentialUtil.toTemporaryCredentials(
-            DeltaStorageCredentialUtil.selectForLocation(
-                credId.location(), response.getStorageCredentials())));
+        DeltaStorageCredentialUtil.toTemporaryCredentials(primary), additionalScopedCredentials);
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -84,8 +84,11 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    CredId key = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
+    // Paths covered by another credential scope get that scope's credentials overlaid, yielding a
+    // distinct key and delegate per scope.
+    Configuration effectiveConf = CredentialScopes.selectConf(uri, conf);
+    CredId key = CredId.create(effectiveConf, () -> new DefaultCredId(uri, effectiveConf));
+    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, effectiveConf));
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredentialScopes.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredentialScopes.java
@@ -1,0 +1,72 @@
+package io.unitycatalog.hadoop.internal.fs;
+
+import io.unitycatalog.hadoop.internal.DeltaStorageCredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.net.URI;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Encodes and applies multi-location credential scopes carried in a Hadoop configuration.
+ *
+ * <p>A table whose reads span locations beyond its own carries one scope per extra vended
+ * credential: the location prefix it covers plus a complete set of credential properties for that
+ * prefix. {@link #selectConf} overlays the covering scope's properties — longest covering prefix
+ * wins — so {@link CredScopedFileSystem} creates the delegate for those paths with that scope's
+ * credentials. The selection is prefix-based, not bucket-based, so scopes that share a bucket are
+ * supported, and the overlaid properties may target any cloud scheme.
+ */
+public final class CredentialScopes {
+
+  private CredentialScopes() {}
+
+  /** Writes scope {@code index} ({@code prefix} plus its credential {@code props}) into a map. */
+  public static void encode(
+      Map<String, String> into, int index, String prefix, Map<String, String> props) {
+    String ns = UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX + index;
+    into.put(ns + UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX_SUFFIX, prefix);
+    for (Map.Entry<String, String> e : props.entrySet()) {
+      into.put(ns + UCHadoopConfConstants.UC_CRED_SCOPE_PROP_SUFFIX + e.getKey(), e.getValue());
+    }
+  }
+
+  /**
+   * Returns {@code conf} with the credential properties of the scope covering {@code uri} overlaid,
+   * or {@code conf} unchanged when no scope covers it (the table's own credentials already apply).
+   */
+  public static Configuration selectConf(URI uri, Configuration conf) {
+    int count = conf.getInt(UCHadoopConfConstants.UC_CRED_SCOPE_COUNT_KEY, 0);
+    if (count <= 0 || uri == null) {
+      return conf;
+    }
+    String path = uri.toString();
+    int best = -1;
+    int bestLength = -1;
+    for (int i = 0; i < count; i++) {
+      String prefix =
+          conf.get(
+              UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX
+                  + i
+                  + UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX_SUFFIX);
+      if (prefix == null || !DeltaStorageCredentialUtil.prefixCovers(path, prefix)) {
+        continue;
+      }
+      if (prefix.length() > bestLength) {
+        best = i;
+        bestLength = prefix.length();
+      }
+    }
+    if (best < 0) {
+      return conf;
+    }
+    String propNamespace =
+        UCHadoopConfConstants.UC_CRED_SCOPE_PREFIX
+            + best
+            + UCHadoopConfConstants.UC_CRED_SCOPE_PROP_SUFFIX;
+    Configuration effective = new Configuration(conf);
+    for (Map.Entry<String, String> entry : conf.getPropsWithPrefix(propNamespace).entrySet()) {
+      effective.set(entry.getKey(), entry.getValue());
+    }
+    return effective;
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1635/files/8f16cd2ef54183bf67f7d3662944e2bd5298da2e..461be13f9b828b142affc5ca910105020052dc06) to review incremental changes.
- [stack/hadoop-cred-scopes-extract](https://github.com/unitycatalog/unitycatalog/pull/1633) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1633/files)]
  - [stack/hadoop-cred-scopes-overlay](https://github.com/unitycatalog/unitycatalog/pull/1634) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1634/files/d696d40fd9b56df3db85dada833afed8bc1fb3d2..8f16cd2ef54183bf67f7d3662944e2bd5298da2e)]
    - [**stack/hadoop-cred-scopes-emit**](https://github.com/unitycatalog/unitycatalog/pull/1635) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1635/files/8f16cd2ef54183bf67f7d3662944e2bd5298da2e..461be13f9b828b142affc5ca910105020052dc06)] ← _this PR_

---------

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`CredPropsUtil` now writes each additional vended credential into the `fs.unitycatalog.credscope.*` keys the filesystem reads back, activating multi-scope credential use end to end.

- `createDeltaTableCredProps` fetches the table's vend once through the existing (optionally cached) credential path; the additional scopes ride on the returned credential, so a cache hit still exposes the whole vend.
- For each additional scope, it builds that scope's namespaced properties — keyed by the scope's own prefix so it renews independently, like the table's own credential — and encodes them via `CredentialScopes.encode`.
- A single-credential vend emits no `credscope.*` keys, so its output is unchanged.
- Extracted a `buildSchemeProps` helper so the primary and each scope build props from an already-fetched credential without a second fetch.
