### PR TITLE
Fix permission GET endpoints to work with authorization enabled (#1604)

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
@@ -103,4 +103,11 @@ public final class AuthorizeExpressions {
           : (#authorize(#principal, #table, OWNER) ||
               #authorizeAll(#principal, #table, SELECT, MODIFY)))
       """;
+
+  /**
+   * Authorization policy for the {@code get*Authorization} (permission read) endpoints. These
+   * endpoints check authorization themselves and tailor the response based on whether the principal
+   * is an owner, so the only requirement here is that the caller is authenticated.
+   */
+  public static final String GET_RESOURCE_AUTHORIZATION = "#principal != null";
 }

--- a/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
@@ -11,6 +11,7 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 import static io.unitycatalog.server.model.SecurableType.VOLUME;
 
 import io.unitycatalog.control.model.User;
+import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
@@ -80,54 +81,65 @@ public class PermissionService {
 
   // TODO: Refactor these endpoints to use a common method with dynamic resource id lookup
   @Get("/metastore/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getMetastoreAuthorization(
       @Param("name") String name) {
     return getAuthorization(METASTORE, name);
   }
 
   @Get("/catalog/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getCatalogAuthorization(
       @Param("name") String name) {
     return getAuthorization(CATALOG, name);
   }
 
   @Get("/schema/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getSchemaAuthorization(
       @Param("name") String name) {
     return getAuthorization(SCHEMA, name);
   }
 
   @Get("/table/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getTableAuthorization(
       @Param("name") String name) {
     return getAuthorization(TABLE, name);
   }
 
   @Get("/function/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getFunctionAuthorization(
       @Param("name") String name) {
     return getAuthorization(FUNCTION, name);
   }
 
   @Get("/volume/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getVolumeAuthorization(
       @Param("name") String name) {
     return getAuthorization(VOLUME, name);
   }
 
   @Get("/registered_model/{name}")
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
   public HttpResponse getRegisteredModelAuthorization(
       @Param("name") String name) {
     return getAuthorization(REGISTERED_MODEL, name);
   }
 
   @Get("/external_location/{name}")
-  public HttpResponse getExternalLocationAuthorization(@Param("name") String name) {
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
+  public HttpResponse getExternalLocationAuthorization(
+      @Param("name") String name) {
     return getAuthorization(EXTERNAL_LOCATION, name);
   }
 
   @Get("/credential/{name}")
-  public HttpResponse getCredentialAuthorization(@Param("name") String name) {
+  @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
+  public HttpResponse getCredentialAuthorization(
+      @Param("name") String name) {
     return getAuthorization(CREDENTIAL, name);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/service/PermissionServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/PermissionServiceTest.java
@@ -1,0 +1,161 @@
+package io.unitycatalog.server.service;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_FULL_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.TABLE_FULL_NAME;
+import static io.unitycatalog.server.utils.TestUtils.TABLE_NAME;
+import static io.unitycatalog.server.utils.TestUtils.assertApiException;
+import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.api.GrantsApi;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.PermissionsChange;
+import io.unitycatalog.client.model.PermissionsList;
+import io.unitycatalog.client.model.Privilege;
+import io.unitycatalog.client.model.PrivilegeAssignment;
+import io.unitycatalog.client.model.SecurableType;
+import io.unitycatalog.client.model.UpdatePermissions;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.sdk.access.SdkAccessControlBaseCRUDTest;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link PermissionService} with authorization enabled.
+ *
+ * <p>A real Unity Catalog server is booted (via {@link SdkAccessControlBaseCRUDTest}) with {@code
+ * server.authorization=enable} and the permission endpoints are exercised end-to-end through the
+ * generated {@link GrantsApi} SDK client (built with {@link TestUtils#createApiClient}). Driving
+ * the SDK rather than a raw HTTP client also exercises the Armeria authentication ({@code
+ * AuthDecorator}) and authorization ({@code UnityAccessDecorator}) decorators wrapping the service.
+ */
+public class PermissionServiceTest extends SdkAccessControlBaseCRUDTest {
+
+  @BeforeEach
+  @SneakyThrows
+  public void setUp() {
+    super.setUp();
+    createTestUser(REGULAR_1);
+    createTestUser(REGULAR_2);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @SneakyThrows
+  public void testPermissionsServiceUseCases() {
+    // Grants are scoped to a single securable, so we exercise the catalog, schema and table levels
+    // independently and then read each one back. The base test only creates the catalog and schema,
+    // so the table is created here before privileges can be granted on it.
+    createExternalTable(
+        new TablesApi(adminApiClient), CATALOG_NAME, SCHEMA_NAME, TABLE_NAME, "/tmp/" + TABLE_NAME);
+
+    // Admin (metastore owner) grants catalog-level privileges.
+    grantsApi.update(
+        SecurableType.CATALOG,
+        CATALOG_NAME,
+        addPrivileges(REGULAR_1, Privilege.USE_CATALOG, Privilege.CREATE_SCHEMA));
+    grantsApi.update(
+        SecurableType.CATALOG, CATALOG_NAME, addPrivileges(REGULAR_2, Privilege.USE_CATALOG));
+
+    // Schema-level privileges for regular-1.
+    grantsApi.update(
+        SecurableType.SCHEMA,
+        SCHEMA_FULL_NAME,
+        addPrivileges(REGULAR_1, Privilege.USE_SCHEMA, Privilege.CREATE_TABLE));
+
+    // Table-level privileges for regular-1.
+    grantsApi.update(
+        SecurableType.TABLE,
+        TABLE_FULL_NAME,
+        addPrivileges(REGULAR_1, Privilege.SELECT, Privilege.MODIFY));
+
+    // Reading back as the owner exposes the full ACL. Each securable is queried separately because
+    // a GET only returns the privileges granted directly on that securable.
+    PermissionsList catalogPermissions = grantsApi.get(SecurableType.CATALOG, CATALOG_NAME, null);
+    assertThat(privilegesFor(catalogPermissions, REGULAR_1))
+        .containsExactlyInAnyOrder(Privilege.USE_CATALOG, Privilege.CREATE_SCHEMA);
+    assertThat(privilegesFor(catalogPermissions, REGULAR_2)).containsExactly(Privilege.USE_CATALOG);
+
+    PermissionsList schemaPermissions = grantsApi.get(SecurableType.SCHEMA, SCHEMA_FULL_NAME, null);
+    assertThat(privilegesFor(schemaPermissions, REGULAR_1))
+        .containsExactlyInAnyOrder(Privilege.USE_SCHEMA, Privilege.CREATE_TABLE);
+    assertThat(privilegesFor(schemaPermissions, REGULAR_2)).isEmpty();
+
+    PermissionsList tablePermissions = grantsApi.get(SecurableType.TABLE, TABLE_FULL_NAME, null);
+    assertThat(privilegesFor(tablePermissions, REGULAR_1))
+        .containsExactlyInAnyOrder(Privilege.SELECT, Privilege.MODIFY);
+    assertThat(privilegesFor(tablePermissions, REGULAR_2)).isEmpty();
+  }
+
+  @Test
+  @SneakyThrows
+  public void nonOwnerCannotGrantPermissionsToOthers() {
+    // regular-1 cannot grant permissions to regular-2
+    assertPermissionDenied(
+        () ->
+            grantsApiFor(REGULAR_1)
+                .update(
+                    SecurableType.CATALOG,
+                    CATALOG_NAME,
+                    addPrivileges(REGULAR_2, Privilege.USE_CATALOG)));
+  }
+
+  @Test
+  @SneakyThrows
+  public void nonOwnerCanReadCatalogPermissions() {
+    // GET is gated only on authentication, so a non-owner gets their own (empty) view.
+    PermissionsList response =
+        grantsApiFor(REGULAR_1).get(SecurableType.CATALOG, CATALOG_NAME, null);
+    assertThat(privilegesFor(response, REGULAR_1)).isEmpty();
+  }
+
+  @Test
+  public void unauthenticatedRequestIsRejected() {
+    // No bearer token -> the AuthDecorator rejects the request before it reaches the service.
+    GrantsApi unauthGrantsApi = new GrantsApi(TestUtils.createApiClient(serverConfig));
+    assertApiException(
+        () -> unauthGrantsApi.get(SecurableType.CATALOG, CATALOG_NAME, null),
+        ErrorCode.UNAUTHENTICATED,
+        "authorization");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Builds a {@link GrantsApi} client authenticated as the given test user. */
+  private GrantsApi grantsApiFor(String userEmail) {
+    ServerConfig userConfig = createTestUserServerConfig(userEmail);
+    return new GrantsApi(TestUtils.createApiClient(userConfig));
+  }
+
+  private static UpdatePermissions addPrivileges(String principal, Privilege... privileges) {
+    PermissionsChange change =
+        new PermissionsChange().principal(principal).add(List.of(privileges)).remove(List.of());
+    return new UpdatePermissions().changes(List.of(change));
+  }
+
+  /** Returns the privileges assigned to {@code principal} in a PermissionsList response. */
+  private static List<Privilege> privilegesFor(PermissionsList permissionsList, String principal) {
+    List<Privilege> privileges = new ArrayList<>();
+    if (permissionsList.getPrivilegeAssignments() == null) {
+      return privileges;
+    }
+    for (PrivilegeAssignment assignment : permissionsList.getPrivilegeAssignments()) {
+      if (principal.equals(assignment.getPrincipal())) {
+        privileges.addAll(assignment.getPrivileges());
+      }
+    }
+    return privileges;
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Issue**
https://github.com/unitycatalog/unitycatalog/issues/1603

**Description of changes**

PermissionService.java

Added @AuthorizeExpression to ensure the GET routes would authenticate as they were throwing 500s before when authenticated.

PermissionServiceTest was added to cover the GET permissions route behaviors across metastore, catalog, schema, table, and others.
