### PR TITLE
[Spark] Local-run e2e test for metric views (Spark 4.2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -699,7 +699,8 @@ lazy val spark = (project in file("connectors/spark"))
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.0",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.0",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.0",
-      "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
+      // jackson-core >= 2.18 required by Spark 4.2's jackson-dataformat-yaml (YAMLParser._updateToken).
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.19.2",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.15.0",
       "org.antlr" % "antlr4-runtime" % "4.13.1",
       "org.antlr" % "antlr4" % "4.13.1",

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -84,6 +84,14 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
     return session.sql(String.format(statement, args)).collectAsList();
   }
 
+  /** True when the running Spark is at least {@code major.minor} (e.g. for version-gated tests). */
+  protected static boolean isSparkAtLeast(int major, int minor) {
+    String[] parts = org.apache.spark.package$.MODULE$.SPARK_VERSION().split("\\.");
+    int runMajor = Integer.parseInt(parts[0]);
+    int runMinor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+    return runMajor > major || (runMajor == major && runMinor >= minor);
+  }
+
   @BeforeEach
   @Override
   public void setUp() {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/MetricViewE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/MetricViewE2ETest.java
@@ -1,0 +1,140 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end test for metric views: drives the real {@code CREATE VIEW ... WITH METRICS} SQL DDL
+ * (SPARK-56920) through the connector against an embedded {@code UnityCatalogServer}. Skipped on
+ * Spark below 4.2, where the metric-view DDL does not exist.
+ */
+public class MetricViewE2ETest extends BaseSparkIntegrationTest {
+
+  @TempDir private File sourceTableDir;
+
+  /** Metric views require Spark 4.2+; skip (rather than fail) the whole class on older runtimes. */
+  @BeforeAll
+  public static void assumeMetricViewsSupported() {
+    Assumptions.assumeTrue(
+        isSparkAtLeast(4, 2),
+        "Metric views require Spark 4.2+, but runtime is "
+            + org.apache.spark.package$.MODULE$.SPARK_VERSION());
+  }
+
+  private String tbl(String name) {
+    return CATALOG_NAME + "." + SCHEMA_NAME + "." + name;
+  }
+
+  /**
+   * Creates the UC-backed source table the metric view reads from. The metric-view CREATE path
+   * eagerly resolves the YAML {@code source:} relation, so this table must exist first. A plain
+   * parquet external table keeps the source setup independent of the Delta create path.
+   */
+  private void createEventsSource() {
+    sql(
+        "CREATE TABLE %s (region STRING, cnt INT) USING parquet LOCATION '%s'",
+        tbl("events"), sourceTableDir.toURI());
+    sql("INSERT INTO %s VALUES ('us', 1), ('us', 2), ('eu', 3)", tbl("events"));
+  }
+
+  /** {@code CREATE VIEW ... WITH METRICS LANGUAGE YAML AS $$...$$} against the UC v2 catalog. */
+  private void createMetricView(String name) {
+    sql(
+        "CREATE VIEW %s\n"
+            + "WITH METRICS\n"
+            + "LANGUAGE YAML\n"
+            + "AS\n"
+            + "$$\n"
+            + "version: \"0.1\"\n"
+            + "source: %s\n"
+            + "dimensions:\n"
+            + "  - name: region\n"
+            + "    expr: region\n"
+            + "measures:\n"
+            + "  - name: cnt_sum\n"
+            + "    expr: sum(cnt)\n"
+            + "$$",
+        tbl(name), tbl("events"));
+  }
+
+  @Test
+  public void testMetricViewOperations() throws Exception {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    createEventsSource();
+
+    // CREATE VIEW ... WITH METRICS -> CreateV2MetricViewExec -> connector.createView, persisted
+    // by the embedded UC server.
+    createMetricView("mv_e2e");
+
+    // SHOW VIEWS shows views only: the metric view is listed, the source table `events` is not.
+    List<String> views =
+        sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME).stream()
+            .map(r -> r.getString(1))
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(views).contains("mv_e2e").doesNotContain("events");
+
+    // SHOW TABLES unions tables and views on Spark 4.2 (a RelationCatalog resolves it through
+    // `listRelationSummaries`), so both the source table and the metric view are listed.
+    List<String> tables =
+        sql("SHOW TABLES IN %s.%s", CATALOG_NAME, SCHEMA_NAME).stream()
+            .map(r -> r.getString(1))
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(tables).contains("events", "mv_e2e");
+
+    // DESCRIBE resolves the ident through the connector's `loadRelation`: `delegate.loadTable`
+    // throws NoSuchTableException for a view, so it falls back to `ucProxy.loadView` and returns
+    // the metric view's columns (the dimension + measure) with their resolved data types.
+    List<Row> describe = sql("DESCRIBE %s", tbl("mv_e2e"));
+    assertThat(describe.stream().map(r -> r.getString(0) + ":" + r.getString(1)))
+        .contains("region:string", "cnt_sum:bigint");
+
+    // DESCRIBE EXTENDED additionally reports the detailed view info -- notably that the object is
+    // a METRIC_VIEW -- alongside the same column rows.
+    List<Row> descExt = sql("DESCRIBE EXTENDED %s", tbl("mv_e2e"));
+    assertThat(descExt.stream().map(r -> r.getString(0) + ":" + r.getString(1)))
+        .contains("region:string", "cnt_sum:bigint", "Type:METRIC_VIEW");
+
+    // SELECT through the metric view aggregates the source rows (eu=3, us=1+2=3). A measure is read
+    // via the `measure(...)` function with GROUP BY on the dimensions.
+    List<Row> rows =
+        sql(
+            "SELECT region, measure(cnt_sum) FROM %s GROUP BY region ORDER BY region",
+            tbl("mv_e2e"));
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).getString(0)).isEqualTo("eu");
+    assertThat(rows.get(0).getLong(1)).isEqualTo(3L);
+    assertThat(rows.get(1).getString(0)).isEqualTo("us");
+    assertThat(rows.get(1).getLong(1)).isEqualTo(3L);
+
+    // ALTER VIEW ... RENAME TO delegates to UCSingleCatalogViewSupport.renameView ->
+    // ucProxy.renameView, which is unsupported today, so the rename fails with a clear
+    // UnsupportedOperationException and leaves the original view in place (target not created).
+    assertThatThrownBy(() -> sql("ALTER VIEW %s RENAME TO %s", tbl("mv_e2e"), tbl("mv_renamed")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Renaming a view is not supported");
+    List<String> afterRename =
+        sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME).stream()
+            .map(r -> r.getString(1))
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(afterRename).contains("mv_e2e").doesNotContain("mv_renamed");
+
+    // DROP VIEW removes it; it no longer shows up.
+    sql("DROP VIEW %s", tbl("mv_e2e"));
+    List<Row> afterDrop = sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME);
+    assertThat(afterDrop.stream().anyMatch(r -> r.getString(1).equals("mv_e2e"))).isFalse();
+
+    // DROP VIEW IF EXISTS on the now-missing view (and any absent view) is a no-op, not an error.
+    sql("DROP VIEW IF EXISTS %s", tbl("mv_e2e"));
+    sql("DROP VIEW IF EXISTS %s", tbl("does_not_exist"));
+  }
+}


### PR DESCRIPTION
Now that the Spark 4.2.0 connector port has merged (#1675), this PR is rebased directly onto `main` and its diff is just this test plus a small build fix it surfaced. Verified passing end-to-end against published Spark 4.2.0.

### What this PR does
Adds `MetricViewE2ETest` — a local-run end-to-end test that exercises the full connector → UC-server round-trip for metric views against an **embedded** `UnityCatalogServer` via `UCSingleCatalog` (real HTTP + persistence, not mocks).

Metric views are created with the **actual SQL DDL** a user runs — `CREATE VIEW ... WITH METRICS LANGUAGE YAML AS $$...$$` (SPARK-56920). On a DS v2 catalog like `UCSingleCatalog`, Spark's `DataSourceV2Strategy` routes the parsed `CreateMetricView` plan through `CreateV2MetricViewExec`, which builds the Spark 4.2 V2 `View` (metric-view type + query text + typed table dependencies) and calls the connector's `createView`. The test drives that whole path — parse → analyze → route → persist — plus `SHOW VIEWS`, `SHOW TABLES`, a `SELECT` through the view, and `DROP VIEW`.

The `SELECT` reads a measure via the metric-view `measure(...)` function with `GROUP BY` on the dimension (`SELECT region, measure(cnt_sum) FROM mv GROUP BY region`), which Spark rewrites into the underlying aggregation over the source table.

Spark-4.2-only (lives under `src/test/scala-shims/spark-4.2/`), where the metric-view DDL and view-catalog APIs exist; it therefore compiles/runs only on the Spark 4.2 build, not 4.0/4.1.

### Also included: a jackson-core fix surfaced by the test
On published Spark 4.2.0 the spark module's `jackson-core` `dependencyOverride` (pinned to `2.15.0`) is too old for Spark 4.2's `jackson-dataformat-yaml` (2.21.2), which calls `YAMLParser._updateToken(JsonToken)` — a method added in jackson-core 2.18 — while parsing the metric-view YAML. This throws `NoSuchMethodError` on `CREATE VIEW ... WITH METRICS`. Fix: bump only the spark-module `jackson-core` override to `2.19.2` (the highest core with a matching published `jackson-annotations`, and already what Spark 4.0/4.1/4.2 resolve); the other jackson modules stay at 2.15.0.

### Note on `SHOW TABLES`
On Spark 4.2 a `RelationCatalog` resolves `SHOW TABLES` through `listRelationSummaries`, whose default unions tables and views (views carry a `VIEW` table-type in the summary). So a metric view correctly appears on **both** `SHOW VIEWS` and `SHOW TABLES`; the test asserts that.

### Stack
1. #1644 — extract `UCColumnConversions` (merged)
2. #1645 — shim scaffolding (merged)
3. #1646 — view glue + `UCViewTypes` + unit tests (merged)
4. #1675 — upgrade the connector to Apache Spark 4.2.0 (`RelationCatalog`/`View`/`loadRelation`) (merged)
5. **this PR** — local-run e2e test for metric views + the jackson-core fix above

