### PR TITLE
[Spark] Per-Spark-version view-shim scaffolding.

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.0/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -1,0 +1,16 @@
+package io.unitycatalog.spark
+
+import io.unitycatalog.client.model.{TableInfo => UCTableInfo}
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark 4.0 does not support the metric-view API, so this shim leaves views unsupported: the
+ * `wrapAsView` hook throws because no view types exist on this Spark version. The shared
+ * `UCProxy.loadTable` only calls this hook for a view-like UC `tableType`, which cannot occur on a
+ * Spark version without view support.
+ */
+trait UCProxyViewSupport { self: UCProxy =>
+  protected def wrapAsView(t: UCTableInfo, ident: Identifier): Table =
+    throw new NoSuchTableException(ident)
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.0/io/unitycatalog/spark/ViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0/io/unitycatalog/spark/ViewSupport.scala
@@ -1,0 +1,15 @@
+package io.unitycatalog.spark
+
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark 4.0 does not have the metric-view APIs (`TableViewCatalog`, `loadTableOrView`,
+ * `createView`, `loadView`, ...), so this shim provides `rejectIfShimmedView` as a no-op. It
+ * lets the shared [[UCSingleCatalog.loadTable]] body compile and run without referencing any
+ * view-only types. The `with TableViewCatalog` mixin on `UCSingleCatalog` resolves to the
+ * [[org.apache.spark.sql.connector.catalog.TableViewCatalog]] stub trait also defined in this
+ * shim directory.
+ */
+trait ViewSupport { self: UCSingleCatalog =>
+  protected def rejectIfShimmedView(t: Table, ident: Identifier): Unit = ()
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/connector/catalog/TableViewCatalog.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/connector/catalog/TableViewCatalog.scala
@@ -1,0 +1,16 @@
+package org.apache.spark.sql.connector.catalog
+
+/**
+ * Stub for the real `TableViewCatalog` interface that Spark 4.2 introduced in
+ * [SPARK-52729](https://github.com/apache/spark/pull/51419). On Spark 4.0 and 4.1 the
+ * real interface does not exist on the classpath, so the connector's
+ * `with TableViewCatalog` mixin would fail to verify at class-loading time. This stub
+ * lets the connector compile against all three Spark versions while leaving the
+ * actual view-side implementation to per-version `ViewSupport` shims.
+ *
+ * On Spark 4.2 the real Spark interface is on the classpath, so this stub file is
+ * absent under `scala-shims/spark-4.2/`. The Delta connector uses the same
+ * fake-interface trick for `SupportsV1OverwriteWithSaveAsTable` (see Delta's
+ * `spark/src/main/scala-shims/spark-4.0/SupportsV1OverwriteWithSaveAsTable.scala`).
+ */
+trait TableViewCatalog extends TableCatalog

--- a/connectors/spark/src/main/scala-shims/spark-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -1,0 +1,16 @@
+package io.unitycatalog.spark
+
+import io.unitycatalog.client.model.{TableInfo => UCTableInfo}
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark 4.1 does not support the metric-view API, so this shim leaves views unsupported: the
+ * `wrapAsView` hook throws because no view types exist on this Spark version. The shared
+ * `UCProxy.loadTable` only calls this hook for a view-like UC `tableType`, which cannot occur on a
+ * Spark version without view support.
+ */
+trait UCProxyViewSupport { self: UCProxy =>
+  protected def wrapAsView(t: UCTableInfo, ident: Identifier): Table =
+    throw new NoSuchTableException(ident)
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.1/io/unitycatalog/spark/ViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.1/io/unitycatalog/spark/ViewSupport.scala
@@ -1,0 +1,15 @@
+package io.unitycatalog.spark
+
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark 4.1 does not have the metric-view APIs (`TableViewCatalog`, `loadTableOrView`,
+ * `createView`, `loadView`, ...), so this shim provides `rejectIfShimmedView` as a no-op. It
+ * lets the shared [[UCSingleCatalog.loadTable]] body compile and run without referencing any
+ * view-only types. The `with TableViewCatalog` mixin on `UCSingleCatalog` resolves to the
+ * [[org.apache.spark.sql.connector.catalog.TableViewCatalog]] stub trait also defined in this
+ * shim directory.
+ */
+trait ViewSupport { self: UCSingleCatalog =>
+  protected def rejectIfShimmedView(t: Table, ident: Identifier): Unit = ()
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.1/org/apache/spark/sql/connector/catalog/TableViewCatalog.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.1/org/apache/spark/sql/connector/catalog/TableViewCatalog.scala
@@ -1,0 +1,16 @@
+package org.apache.spark.sql.connector.catalog
+
+/**
+ * Stub for the real `TableViewCatalog` interface that Spark 4.2 introduced in
+ * [SPARK-52729](https://github.com/apache/spark/pull/51419). On Spark 4.0 and 4.1 the
+ * real interface does not exist on the classpath, so the connector's
+ * `with TableViewCatalog` mixin would fail to verify at class-loading time. This stub
+ * lets the connector compile against all three Spark versions while leaving the
+ * actual view-side implementation to per-version `ViewSupport` shims.
+ *
+ * On Spark 4.2 the real Spark interface is on the classpath, so this stub file is
+ * absent under `scala-shims/spark-4.2/`. The Delta connector uses the same
+ * fake-interface trick for `SupportsV1OverwriteWithSaveAsTable` (see Delta's
+ * `spark/src/main/scala-shims/spark-4.0/SupportsV1OverwriteWithSaveAsTable.scala`).
+ */
+trait TableViewCatalog extends TableCatalog

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -1,0 +1,17 @@
+package io.unitycatalog.spark
+
+import io.unitycatalog.client.model.{TableInfo => UCTableInfo}
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark-4.2 placeholder for [[UCProxyViewSupport]]. Scaffolding only: this shim currently mirrors
+ * the no-op 4.0/4.1 version (the `wrapAsView` hook throws `NoSuchTableException`). The real
+ * Spark-4.2 implementation -- wrapping a view-like UC row as a `MetadataTable`+`ViewInfo` and
+ * implementing the view CRUD surface -- is added in a follow-up change once the connector's view
+ * glue lands.
+ */
+trait UCProxyViewSupport { self: UCProxy =>
+  protected def wrapAsView(t: UCTableInfo, ident: Identifier): Table =
+    throw new NoSuchTableException(ident)
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/ViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/ViewSupport.scala
@@ -1,0 +1,15 @@
+package io.unitycatalog.spark
+
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Spark-4.2 placeholder for [[ViewSupport]]. Scaffolding only: this shim currently mirrors the
+ * no-op 4.0/4.1 versions (the `rejectIfShimmedView` hook is a no-op and no view CRUD is wired in
+ * yet). The real Spark-4.2 view implementation -- mixing in the native
+ * `org.apache.spark.sql.connector.catalog.TableViewCatalog` and delegating `createView`/`loadView`
+ * /`dropView`/... to the UC proxy -- is added in a follow-up change once the connector's view
+ * glue lands.
+ */
+trait ViewSupport { self: UCSingleCatalog =>
+  protected def rejectIfShimmedView(t: Table, ident: Identifier): Unit = ()
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -601,7 +601,7 @@ object UCSingleCatalog {
 }
 
 // An internal proxy to talk to the UC client.
-private class UCProxy(
+private[spark] class UCProxy(
     uri: URI,
     tokenProvider: TokenProvider,
     renewCredEnabled: Boolean,


### PR DESCRIPTION
**Stack 2/4** — split of #1554. Stacked on #1644.

> This PR is based on #1644. GitHub shows the cumulative diff (fork-based stacks can't use a fork branch as the PR base); **review only this PR's own commit** `57a6c3bb`, and merge after #1644.

### What this PR does
Adds the per-Spark-version shim source files so the connector compiles against Spark 4.0/4.1/4.2 while the view-catalog APIs (`TableViewCatalog`, `ViewInfo`, `MetadataTable`) only exist on 4.2. **No behavior** — no traits are mixed in yet.

- `scala-shims/spark-{4.0,4.1}`: a compile-time `TableViewCatalog` stub (the real interface arrives in Spark 4.2 via [SPARK-52729](https://github.com/apache/spark/pull/51419)) + no-op `ViewSupport` / `UCProxyViewSupport` traits.
- `scala-shims/spark-4.2`: placeholder `ViewSupport` / `UCProxyViewSupport` (still no-ops here; the real 4.2 impl lands in stack PR 3).
- Widens `UCProxy` to `private[spark]` so the shim trait can self-type to it.

Answers @openinx's "where is `TableViewCatalog`?" — it's the SPARK-52729 interface; 4.0/4.1 get the vendored stub, 4.2 uses real Spark.

### Stack
1. #1644 — extract `UCColumnConversions`
2. **this PR** — shim scaffolding
3. wire metric-view support + `UCViewTypes` + unit tests
4. local-run e2e tests

Verified: compiles on Spark 4.0/4.1/4.2; no behavior change.

This pull request and its description were written by Isaac.

This PR is assisted by Isaac Autopilot: [View the full session spec, test plan, and artifacts](http://go/isaac-autopilot/cli-viewer/1782162701477/chen-wang_data).