### PR TITLE
[Hadoop][Spark] Add QueryCredId and credential.cache.scope for per-query caching

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -6,6 +6,7 @@ import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -82,6 +83,9 @@ public final class UCCredentialHadoopConfs {
     private ApiClient apiClient;
     private boolean credentialRenewalEnabled = true;
     private boolean credentialScopedFsEnabled = true;
+    private String credentialCacheScope =
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE;
+    private String queryCredId;
 
     private Configuration hadoopConf = new Configuration(false);
     private final Map<String, String> appVersions = new LinkedHashMap<>();
@@ -125,6 +129,37 @@ public final class UCCredentialHadoopConfs {
      */
     public Builder enableCredentialScopedFs(boolean enabled) {
       this.credentialScopedFsEnabled = enabled;
+      return this;
+    }
+
+    /**
+     * Credential cache scope (default {@code cluster}).
+     *
+     * <ul>
+     *   <li>{@code query} — isolate vended credentials per query via {@link
+     *       io.unitycatalog.hadoop.internal.id.QueryCredId}.
+     *   <li>{@code cluster} — share vended credentials cluster-wide keyed by {@link
+     *       io.unitycatalog.hadoop.internal.id.CredId}.
+     * </ul>
+     */
+    public Builder credentialCacheScope(String scope) {
+      Preconditions.checkArgument(
+          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(scope)
+              || UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER.equals(scope),
+          "credential cache scope must be '%s' or '%s', got '%s'",
+          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY,
+          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER,
+          scope);
+      this.credentialCacheScope = scope;
+      return this;
+    }
+
+    /**
+     * Per-query credential cache identity. Required when {@link #credentialCacheScope} is {@code
+     * query}; when absent, a random UUID is generated at props-build time.
+     */
+    public Builder queryCredId(String queryCredId) {
+      this.queryCredId = queryCredId;
       return this;
     }
 
@@ -178,7 +213,9 @@ public final class UCCredentialHadoopConfs {
           tokenProvider,
           tableId,
           tableOperation,
-          appVersions);
+          appVersions,
+          credentialCacheScope,
+          queryCredId);
     }
 
     /**
@@ -213,7 +250,9 @@ public final class UCCredentialHadoopConfs {
           identifier,
           location,
           operation,
-          appVersions);
+          appVersions,
+          credentialCacheScope,
+          queryCredId);
     }
 
     /**
@@ -244,7 +283,9 @@ public final class UCCredentialHadoopConfs {
           tokenProvider,
           stagingTableId,
           location,
-          appVersions);
+          appVersions,
+          credentialCacheScope,
+          queryCredId);
     }
 
     /**
@@ -267,7 +308,9 @@ public final class UCCredentialHadoopConfs {
           tokenProvider,
           path,
           pathOperation,
-          appVersions);
+          appVersions,
+          credentialCacheScope,
+          queryCredId);
     }
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -60,6 +60,42 @@ public final class UCCredentialHadoopConfs {
   }
 
   /**
+   * Credential cache scope.
+   *
+   * @since 0.5.0
+   */
+  public enum CredentialCacheScope {
+    QUERY(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY),
+    CLUSTER(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER);
+
+    private final String value;
+
+    CredentialCacheScope(String value) {
+      this.value = value;
+    }
+
+    public String value() {
+      return value;
+    }
+
+    public static CredentialCacheScope fromValue(String value) {
+      for (CredentialCacheScope scope : values()) {
+        if (scope.value.equals(value)) {
+          return scope;
+        }
+      }
+      throw new IllegalArgumentException(
+          "credential cache scope must be '"
+              + QUERY.value
+              + "' or '"
+              + CLUSTER.value
+              + "', got '"
+              + value
+              + "'");
+    }
+  }
+
+  /**
    * Creates a new {@link Builder} with the two required fields.
    *
    * @param catalogUri the Unity Catalog server base URI, e.g. {@code "https://my-uc-server"}
@@ -83,9 +119,7 @@ public final class UCCredentialHadoopConfs {
     private ApiClient apiClient;
     private boolean credentialRenewalEnabled = true;
     private boolean credentialScopedFsEnabled = true;
-    private String credentialCacheScope =
-        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE;
-    private String queryCredId;
+    private CredentialCacheScope credentialCacheScope = CredentialCacheScope.CLUSTER;
 
     private Configuration hadoopConf = new Configuration(false);
     private final Map<String, String> appVersions = new LinkedHashMap<>();
@@ -133,34 +167,23 @@ public final class UCCredentialHadoopConfs {
     }
 
     /**
-     * Credential cache scope (default {@code cluster}).
+     * Credential cache scope (default {@link CredentialCacheScope#CLUSTER}).
      *
      * <ul>
-     *   <li>{@code query} — isolate vended credentials per query via {@link
+     *   <li>{@link CredentialCacheScope#QUERY} — isolate vended credentials per query via {@link
      *       io.unitycatalog.hadoop.internal.id.QueryCredId}.
-     *   <li>{@code cluster} — share vended credentials cluster-wide keyed by {@link
-     *       io.unitycatalog.hadoop.internal.id.CredId}.
+     *   <li>{@link CredentialCacheScope#CLUSTER} — share vended credentials cluster-wide keyed by
+     *       {@link io.unitycatalog.hadoop.internal.id.CredId}.
      * </ul>
      */
-    public Builder credentialCacheScope(String scope) {
-      Preconditions.checkArgument(
-          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(scope)
-              || UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER.equals(scope),
-          "credential cache scope must be '%s' or '%s', got '%s'",
-          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY,
-          UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER,
-          scope);
+    public Builder credentialCacheScope(CredentialCacheScope scope) {
+      Preconditions.checkNotNull(scope, "scope is required");
       this.credentialCacheScope = scope;
       return this;
     }
 
-    /**
-     * Per-query credential cache identity. Required when {@link #credentialCacheScope} is {@code
-     * query}; when absent, a random UUID is generated at props-build time.
-     */
-    public Builder queryCredId(String queryCredId) {
-      this.queryCredId = queryCredId;
-      return this;
+    public Builder credentialCacheScope(String scope) {
+      return credentialCacheScope(CredentialCacheScope.fromValue(scope));
     }
 
     /**
@@ -215,7 +238,7 @@ public final class UCCredentialHadoopConfs {
           tableOperation,
           appVersions,
           credentialCacheScope,
-          queryCredId);
+          hadoopConf);
     }
 
     /**
@@ -252,7 +275,7 @@ public final class UCCredentialHadoopConfs {
           operation,
           appVersions,
           credentialCacheScope,
-          queryCredId);
+          hadoopConf);
     }
 
     /**
@@ -285,7 +308,7 @@ public final class UCCredentialHadoopConfs {
           location,
           appVersions,
           credentialCacheScope,
-          queryCredId);
+          hadoopConf);
     }
 
     /**
@@ -310,7 +333,7 @@ public final class UCCredentialHadoopConfs {
           pathOperation,
           appVersions,
           credentialCacheScope,
-          queryCredId);
+          hadoopConf);
     }
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -79,6 +80,19 @@ public class CredPropsUtil {
       tokenProvider
           .configs()
           .forEach((key, value) -> builder.put(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
+      return self();
+    }
+
+    /** Applies credential cache scope and optional per-query identity to credential props. */
+    public T credentialCache(String scope, String queryCredId) {
+      set(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY, scope);
+      if (UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(scope)) {
+        String id =
+            queryCredId != null && !queryCredId.isEmpty()
+                ? queryCredId
+                : UUID.randomUUID().toString();
+        set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, id);
+      }
       return self();
     }
 
@@ -339,6 +353,36 @@ public class CredPropsUtil {
       UCCredentialHadoopConfs.TableOperation tableOp,
       Map<String, String> appVersions)
       throws ApiException {
+    return createTableCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        apiClient,
+        catalogUri,
+        tokenProvider,
+        tableId,
+        tableOp,
+        appVersions,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
+        null);
+  }
+
+  /** Fetches table credentials from the UC REST API and builds Hadoop configuration properties. */
+  public static Map<String, String> createTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      String tableId,
+      UCCredentialHadoopConfs.TableOperation tableOp,
+      Map<String, String> appVersions,
+      String credentialCacheScope,
+      String queryCredId)
+      throws ApiException {
     return createCredProps(
         renewCredEnabled,
         credScopedFsEnabled,
@@ -348,7 +392,9 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new TableCredId(tableId, tableOp.value()));
+        new TableCredId(tableId, tableOp.value()),
+        credentialCacheScope,
+        queryCredId);
   }
 
   /**
@@ -368,6 +414,41 @@ public class CredPropsUtil {
       UCCredentialHadoopConfs.TableOperation tableOp,
       Map<String, String> appVersions)
       throws ApiException {
+    return createDeltaTableCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        apiClient,
+        catalogUri,
+        tokenProvider,
+        identifier,
+        location,
+        tableOp,
+        appVersions,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
+        null);
+  }
+
+  /**
+   * Fetches Delta table credentials from the UC Delta API and builds Hadoop configuration
+   * properties.
+   */
+  public static Map<String, String> createDeltaTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      UCDeltaTableIdentifier identifier,
+      String location,
+      UCCredentialHadoopConfs.TableOperation tableOp,
+      Map<String, String> appVersions,
+      String credentialCacheScope,
+      String queryCredId)
+      throws ApiException {
     return createCredProps(
         renewCredEnabled,
         credScopedFsEnabled,
@@ -377,7 +458,9 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaTableCredId(identifier, tableOp.value(), location));
+        new DeltaTableCredId(identifier, tableOp.value(), location),
+        credentialCacheScope,
+        queryCredId);
   }
 
   /**
@@ -396,6 +479,39 @@ public class CredPropsUtil {
       String location,
       Map<String, String> appVersions)
       throws ApiException {
+    return createDeltaStagingTableCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        apiClient,
+        catalogUri,
+        tokenProvider,
+        stagingTableId,
+        location,
+        appVersions,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
+        null);
+  }
+
+  /**
+   * Fetches Delta staging table credentials from the UC Delta API and builds Hadoop configuration
+   * properties.
+   */
+  public static Map<String, String> createDeltaStagingTableCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      String stagingTableId,
+      String location,
+      Map<String, String> appVersions,
+      String credentialCacheScope,
+      String queryCredId)
+      throws ApiException {
     return createCredProps(
         renewCredEnabled,
         credScopedFsEnabled,
@@ -405,7 +521,9 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaStagingTableCredId(stagingTableId, location));
+        new DeltaStagingTableCredId(stagingTableId, location),
+        credentialCacheScope,
+        queryCredId);
   }
 
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -421,6 +539,36 @@ public class CredPropsUtil {
       UCCredentialHadoopConfs.PathOperation pathOp,
       Map<String, String> appVersions)
       throws ApiException {
+    return createPathCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        apiClient,
+        catalogUri,
+        tokenProvider,
+        path,
+        pathOp,
+        appVersions,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
+        null);
+  }
+
+  /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
+  public static Map<String, String> createPathCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      String path,
+      UCCredentialHadoopConfs.PathOperation pathOp,
+      Map<String, String> appVersions,
+      String credentialCacheScope,
+      String queryCredId)
+      throws ApiException {
     return createCredProps(
         renewCredEnabled,
         credScopedFsEnabled,
@@ -430,7 +578,9 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new PathCredId(path, pathOp.value()));
+        new PathCredId(path, pathOp.value()),
+        credentialCacheScope,
+        queryCredId);
   }
 
   /**
@@ -447,7 +597,9 @@ public class CredPropsUtil {
       String catalogUri,
       TokenProvider tokenProvider,
       Map<String, String> appVersions,
-      CredId credId)
+      CredId credId,
+      String credentialCacheScope,
+      String queryCredId)
       throws ApiException {
     TemporaryCredentials tempCreds =
         fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, credId);
@@ -457,6 +609,7 @@ public class CredPropsUtil {
           return s3TempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
+              .credentialCache(credentialCacheScope, queryCredId)
               .appVersions(appVersions)
               .build();
         } else {
@@ -467,6 +620,7 @@ public class CredPropsUtil {
           return gcsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
+              .credentialCache(credentialCacheScope, queryCredId)
               .appVersions(appVersions)
               .build();
         } else {
@@ -478,6 +632,7 @@ public class CredPropsUtil {
           return abfsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
+              .credentialCache(credentialCacheScope, queryCredId)
               .appVersions(appVersions)
               .build();
         } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -9,6 +9,7 @@ import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs.CredentialCacheScope;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
@@ -83,15 +84,15 @@ public class CredPropsUtil {
       return self();
     }
 
-    /** Applies credential cache scope and optional per-query identity to credential props. */
-    public T credentialCache(String scope, String queryCredId) {
-      set(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY, scope);
-      if (UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(scope)) {
-        String id =
-            queryCredId != null && !queryCredId.isEmpty()
-                ? queryCredId
-                : UUID.randomUUID().toString();
-        set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, id);
+    /** Applies credential cache scope and per-query identity to credential props. */
+    public T credentialCache(CredentialCacheScope scope, Configuration hadoopConf) {
+      set(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY, scope.value());
+      if (scope == CredentialCacheScope.QUERY) {
+        String uuid = hadoopConf.get(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY);
+        if (uuid == null || uuid.isEmpty()) {
+          uuid = UUID.randomUUID().toString();
+        }
+        set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, uuid);
       }
       return self();
     }
@@ -364,8 +365,8 @@ public class CredPropsUtil {
         tableId,
         tableOp,
         appVersions,
-        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
-        null);
+        CredentialCacheScope.CLUSTER,
+        hadoopConf);
   }
 
   /** Fetches table credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -380,8 +381,8 @@ public class CredPropsUtil {
       String tableId,
       UCCredentialHadoopConfs.TableOperation tableOp,
       Map<String, String> appVersions,
-      String credentialCacheScope,
-      String queryCredId)
+      CredentialCacheScope credentialCacheScope,
+      Configuration credentialCacheConf)
       throws ApiException {
     return createCredProps(
         renewCredEnabled,
@@ -394,7 +395,7 @@ public class CredPropsUtil {
         appVersions,
         new TableCredId(tableId, tableOp.value()),
         credentialCacheScope,
-        queryCredId);
+        credentialCacheConf);
   }
 
   /**
@@ -426,8 +427,8 @@ public class CredPropsUtil {
         location,
         tableOp,
         appVersions,
-        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
-        null);
+        CredentialCacheScope.CLUSTER,
+        hadoopConf);
   }
 
   /**
@@ -446,8 +447,8 @@ public class CredPropsUtil {
       String location,
       UCCredentialHadoopConfs.TableOperation tableOp,
       Map<String, String> appVersions,
-      String credentialCacheScope,
-      String queryCredId)
+      CredentialCacheScope credentialCacheScope,
+      Configuration credentialCacheConf)
       throws ApiException {
     return createCredProps(
         renewCredEnabled,
@@ -460,7 +461,7 @@ public class CredPropsUtil {
         appVersions,
         new DeltaTableCredId(identifier, tableOp.value(), location),
         credentialCacheScope,
-        queryCredId);
+        credentialCacheConf);
   }
 
   /**
@@ -490,8 +491,8 @@ public class CredPropsUtil {
         stagingTableId,
         location,
         appVersions,
-        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
-        null);
+        CredentialCacheScope.CLUSTER,
+        hadoopConf);
   }
 
   /**
@@ -509,8 +510,8 @@ public class CredPropsUtil {
       String stagingTableId,
       String location,
       Map<String, String> appVersions,
-      String credentialCacheScope,
-      String queryCredId)
+      CredentialCacheScope credentialCacheScope,
+      Configuration credentialCacheConf)
       throws ApiException {
     return createCredProps(
         renewCredEnabled,
@@ -523,7 +524,7 @@ public class CredPropsUtil {
         appVersions,
         new DeltaStagingTableCredId(stagingTableId, location),
         credentialCacheScope,
-        queryCredId);
+        credentialCacheConf);
   }
 
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -550,8 +551,8 @@ public class CredPropsUtil {
         path,
         pathOp,
         appVersions,
-        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE,
-        null);
+        CredentialCacheScope.CLUSTER,
+        hadoopConf);
   }
 
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -566,8 +567,8 @@ public class CredPropsUtil {
       String path,
       UCCredentialHadoopConfs.PathOperation pathOp,
       Map<String, String> appVersions,
-      String credentialCacheScope,
-      String queryCredId)
+      CredentialCacheScope credentialCacheScope,
+      Configuration credentialCacheConf)
       throws ApiException {
     return createCredProps(
         renewCredEnabled,
@@ -580,7 +581,7 @@ public class CredPropsUtil {
         appVersions,
         new PathCredId(path, pathOp.value()),
         credentialCacheScope,
-        queryCredId);
+        credentialCacheConf);
   }
 
   /**
@@ -598,8 +599,8 @@ public class CredPropsUtil {
       TokenProvider tokenProvider,
       Map<String, String> appVersions,
       CredId credId,
-      String credentialCacheScope,
-      String queryCredId)
+      CredentialCacheScope credentialCacheScope,
+      Configuration credentialCacheConf)
       throws ApiException {
     TemporaryCredentials tempCreds =
         fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, credId);
@@ -609,7 +610,7 @@ public class CredPropsUtil {
           return s3TempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
-              .credentialCache(credentialCacheScope, queryCredId)
+              .credentialCache(credentialCacheScope, credentialCacheConf)
               .appVersions(appVersions)
               .build();
         } else {
@@ -620,7 +621,7 @@ public class CredPropsUtil {
           return gcsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
-              .credentialCache(credentialCacheScope, queryCredId)
+              .credentialCache(credentialCacheScope, credentialCacheConf)
               .appVersions(appVersions)
               .build();
         } else {
@@ -632,7 +633,7 @@ public class CredPropsUtil {
           return abfsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
               .credId(credId)
-              .credentialCache(credentialCacheScope, queryCredId)
+              .credentialCache(credentialCacheScope, credentialCacheConf)
               .appVersions(appVersions)
               .build();
         } else {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -95,6 +95,17 @@ public class UCHadoopConfConstants {
       "fs.unitycatalog.credential.cache.enabled";
   public static final boolean UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE = true;
 
+  // Credential cache scope: "query" isolates per query; "cluster" shares cluster-wide.
+  public static final String UC_CREDENTIAL_CACHE_SCOPE_KEY =
+      "fs.unitycatalog.credential.cache.scope";
+  public static final String UC_CREDENTIAL_CACHE_SCOPE_QUERY = "query";
+  public static final String UC_CREDENTIAL_CACHE_SCOPE_CLUSTER = "cluster";
+  public static final String UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE =
+      UC_CREDENTIAL_CACHE_SCOPE_CLUSTER;
+
+  // Per-query credential cache identity, propagated from the Spark driver to executors.
+  public static final String UC_QUERY_CRED_ID_KEY = "fs.unitycatalog.credentials.query.id";
+
   // Keys for HTTP request configuration - see ApiClientConf for more details.
   public static final String REQUEST_RETRY_MAX_ATTEMPTS_KEY =
       "fs.unitycatalog.request.retry.maxAttempts";

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -103,8 +103,10 @@ public class UCHadoopConfConstants {
   public static final String UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE =
       UC_CREDENTIAL_CACHE_SCOPE_CLUSTER;
 
-  // Per-query credential cache identity, propagated from the Spark driver to executors.
-  public static final String UC_QUERY_CRED_ID_KEY = "fs.unitycatalog.credentials.query.id";
+  // Key representing a unique credential ID. It identifies a job-level credential for a specific
+  // table, meaning that the same job–table combination shares the same credential. Cached
+  // credentials are indexed by this key and are not reused across different jobs.
+  public static final String UC_CREDENTIALS_UID_KEY = "fs.unitycatalog.credentials.uid";
 
   // Keys for HTTP request configuration - see ApiClientConf for more details.
   public static final String REQUEST_RETRY_MAX_ATTEMPTS_KEY =

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -3,7 +3,7 @@ package io.unitycatalog.hadoop.internal.auth;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
-import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.id.QueryCredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import org.apache.hadoop.conf.Configuration;
 
@@ -16,7 +16,7 @@ import org.apache.hadoop.conf.Configuration;
 public abstract class GenericCredentialProvider {
   // The credential cache, for saving QPS to unity catalog server. Keyed by the credential scope
   // ({@link CredId}) so that requests targeting the same scope can share a vended credential.
-  static final BoundedKeyedCache<CredId, GenericCredential> globalCache;
+  static final BoundedKeyedCache<Object, GenericCredential> globalCache;
   private static final String UC_CREDENTIAL_CACHE_MAX_SIZE =
       "unitycatalog.credential.cache.maxSize";
   private static final int UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
@@ -30,7 +30,7 @@ public abstract class GenericCredentialProvider {
   private Configuration conf;
   private Clock clock;
   private long renewalLeadTimeMillis;
-  private CredId cacheKey;
+  private Object cacheKey;
   private boolean credCacheEnabled;
 
   private volatile GenericCredential credential;
@@ -48,9 +48,15 @@ public abstract class GenericCredentialProvider {
             UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY,
             UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
 
-    // Identify the credential scope; used as the global cache key so that requests targeting the
-    // same scope can share a vended credential.
-    this.cacheKey = CredId.create(conf);
+    // Identify the credential cache key. Cluster scope shares by CredId; query scope isolates by
+    // (CredId, queryId).
+    this.cacheKey =
+        QueryCredId.resolveCacheKey(
+            conf,
+            () -> {
+              throw new IllegalArgumentException(
+                  "Cannot recognize the hadoop config to initialize the credential cache key.");
+            });
 
     this.credCacheEnabled =
         conf.getBoolean(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -3,6 +3,7 @@ package io.unitycatalog.hadoop.internal.auth;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.QueryCredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import org.apache.hadoop.conf.Configuration;
@@ -16,7 +17,7 @@ import org.apache.hadoop.conf.Configuration;
 public abstract class GenericCredentialProvider {
   // The credential cache, for saving QPS to unity catalog server. Keyed by the credential scope
   // ({@link CredId}) so that requests targeting the same scope can share a vended credential.
-  static final BoundedKeyedCache<Object, GenericCredential> globalCache;
+  static final BoundedKeyedCache<CredId, GenericCredential> globalCache;
   private static final String UC_CREDENTIAL_CACHE_MAX_SIZE =
       "unitycatalog.credential.cache.maxSize";
   private static final int UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
@@ -30,7 +31,7 @@ public abstract class GenericCredentialProvider {
   private Configuration conf;
   private Clock clock;
   private long renewalLeadTimeMillis;
-  private Object cacheKey;
+  private CredId cacheKey;
   private boolean credCacheEnabled;
 
   private volatile GenericCredential credential;
@@ -49,7 +50,7 @@ public abstract class GenericCredentialProvider {
             UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
 
     // Identify the credential cache key. Cluster scope shares by CredId; query scope isolates by
-    // (CredId, queryId).
+    // (CredId, uuid).
     this.cacheKey =
         QueryCredId.resolveCacheKey(
             conf,

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -2,6 +2,7 @@ package io.unitycatalog.hadoop.internal.fs;
 
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DefaultCredId;
+import io.unitycatalog.hadoop.internal.id.QueryCredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import io.unitycatalog.hadoop.internal.util.CloseableUtils;
 import java.io.IOException;
@@ -64,7 +65,7 @@ public class CredScopedFileSystem extends FilterFileSystem {
    * {@code unitycatalog.credScopedFs.cache.maxSize}.
    */
   /** Visible for testing. */
-  static final BoundedKeyedCache<CredId, FileSystem> CACHE;
+  static final BoundedKeyedCache<Object, FileSystem> CACHE;
 
   static {
     int maxSize =
@@ -84,7 +85,7 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    CredId key = CredId.create(conf, () -> new DefaultCredId(uri, conf));
+    Object key = QueryCredId.resolveCacheKey(conf, () -> new DefaultCredId(uri, conf));
     this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -65,7 +65,7 @@ public class CredScopedFileSystem extends FilterFileSystem {
    * {@code unitycatalog.credScopedFs.cache.maxSize}.
    */
   /** Visible for testing. */
-  static final BoundedKeyedCache<Object, FileSystem> CACHE;
+  static final BoundedKeyedCache<CredId, FileSystem> CACHE;
 
   static {
     int maxSize =
@@ -85,7 +85,7 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    Object key = QueryCredId.resolveCacheKey(conf, () -> new DefaultCredId(uri, conf));
+    CredId key = QueryCredId.resolveCacheKey(conf, () -> new DefaultCredId(uri, conf));
     this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.conf.Configuration;
  * <p>Two requests sharing the same {@code CredId} target the same credential scope and can reuse a
  * vended credential, while requests with different ids are isolated.
  *
- * <p>There are five implementations:
+ * <p>There are six implementations:
  *
  * <ul>
  *   <li>{@link TableCredId} — keyed by table ID and operation; used for table-level temporary
@@ -41,6 +41,8 @@ import org.apache.hadoop.conf.Configuration;
  *       staging-table-level temporary credentials via the UC Delta credentials API.
  *   <li>{@link DefaultCredId} — keyed by URI scheme and authority; used as a fallback when no Unity
  *       Catalog credential type is present in the configuration.
+ *   <li>{@link QueryCredId} — per-query cache identity used when credential cache scope is {@code
+ *       query}.
  * </ul>
  */
 public interface CredId {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/QueryCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/QueryCredId.java
@@ -1,0 +1,99 @@
+package io.unitycatalog.hadoop.internal.id;
+
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY;
+
+import io.unitycatalog.client.internal.Preconditions;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Credential cache key that isolates vended credentials to a single query.
+ *
+ * <p>When {@link #isQueryScoped(Configuration)} is true, the global credential cache keys entries
+ * by {@code (CredId, queryId)} instead of {@link CredId} alone, so separate queries do not reuse
+ * each other's credentials even when they target the same table or path.
+ */
+public final class QueryCredId {
+  private final CredId scope;
+  private final String queryId;
+
+  public QueryCredId(CredId scope, String queryId) {
+    Preconditions.checkNotNull(scope, "scope is required");
+    Preconditions.checkNotNull(queryId, "queryId is required");
+    Preconditions.checkArgument(!queryId.isEmpty(), "queryId cannot be empty");
+    this.scope = scope;
+    this.queryId = queryId;
+  }
+
+  public CredId scope() {
+    return scope;
+  }
+
+  public String queryId() {
+    return queryId;
+  }
+
+  /** Returns the Hadoop properties needed to reconstruct this query-scoped cache key. */
+  public Map<String, String> props() {
+    return Map.of(
+        UC_CREDENTIAL_CACHE_SCOPE_KEY,
+        UC_CREDENTIAL_CACHE_SCOPE_QUERY,
+        UC_QUERY_CRED_ID_KEY,
+        queryId);
+  }
+
+  public static boolean isQueryScoped(Configuration conf) {
+    return UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(
+        conf.get(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE));
+  }
+
+  /**
+   * Resolves the credential cache key for {@code conf}.
+   *
+   * <p>Returns a {@link QueryCredId} when the cache scope is {@code query}; otherwise returns the
+   * credential scope {@link CredId}.
+   */
+  public static Object resolveCacheKey(Configuration conf, Supplier<CredId> defaultCredId) {
+    CredId scope = CredId.create(conf, defaultCredId);
+    if (isQueryScoped(conf)) {
+      return new QueryCredId(scope, requireQueryId(conf));
+    }
+    return scope;
+  }
+
+  private static String requireQueryId(Configuration conf) {
+    String queryId = conf.get(UC_QUERY_CRED_ID_KEY);
+    Preconditions.checkState(
+        queryId != null && !queryId.isEmpty(),
+        "Query-scoped credential cache requires '%s' in hadoop configuration",
+        UC_QUERY_CRED_ID_KEY);
+    return queryId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof QueryCredId)) {
+      return false;
+    }
+    QueryCredId that = (QueryCredId) o;
+    return Objects.equals(scope, that.scope) && Objects.equals(queryId, that.queryId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scope, queryId);
+  }
+
+  @Override
+  public String toString() {
+    return "QueryCredId{scope=" + scope + ", queryId=" + queryId + "}";
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/QueryCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/QueryCredId.java
@@ -1,78 +1,73 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY;
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY;
 
 import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs.CredentialCacheScope;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 
 /**
- * Credential cache key that isolates vended credentials to a single query.
+ * Per-query credential cache identity.
  *
- * <p>When {@link #isQueryScoped(Configuration)} is true, the global credential cache keys entries
- * by {@code (CredId, queryId)} instead of {@link CredId} alone, so separate queries do not reuse
- * each other's credentials even when they target the same table or path.
+ * <p>Used only when credential cache scope is {@code query}. Cluster-scoped caching continues to
+ * key entries by the resource {@link CredId} alone.
  */
-public final class QueryCredId {
-  private final CredId scope;
-  private final String queryId;
+public final class QueryCredId implements CredId {
+  private final String uuid;
 
-  public QueryCredId(CredId scope, String queryId) {
-    Preconditions.checkNotNull(scope, "scope is required");
-    Preconditions.checkNotNull(queryId, "queryId is required");
-    Preconditions.checkArgument(!queryId.isEmpty(), "queryId cannot be empty");
-    this.scope = scope;
-    this.queryId = queryId;
+  public QueryCredId(String uuid) {
+    Preconditions.checkNotNull(uuid, "uuid is required");
+    Preconditions.checkArgument(!uuid.isEmpty(), "uuid cannot be empty");
+    this.uuid = uuid;
   }
 
-  public CredId scope() {
-    return scope;
+  public String uuid() {
+    return uuid;
   }
 
-  public String queryId() {
-    return queryId;
-  }
-
-  /** Returns the Hadoop properties needed to reconstruct this query-scoped cache key. */
+  @Override
   public Map<String, String> props() {
     return Map.of(
         UC_CREDENTIAL_CACHE_SCOPE_KEY,
         UC_CREDENTIAL_CACHE_SCOPE_QUERY,
-        UC_QUERY_CRED_ID_KEY,
-        queryId);
+        UC_CREDENTIALS_UID_KEY,
+        uuid);
   }
 
   public static boolean isQueryScoped(Configuration conf) {
-    return UC_CREDENTIAL_CACHE_SCOPE_QUERY.equals(
-        conf.get(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE));
+    return CredentialCacheScope.QUERY
+        .value()
+        .equals(conf.get(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_DEFAULT_VALUE));
   }
 
   /**
    * Resolves the credential cache key for {@code conf}.
    *
-   * <p>Returns a {@link QueryCredId} when the cache scope is {@code query}; otherwise returns the
-   * credential scope {@link CredId}.
+   * <p>Returns a query-scoped composite key when cache scope is {@code query}; otherwise returns
+   * the resource {@link CredId}.
    */
-  public static Object resolveCacheKey(Configuration conf, Supplier<CredId> defaultCredId) {
-    CredId scope = CredId.create(conf, defaultCredId);
+  public static CredId resolveCacheKey(Configuration conf, Supplier<CredId> defaultCredId) {
+    CredId credId = CredId.create(conf, defaultCredId);
     if (isQueryScoped(conf)) {
-      return new QueryCredId(scope, requireQueryId(conf));
+      return new QueryScopedCacheKey(credId, new QueryCredId(requireUuid(conf)));
     }
-    return scope;
+    return credId;
   }
 
-  private static String requireQueryId(Configuration conf) {
-    String queryId = conf.get(UC_QUERY_CRED_ID_KEY);
+  static String requireUuid(Configuration conf) {
+    String uuid = conf.get(UC_CREDENTIALS_UID_KEY);
     Preconditions.checkState(
-        queryId != null && !queryId.isEmpty(),
+        uuid != null && !uuid.isEmpty(),
         "Query-scoped credential cache requires '%s' in hadoop configuration",
-        UC_QUERY_CRED_ID_KEY);
-    return queryId;
+        UC_CREDENTIALS_UID_KEY);
+    return uuid;
   }
 
   @Override
@@ -84,16 +79,56 @@ public final class QueryCredId {
       return false;
     }
     QueryCredId that = (QueryCredId) o;
-    return Objects.equals(scope, that.scope) && Objects.equals(queryId, that.queryId);
+    return Objects.equals(uuid, that.uuid);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scope, queryId);
+    return Objects.hash(uuid);
   }
 
   @Override
   public String toString() {
-    return "QueryCredId{scope=" + scope + ", queryId=" + queryId + "}";
+    return "QueryCredId{uuid=" + uuid + "}";
+  }
+
+  /** Cache key combining a resource {@link CredId} with a per-query {@link QueryCredId}. */
+  private static final class QueryScopedCacheKey implements CredId {
+    private final CredId credId;
+    private final QueryCredId queryCredId;
+
+    private QueryScopedCacheKey(CredId credId, QueryCredId queryCredId) {
+      this.credId = credId;
+      this.queryCredId = queryCredId;
+    }
+
+    @Override
+    public Map<String, String> props() {
+      Map<String, String> merged = new LinkedHashMap<>(credId.props());
+      merged.putAll(queryCredId.props());
+      return Map.copyOf(merged);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof QueryScopedCacheKey)) {
+        return false;
+      }
+      QueryScopedCacheKey that = (QueryScopedCacheKey) o;
+      return Objects.equals(credId, that.credId) && Objects.equals(queryCredId, that.queryCredId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(credId, queryCredId);
+    }
+
+    @Override
+    public String toString() {
+      return "QueryScopedCacheKey{credId=" + credId + ", queryCredId=" + queryCredId + "}";
+    }
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -772,6 +772,33 @@ class CredPropsUtilTest {
   }
 
   @Test
+  void createTableCredPropsIncludesQueryCacheScopeAndQueryId() throws Exception {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> mockGenericCredentialFetcher(s3Creds());
+
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            null,
+            "http://uc",
+            tokenProvider(),
+            "tid",
+            UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+            Map.of(),
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY,
+            "query-1");
+
+    assertThat(props)
+        .containsEntry(
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY)
+        .containsEntry(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-1");
+  }
+
+  @Test
   void createDeltaTableCredPropsAssemblesReqConfAndReturnsCredProps() throws Exception {
     AtomicReference<CredId> captured = new AtomicReference<>();
     CredPropsUtil.genericCredFetcherFactory =

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -772,15 +772,17 @@ class CredPropsUtilTest {
   }
 
   @Test
-  void createTableCredPropsIncludesQueryCacheScopeAndQueryId() throws Exception {
+  void createTableCredPropsIncludesQueryCacheScopeAndUuid() throws Exception {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> mockGenericCredentialFetcher(s3Creds());
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, "query-1");
 
     Map<String, String> props =
         CredPropsUtil.createTableCredProps(
             true,
             false,
-            new Configuration(false),
+            conf,
             "s3",
             null,
             "http://uc",
@@ -788,14 +790,14 @@ class CredPropsUtilTest {
             "tid",
             UCCredentialHadoopConfs.TableOperation.READ_WRITE,
             Map.of(),
-            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY,
-            "query-1");
+            UCCredentialHadoopConfs.CredentialCacheScope.QUERY,
+            conf);
 
     assertThat(props)
         .containsEntry(
             UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
             UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY)
-        .containsEntry(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-1");
+        .containsEntry(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, "query-1");
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -319,6 +319,42 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     assertGlobalCache(4, tableACred2, tableBCred2, pathACred2, pathBCred2);
   }
 
+  @Test
+  public void testQueryScopedCredCache() throws Exception {
+    Configuration query1Conf = newTableBasedConf("tableA");
+    query1Conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    query1Conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    query1Conf.set(
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY);
+    query1Conf.set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-1");
+
+    Configuration query2Conf = newTableBasedConf("tableA");
+    query2Conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    query2Conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+    query2Conf.set(
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY);
+    query2Conf.set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-2");
+
+    TemporaryCredentialsApi tempCredApi = mock(TemporaryCredentialsApi.class);
+    TemporaryCredentials cred1 = newTempCred("query_1", clock.now().toEpochMilli() + 2000L);
+    TemporaryCredentials cred2 = newTempCred("query_2", clock.now().toEpochMilli() + 2000L);
+    when(tempCredApi.generateTemporaryTableCredentials(any())).thenReturn(cred1).thenReturn(cred2);
+
+    T providerQuery1 = createTestProvider(query1Conf, tempCredApi);
+    T providerQuery2 = createTestProvider(query2Conf, tempCredApi);
+
+    assertCred(providerQuery1, cred1);
+    assertGlobalCache(1, cred1);
+
+    assertCred(providerQuery2, cred2);
+    assertGlobalCache(2, cred1, cred2);
+
+    assertCred(providerQuery1, cred1);
+    assertGlobalCache(2, cred1, cred2);
+  }
+
   private static void assertGlobalCache(int expectedSize, TemporaryCredentials... creds) {
     assertThat(expectedSize).isEqualTo(creds.length);
     assertThat(GenericCredentialProvider.globalCache.size()).isEqualTo(expectedSize);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -327,7 +327,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     query1Conf.set(
         UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY);
-    query1Conf.set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-1");
+    query1Conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, "query-1");
 
     Configuration query2Conf = newTableBasedConf("tableA");
     query2Conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
@@ -335,7 +335,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     query2Conf.set(
         UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY);
-    query2Conf.set(UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY, "query-2");
+    query2Conf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, "query-2");
 
     TemporaryCredentialsApi tempCredApi = mock(TemporaryCredentialsApi.class);
     TemporaryCredentials cred1 = newTempCred("query_1", clock.now().toEpochMilli() + 2000L);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/QueryCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/QueryCredIdTest.java
@@ -2,10 +2,9 @@ package io.unitycatalog.hadoop.internal.id;
 
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY;
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,43 +18,44 @@ class QueryCredIdTest {
   @Test
   void resolveCacheKeyUsesCredIdForClusterScope() {
     Configuration conf = tableConf();
-    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_CLUSTER);
+    conf.set(
+        UC_CREDENTIAL_CACHE_SCOPE_KEY,
+        io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER);
 
-    Object cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
+    CredId cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
 
-    assertThat(cacheKey).isInstanceOf(TableCredId.class);
     assertThat(cacheKey).isEqualTo(new TableCredId("tableA", "READ"));
   }
 
   @Test
-  void resolveCacheKeyUsesQueryCredIdForQueryScope() {
-    Configuration conf = tableConf();
-    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY);
-    conf.set(UC_QUERY_CRED_ID_KEY, "query-1");
+  void resolveCacheKeyUsesQueryScopedKeyForQueryScope() {
+    Configuration conf = tableConfWithQueryScope("query-1");
 
-    Object cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
+    CredId cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
 
-    assertThat(cacheKey).isEqualTo(new QueryCredId(new TableCredId("tableA", "READ"), "query-1"));
+    assertThat(cacheKey.props())
+        .containsEntry(UC_TABLE_ID_KEY, "tableA")
+        .containsEntry(UC_CREDENTIALS_UID_KEY, "query-1");
   }
 
   @Test
-  void resolveCacheKeyRequiresQueryIdForQueryScope() {
+  void resolveCacheKeyRequiresUuidForQueryScope() {
     Configuration conf = tableConf();
     conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY);
 
     assertThatThrownBy(
             () -> QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ")))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(UC_QUERY_CRED_ID_KEY);
+        .hasMessageContaining(UC_CREDENTIALS_UID_KEY);
   }
 
   @Test
-  void propsIncludeScopeAndQueryId() {
-    QueryCredId queryCredId = new QueryCredId(new TableCredId("tableA", "READ"), "query-1");
+  void propsIncludeScopeAndUuid() {
+    QueryCredId queryCredId = new QueryCredId("query-1");
 
     assertThat(queryCredId.props())
         .containsEntry(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY)
-        .containsEntry(UC_QUERY_CRED_ID_KEY, "query-1");
+        .containsEntry(UC_CREDENTIALS_UID_KEY, "query-1");
   }
 
   private static Configuration tableConf() {
@@ -63,6 +63,13 @@ class QueryCredIdTest {
     conf.set(UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_TABLE_VALUE);
     conf.set(UC_TABLE_ID_KEY, "tableA");
     conf.set(UC_TABLE_OPERATION_KEY, "READ");
+    return conf;
+  }
+
+  private static Configuration tableConfWithQueryScope(String uuid) {
+    Configuration conf = tableConf();
+    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY);
+    conf.set(UC_CREDENTIALS_UID_KEY, uuid);
     return conf;
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/QueryCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/QueryCredIdTest.java
@@ -1,0 +1,68 @@
+package io.unitycatalog.hadoop.internal.id;
+
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_CLUSTER;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIAL_CACHE_SCOPE_QUERY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_QUERY_CRED_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+class QueryCredIdTest {
+
+  @Test
+  void resolveCacheKeyUsesCredIdForClusterScope() {
+    Configuration conf = tableConf();
+    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_CLUSTER);
+
+    Object cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
+
+    assertThat(cacheKey).isInstanceOf(TableCredId.class);
+    assertThat(cacheKey).isEqualTo(new TableCredId("tableA", "READ"));
+  }
+
+  @Test
+  void resolveCacheKeyUsesQueryCredIdForQueryScope() {
+    Configuration conf = tableConf();
+    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY);
+    conf.set(UC_QUERY_CRED_ID_KEY, "query-1");
+
+    Object cacheKey = QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ"));
+
+    assertThat(cacheKey).isEqualTo(new QueryCredId(new TableCredId("tableA", "READ"), "query-1"));
+  }
+
+  @Test
+  void resolveCacheKeyRequiresQueryIdForQueryScope() {
+    Configuration conf = tableConf();
+    conf.set(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY);
+
+    assertThatThrownBy(
+            () -> QueryCredId.resolveCacheKey(conf, () -> new TableCredId("fallback", "READ")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(UC_QUERY_CRED_ID_KEY);
+  }
+
+  @Test
+  void propsIncludeScopeAndQueryId() {
+    QueryCredId queryCredId = new QueryCredId(new TableCredId("tableA", "READ"), "query-1");
+
+    assertThat(queryCredId.props())
+        .containsEntry(UC_CREDENTIAL_CACHE_SCOPE_KEY, UC_CREDENTIAL_CACHE_SCOPE_QUERY)
+        .containsEntry(UC_QUERY_CRED_ID_KEY, "query-1");
+  }
+
+  private static Configuration tableConf() {
+    Configuration conf = new Configuration();
+    conf.set(UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UC_TABLE_ID_KEY, "tableA");
+    conf.set(UC_TABLE_OPERATION_KEY, "READ");
+    return conf;
+  }
+}

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -12,6 +12,11 @@ public class OptionsUtil {
 
   public static final String CRED_SCOPED_FS_ENABLED = "credScopedFs.enabled";
   public static final boolean DEFAULT_CRED_SCOPED_FS_ENABLED = true;
+
+  public static final String CREDENTIAL_CACHE_SCOPE = "credential.cache.scope";
+  public static final String CREDENTIAL_CACHE_SCOPE_QUERY = "query";
+  public static final String CREDENTIAL_CACHE_SCOPE_CLUSTER = "cluster";
+  public static final String DEFAULT_CREDENTIAL_CACHE_SCOPE = CREDENTIAL_CACHE_SCOPE_QUERY;
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
   public static final String DELTA_API_ENABLED = "deltaRestApi.enabled";

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -17,8 +17,10 @@ public class OptionsUtil {
   public static final String CREDENTIAL_CACHE_SCOPE_QUERY = "query";
   public static final String CREDENTIAL_CACHE_SCOPE_CLUSTER = "cluster";
   public static final String DEFAULT_CREDENTIAL_CACHE_SCOPE = CREDENTIAL_CACHE_SCOPE_QUERY;
+
   public static final String SERVER_SIDE_PLANNING_ENABLED = "serverSidePlanning.enabled";
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
+
   public static final String DELTA_API_ENABLED = "deltaRestApi.enabled";
   public static final boolean DEFAULT_DELTA_API_ENABLED = true;
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -8,6 +8,7 @@ import io.unitycatalog.client.retry.JitterDelayRetryPolicy
 import io.unitycatalog.client.{ApiClient, ApiException}
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs.{PathOperation, TableOperation}
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants
 import io.unitycatalog.spark.auth.AuthConfigUtils
 import io.unitycatalog.spark.compat.SparkCatalogCompatibility
 import io.unitycatalog.spark.utils.OptionsUtil
@@ -553,12 +554,11 @@ object UCSingleCatalog {
   def configureCredentialCache(
       builder: UCCredentialHadoopConfs.Builder,
       credentialCacheScope: String): UCCredentialHadoopConfs.Builder = {
-    val configured = builder.credentialCacheScope(credentialCacheScope)
+    val hadoopConf = new Configuration(UCSingleCatalog.sessionHadoopConf())
     if (OptionsUtil.CREDENTIAL_CACHE_SCOPE_QUERY == credentialCacheScope) {
-      configured.queryCredId(currentQueryCredId())
-    } else {
-      configured
+      hadoopConf.set(UCHadoopConfConstants.UC_CREDENTIALS_UID_KEY, currentQueryCredId())
     }
+    builder.credentialCacheScope(credentialCacheScope).hadoopConf(hadoopConf)
   }
 
   def setCredentialProps(props: util.HashMap[String, String],

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, Ca
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.json4s.JsonDSL._
@@ -46,6 +47,7 @@ class UCSingleCatalog
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = true
+  private[this] var credentialCacheScope: String = OptionsUtil.DEFAULT_CREDENTIAL_CACHE_SCOPE
   private[this] var apiClient: ApiClient = null;
   private[this] var tablesApi: TablesApi = null
 
@@ -72,6 +74,8 @@ class UCSingleCatalog
       OptionsUtil.RENEW_CREDENTIAL_ENABLED, OptionsUtil.DEFAULT_RENEW_CREDENTIAL_ENABLED)
     credScopedFsEnabled = options.getBoolean(
       OptionsUtil.CRED_SCOPED_FS_ENABLED, OptionsUtil.DEFAULT_CRED_SCOPED_FS_ENABLED)
+    credentialCacheScope = Option(options.get(OptionsUtil.CREDENTIAL_CACHE_SCOPE))
+      .getOrElse(OptionsUtil.DEFAULT_CREDENTIAL_CACHE_SCOPE)
     val serverSidePlanningEnabled = options.getBoolean(
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED, OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
     deltaRestApiEnabled = options.getBoolean(
@@ -81,7 +85,7 @@ class UCSingleCatalog
       JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
     tablesApi = new TablesApi(apiClient)
     val proxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
-      serverSidePlanningEnabled, apiClient, tablesApi)
+      credentialCacheScope, serverSidePlanningEnabled, apiClient, tablesApi)
     proxy.initialize(name, options)
     if (UCSingleCatalog.LOAD_DELTA_CATALOG.get()) {
       try {
@@ -204,14 +208,16 @@ class UCSingleCatalog
     // user-specified but system-generated, which is exactly the case here.
     newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
 
-    val credentialProps = UCCredentialHadoopConfs
-      .builder(uri.toString, CatalogUtils.stringToURI(stagingLocation).getScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
-      .tokenProvider(tokenProvider)
-      .apiClient(apiClient)
-      .enableCredentialRenewal(renewCredEnabled)
-      .enableCredentialScopedFs(credScopedFsEnabled)
-      .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+    val credentialProps = UCSingleCatalog.configureCredentialCache(
+      UCCredentialHadoopConfs
+        .builder(uri.toString, CatalogUtils.stringToURI(stagingLocation).getScheme)
+        .addAppVersions(ApiClientFactory.appEngineVersions())
+        .tokenProvider(tokenProvider)
+        .apiClient(apiClient)
+        .enableCredentialRenewal(renewCredEnabled)
+        .enableCredentialScopedFs(credScopedFsEnabled)
+        .hadoopConf(UCSingleCatalog.sessionHadoopConf()),
+      credentialCacheScope)
       .buildForTable(stagingTableId, TableOperation.READ_WRITE)
     UCSingleCatalog.setCredentialProps(newProps, credentialProps)
     newProps
@@ -308,14 +314,16 @@ class UCSingleCatalog
 
     // Finally, vend fresh READ_WRITE credentials for the existing table location.
     val tableUriScheme = new Path(tableLocation).toUri.getScheme
-    val credentialProps = UCCredentialHadoopConfs
-      .builder(uri.toString, tableUriScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
-      .tokenProvider(tokenProvider)
-      .apiClient(apiClient)
-      .enableCredentialRenewal(renewCredEnabled)
-      .enableCredentialScopedFs(credScopedFsEnabled)
-      .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+    val credentialProps = UCSingleCatalog.configureCredentialCache(
+      UCCredentialHadoopConfs
+        .builder(uri.toString, tableUriScheme)
+        .addAppVersions(ApiClientFactory.appEngineVersions())
+        .tokenProvider(tokenProvider)
+        .apiClient(apiClient)
+        .enableCredentialRenewal(renewCredEnabled)
+        .enableCredentialScopedFs(credScopedFsEnabled)
+        .hadoopConf(UCSingleCatalog.sessionHadoopConf()),
+      credentialCacheScope)
       .buildForTable(tableId, TableOperation.READ_WRITE)
     UCSingleCatalog.setCredentialProps(newProps, credentialProps)
     newProps
@@ -344,14 +352,16 @@ class UCSingleCatalog
     val newProps = new util.HashMap[String, String]
     newProps.putAll(properties)
 
-    val credentialProps = UCCredentialHadoopConfs
-      .builder(uri.toString, CatalogUtils.stringToURI(location).getScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
-      .tokenProvider(tokenProvider)
-      .apiClient(apiClient)
-      .enableCredentialRenewal(renewCredEnabled)
-      .enableCredentialScopedFs(credScopedFsEnabled)
-      .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+    val credentialProps = UCSingleCatalog.configureCredentialCache(
+      UCCredentialHadoopConfs
+        .builder(uri.toString, CatalogUtils.stringToURI(location).getScheme)
+        .addAppVersions(ApiClientFactory.appEngineVersions())
+        .tokenProvider(tokenProvider)
+        .apiClient(apiClient)
+        .enableCredentialRenewal(renewCredEnabled)
+        .enableCredentialScopedFs(credScopedFsEnabled)
+        .hadoopConf(UCSingleCatalog.sessionHadoopConf()),
+      credentialCacheScope)
       .buildForPath(location, PathOperation.PATH_CREATE_TABLE)
 
     UCSingleCatalog.setCredentialProps(newProps, credentialProps)
@@ -529,6 +539,28 @@ object UCSingleCatalog {
       .getOrElse(new Configuration())
   }
 
+  /**
+   * Returns the per-query credential cache identity for the active Spark SQL execution, or a fresh
+   * UUID when no execution is active (for example in unit tests).
+   */
+  def currentQueryCredId(): String = {
+    SparkSession.getActiveSession
+      .flatMap(session => Option(session.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)))
+      .map(_.toString)
+      .getOrElse(java.util.UUID.randomUUID().toString)
+  }
+
+  def configureCredentialCache(
+      builder: UCCredentialHadoopConfs.Builder,
+      credentialCacheScope: String): UCCredentialHadoopConfs.Builder = {
+    val configured = builder.credentialCacheScope(credentialCacheScope)
+    if (OptionsUtil.CREDENTIAL_CACHE_SCOPE_QUERY == credentialCacheScope) {
+      configured.queryCredId(currentQueryCredId())
+    } else {
+      configured
+    }
+  }
+
   def setCredentialProps(props: util.HashMap[String, String],
                          credentialProps: util.Map[String, String]): Unit = {
     props.putAll(credentialProps)
@@ -608,6 +640,7 @@ private class UCProxy(
     tokenProvider: TokenProvider,
     renewCredEnabled: Boolean,
     credScopedFsEnabled: Boolean,
+    credentialCacheScope: String,
     serverSidePlanningEnabled: Boolean,
     apiClient: ApiClient,
     tablesApi: TablesApi) extends TableCatalog with SupportsNamespaces with Logging {
@@ -661,7 +694,7 @@ private class UCProxy(
     val locationUri = CatalogUtils.stringToURI(t.getStorageLocation)
     val tableId = t.getTableId
 
-    val credBuilder =
+    val credBuilder = UCSingleCatalog.configureCredentialCache(
       UCCredentialHadoopConfs
         .builder(uri.toString, locationUri.getScheme)
         .addAppVersions(ApiClientFactory.appEngineVersions())
@@ -669,7 +702,8 @@ private class UCProxy(
         .apiClient(apiClient)
         .enableCredentialRenewal(renewCredEnabled)
         .enableCredentialScopedFs(credScopedFsEnabled)
-        .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+        .hadoopConf(UCSingleCatalog.sessionHadoopConf()),
+      credentialCacheScope)
 
     // TODO: at this time, we don't know if the table will be read or written. For now we always
     //       request READ_WRITE credentials as the server doesn't distinguish between READ and


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Follow-up to #1586. That PR keyed the global credential cache by `CredId`, enabling cross-query credential reuse in the cluster. This PR adds a configurable cache scope so Spark can default back to per-query isolation when desired.

- Introduce `QueryCredId` and `CredentialCacheScope` (`query` | `cluster`).
- Spark catalog option `credential.cache.scope` (default `query`) controls whether credentials are isolated per SQL execution or shared cluster-wide.
- Restore `fs.unitycatalog.credentials.uid` for per-query identity; Spark propagates the active SQL execution id (or a fresh UUID in tests) via Hadoop conf to executors.
- Hadoop default remains `cluster` for backward compatibility outside Spark.

Example Spark config:

```properties
# Per-query cache (default)
spark.sql.catalog.mycat.credential.cache.scope=query

# Cross-query cluster-wide cache (#1586 behavior)
spark.sql.catalog.mycat.credential.cache.scope=cluster
```

**Test plan**

- [x] `sbt -mem 4096 hadoop/test` — 148 tests pass
- [x] `sbt -mem 4096 spark/compile`