### PR TITLE
[Spark] Extract table-create column/partition conversions into UCColumnConversions

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCColumnConversions.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCColumnConversions.java
@@ -1,0 +1,105 @@
+package io.unitycatalog.spark;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.unitycatalog.client.ApiException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructField;
+
+/**
+ * Shared helpers for converting Spark schema/partitioning into the wire shapes Unity Catalog
+ * expects when creating a table. Extracted from {@code UCSingleCatalog}/{@code UCProxy} so the
+ * single table-create path has one implementation (and so the view-create path can reuse the same
+ * serialization instead of duplicating it).
+ */
+public final class UCColumnConversions {
+
+  private UCColumnConversions() {}
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Serialize a Spark {@link StructField} to the canonical "StructField-shape" JSON that Unity
+   * Catalog stores in {@code ColumnInfo.type_json}: {@code {name, type, nullable, metadata}}.
+   * Matches the shape produced by {@code StructField.toJson}. The field's {@code metadata} (which
+   * on a {@code StructField} already carries the column comment under the {@code "comment"} key) is
+   * emitted verbatim.
+   */
+  public static String toStructFieldJson(StructField field) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("name", field.name());
+    // dataType().json() / metadata().json() are already JSON documents; embed them as parsed nodes
+    // so they are not re-escaped as strings.
+    node.set("type", readTree(field.dataType().json()));
+    node.put("nullable", field.nullable());
+    node.set("metadata", readTree(field.metadata().json()));
+    return writeValueAsString(node);
+  }
+
+  /**
+   * Resolve the partition column names from Spark's V2 partition {@link Transform}s.
+   *
+   * <ul>
+   *   <li>{@code identity(col)} is a real partition column; UC's wire model records partition
+   *       columns by name, so we take the referenced field name. An identity transform references
+   *       exactly one field, hence the single-field check.
+   *   <li>{@code cluster_by(...)} is liquid clustering, not partitioning. UC's create-table wire
+   *       model has no clustering concept, so these transforms contribute no partition columns
+   *       (dropped).
+   *   <li>Anything else is not representable and is rejected.
+   * </ul>
+   */
+  public static List<String> partitionColumnNames(Transform[] partitions) throws ApiException {
+    List<String> names = new ArrayList<>();
+    if (partitions == null) {
+      return names;
+    }
+    for (Transform t : partitions) {
+      switch (t.name()) {
+        case "identity":
+          List<String> fieldNames = new ArrayList<>();
+          for (NamedReference ref : t.references()) {
+            for (String part : ref.fieldNames()) {
+              fieldNames.add(part);
+            }
+          }
+          if (fieldNames.size() != 1) {
+            throw new IllegalArgumentException(
+                "Expected single-field partition reference but got: "
+                    + String.join(".", fieldNames));
+          }
+          names.add(fieldNames.get(0));
+          break;
+        case "cluster_by":
+          break;
+        default:
+          throw new ApiException("Unsupported partition transform: " + t.name());
+      }
+    }
+    return names;
+  }
+
+  /** {@link ObjectMapper#readTree(String)} with the checked exception rethrown as unchecked. */
+  private static JsonNode readTree(String json) {
+    try {
+      return MAPPER.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Malformed column JSON: " + e.getMessage(), e);
+    }
+  }
+
+  /** {@link ObjectMapper#writeValueAsString} with the checked exception rethrown as unchecked. */
+  private static String writeValueAsString(JsonNode node) {
+    try {
+      return MAPPER.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      // Serializing an in-memory node should never fail.
+      throw new IllegalStateException("Failed to serialize column JSON", e);
+    }
+  }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -22,8 +22,6 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods.{compact, parse, render}
 import org.sparkproject.guava.base.Preconditions
 
 import java.net.URI
@@ -751,19 +749,8 @@ private class UCProxy(
     }
     createTable.setStorageLocation(storageLocation)
 
-    val partitionColNames: Seq[String] = partitions.flatMap { t =>
-      t.name() match {
-        case "identity" =>
-          val fieldNames = t.references().flatMap(_.fieldNames())
-          require(fieldNames.length == 1,
-            s"Expected single-field partition reference but got: ${fieldNames.mkString(".")}")
-          Some(fieldNames.head)
-        case "cluster_by" =>
-          None
-        case other =>
-          throw new ApiException(s"Unsupported partition transform: $other")
-      }
-    }.toSeq
+    val partitionColNames: Seq[String] =
+      UCColumnConversions.partitionColumnNames(partitions).asScala.toSeq
     val columns: Seq[ColumnInfo] = schema.fields.toSeq.zipWithIndex.map { case (field, i) =>
       val column = new ColumnInfo()
       column.setName(field.name)
@@ -773,7 +760,7 @@ private class UCProxy(
       column.setNullable(field.nullable)
       column.setTypeText(field.dataType.catalogString)
       column.setTypeName(convertDataTypeToTypeName(field.dataType))
-      column.setTypeJson(toStructFieldJson(field))
+      column.setTypeJson(UCColumnConversions.toStructFieldJson(field))
       column.setPosition(i)
       val partitionIdx = partitionColNames.indexWhere(_.equalsIgnoreCase(field.name))
       if (partitionIdx >= 0) column.setPartitionIndex(partitionIdx)
@@ -791,13 +778,6 @@ private class UCProxy(
     loadTable(ident)
   }
 
-  private def toStructFieldJson(field: StructField): String = {
-    compact(render(
-      ("name" -> field.name) ~
-        ("type" -> parse(field.dataType.json)) ~
-        ("nullable" -> field.nullable) ~
-        ("metadata" -> parse(field.metadata.json))))
-  }
 
   private def convertDatasourceFormat(format: String): DataSourceFormat = {
     format.toUpperCase match {


### PR DESCRIPTION
**Stack 1/4** — first of a 4-PR split of #1554 (metric-view connector). Review bottom-up; merge in order.

### What this PR does
Pure refactor (no behavior change): extract the table-create column/partition conversions out of `UCSingleCatalog` into a shared `UCColumnConversions` object.

- `toStructFieldJson(StructField)` — the `{name,type,nullable,metadata}` `type_json` serializer, moved out of `UCSingleCatalog`.
- `partitionColumnNames(Array[Transform])` — the `identity`/`cluster_by` partition-transform logic, moved out and documented (answers the "why single field / why drop cluster_by" review questions).

This gives the upcoming view-create path one serializer to reuse instead of duplicating the `StructField`/`Column` → `type_json` logic (addresses @openinx's "unify `toStructFieldJson`" comment). The `Column` overload lands in stack PR 3.

### Stack
1. **this PR** — extract `UCColumnConversions`
2. per-Spark-version shim scaffolding
3. wire metric-view support + move view-type mapping to `UCViewTypes` + unit tests
4. local-run e2e tests

Verified: compiles on Spark 4.0/4.1/4.2; `UCProxySuite` (normal-table create path) green.

This pull request and its description were written by Isaac.

This PR is assisted by Isaac Autopilot: [View the full session spec, test plan, and artifacts](http://go/isaac-autopilot/cli-viewer/1782162701477/chen-wang_data).