### PR TITLE
[Hadoop] Add the initial credential into the global cache to reuse cred across queries. 

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -48,22 +48,7 @@ public class CredPropsUtil {
   public static volatile GenericCredentialFetcherFactory genericCredFetcherFactory =
       GenericCredentialFetcher::create;
 
-  // Caches the initial credential fetched here so that different queries targeting the same
-  // credential scope ({@link CredId}) reuse the same vended credential instead of re-fetching from
-  // the UC server. It is re-fetched only once the cached credential is about to expire. Kept
-  // separate from the token-provider renewal cache since this runs on the query-planning side (e.g.
-  // the Spark driver), which is engine-agnostic here.
-  private static final String UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE =
-      "unitycatalog.initial.credential.cache.maxSize";
-  private static final int UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
-  static final CredentialCache initialCredCache;
-
-  static {
-    int maxSize =
-        Integer.getInteger(
-            UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE, UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT);
-    initialCredCache = new CredentialCache(maxSize);
-  }
+  static final CredentialCache initialCredCache = CredentialCache.createInitialCredentialCache();
 
   private static final String CRED_SCOPED_FS_CLASS =
       "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -4,7 +4,6 @@ import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
-import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
@@ -19,6 +18,7 @@ import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -536,14 +536,13 @@ public class CredPropsUtil {
         hadoopConf.getLong(
             UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY,
             UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
-    Clock clock = clock(hadoopConf);
 
     return initialCredCache.access(
         credId,
         () ->
             new RenewableCredential(
                 renewalLeadTimeMillis,
-                clock,
+                ClockUtil.resolveClock(hadoopConf),
                 createCredential(apiClient, catalogUri, tokenProvider, appVersions, credId)));
   }
 
@@ -557,12 +556,6 @@ public class CredPropsUtil {
     ApiClient client =
         apiClient != null ? apiClient : createApiClient(catalogUri, tokenProvider, appVersions);
     return genericCredFetcherFactory.create(client, credId).createCredential();
-  }
-
-  private static Clock clock(Configuration hadoopConf) {
-    // Use the test clock if one is intentionally configured for testing.
-    String clockName = hadoopConf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
-    return clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
   }
 
   private static ApiClient createApiClient(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -4,11 +4,15 @@ import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
+import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
@@ -43,6 +47,23 @@ public class CredPropsUtil {
 
   public static volatile GenericCredentialFetcherFactory genericCredFetcherFactory =
       GenericCredentialFetcher::create;
+
+  // Caches the initial credential fetched here so that different queries targeting the same
+  // credential scope ({@link CredId}) reuse the same vended credential instead of re-fetching from
+  // the UC server. It is re-fetched only once the cached credential is about to expire. Kept
+  // separate from the token-provider renewal cache since this runs on the query-planning side (e.g.
+  // the Spark driver), which is engine-agnostic here.
+  private static final String UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE =
+      "unitycatalog.initial.credential.cache.maxSize";
+  private static final int UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
+  static final CredentialCache initialCredCache;
+
+  static {
+    int maxSize =
+        Integer.getInteger(
+            UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE, UC_INITIAL_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT);
+    initialCredCache = new CredentialCache(maxSize);
+  }
 
   private static final String CRED_SCOPED_FS_CLASS =
       "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";
@@ -221,7 +242,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> s3FixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     return new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
         .set("fs.s3a.access.key", awsCred.getAccessKeyId())
@@ -235,7 +257,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     S3PropsBuilder builder =
         new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -257,7 +280,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> gsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     GcpOauthToken gcpOauthToken = tempCreds.getGcpOauthToken();
     Long expirationTime =
         tempCreds.getExpirationTime() == null ? Long.MAX_VALUE : tempCreds.getExpirationTime();
@@ -272,7 +296,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     GcpOauthToken gcpToken = tempCreds.getGcpOauthToken();
     GcsPropsBuilder builder =
         new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -293,7 +318,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> abfsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     return new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
         .set(ABFS_FIXED_SAS_TOKEN_KEY, azureSas.getSasToken())
@@ -305,7 +331,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     AbfsPropsBuilder builder =
         new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -449,46 +476,78 @@ public class CredPropsUtil {
       Map<String, String> appVersions,
       CredId credId)
       throws ApiException {
-    TemporaryCredentials tempCreds =
-        fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, credId);
+    GenericCredential cred =
+        fetchGenericCredential(
+            hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
     switch (scheme) {
       case "s3":
         if (renewCredEnabled) {
           return s3TempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       case "gs":
         if (renewCredEnabled) {
           return gcsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       case "abfss":
       case "abfs":
         if (renewCredEnabled) {
           return abfsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       default:
         return Collections.emptyMap();
     }
   }
 
-  private static TemporaryCredentials fetchTemporaryCredentials(
+  private static GenericCredential fetchGenericCredential(
+      Configuration hadoopConf,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions,
+      CredId credId)
+      throws ApiException {
+    boolean credCacheEnabled =
+        hadoopConf.getBoolean(
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY,
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE);
+    if (!credCacheEnabled) {
+      return createCredential(apiClient, catalogUri, tokenProvider, appVersions, credId);
+    }
+
+    long renewalLeadTimeMillis =
+        hadoopConf.getLong(
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY,
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
+    Clock clock = clock(hadoopConf);
+
+    return initialCredCache.access(
+        credId,
+        () ->
+            new RenewableCredential(
+                renewalLeadTimeMillis,
+                clock,
+                createCredential(apiClient, catalogUri, tokenProvider, appVersions, credId)));
+  }
+
+  private static GenericCredential createCredential(
       ApiClient apiClient,
       String catalogUri,
       TokenProvider tokenProvider,
@@ -497,10 +556,13 @@ public class CredPropsUtil {
       throws ApiException {
     ApiClient client =
         apiClient != null ? apiClient : createApiClient(catalogUri, tokenProvider, appVersions);
-    return genericCredFetcherFactory
-        .create(client, credId)
-        .createCredential()
-        .temporaryCredentials();
+    return genericCredFetcherFactory.create(client, credId).createCredential();
+  }
+
+  private static Clock clock(Configuration hadoopConf) {
+    // Use the test clock if one is intentionally configured for testing.
+    String clockName = hadoopConf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
+    return clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
   }
 
   private static ApiClient createApiClient(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -13,10 +13,33 @@ import java.util.stream.Collectors;
  * is about to expire.
  */
 public class CredentialCache {
+  // Max number of distinct credential scopes ({@link CredId}) held before the eldest is evicted.
+  private static final int DEFAULT_MAX_SIZE = 1024;
+  private static final String GLOBAL_CACHE_MAX_SIZE_KEY = "unitycatalog.credential.cache.maxSize";
+  private static final String INITIAL_CACHE_MAX_SIZE_KEY =
+      "unitycatalog.initial.credential.cache.maxSize";
+
   private final BoundedKeyedCache<CredId, RenewableCredential> cache;
 
   public CredentialCache(int maxSize) {
     this.cache = new BoundedKeyedCache<>(maxSize);
+  }
+
+  /**
+   * Creates the JVM-wide cache used by the Hadoop token providers to renew and share vended
+   * credentials across requests targeting the same scope, saving QPS to the Unity Catalog server.
+   */
+  public static CredentialCache createGlobalCache() {
+    return new CredentialCache(Integer.getInteger(GLOBAL_CACHE_MAX_SIZE_KEY, DEFAULT_MAX_SIZE));
+  }
+
+  /**
+   * Creates the cache for the initial credential fetched during query planning (e.g. on the Spark
+   * driver) so that different queries targeting the same scope reuse the same vended credential
+   * instead of re-fetching from the Unity Catalog server.
+   */
+  public static CredentialCache createInitialCredentialCache() {
+    return new CredentialCache(Integer.getInteger(INITIAL_CACHE_MAX_SIZE_KEY, DEFAULT_MAX_SIZE));
   }
 
   public GenericCredential access(CredId credId, RenewableCredentialFactory factory)

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -4,8 +4,6 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Caches vended {@link GenericCredential}s keyed by their scope ({@link CredId}). A cached
@@ -13,13 +11,13 @@ import java.util.stream.Collectors;
  * is about to expire.
  */
 public class CredentialCache {
-  // Max number of distinct credential scopes ({@link CredId}) held before the eldest is evicted.
   private static final int DEFAULT_MAX_SIZE = 1024;
   private static final String GLOBAL_CACHE_MAX_SIZE_KEY = "unitycatalog.credential.cache.maxSize";
   private static final String INITIAL_CACHE_MAX_SIZE_KEY =
       "unitycatalog.initial.credential.cache.maxSize";
 
-  private final BoundedKeyedCache<CredId, RenewableCredential> cache;
+  // Visible for testing so tests can inspect and reset the underlying cache directly.
+  public final BoundedKeyedCache<CredId, RenewableCredential> cache;
 
   public CredentialCache(int maxSize) {
     this.cache = new BoundedKeyedCache<>(maxSize);
@@ -42,6 +40,15 @@ public class CredentialCache {
     return new CredentialCache(Integer.getInteger(INITIAL_CACHE_MAX_SIZE_KEY, DEFAULT_MAX_SIZE));
   }
 
+  /**
+   * Returns the credential for {@code credId}, handling three cases:
+   *
+   * <ul>
+   *   <li>Cached and still valid: return it as is.
+   *   <li>Cached but about to expire: create a fresh one via {@code factory}, cache it, return it.
+   *   <li>Not cached: create it via {@code factory}, cache it, return it.
+   * </ul>
+   */
   public GenericCredential access(CredId credId, RenewableCredentialFactory factory)
       throws ApiException {
     synchronized (cache) {
@@ -55,20 +62,6 @@ public class CredentialCache {
       cache.put(credId, created);
       return created.credential();
     }
-  }
-
-  public void clear() {
-    cache.clear();
-  }
-
-  public int size() {
-    return cache.size();
-  }
-
-  public List<GenericCredential> values() {
-    return cache.values().stream()
-        .map(RenewableCredential::credential)
-        .collect(Collectors.toList());
   }
 
   @FunctionalInterface

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -1,0 +1,76 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.internal.Clock;
+import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Caches vended {@link GenericCredential}s keyed by their scope ({@link CredId}). A cached
+ * credential is reused while it is still valid and re-fetched via the supplied factory only once it
+ * is about to expire.
+ */
+public class CredentialCache {
+  private final BoundedKeyedCache<CredId, RenewableCredential> cache;
+
+  public CredentialCache(int maxSize) {
+    this.cache = new BoundedKeyedCache<>(maxSize);
+  }
+
+  public GenericCredential access(CredId credId, RenewableCredentialFactory factory)
+      throws ApiException {
+    synchronized (cache) {
+      RenewableCredential cached = cache.getIfPresent(credId);
+      // Reuse the cached credential while it's still valid; otherwise fetch and cache a fresh one.
+      if (cached != null && !cached.readyToRenew()) {
+        return cached.credential();
+      }
+
+      RenewableCredential created = factory.create();
+      cache.put(credId, created);
+      return created.credential();
+    }
+  }
+
+  public void clear() {
+    cache.clear();
+  }
+
+  public int size() {
+    return cache.size();
+  }
+
+  public List<GenericCredential> values() {
+    return cache.values().stream()
+        .map(RenewableCredential::credential)
+        .collect(Collectors.toList());
+  }
+
+  @FunctionalInterface
+  public interface RenewableCredentialFactory {
+    RenewableCredential create() throws ApiException;
+  }
+
+  public static class RenewableCredential {
+    private final long renewalLeadTimeMillis;
+    private final Clock clock;
+    private final GenericCredential credential;
+
+    public RenewableCredential(
+        long renewalLeadTimeMillis, Clock clock, GenericCredential credential) {
+      this.renewalLeadTimeMillis = renewalLeadTimeMillis;
+      this.clock = clock;
+      this.credential = credential;
+    }
+
+    public GenericCredential credential() {
+      return credential;
+    }
+
+    public boolean readyToRenew() {
+      return credential.readyToRenew(clock, renewalLeadTimeMillis);
+    }
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -53,6 +53,12 @@ public class CredentialCache {
     RenewableCredential create() throws ApiException;
   }
 
+  /**
+   * A cached credential together with the renewal policy ({@code clock} and {@code
+   * renewalLeadTimeMillis}) used to decide when it should be renewed. The policy is captured from
+   * the caller that created the entry; since both are derived from the same Hadoop configuration,
+   * later readers observe the same renewal behavior.
+   */
   public static class RenewableCredential {
     private final long renewalLeadTimeMillis;
     private final Clock clock;

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -4,6 +4,8 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Caches vended {@link GenericCredential}s keyed by their scope ({@link CredId}). A cached
@@ -16,8 +18,7 @@ public class CredentialCache {
   private static final String INITIAL_CACHE_MAX_SIZE_KEY =
       "unitycatalog.initial.credential.cache.maxSize";
 
-  // Visible for testing so tests can inspect and reset the underlying cache directly.
-  public final BoundedKeyedCache<CredId, RenewableCredential> cache;
+  private final BoundedKeyedCache<CredId, RenewableCredential> cache;
 
   public CredentialCache(int maxSize) {
     this.cache = new BoundedKeyedCache<>(maxSize);
@@ -62,6 +63,23 @@ public class CredentialCache {
       cache.put(credId, created);
       return created.credential();
     }
+  }
+
+  /** Removes all cached credentials. Public so tests in other packages can reset shared caches. */
+  public void clear() {
+    cache.clear();
+  }
+
+  // Visible for testing only.
+  int size() {
+    return cache.size();
+  }
+
+  // Visible for testing only.
+  List<GenericCredential> credentials() {
+    return cache.values().stream()
+        .map(RenewableCredential::credential)
+        .collect(Collectors.toList());
   }
 
   @FunctionalInterface

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -5,6 +5,7 @@ import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
 import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -38,10 +39,7 @@ public abstract class GenericCredentialProvider {
 
   protected void initialize(Configuration conf) {
     this.conf = conf;
-
-    // Use the test clock if one is intentionally configured for testing.
-    String clockName = conf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
-    this.clock = clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
+    this.clock = ClockUtil.resolveClock(conf);
 
     this.renewalLeadTimeMillis =
         conf.getLong(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -15,18 +15,7 @@ import org.apache.hadoop.conf.Configuration;
  * cache lookup.
  */
 public abstract class GenericCredentialProvider {
-  // The credential cache, for saving QPS to unity catalog server. Keyed by the credential scope
-  // ({@link CredId}) so that requests targeting the same scope can share a vended credential.
-  static final CredentialCache globalCache;
-  private static final String UC_CREDENTIAL_CACHE_MAX_SIZE =
-      "unitycatalog.credential.cache.maxSize";
-  private static final int UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
-
-  static {
-    int maxSize =
-        Integer.getInteger(UC_CREDENTIAL_CACHE_MAX_SIZE, UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT);
-    globalCache = new CredentialCache(maxSize);
-  }
+  static final CredentialCache globalCache = CredentialCache.createGlobalCache();
 
   private Configuration conf;
   private Clock clock;

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -3,8 +3,8 @@ package io.unitycatalog.hadoop.internal.auth;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
 import io.unitycatalog.hadoop.internal.id.CredId;
-import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -16,7 +16,7 @@ import org.apache.hadoop.conf.Configuration;
 public abstract class GenericCredentialProvider {
   // The credential cache, for saving QPS to unity catalog server. Keyed by the credential scope
   // ({@link CredId}) so that requests targeting the same scope can share a vended credential.
-  static final BoundedKeyedCache<CredId, GenericCredential> globalCache;
+  static final CredentialCache globalCache;
   private static final String UC_CREDENTIAL_CACHE_MAX_SIZE =
       "unitycatalog.credential.cache.maxSize";
   private static final int UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
@@ -24,7 +24,7 @@ public abstract class GenericCredentialProvider {
   static {
     int maxSize =
         Integer.getInteger(UC_CREDENTIAL_CACHE_MAX_SIZE, UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT);
-    globalCache = new BoundedKeyedCache<>(maxSize, ignored -> {});
+    globalCache = new CredentialCache(maxSize);
   }
 
   private Configuration conf;
@@ -92,16 +92,11 @@ public abstract class GenericCredentialProvider {
 
   private GenericCredential renewCredential() throws ApiException {
     if (credCacheEnabled) {
-      synchronized (globalCache) {
-        GenericCredential cached = globalCache.getIfPresent(cacheKey);
-        // Use the cached one if existing and valid.
-        if (cached != null && !cached.readyToRenew(clock, renewalLeadTimeMillis)) {
-          return cached;
-        }
-        GenericCredential created = genericCredentialFetcher().createCredential();
-        globalCache.put(cacheKey, created);
-        return created;
-      }
+      return globalCache.access(
+          cacheKey,
+          () ->
+              new RenewableCredential(
+                  renewalLeadTimeMillis, clock, genericCredentialFetcher().createCredential()));
     } else {
       return genericCredentialFetcher().createCredential();
     }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/ClockUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/ClockUtil.java
@@ -1,0 +1,14 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import io.unitycatalog.client.internal.Clock;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+
+public final class ClockUtil {
+  private ClockUtil() {}
+
+  public static Clock resolveClock(Configuration conf) {
+    String clockName = conf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
+    return clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -41,7 +41,7 @@ class CredPropsUtilTest {
 
   @BeforeEach
   void clearCredentialCache() {
-    CredPropsUtil.initialCredCache.cache.clear();
+    CredPropsUtil.initialCredCache.clear();
   }
 
   @Test
@@ -749,7 +749,7 @@ class CredPropsUtilTest {
   @AfterEach
   void resetFactory() {
     CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
-    CredPropsUtil.initialCredCache.cache.clear();
+    CredPropsUtil.initialCredCache.clear();
   }
 
   // Driver-side credential cache: different queries reuse the same credential for the same credId.

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
@@ -15,10 +16,14 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
+import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,6 +38,11 @@ class CredPropsUtilTest {
   private static final String CUSTOM_GS_IMPL = "com.example.CustomGcsFileSystem";
   private static final String CUSTOM_ABFS_IMPL = "com.example.CustomAbfsFileSystem";
   private static final String CUSTOM_ABFSS_IMPL = "com.example.CustomAbfssFileSystem";
+
+  @BeforeEach
+  void clearCredentialCache() {
+    CredPropsUtil.initialCredCache.clear();
+  }
 
   @Test
   void s3OriginalImplPreservedFromExistingProps() throws Exception {
@@ -739,6 +749,122 @@ class CredPropsUtilTest {
   @AfterEach
   void resetFactory() {
     CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
+    CredPropsUtil.initialCredCache.clear();
+  }
+
+  // Driver-side credential cache: different queries reuse the same credential for the same credId.
+
+  @Test
+  void sameCredIdReusesCachedCredentialAcrossQueries() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    Map<String, String> first = createTableCredProps(new Configuration(false));
+    Map<String, String> second = createTableCredProps(new Configuration(false));
+
+    assertThat(fetches.get()).isEqualTo(1);
+    assertThat(first).isEqualTo(second).containsEntry("fs.s3a.access.key", "ak");
+  }
+
+  @Test
+  void differentCredIdsAreCachedSeparately() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    CredPropsUtil.createTableCredProps(
+        false,
+        false,
+        new Configuration(false),
+        "s3",
+        null,
+        "http://uc",
+        tokenProvider(),
+        "tidA",
+        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+        Map.of());
+    CredPropsUtil.createTableCredProps(
+        false,
+        false,
+        new Configuration(false),
+        "s3",
+        null,
+        "http://uc",
+        tokenProvider(),
+        "tidB",
+        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+        Map.of());
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
+  @Test
+  void cacheDisabledFetchesForEveryQuery() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+
+    createTableCredProps(conf);
+    createTableCredProps(conf);
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
+  @Test
+  void expiredCachedCredentialIsRefetched() throws Exception {
+    String clockName = UUID.randomUUID().toString();
+    Clock clock = Clock.getManualClock(clockName);
+    try {
+      TemporaryCredentials cred1 = s3CredsExpiringAt("1", clock.now().toEpochMilli() + 2000L);
+      TemporaryCredentials cred2 = s3CredsExpiringAt("2", clock.now().toEpochMilli() + 20000L);
+      AtomicInteger fetches = new AtomicInteger();
+      CredPropsUtil.genericCredFetcherFactory =
+          (apiClient, credId) ->
+              mockGenericCredentialFetcher(fetches.getAndIncrement() == 0 ? cred1 : cred2);
+
+      Configuration conf = new Configuration(false);
+      conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+      conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+
+      // 1st query fetches cred1 and caches it.
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st1");
+      // 2nd query reuses cred1 while it is still valid.
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st1");
+      assertThat(fetches.get()).isEqualTo(1);
+
+      // Advance the clock so cred1 is within the renewal lead time; the next query refetches cred2.
+      clock.sleep(Duration.ofMillis(1500));
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st2");
+      assertThat(fetches.get()).isEqualTo(2);
+    } finally {
+      Clock.removeManualClock(clockName);
+    }
+  }
+
+  private static Map<String, String> createTableCredProps(Configuration conf) throws Exception {
+    return CredPropsUtil.createTableCredProps(
+        false,
+        false,
+        conf,
+        "s3",
+        null,
+        "http://uc",
+        tokenProvider(),
+        "tid",
+        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+        Map.of());
   }
 
   @Test
@@ -1014,6 +1140,16 @@ class CredPropsUtilTest {
     return new TemporaryCredentials()
         .awsTempCredentials(
             new AwsCredentials().accessKeyId("ak").secretAccessKey("sk").sessionToken("st"));
+  }
+
+  private static TemporaryCredentials s3CredsExpiringAt(String id, long expirationMillis) {
+    return new TemporaryCredentials()
+        .awsTempCredentials(
+            new AwsCredentials()
+                .accessKeyId("ak" + id)
+                .secretAccessKey("sk" + id)
+                .sessionToken("st" + id))
+        .expirationTime(expirationMillis);
   }
 
   private static TemporaryCredentials gcsCreds() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -779,28 +779,8 @@ class CredPropsUtilTest {
           return mockGenericCredentialFetcher(s3Creds());
         };
 
-    CredPropsUtil.createTableCredProps(
-        false,
-        false,
-        new Configuration(false),
-        "s3",
-        null,
-        "http://uc",
-        tokenProvider(),
-        "tidA",
-        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
-        Map.of());
-    CredPropsUtil.createTableCredProps(
-        false,
-        false,
-        new Configuration(false),
-        "s3",
-        null,
-        "http://uc",
-        tokenProvider(),
-        "tidB",
-        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
-        Map.of());
+    createTableCredProps(new Configuration(false), "tidA");
+    createTableCredProps(new Configuration(false), "tidB");
 
     assertThat(fetches.get()).isEqualTo(2);
   }
@@ -854,6 +834,11 @@ class CredPropsUtilTest {
   }
 
   private static Map<String, String> createTableCredProps(Configuration conf) throws Exception {
+    return createTableCredProps(conf, "tid");
+  }
+
+  private static Map<String, String> createTableCredProps(Configuration conf, String tableId)
+      throws Exception {
     return CredPropsUtil.createTableCredProps(
         false,
         false,
@@ -862,7 +847,7 @@ class CredPropsUtilTest {
         null,
         "http://uc",
         tokenProvider(),
-        "tid",
+        tableId,
         UCCredentialHadoopConfs.TableOperation.READ_WRITE,
         Map.of());
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -41,7 +41,7 @@ class CredPropsUtilTest {
 
   @BeforeEach
   void clearCredentialCache() {
-    CredPropsUtil.initialCredCache.clear();
+    CredPropsUtil.initialCredCache.cache.clear();
   }
 
   @Test
@@ -749,7 +749,7 @@ class CredPropsUtilTest {
   @AfterEach
   void resetFactory() {
     CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
-    CredPropsUtil.initialCredCache.clear();
+    CredPropsUtil.initialCredCache.cache.clear();
   }
 
   // Driver-side credential cache: different queries reuse the same credential for the same credId.

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -15,7 +15,9 @@ import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +55,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   public void before() {
     clockName = UUID.randomUUID().toString();
     clock = Clock.getManualClock(clockName);
-    GenericCredentialProvider.globalCache.clear();
+    GenericCredentialProvider.globalCache.cache.clear();
   }
 
   @AfterEach
@@ -61,7 +63,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     Clock.removeManualClock(clockName);
     clock = null;
     clockName = null;
-    GenericCredentialProvider.globalCache.clear();
+    GenericCredentialProvider.globalCache.cache.clear();
   }
 
   @Test
@@ -321,10 +323,13 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   private static void assertGlobalCache(int expectedSize, TemporaryCredentials... creds) {
     assertThat(expectedSize).isEqualTo(creds.length);
-    assertThat(GenericCredentialProvider.globalCache.size()).isEqualTo(expectedSize);
+    assertThat(GenericCredentialProvider.globalCache.cache.size()).isEqualTo(expectedSize);
+    List<GenericCredential> cachedCreds =
+        GenericCredentialProvider.globalCache.cache.values().stream()
+            .map(CredentialCache.RenewableCredential::credential)
+            .collect(Collectors.toList());
     for (TemporaryCredentials cred : creds) {
-      assertThat(GenericCredentialProvider.globalCache.values())
-          .contains(new GenericCredential(cred));
+      assertThat(cachedCreds).contains(new GenericCredential(cred));
     }
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -15,9 +15,7 @@ import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +53,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   public void before() {
     clockName = UUID.randomUUID().toString();
     clock = Clock.getManualClock(clockName);
-    GenericCredentialProvider.globalCache.cache.clear();
+    GenericCredentialProvider.globalCache.clear();
   }
 
   @AfterEach
@@ -63,7 +61,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     Clock.removeManualClock(clockName);
     clock = null;
     clockName = null;
-    GenericCredentialProvider.globalCache.cache.clear();
+    GenericCredentialProvider.globalCache.clear();
   }
 
   @Test
@@ -323,13 +321,10 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   private static void assertGlobalCache(int expectedSize, TemporaryCredentials... creds) {
     assertThat(expectedSize).isEqualTo(creds.length);
-    assertThat(GenericCredentialProvider.globalCache.cache.size()).isEqualTo(expectedSize);
-    List<GenericCredential> cachedCreds =
-        GenericCredentialProvider.globalCache.cache.values().stream()
-            .map(CredentialCache.RenewableCredential::credential)
-            .collect(Collectors.toList());
+    assertThat(GenericCredentialProvider.globalCache.size()).isEqualTo(expectedSize);
     for (TemporaryCredentials cred : creds) {
-      assertThat(cachedCreds).contains(new GenericCredential(cred));
+      assertThat(GenericCredentialProvider.globalCache.credentials())
+          .contains(new GenericCredential(cred));
     }
   }
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

In this PR, we introduce a initCredentialCache, so that we can cache the initial credential at the driver side,  which can accelerate the cross queries credential access. 

For example.  Q1 access the table , and Q2 access the same table again,  then the credential will be shared for the two queries.  that can be helpful to accelerate the query performance. 