### PR TITLE
[Hadoop] Key credential caches by full credential context (catalogUri, scheme, auth)

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -516,9 +516,8 @@ public class CredPropsUtil {
   /**
    * Derives a stable id for the credential context so caches only reuse a vended credential across
    * requests that would receive the same one. A vended credential is a function of the catalog
-   * endpoint, storage scheme, and auth identity, so all three are folded into the hash. The {@code
-   * TokenProvider} config keys ({@code type}, {@code token}, {@code oauth.*}, ...) never overlap
-   * with the catalog and scheme keys.
+   * endpoint, storage scheme, and auth identity, so all three are folded into the hash alongside
+   * the auth configs from {@code tokenProvider}.
    */
   static String credContextId(String catalogUri, String scheme, TokenProvider tokenProvider) {
     Objects.requireNonNull(catalogUri, "catalogUri is required");

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -19,10 +19,12 @@ import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import io.unitycatalog.hadoop.internal.util.ClockUtil;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -360,7 +362,7 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new TableCredId(tableId, tableOp.value()));
+        new TableCredId(authUniqueId(tokenProvider), tableId, tableOp.value()));
   }
 
   /**
@@ -389,7 +391,7 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaTableCredId(identifier, tableOp.value(), location));
+        new DeltaTableCredId(authUniqueId(tokenProvider), identifier, tableOp.value(), location));
   }
 
   /**
@@ -417,7 +419,7 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaStagingTableCredId(stagingTableId, location));
+        new DeltaStagingTableCredId(authUniqueId(tokenProvider), stagingTableId, location));
   }
 
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -442,7 +444,7 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new PathCredId(path, pathOp.value()));
+        new PathCredId(authUniqueId(tokenProvider), path, pathOp.value()));
   }
 
   /**
@@ -499,6 +501,11 @@ public class CredPropsUtil {
       default:
         return Collections.emptyMap();
     }
+  }
+
+  private static String authUniqueId(TokenProvider tokenProvider) {
+    Objects.requireNonNull(tokenProvider, "tokenProvider is required");
+    return MapIdGenerator.generateId(tokenProvider.configs());
   }
 
   private static GenericCredential fetchGenericCredential(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -516,11 +516,11 @@ public class CredPropsUtil {
   /**
    * Derives a stable id for the credential context so caches only reuse a vended credential across
    * requests that would receive the same one. A vended credential is a function of the catalog
-   * endpoint, storage scheme, and auth identity, so all three are folded into the hash. The auth
-   * configs are namespaced under {@code auth.} to avoid colliding with the other two keys.
+   * endpoint, storage scheme, and auth identity, so all three are folded into the hash. The {@code
+   * TokenProvider} config keys ({@code type}, {@code token}, {@code oauth.*}, ...) never overlap
+   * with the catalog and scheme keys.
    */
-  private static String credContextId(
-      String catalogUri, String scheme, TokenProvider tokenProvider) {
+  static String credContextId(String catalogUri, String scheme, TokenProvider tokenProvider) {
     Objects.requireNonNull(catalogUri, "catalogUri is required");
     Objects.requireNonNull(scheme, "scheme is required");
     Objects.requireNonNull(tokenProvider, "tokenProvider is required");

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -68,6 +68,10 @@ public class CredPropsUtil {
   private static final String GCS_CONFLICT_CHECK_KEY = "fs.gs.create.items.conflict.check.enable";
   private static final String ABFS_FIXED_SAS_TOKEN_KEY = "fs.azure.sas.fixed.token";
 
+  // Keys used to build the credential-context id (see #credContextId).
+  private static final String CRED_CONTEXT_CATALOG_URI_KEY = "catalogUri";
+  private static final String CRED_CONTEXT_SCHEME_KEY = "scheme";
+
   private abstract static class PropsBuilder<T extends PropsBuilder<T>> {
     private final HashMap<String, String> builder = new HashMap<>();
 
@@ -362,7 +366,8 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new TableCredId(authUniqueId(tokenProvider), tableId, tableOp.value()));
+        new TableCredId(
+            credContextId(catalogUri, scheme, tokenProvider), tableId, tableOp.value()));
   }
 
   /**
@@ -391,7 +396,11 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaTableCredId(authUniqueId(tokenProvider), identifier, tableOp.value(), location));
+        new DeltaTableCredId(
+            credContextId(catalogUri, scheme, tokenProvider),
+            identifier,
+            tableOp.value(),
+            location));
   }
 
   /**
@@ -419,7 +428,8 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new DeltaStagingTableCredId(authUniqueId(tokenProvider), stagingTableId, location));
+        new DeltaStagingTableCredId(
+            credContextId(catalogUri, scheme, tokenProvider), stagingTableId, location));
   }
 
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
@@ -444,7 +454,7 @@ public class CredPropsUtil {
         catalogUri,
         tokenProvider,
         appVersions,
-        new PathCredId(authUniqueId(tokenProvider), path, pathOp.value()));
+        new PathCredId(credContextId(catalogUri, scheme, tokenProvider), path, pathOp.value()));
   }
 
   /**
@@ -503,9 +513,22 @@ public class CredPropsUtil {
     }
   }
 
-  private static String authUniqueId(TokenProvider tokenProvider) {
+  /**
+   * Derives a stable id for the credential context so caches only reuse a vended credential across
+   * requests that would receive the same one. A vended credential is a function of the catalog
+   * endpoint, storage scheme, and auth identity, so all three are folded into the hash. The auth
+   * configs are namespaced under {@code auth.} to avoid colliding with the other two keys.
+   */
+  private static String credContextId(
+      String catalogUri, String scheme, TokenProvider tokenProvider) {
+    Objects.requireNonNull(catalogUri, "catalogUri is required");
+    Objects.requireNonNull(scheme, "scheme is required");
     Objects.requireNonNull(tokenProvider, "tokenProvider is required");
-    return MapIdGenerator.generateId(tokenProvider.configs());
+
+    Map<String, String> context = new HashMap<>(tokenProvider.configs());
+    context.put(CRED_CONTEXT_CATALOG_URI_KEY, catalogUri);
+    context.put(CRED_CONTEXT_SCHEME_KEY, scheme);
+    return MapIdGenerator.generateId(context);
   }
 
   private static GenericCredential fetchGenericCredential(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -46,8 +46,11 @@ public class UCHadoopConfConstants {
   public static final String UC_AUTH_PREFIX = "fs.unitycatalog.auth.";
   public static final String UC_AUTH_TYPE = "fs.unitycatalog.auth.type";
   public static final String UC_AUTH_TOKEN_KEY = "fs.unitycatalog.auth.token";
-  /** Stable id derived from {@code TokenProvider.configs()} to isolate caches per auth config. */
-  public static final String UC_AUTH_UNIQUE_ID_KEY = "fs.unitycatalog.auth.uniqueId";
+  /**
+   * Stable id derived from the credential context ({@code catalogUri}, storage {@code scheme}, and
+   * {@code TokenProvider.configs()}) to isolate caches per credential context.
+   */
+  public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.contextId";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -46,6 +46,8 @@ public class UCHadoopConfConstants {
   public static final String UC_AUTH_PREFIX = "fs.unitycatalog.auth.";
   public static final String UC_AUTH_TYPE = "fs.unitycatalog.auth.type";
   public static final String UC_AUTH_TOKEN_KEY = "fs.unitycatalog.auth.token";
+  /** Stable id derived from {@code TokenProvider.configs()} to isolate caches per auth config. */
+  public static final String UC_AUTH_UNIQUE_ID_KEY = "fs.unitycatalog.auth.uniqueId";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -49,8 +49,11 @@ public class UCHadoopConfConstants {
   /**
    * Stable id derived from the credential context ({@code catalogUri}, storage {@code scheme}, and
    * {@code TokenProvider.configs()}) to isolate caches per credential context.
+   *
+   * <p>The key is intentionally all lowercase: these props flow through Spark's case-insensitive
+   * table option handling, which lowercases option keys, so a mixed-case key would not round-trip.
    */
-  public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.contextId";
+  public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -17,6 +17,7 @@ import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_OPER
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
 
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
@@ -134,6 +135,11 @@ public interface CredId {
 
   static String readCredContextId(Configuration conf) {
     String credContextId = conf.get(UC_CRED_CONTEXT_ID_KEY);
-    return credContextId != null ? credContextId : EMPTY_CRED_CONTEXT_ID;
+    // Every CredId variant persists the context id via props(), so its absence means the config was
+    // built incorrectly. Fail fast instead of falling back to a shared default id, which would
+    // silently let unrelated sessions reuse each other's credentials.
+    Preconditions.checkNotNull(
+        credContextId, "Missing required config '%s'", UC_CRED_CONTEXT_ID_KEY);
+    return credContextId;
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
@@ -17,6 +18,9 @@ import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
 
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -31,19 +35,22 @@ import org.apache.hadoop.conf.Configuration;
  * <p>There are five implementations:
  *
  * <ul>
- *   <li>{@link TableCredId} — keyed by table ID and operation; used for table-level temporary
- *       credentials via the UC credentials API.
- *   <li>{@link PathCredId} — keyed by path and operation; used for path-level temporary
- *       credentials.
- *   <li>{@link DeltaTableCredId} — keyed by table identity, operation, and location; used for
- *       table-level temporary credentials via the UC Delta credentials API.
- *   <li>{@link DeltaStagingTableCredId} — keyed by staging table ID and location; used for
- *       staging-table-level temporary credentials via the UC Delta credentials API.
+ *   <li>{@link TableCredId} — keyed by auth config, table ID, and operation; used for table-level
+ *       temporary credentials via the UC credentials API.
+ *   <li>{@link PathCredId} — keyed by auth config, path, and operation; used for path-level
+ *       temporary credentials.
+ *   <li>{@link DeltaTableCredId} — keyed by auth config, table identity, operation, and location;
+ *       used for table-level temporary credentials via the UC Delta credentials API.
+ *   <li>{@link DeltaStagingTableCredId} — keyed by auth config, staging table ID, and location;
+ *       used for staging-table-level temporary credentials via the UC Delta credentials API.
  *   <li>{@link DefaultCredId} — keyed by URI scheme and authority; used as a fallback when no Unity
  *       Catalog credential type is present in the configuration.
  * </ul>
  */
 public interface CredId {
+
+  /** Stable id used when {@link UCHadoopConfConstants#UC_AUTH_UNIQUE_ID_KEY} is absent. */
+  String EMPTY_AUTH_UNIQUE_ID = MapIdGenerator.generateId(Collections.emptyMap());
 
   static CredId create(Configuration conf) {
     return create(
@@ -70,23 +77,26 @@ public interface CredId {
     boolean hasUcDeltaStagingTableId = stagingTableId != null && !stagingTableId.isEmpty();
 
     if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && !isDeltaApi && !hasUcDeltaStagingTableId) {
-      // Case 1: UC table (legacy API) — keyed by table ID + operation.
+      // Case 1: UC table (legacy API) — keyed by auth config + table ID + operation.
+      String authUniqueId = readAuthUniqueId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       String tableId = conf.get(UC_TABLE_ID_KEY);
-      return new TableCredId(tableId, tableOp);
+      return new TableCredId(authUniqueId, tableId, tableOp);
 
     } else if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)
         && !isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 2: Path-based credentials (legacy UC API) — keyed by path + operation.
+      // Case 2: Path-based credentials (legacy UC API) — keyed by auth config + path + operation.
+      String authUniqueId = readAuthUniqueId(conf);
       String path = conf.get(UC_PATH_KEY);
       String pathOp = conf.get(UC_PATH_OPERATION_KEY);
-      return new PathCredId(path, pathOp);
+      return new PathCredId(authUniqueId, path, pathOp);
 
     } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)
         && isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 3: Delta table — keyed by catalog.schema.table + operation + location.
+      // Case 3: Delta table — keyed by auth config + catalog.schema.table + operation + location.
+      String authUniqueId = readAuthUniqueId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       UCDeltaTableIdentifier identifier =
           UCDeltaTableIdentifier.of(
@@ -94,12 +104,13 @@ public interface CredId {
               conf.get(UC_DELTA_SCHEMA_KEY),
               conf.get(UC_DELTA_TABLE_NAME_KEY));
       String location = conf.get(UC_DELTA_LOCATION_KEY);
-      return new DeltaTableCredId(identifier, tableOp, location);
+      return new DeltaTableCredId(authUniqueId, identifier, tableOp, location);
 
     } else if (hasUcDeltaStagingTableId) {
-      // Case 4: Delta staging table — keyed by staging table UUID + location.
+      // Case 4: Delta staging table — keyed by auth config + staging table UUID + location.
+      String authUniqueId = readAuthUniqueId(conf);
       String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
-      return new DeltaStagingTableCredId(stagingTableId, location);
+      return new DeltaStagingTableCredId(authUniqueId, stagingTableId, location);
 
     } else {
       // Case 5: No recognized credential type — delegate to the caller-provided fallback.
@@ -115,4 +126,9 @@ public interface CredId {
    *     carries no Unity Catalog credential-request properties (e.g. {@link DefaultCredId}).
    */
   Map<String, String> props();
+
+  static String readAuthUniqueId(Configuration conf) {
+    String authUniqueId = conf.get(UC_AUTH_UNIQUE_ID_KEY);
+    return authUniqueId != null ? authUniqueId : EMPTY_AUTH_UNIQUE_ID;
+  }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -20,8 +20,6 @@ import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPE
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
-import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -54,9 +52,6 @@ import org.apache.hadoop.conf.Configuration;
  * </ul>
  */
 public interface CredId {
-
-  /** Stable id used when {@link UCHadoopConfConstants#UC_CRED_CONTEXT_ID_KEY} is absent. */
-  String EMPTY_CRED_CONTEXT_ID = MapIdGenerator.generateId(Collections.emptyMap());
 
   static CredId create(Configuration conf) {
     return create(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -1,9 +1,9 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CATALOG_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_DEFAULT_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY;
@@ -34,23 +34,28 @@ import org.apache.hadoop.conf.Configuration;
  *
  * <p>There are five implementations:
  *
+ * <p>The credential context is the {@code catalogUri}, storage {@code scheme}, and {@code
+ * TokenProvider.configs()} a credential is vended from, hashed into a single id (see {@link
+ * UCHadoopConfConstants#UC_CRED_CONTEXT_ID_KEY}).
+ *
  * <ul>
- *   <li>{@link TableCredId} — keyed by auth config, table ID, and operation; used for table-level
- *       temporary credentials via the UC credentials API.
- *   <li>{@link PathCredId} — keyed by auth config, path, and operation; used for path-level
+ *   <li>{@link TableCredId} — keyed by credential context, table ID, and operation; used for
+ *       table-level temporary credentials via the UC credentials API.
+ *   <li>{@link PathCredId} — keyed by credential context, path, and operation; used for path-level
  *       temporary credentials.
- *   <li>{@link DeltaTableCredId} — keyed by auth config, table identity, operation, and location;
- *       used for table-level temporary credentials via the UC Delta credentials API.
- *   <li>{@link DeltaStagingTableCredId} — keyed by auth config, staging table ID, and location;
- *       used for staging-table-level temporary credentials via the UC Delta credentials API.
+ *   <li>{@link DeltaTableCredId} — keyed by credential context, table identity, operation, and
+ *       location; used for table-level temporary credentials via the UC Delta credentials API.
+ *   <li>{@link DeltaStagingTableCredId} — keyed by credential context, staging table ID, and
+ *       location; used for staging-table-level temporary credentials via the UC Delta credentials
+ *       API.
  *   <li>{@link DefaultCredId} — keyed by URI scheme and authority; used as a fallback when no Unity
  *       Catalog credential type is present in the configuration.
  * </ul>
  */
 public interface CredId {
 
-  /** Stable id used when {@link UCHadoopConfConstants#UC_AUTH_UNIQUE_ID_KEY} is absent. */
-  String EMPTY_AUTH_UNIQUE_ID = MapIdGenerator.generateId(Collections.emptyMap());
+  /** Stable id used when {@link UCHadoopConfConstants#UC_CRED_CONTEXT_ID_KEY} is absent. */
+  String EMPTY_CRED_CONTEXT_ID = MapIdGenerator.generateId(Collections.emptyMap());
 
   static CredId create(Configuration conf) {
     return create(
@@ -77,26 +82,26 @@ public interface CredId {
     boolean hasUcDeltaStagingTableId = stagingTableId != null && !stagingTableId.isEmpty();
 
     if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && !isDeltaApi && !hasUcDeltaStagingTableId) {
-      // Case 1: UC table (legacy API) — keyed by auth config + table ID + operation.
-      String authUniqueId = readAuthUniqueId(conf);
+      // Case 1: UC table (legacy API) — keyed by cred context + table ID + operation.
+      String credContextId = readCredContextId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       String tableId = conf.get(UC_TABLE_ID_KEY);
-      return new TableCredId(authUniqueId, tableId, tableOp);
+      return new TableCredId(credContextId, tableId, tableOp);
 
     } else if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)
         && !isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 2: Path-based credentials (legacy UC API) — keyed by auth config + path + operation.
-      String authUniqueId = readAuthUniqueId(conf);
+      // Case 2: Path-based credentials (legacy UC API) — keyed by cred context + path + operation.
+      String credContextId = readCredContextId(conf);
       String path = conf.get(UC_PATH_KEY);
       String pathOp = conf.get(UC_PATH_OPERATION_KEY);
-      return new PathCredId(authUniqueId, path, pathOp);
+      return new PathCredId(credContextId, path, pathOp);
 
     } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)
         && isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 3: Delta table — keyed by auth config + catalog.schema.table + operation + location.
-      String authUniqueId = readAuthUniqueId(conf);
+      // Case 3: Delta table — keyed by cred context + catalog.schema.table + operation + location.
+      String credContextId = readCredContextId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       UCDeltaTableIdentifier identifier =
           UCDeltaTableIdentifier.of(
@@ -104,13 +109,13 @@ public interface CredId {
               conf.get(UC_DELTA_SCHEMA_KEY),
               conf.get(UC_DELTA_TABLE_NAME_KEY));
       String location = conf.get(UC_DELTA_LOCATION_KEY);
-      return new DeltaTableCredId(authUniqueId, identifier, tableOp, location);
+      return new DeltaTableCredId(credContextId, identifier, tableOp, location);
 
     } else if (hasUcDeltaStagingTableId) {
-      // Case 4: Delta staging table — keyed by auth config + staging table UUID + location.
-      String authUniqueId = readAuthUniqueId(conf);
+      // Case 4: Delta staging table — keyed by cred context + staging table UUID + location.
+      String credContextId = readCredContextId(conf);
       String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
-      return new DeltaStagingTableCredId(authUniqueId, stagingTableId, location);
+      return new DeltaStagingTableCredId(credContextId, stagingTableId, location);
 
     } else {
       // Case 5: No recognized credential type — delegate to the caller-provided fallback.
@@ -127,8 +132,8 @@ public interface CredId {
    */
   Map<String, String> props();
 
-  static String readAuthUniqueId(Configuration conf) {
-    String authUniqueId = conf.get(UC_AUTH_UNIQUE_ID_KEY);
-    return authUniqueId != null ? authUniqueId : EMPTY_AUTH_UNIQUE_ID;
+  static String readCredContextId(Configuration conf) {
+    String credContextId = conf.get(UC_CRED_CONTEXT_ID_KEY);
+    return credContextId != null ? credContextId : EMPTY_CRED_CONTEXT_ID;
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -32,11 +32,11 @@ import org.apache.hadoop.conf.Configuration;
  * <p>Two requests sharing the same {@code CredId} target the same credential scope and can reuse a
  * vended credential, while requests with different ids are isolated.
  *
- * <p>There are five implementations:
- *
  * <p>The credential context is the {@code catalogUri}, storage {@code scheme}, and {@code
  * TokenProvider.configs()} a credential is vended from, hashed into a single id (see {@link
  * UCHadoopConfConstants#UC_CRED_CONTEXT_ID_KEY}).
+ *
+ * <p>There are five implementations:
  *
  * <ul>
  *   <li>{@link TableCredId} — keyed by credential context, table ID, and operation; used for

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
@@ -1,6 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY;
@@ -10,25 +10,25 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by auth config, staging table ID, and location; used for staging-table-level
- * temporary credentials via the UC Delta credentials API.
+ * {@link CredId} keyed by credential context, staging table ID, and location; used for
+ * staging-table-level temporary credentials via the UC Delta credentials API.
  */
 public class DeltaStagingTableCredId implements CredId {
-  private final String authUniqueId;
+  private final String credContextId;
   private final String stagingTableId;
   private final String location;
 
-  public DeltaStagingTableCredId(String authUniqueId, String stagingTableId, String location) {
-    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
+  public DeltaStagingTableCredId(String credContextId, String stagingTableId, String location) {
+    Preconditions.checkNotNull(credContextId, "credContextId is required");
     Preconditions.checkNotNull(stagingTableId, "stagingTableId is required");
     Preconditions.checkNotNull(location, "location is required");
-    this.authUniqueId = authUniqueId;
+    this.credContextId = credContextId;
     this.stagingTableId = stagingTableId;
     this.location = location;
   }
 
-  public String authUniqueId() {
-    return authUniqueId;
+  public String credContextId() {
+    return credContextId;
   }
 
   public String stagingTableId() {
@@ -42,7 +42,7 @@ public class DeltaStagingTableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
-        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
+        UC_CRED_CONTEXT_ID_KEY, credContextId,
         UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true",
         UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId,
         UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
@@ -53,20 +53,20 @@ public class DeltaStagingTableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof DeltaStagingTableCredId)) return false;
     DeltaStagingTableCredId that = (DeltaStagingTableCredId) o;
-    return Objects.equals(authUniqueId, that.authUniqueId)
+    return Objects.equals(credContextId, that.credContextId)
         && Objects.equals(stagingTableId, that.stagingTableId)
         && Objects.equals(location, that.location);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(authUniqueId, stagingTableId, location);
+    return Objects.hash(credContextId, stagingTableId, location);
   }
 
   @Override
   public String toString() {
-    return "DeltaStagingTableCredId{authUniqueId="
-        + authUniqueId
+    return "DeltaStagingTableCredId{credContextId="
+        + credContextId
         + ", stagingTableId="
         + stagingTableId
         + ", location="

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY;
@@ -9,18 +10,25 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by staging table ID and location; used for staging-table-level temporary
- * credentials via the UC Delta credentials API.
+ * {@link CredId} keyed by auth config, staging table ID, and location; used for staging-table-level
+ * temporary credentials via the UC Delta credentials API.
  */
 public class DeltaStagingTableCredId implements CredId {
+  private final String authUniqueId;
   private final String stagingTableId;
   private final String location;
 
-  public DeltaStagingTableCredId(String stagingTableId, String location) {
+  public DeltaStagingTableCredId(String authUniqueId, String stagingTableId, String location) {
+    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
     Preconditions.checkNotNull(stagingTableId, "stagingTableId is required");
     Preconditions.checkNotNull(location, "location is required");
+    this.authUniqueId = authUniqueId;
     this.stagingTableId = stagingTableId;
     this.location = location;
+  }
+
+  public String authUniqueId() {
+    return authUniqueId;
   }
 
   public String stagingTableId() {
@@ -34,6 +42,7 @@ public class DeltaStagingTableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
+        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
         UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true",
         UC_DELTA_STAGING_TABLE_ID_KEY, stagingTableId,
         UC_DELTA_STAGING_TABLE_LOCATION_KEY, location);
@@ -44,18 +53,21 @@ public class DeltaStagingTableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof DeltaStagingTableCredId)) return false;
     DeltaStagingTableCredId that = (DeltaStagingTableCredId) o;
-    return Objects.equals(stagingTableId, that.stagingTableId)
+    return Objects.equals(authUniqueId, that.authUniqueId)
+        && Objects.equals(stagingTableId, that.stagingTableId)
         && Objects.equals(location, that.location);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(stagingTableId, location);
+    return Objects.hash(authUniqueId, stagingTableId, location);
   }
 
   @Override
   public String toString() {
-    return "DeltaStagingTableCredId{stagingTableId="
+    return "DeltaStagingTableCredId{authUniqueId="
+        + authUniqueId
+        + ", stagingTableId="
         + stagingTableId
         + ", location="
         + location

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
@@ -27,10 +27,6 @@ public class DeltaStagingTableCredId implements CredId {
     this.location = location;
   }
 
-  public String credContextId() {
-    return credContextId;
-  }
-
   public String stagingTableId() {
     return stagingTableId;
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
@@ -40,10 +40,6 @@ public class DeltaTableCredId implements CredId {
     this.location = location;
   }
 
-  public String credContextId() {
-    return credContextId;
-  }
-
   public UCDeltaTableIdentifier identifier() {
     return identifier;
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
@@ -1,8 +1,8 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CATALOG_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_LOCATION_KEY;
@@ -16,32 +16,32 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by auth config, table identity, operation, and location; used for
+ * {@link CredId} keyed by credential context, table identity, operation, and location; used for
  * table-level temporary credentials via the UC Delta credentials API.
  */
 public class DeltaTableCredId implements CredId {
-  private final String authUniqueId;
+  private final String credContextId;
   private final UCDeltaTableIdentifier identifier;
   private final String tableOperation;
   private final String location;
 
   public DeltaTableCredId(
-      String authUniqueId,
+      String credContextId,
       UCDeltaTableIdentifier identifier,
       String tableOperation,
       String location) {
-    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
+    Preconditions.checkNotNull(credContextId, "credContextId is required");
     Preconditions.checkNotNull(identifier, "identifier is required");
     Preconditions.checkNotNull(tableOperation, "tableOperation is required");
     Preconditions.checkNotNull(location, "location is required");
-    this.authUniqueId = authUniqueId;
+    this.credContextId = credContextId;
     this.identifier = identifier;
     this.tableOperation = tableOperation;
     this.location = location;
   }
 
-  public String authUniqueId() {
-    return authUniqueId;
+  public String credContextId() {
+    return credContextId;
   }
 
   public UCDeltaTableIdentifier identifier() {
@@ -59,8 +59,8 @@ public class DeltaTableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
-        UC_AUTH_UNIQUE_ID_KEY,
-        authUniqueId,
+        UC_CRED_CONTEXT_ID_KEY,
+        credContextId,
         UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
         "true",
         UC_CREDENTIALS_TYPE_KEY,
@@ -82,7 +82,7 @@ public class DeltaTableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof DeltaTableCredId)) return false;
     DeltaTableCredId that = (DeltaTableCredId) o;
-    return Objects.equals(authUniqueId, that.authUniqueId)
+    return Objects.equals(credContextId, that.credContextId)
         && Objects.equals(identifier, that.identifier)
         && Objects.equals(tableOperation, that.tableOperation)
         && Objects.equals(location, that.location);
@@ -90,13 +90,13 @@ public class DeltaTableCredId implements CredId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(authUniqueId, identifier, tableOperation, location);
+    return Objects.hash(credContextId, identifier, tableOperation, location);
   }
 
   @Override
   public String toString() {
-    return "DeltaTableCredId{authUniqueId="
-        + authUniqueId
+    return "DeltaTableCredId{credContextId="
+        + credContextId
         + ", table="
         + identifier
         + ", op="

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_CATALOG_KEY;
@@ -15,22 +16,32 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by table identity, operation, and location; used for table-level temporary
- * credentials via the UC Delta credentials API.
+ * {@link CredId} keyed by auth config, table identity, operation, and location; used for
+ * table-level temporary credentials via the UC Delta credentials API.
  */
 public class DeltaTableCredId implements CredId {
+  private final String authUniqueId;
   private final UCDeltaTableIdentifier identifier;
   private final String tableOperation;
   private final String location;
 
   public DeltaTableCredId(
-      UCDeltaTableIdentifier identifier, String tableOperation, String location) {
+      String authUniqueId,
+      UCDeltaTableIdentifier identifier,
+      String tableOperation,
+      String location) {
+    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
     Preconditions.checkNotNull(identifier, "identifier is required");
     Preconditions.checkNotNull(tableOperation, "tableOperation is required");
     Preconditions.checkNotNull(location, "location is required");
+    this.authUniqueId = authUniqueId;
     this.identifier = identifier;
     this.tableOperation = tableOperation;
     this.location = location;
+  }
+
+  public String authUniqueId() {
+    return authUniqueId;
   }
 
   public UCDeltaTableIdentifier identifier() {
@@ -48,6 +59,8 @@ public class DeltaTableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
+        UC_AUTH_UNIQUE_ID_KEY,
+        authUniqueId,
         UC_DELTA_CREDENTIALS_API_ENABLED_KEY,
         "true",
         UC_CREDENTIALS_TYPE_KEY,
@@ -69,19 +82,22 @@ public class DeltaTableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof DeltaTableCredId)) return false;
     DeltaTableCredId that = (DeltaTableCredId) o;
-    return Objects.equals(identifier, that.identifier)
+    return Objects.equals(authUniqueId, that.authUniqueId)
+        && Objects.equals(identifier, that.identifier)
         && Objects.equals(tableOperation, that.tableOperation)
         && Objects.equals(location, that.location);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(identifier, tableOperation, location);
+    return Objects.hash(authUniqueId, identifier, tableOperation, location);
   }
 
   @Override
   public String toString() {
-    return "DeltaTableCredId{table="
+    return "DeltaTableCredId{authUniqueId="
+        + authUniqueId
+        + ", table="
         + identifier
         + ", op="
         + tableOperation

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
@@ -1,8 +1,8 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_OPERATION_KEY;
 
@@ -11,25 +11,25 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by auth config, path, and operation; used for path-level temporary
+ * {@link CredId} keyed by credential context, path, and operation; used for path-level temporary
  * credentials.
  */
 public class PathCredId implements CredId {
-  private final String authUniqueId;
+  private final String credContextId;
   private final String path;
   private final String pathOperation;
 
-  public PathCredId(String authUniqueId, String path, String pathOperation) {
-    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
+  public PathCredId(String credContextId, String path, String pathOperation) {
+    Preconditions.checkNotNull(credContextId, "credContextId is required");
     Preconditions.checkNotNull(path, "path is required");
     Preconditions.checkNotNull(pathOperation, "pathOperation is required");
-    this.authUniqueId = authUniqueId;
+    this.credContextId = credContextId;
     this.path = path;
     this.pathOperation = pathOperation;
   }
 
-  public String authUniqueId() {
-    return authUniqueId;
+  public String credContextId() {
+    return credContextId;
   }
 
   public String path() {
@@ -43,7 +43,7 @@ public class PathCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
-        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
+        UC_CRED_CONTEXT_ID_KEY, credContextId,
         UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_PATH_VALUE,
         UC_PATH_KEY, path,
         UC_PATH_OPERATION_KEY, pathOperation);
@@ -54,20 +54,20 @@ public class PathCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof PathCredId)) return false;
     PathCredId that = (PathCredId) o;
-    return Objects.equals(authUniqueId, that.authUniqueId)
+    return Objects.equals(credContextId, that.credContextId)
         && Objects.equals(path, that.path)
         && Objects.equals(pathOperation, that.pathOperation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(authUniqueId, path, pathOperation);
+    return Objects.hash(credContextId, path, pathOperation);
   }
 
   @Override
   public String toString() {
-    return "PathCredId{authUniqueId="
-        + authUniqueId
+    return "PathCredId{credContextId="
+        + credContextId
         + ", path="
         + path
         + ", op="

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
@@ -28,10 +28,6 @@ public class PathCredId implements CredId {
     this.pathOperation = pathOperation;
   }
 
-  public String credContextId() {
-    return credContextId;
-  }
-
   public String path() {
     return path;
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/PathCredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_KEY;
@@ -9,16 +10,26 @@ import io.unitycatalog.client.internal.Preconditions;
 import java.util.Map;
 import java.util.Objects;
 
-/** {@link CredId} keyed by path and operation; used for path-level temporary credentials. */
+/**
+ * {@link CredId} keyed by auth config, path, and operation; used for path-level temporary
+ * credentials.
+ */
 public class PathCredId implements CredId {
+  private final String authUniqueId;
   private final String path;
   private final String pathOperation;
 
-  public PathCredId(String path, String pathOperation) {
+  public PathCredId(String authUniqueId, String path, String pathOperation) {
+    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
     Preconditions.checkNotNull(path, "path is required");
     Preconditions.checkNotNull(pathOperation, "pathOperation is required");
+    this.authUniqueId = authUniqueId;
     this.path = path;
     this.pathOperation = pathOperation;
+  }
+
+  public String authUniqueId() {
+    return authUniqueId;
   }
 
   public String path() {
@@ -32,6 +43,7 @@ public class PathCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
+        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
         UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_PATH_VALUE,
         UC_PATH_KEY, path,
         UC_PATH_OPERATION_KEY, pathOperation);
@@ -42,16 +54,24 @@ public class PathCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof PathCredId)) return false;
     PathCredId that = (PathCredId) o;
-    return Objects.equals(path, that.path) && Objects.equals(pathOperation, that.pathOperation);
+    return Objects.equals(authUniqueId, that.authUniqueId)
+        && Objects.equals(path, that.path)
+        && Objects.equals(pathOperation, that.pathOperation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, pathOperation);
+    return Objects.hash(authUniqueId, path, pathOperation);
   }
 
   @Override
   public String toString() {
-    return "PathCredId{path=" + path + ", op=" + pathOperation + "}";
+    return "PathCredId{authUniqueId="
+        + authUniqueId
+        + ", path="
+        + path
+        + ", op="
+        + pathOperation
+        + "}";
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
@@ -28,10 +28,6 @@ public class TableCredId implements CredId {
     this.tableOperation = tableOperation;
   }
 
-  public String credContextId() {
-    return credContextId;
-  }
-
   public String tableId() {
     return tableId;
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
@@ -1,8 +1,8 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_OPERATION_KEY;
 
@@ -11,25 +11,25 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by auth config, table ID, and operation; used for table-level temporary
- * credentials via the UC credentials API.
+ * {@link CredId} keyed by credential context, table ID, and operation; used for table-level
+ * temporary credentials via the UC credentials API.
  */
 public class TableCredId implements CredId {
-  private final String authUniqueId;
+  private final String credContextId;
   private final String tableId;
   private final String tableOperation;
 
-  public TableCredId(String authUniqueId, String tableId, String tableOperation) {
-    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
+  public TableCredId(String credContextId, String tableId, String tableOperation) {
+    Preconditions.checkNotNull(credContextId, "credContextId is required");
     Preconditions.checkNotNull(tableId, "tableId is required");
     Preconditions.checkNotNull(tableOperation, "tableOperation is required");
-    this.authUniqueId = authUniqueId;
+    this.credContextId = credContextId;
     this.tableId = tableId;
     this.tableOperation = tableOperation;
   }
 
-  public String authUniqueId() {
-    return authUniqueId;
+  public String credContextId() {
+    return credContextId;
   }
 
   public String tableId() {
@@ -43,7 +43,7 @@ public class TableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
-        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
+        UC_CRED_CONTEXT_ID_KEY, credContextId,
         UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_TABLE_VALUE,
         UC_TABLE_ID_KEY, tableId,
         UC_TABLE_OPERATION_KEY, tableOperation);
@@ -54,20 +54,20 @@ public class TableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof TableCredId)) return false;
     TableCredId that = (TableCredId) o;
-    return Objects.equals(authUniqueId, that.authUniqueId)
+    return Objects.equals(credContextId, that.credContextId)
         && Objects.equals(tableId, that.tableId)
         && Objects.equals(tableOperation, that.tableOperation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(authUniqueId, tableId, tableOperation);
+    return Objects.hash(credContextId, tableId, tableOperation);
   }
 
   @Override
   public String toString() {
-    return "TableCredId{authUniqueId="
-        + authUniqueId
+    return "TableCredId{credContextId="
+        + credContextId
         + ", tableId="
         + tableId
         + ", op="

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/TableCredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
@@ -10,18 +11,25 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * {@link CredId} keyed by table ID and operation; used for table-level temporary credentials via
- * the UC credentials API.
+ * {@link CredId} keyed by auth config, table ID, and operation; used for table-level temporary
+ * credentials via the UC credentials API.
  */
 public class TableCredId implements CredId {
+  private final String authUniqueId;
   private final String tableId;
   private final String tableOperation;
 
-  public TableCredId(String tableId, String tableOperation) {
+  public TableCredId(String authUniqueId, String tableId, String tableOperation) {
+    Preconditions.checkNotNull(authUniqueId, "authUniqueId is required");
     Preconditions.checkNotNull(tableId, "tableId is required");
     Preconditions.checkNotNull(tableOperation, "tableOperation is required");
+    this.authUniqueId = authUniqueId;
     this.tableId = tableId;
     this.tableOperation = tableOperation;
+  }
+
+  public String authUniqueId() {
+    return authUniqueId;
   }
 
   public String tableId() {
@@ -35,6 +43,7 @@ public class TableCredId implements CredId {
   @Override
   public Map<String, String> props() {
     return Map.of(
+        UC_AUTH_UNIQUE_ID_KEY, authUniqueId,
         UC_CREDENTIALS_TYPE_KEY, UC_CREDENTIALS_TYPE_TABLE_VALUE,
         UC_TABLE_ID_KEY, tableId,
         UC_TABLE_OPERATION_KEY, tableOperation);
@@ -45,17 +54,24 @@ public class TableCredId implements CredId {
     if (this == o) return true;
     if (!(o instanceof TableCredId)) return false;
     TableCredId that = (TableCredId) o;
-    return Objects.equals(tableId, that.tableId)
+    return Objects.equals(authUniqueId, that.authUniqueId)
+        && Objects.equals(tableId, that.tableId)
         && Objects.equals(tableOperation, that.tableOperation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableId, tableOperation);
+    return Objects.hash(authUniqueId, tableId, tableOperation);
   }
 
   @Override
   public String toString() {
-    return "TableCredId{tableId=" + tableId + ", op=" + tableOperation + "}";
+    return "TableCredId{authUniqueId="
+        + authUniqueId
+        + ", tableId="
+        + tableId
+        + ", op="
+        + tableOperation
+        + "}";
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/MapIdGenerator.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/MapIdGenerator.java
@@ -1,7 +1,5 @@
 package io.unitycatalog.hadoop.internal.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -26,41 +24,31 @@ public final class MapIdGenerator {
    */
   public static String generateId(Map<String, String> map) {
     Objects.requireNonNull(map, "map cannot be null");
-    return hashCanonical(canonicalBytes(map));
-  }
-
-  private static byte[] canonicalBytes(Map<String, String> map) {
     List<Entry<String, String>> entries = new ArrayList<>(map.entrySet());
     entries.sort(Entry.comparingByKey());
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    MessageDigest digest = sha256();
     for (Entry<String, String> entry : entries) {
-      writeUtf8(out, Objects.requireNonNull(entry.getKey(), "map key cannot be null"));
-      writeUtf8(out, Objects.requireNonNull(entry.getValue(), "map value cannot be null"));
+      update(digest, Objects.requireNonNull(entry.getKey(), "map key cannot be null"));
+      update(digest, Objects.requireNonNull(entry.getValue(), "map value cannot be null"));
     }
-    return out.toByteArray();
+    return toHex(digest.digest());
   }
 
-  private static void writeUtf8(ByteArrayOutputStream out, String value) {
+  /** Feeds a length-prefixed UTF-8 encoding of {@code value} into the digest. */
+  private static void update(MessageDigest digest, String value) {
     byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-    writeInt(out, bytes.length);
-    try {
-      out.write(bytes);
-    } catch (IOException e) {
-      throw new IllegalStateException("failed to write canonical map bytes", e);
-    }
+    int length = bytes.length;
+    digest.update((byte) (length >>> 24));
+    digest.update((byte) (length >>> 16));
+    digest.update((byte) (length >>> 8));
+    digest.update((byte) length);
+    digest.update(bytes);
   }
 
-  private static void writeInt(ByteArrayOutputStream out, int value) {
-    out.write((value >>> 24) & 0xFF);
-    out.write((value >>> 16) & 0xFF);
-    out.write((value >>> 8) & 0xFF);
-    out.write(value & 0xFF);
-  }
-
-  private static String hashCanonical(byte[] canonical) {
+  private static MessageDigest sha256() {
     try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      return toHex(digest.digest(canonical));
+      return MessageDigest.getInstance("SHA-256");
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 not available", e);
     }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/MapIdGenerator.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/MapIdGenerator.java
@@ -1,0 +1,78 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * Generates a stable string id for a {@code Map<String, String>} so it can be used as a map key
+ * instead of the map itself.
+ */
+public final class MapIdGenerator {
+  private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+  private MapIdGenerator() {}
+
+  /**
+   * Returns a stable id for {@code map}. Maps with the same key-value pairs produce the same id
+   * regardless of iteration order; maps with different pairs produce different ids.
+   */
+  public static String generateId(Map<String, String> map) {
+    Objects.requireNonNull(map, "map cannot be null");
+    return hashCanonical(canonicalBytes(map));
+  }
+
+  private static byte[] canonicalBytes(Map<String, String> map) {
+    List<Entry<String, String>> entries = new ArrayList<>(map.entrySet());
+    entries.sort(Entry.comparingByKey());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    for (Entry<String, String> entry : entries) {
+      writeUtf8(out, Objects.requireNonNull(entry.getKey(), "map key cannot be null"));
+      writeUtf8(out, Objects.requireNonNull(entry.getValue(), "map value cannot be null"));
+    }
+    return out.toByteArray();
+  }
+
+  private static void writeUtf8(ByteArrayOutputStream out, String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    writeInt(out, bytes.length);
+    try {
+      out.write(bytes);
+    } catch (IOException e) {
+      throw new IllegalStateException("failed to write canonical map bytes", e);
+    }
+  }
+
+  private static void writeInt(ByteArrayOutputStream out, int value) {
+    out.write((value >>> 24) & 0xFF);
+    out.write((value >>> 16) & 0xFF);
+    out.write((value >>> 8) & 0xFF);
+    out.write(value & 0xFF);
+  }
+
+  private static String hashCanonical(byte[] canonical) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return toHex(digest.digest(canonical));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+
+  private static String toHex(byte[] bytes) {
+    char[] hex = new char[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      int value = bytes[i] & 0xFF;
+      hex[i * 2] = HEX[value >>> 4];
+      hex[i * 2 + 1] = HEX[value & 0x0F];
+    }
+    return new String(hex);
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -16,6 +16,7 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
@@ -786,6 +787,49 @@ class CredPropsUtilTest {
   }
 
   @Test
+  void sameTableDifferentAuthConfigsAreCachedSeparately() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(
+              s3CredsExpiringAt(
+                  String.valueOf(fetches.get()), System.currentTimeMillis() + 60_000));
+        };
+
+    TokenProvider tenantA = TokenProvider.create(Map.of("type", "static", "token", "tenant-a"));
+    TokenProvider tenantB = TokenProvider.create(Map.of("type", "static", "token", "tenant-b"));
+
+    createTableCredProps(new Configuration(false), "shared-table", tenantA);
+    createTableCredProps(new Configuration(false), "shared-table", tenantB);
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
+  @Test
+  void credPropsIncludeAuthUniqueIdFromTokenProvider() throws Exception {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> mockGenericCredentialFetcher(s3Creds());
+    TokenProvider provider = TokenProvider.create(Map.of("type", "static", "token", "tenant-a"));
+    String expectedAuthId = MapIdGenerator.generateId(provider.configs());
+
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            null,
+            "http://uc",
+            provider,
+            "tid",
+            UCCredentialHadoopConfs.TableOperation.READ,
+            Map.of());
+
+    assertThat(props).containsEntry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, expectedAuthId);
+  }
+
+  @Test
   void cacheDisabledFetchesForEveryQuery() throws Exception {
     AtomicInteger fetches = new AtomicInteger();
     CredPropsUtil.genericCredFetcherFactory =
@@ -839,6 +883,11 @@ class CredPropsUtilTest {
 
   private static Map<String, String> createTableCredProps(Configuration conf, String tableId)
       throws Exception {
+    return createTableCredProps(conf, tableId, tokenProvider());
+  }
+
+  private static Map<String, String> createTableCredProps(
+      Configuration conf, String tableId, TokenProvider tokenProvider) throws Exception {
     return CredPropsUtil.createTableCredProps(
         false,
         false,
@@ -846,7 +895,7 @@ class CredPropsUtilTest {
         "s3",
         null,
         "http://uc",
-        tokenProvider(),
+        tokenProvider,
         tableId,
         UCCredentialHadoopConfs.TableOperation.READ_WRITE,
         Map.of());
@@ -874,6 +923,8 @@ class CredPropsUtilTest {
             UCCredentialHadoopConfs.TableOperation.READ_WRITE,
             Map.of());
 
+    assertThat(captured.get().props().get(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY))
+        .isEqualTo(MapIdGenerator.generateId(tokenProvider().configs()));
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY))
         .isEqualTo(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_TABLE_ID_KEY)).isEqualTo("tid");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -18,14 +18,19 @@ import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Verifies that {@link io.unitycatalog.hadoop.internal.CredPropsUtil} saves the original {@code
@@ -806,12 +811,34 @@ class CredPropsUtilTest {
     assertThat(fetches.get()).isEqualTo(2);
   }
 
+  /**
+   * The credential-context id folds in {@code catalogUri}, so the same resource accessed via two
+   * different catalogs with the same auth must not share a cached credential. Covers every {@link
+   * CredId} variant produced by the {@code create*CredProps} entry points.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("credIdVariants")
+  void sameResourceDifferentCatalogUriCachedSeparately(String variant, CredPropsFetch fetch)
+      throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    fetch.fetch("http://uc-a");
+    fetch.fetch("http://uc-b");
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
   @Test
-  void credPropsIncludeAuthUniqueIdFromTokenProvider() throws Exception {
+  void credPropsIncludeCredContextIdFromContext() throws Exception {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> mockGenericCredentialFetcher(s3Creds());
     TokenProvider provider = TokenProvider.create(Map.of("type", "static", "token", "tenant-a"));
-    String expectedAuthId = MapIdGenerator.generateId(provider.configs());
+    String expectedContextId = expectedCredContextId("http://uc", "s3", provider);
 
     Map<String, String> props =
         CredPropsUtil.createTableCredProps(
@@ -826,7 +853,8 @@ class CredPropsUtilTest {
             UCCredentialHadoopConfs.TableOperation.READ,
             Map.of());
 
-    assertThat(props).containsEntry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, expectedAuthId);
+    assertThat(props)
+        .containsEntry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, expectedContextId);
   }
 
   @Test
@@ -888,17 +916,85 @@ class CredPropsUtilTest {
 
   private static Map<String, String> createTableCredProps(
       Configuration conf, String tableId, TokenProvider tokenProvider) throws Exception {
+    return createTableCredProps(conf, "http://uc", tableId, tokenProvider);
+  }
+
+  private static Map<String, String> createTableCredProps(
+      Configuration conf, String catalogUri, String tableId, TokenProvider tokenProvider)
+      throws Exception {
     return CredPropsUtil.createTableCredProps(
         false,
         false,
         conf,
         "s3",
         null,
-        "http://uc",
+        catalogUri,
         tokenProvider,
         tableId,
         UCCredentialHadoopConfs.TableOperation.READ_WRITE,
         Map.of());
+  }
+
+  /** Fetches credential props for one fixed resource + auth against the given catalog. */
+  @FunctionalInterface
+  private interface CredPropsFetch {
+    void fetch(String catalogUri) throws Exception;
+  }
+
+  private static Stream<Arguments> credIdVariants() {
+    return Stream.of(
+        Arguments.of(
+            "TableCredId",
+            (CredPropsFetch)
+                catalogUri ->
+                    createTableCredProps(
+                        new Configuration(false), catalogUri, "shared-table", tokenProvider())),
+        Arguments.of(
+            "PathCredId",
+            (CredPropsFetch)
+                catalogUri ->
+                    CredPropsUtil.createPathCredProps(
+                        false,
+                        false,
+                        new Configuration(false),
+                        "s3",
+                        null,
+                        catalogUri,
+                        tokenProvider(),
+                        "s3://bucket/shared",
+                        UCCredentialHadoopConfs.PathOperation.PATH_READ_WRITE,
+                        Map.of())),
+        Arguments.of(
+            "DeltaTableCredId",
+            (CredPropsFetch)
+                catalogUri ->
+                    CredPropsUtil.createDeltaTableCredProps(
+                        false,
+                        false,
+                        new Configuration(false),
+                        "s3",
+                        null,
+                        catalogUri,
+                        tokenProvider(),
+                        UCDeltaTableIdentifier.of("cat", "sch", "tbl"),
+                        "s3://bucket/tbl",
+                        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+                        Map.of())),
+        Arguments.of(
+            "DeltaStagingTableCredId",
+            (CredPropsFetch)
+                catalogUri ->
+                    CredPropsUtil.createDeltaStagingTableCredProps(
+                        false,
+                        false,
+                        new Configuration(false),
+                        "s3",
+                        null,
+                        catalogUri,
+                        tokenProvider(),
+                        "staging-uuid",
+                        "s3://bucket/staging",
+                        Map.of())));
   }
 
   @Test
@@ -923,8 +1019,8 @@ class CredPropsUtilTest {
             UCCredentialHadoopConfs.TableOperation.READ_WRITE,
             Map.of());
 
-    assertThat(captured.get().props().get(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY))
-        .isEqualTo(MapIdGenerator.generateId(tokenProvider().configs()));
+    assertThat(captured.get().props().get(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY))
+        .isEqualTo(expectedCredContextId("http://uc", "s3", tokenProvider()));
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY))
         .isEqualTo(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_TABLE_ID_KEY)).isEqualTo("tid");
@@ -1170,6 +1266,15 @@ class CredPropsUtilTest {
 
   private static TokenProvider tokenProvider() {
     return TokenProvider.create(Map.of("type", "static", "token", "tok"));
+  }
+
+  /** Mirrors {@code CredPropsUtil#credContextId} so tests can assert the derived id. */
+  private static String expectedCredContextId(
+      String catalogUri, String scheme, TokenProvider provider) {
+    Map<String, String> context = new HashMap<>(provider.configs());
+    context.put("catalogUri", catalogUri);
+    context.put("scheme", scheme);
+    return MapIdGenerator.generateId(context);
   }
 
   private static TemporaryCredentials s3Creds() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -16,9 +16,7 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
-import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -838,7 +836,7 @@ class CredPropsUtilTest {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> mockGenericCredentialFetcher(s3Creds());
     TokenProvider provider = TokenProvider.create(Map.of("type", "static", "token", "tenant-a"));
-    String expectedContextId = expectedCredContextId("http://uc", "s3", provider);
+    String expectedContextId = CredPropsUtil.credContextId("http://uc", "s3", provider);
 
     Map<String, String> props =
         CredPropsUtil.createTableCredProps(
@@ -855,6 +853,20 @@ class CredPropsUtilTest {
 
     assertThat(props)
         .containsEntry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, expectedContextId);
+  }
+
+  @Test
+  void credContextIdVariesByCatalogUriSchemeAndAuth() {
+    TokenProvider auth = tokenProvider();
+    String base = CredPropsUtil.credContextId("http://uc", "s3", auth);
+
+    assertThat(CredPropsUtil.credContextId("http://uc", "s3", auth)).isEqualTo(base);
+    assertThat(CredPropsUtil.credContextId("http://uc-2", "s3", auth)).isNotEqualTo(base);
+    assertThat(CredPropsUtil.credContextId("http://uc", "gs", auth)).isNotEqualTo(base);
+    assertThat(
+            CredPropsUtil.credContextId(
+                "http://uc", "s3", TokenProvider.create(Map.of("type", "static", "token", "x"))))
+        .isNotEqualTo(base);
   }
 
   @Test
@@ -1020,7 +1032,7 @@ class CredPropsUtilTest {
             Map.of());
 
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY))
-        .isEqualTo(expectedCredContextId("http://uc", "s3", tokenProvider()));
+        .isEqualTo(CredPropsUtil.credContextId("http://uc", "s3", tokenProvider()));
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY))
         .isEqualTo(UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
     assertThat(captured.get().props().get(UCHadoopConfConstants.UC_TABLE_ID_KEY)).isEqualTo("tid");
@@ -1266,15 +1278,6 @@ class CredPropsUtilTest {
 
   private static TokenProvider tokenProvider() {
     return TokenProvider.create(Map.of("type", "static", "token", "tok"));
-  }
-
-  /** Mirrors {@code CredPropsUtil#credContextId} so tests can assert the derived id. */
-  private static String expectedCredContextId(
-      String catalogUri, String scheme, TokenProvider provider) {
-    Map<String, String> context = new HashMap<>(provider.configs());
-    context.put("catalogUri", catalogUri);
-    context.put("scheme", scheme);
-    return MapIdGenerator.generateId(context);
   }
 
   private static TemporaryCredentials s3Creds() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.auth;
 
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -365,7 +366,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newTableBasedConf(String tableId) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CredId.EMPTY_CRED_CONTEXT_ID);
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
     conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
     conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
@@ -386,7 +387,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newPathBasedConf(String path) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CredId.EMPTY_CRED_CONTEXT_ID);
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
     conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
     conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -322,17 +322,17 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
   }
 
   @Test
-  public void sameTableDifferentAuthUsesSeparateGlobalCacheEntries() throws Exception {
-    String authA = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
-    String authB = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
+  public void sameTableDifferentCredContextUsesSeparateGlobalCacheEntries() throws Exception {
+    String contextA = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
+    String contextB = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
 
     Configuration confA = newTableBasedConf("shared-table");
-    confA.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authA);
+    confA.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, contextA);
     confA.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
     confA.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 
     Configuration confB = newTableBasedConf("shared-table");
-    confB.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authB);
+    confB.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, contextB);
     confB.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
     confB.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -14,7 +14,9 @@ import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.time.Duration;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
@@ -317,6 +319,39 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     // PathB: 3rd access. renew pathBCred1 to pathBCred2.
     assertCred(providerPathB, pathBCred2);
     assertGlobalCache(4, tableACred2, tableBCred2, pathACred2, pathBCred2);
+  }
+
+  @Test
+  public void sameTableDifferentAuthUsesSeparateGlobalCacheEntries() throws Exception {
+    String authA = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
+    String authB = MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
+
+    Configuration confA = newTableBasedConf("shared-table");
+    confA.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authA);
+    confA.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    confA.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+
+    Configuration confB = newTableBasedConf("shared-table");
+    confB.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authB);
+    confB.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+    confB.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+
+    TemporaryCredentials credA = newTempCred("tenantA", clock.now().toEpochMilli() + 2000L);
+    TemporaryCredentials credB = newTempCred("tenantB", clock.now().toEpochMilli() + 2000L);
+
+    TemporaryCredentialsApi tempCredApi = mock(TemporaryCredentialsApi.class);
+    when(tempCredApi.generateTemporaryTableCredentials(any())).thenReturn(credA).thenReturn(credB);
+
+    T providerA = createTestProvider(confA, tempCredApi);
+    T providerB = createTestProvider(confB, tempCredApi);
+
+    assertCred(providerA, credA);
+    assertCred(providerB, credB);
+    assertGlobalCache(2, credA, credB);
+
+    assertCred(providerA, credA);
+    assertCred(providerB, credB);
+    assertGlobalCache(2, credA, credB);
   }
 
   private static void assertGlobalCache(int expectedSize, TemporaryCredentials... creds) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -365,6 +365,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newTableBasedConf(String tableId) {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CredId.EMPTY_CRED_CONTEXT_ID);
     conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
     conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
     conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");
@@ -385,6 +386,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
 
   public static Configuration newPathBasedConf(String path) {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CredId.EMPTY_CRED_CONTEXT_ID);
     conf.set(UCHadoopConfConstants.UC_URI_KEY, "http://localhost:8080");
     conf.set(UCHadoopConfConstants.UC_AUTH_TYPE, "static");
     conf.set(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "unity-catalog-token");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
@@ -23,7 +23,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialCallsDeltaApiWithCredIdFieldsAndReturnsCredential() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_AUTH_UNIQUE_ID,
+            CredId.EMPTY_CRED_CONTEXT_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -61,7 +61,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialRejectsMissingDeltaCredentialsResponse() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_AUTH_UNIQUE_ID,
+            CredId.EMPTY_CRED_CONTEXT_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -79,7 +79,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void factoryRejectsUnsupportedTableOperation() {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_AUTH_UNIQUE_ID,
+            CredId.EMPTY_CRED_CONTEXT_ID,
             UCDeltaTableIdentifier.of("c", "s", "n"),
             "UNKNOWN",
             "s3://b/p");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
@@ -13,6 +13,7 @@ import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.delta.model.DeltaStorageCredentialConfig;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
+import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialCallsDeltaApiWithCredIdFieldsAndReturnsCredential() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
+            CredId.EMPTY_AUTH_UNIQUE_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -59,6 +61,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialRejectsMissingDeltaCredentialsResponse() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
+            CredId.EMPTY_AUTH_UNIQUE_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -75,7 +78,11 @@ class UCDeltaGenericCredentialFetcherTest {
   @Test
   void factoryRejectsUnsupportedTableOperation() {
     DeltaTableCredId credId =
-        new DeltaTableCredId(UCDeltaTableIdentifier.of("c", "s", "n"), "UNKNOWN", "s3://b/p");
+        new DeltaTableCredId(
+            CredId.EMPTY_AUTH_UNIQUE_ID,
+            UCDeltaTableIdentifier.of("c", "s", "n"),
+            "UNKNOWN",
+            "s3://b/p");
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
     assertThatThrownBy(() -> GenericCredentialFetcher.forUcDelta(credId, api))

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcherTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.auth;
 
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -13,7 +14,6 @@ import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.delta.model.DeltaStorageCredentialConfig;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
-import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialCallsDeltaApiWithCredIdFieldsAndReturnsCredential() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_CRED_CONTEXT_ID,
+            EMPTY_CRED_CONTEXT_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -61,7 +61,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void createCredentialRejectsMissingDeltaCredentialsResponse() throws Exception {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_CRED_CONTEXT_ID,
+            EMPTY_CRED_CONTEXT_ID,
             UCDeltaTableIdentifier.of("main", "default", "events"),
             "READ_WRITE",
             "s3://bucket/events");
@@ -79,10 +79,7 @@ class UCDeltaGenericCredentialFetcherTest {
   void factoryRejectsUnsupportedTableOperation() {
     DeltaTableCredId credId =
         new DeltaTableCredId(
-            CredId.EMPTY_CRED_CONTEXT_ID,
-            UCDeltaTableIdentifier.of("c", "s", "n"),
-            "UNKNOWN",
-            "s3://b/p");
+            EMPTY_CRED_CONTEXT_ID, UCDeltaTableIdentifier.of("c", "s", "n"), "UNKNOWN", "s3://b/p");
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
     assertThatThrownBy(() -> GenericCredentialFetcher.forUcDelta(credId, api))

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
@@ -25,7 +25,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
   @Test
   void createCredentialCallsDeltaStagingApiAndReturnsCredential() throws Exception {
     DeltaStagingTableCredId credId =
-        new DeltaStagingTableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, STAGING_ID.toString(), LOCATION);
+        new DeltaStagingTableCredId(CredId.EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
     DeltaCredentialsResponse response = s3StagingResponse();
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
@@ -46,7 +46,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
   @Test
   void createCredentialRejectsNullResponse() throws Exception {
     DeltaStagingTableCredId credId =
-        new DeltaStagingTableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, STAGING_ID.toString(), LOCATION);
+        new DeltaStagingTableCredId(CredId.EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
     when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(null);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
@@ -12,6 +12,7 @@ import io.unitycatalog.client.delta.model.DeltaCredentialsResponse;
 import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.delta.model.DeltaStorageCredentialConfig;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,8 @@ class UCDeltaStagingTableCredentialFetcherTest {
 
   @Test
   void createCredentialCallsDeltaStagingApiAndReturnsCredential() throws Exception {
-    DeltaStagingTableCredId credId = new DeltaStagingTableCredId(STAGING_ID.toString(), LOCATION);
+    DeltaStagingTableCredId credId =
+        new DeltaStagingTableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, STAGING_ID.toString(), LOCATION);
     DeltaCredentialsResponse response = s3StagingResponse();
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
@@ -43,7 +45,8 @@ class UCDeltaStagingTableCredentialFetcherTest {
 
   @Test
   void createCredentialRejectsNullResponse() throws Exception {
-    DeltaStagingTableCredId credId = new DeltaStagingTableCredId(STAGING_ID.toString(), LOCATION);
+    DeltaStagingTableCredId credId =
+        new DeltaStagingTableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, STAGING_ID.toString(), LOCATION);
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
     when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(null);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcherTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.auth;
 
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -12,7 +13,6 @@ import io.unitycatalog.client.delta.model.DeltaCredentialsResponse;
 import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.delta.model.DeltaStorageCredentialConfig;
 import io.unitycatalog.client.model.TemporaryCredentials;
-import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
   @Test
   void createCredentialCallsDeltaStagingApiAndReturnsCredential() throws Exception {
     DeltaStagingTableCredId credId =
-        new DeltaStagingTableCredId(CredId.EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
+        new DeltaStagingTableCredId(EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
     DeltaCredentialsResponse response = s3StagingResponse();
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
@@ -46,7 +46,7 @@ class UCDeltaStagingTableCredentialFetcherTest {
   @Test
   void createCredentialRejectsNullResponse() throws Exception {
     DeltaStagingTableCredId credId =
-        new DeltaStagingTableCredId(CredId.EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
+        new DeltaStagingTableCredId(EMPTY_CRED_CONTEXT_ID, STAGING_ID.toString(), LOCATION);
 
     DeltaTemporaryCredentialsApi api = mock(DeltaTemporaryCredentialsApi.class);
     when(api.getStagingTableCredentials(STAGING_ID)).thenReturn(null);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.auth;
 
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,7 +16,6 @@ import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
-import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import org.apache.hadoop.conf.Configuration;
@@ -53,7 +53,7 @@ class UCGenericCredentialFetcherTest {
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
             new TableCredId(
-                CredId.EMPTY_CRED_CONTEXT_ID, "original-table-id", TableOperation.READ.getValue()),
+                EMPTY_CRED_CONTEXT_ID, "original-table-id", TableOperation.READ.getValue()),
             api);
 
     credentialFetcher.createCredential();
@@ -74,7 +74,7 @@ class UCGenericCredentialFetcherTest {
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
             new PathCredId(
-                CredId.EMPTY_CRED_CONTEXT_ID,
+                EMPTY_CRED_CONTEXT_ID,
                 "s3://bucket/original-path",
                 PathOperation.PATH_READ.getValue()),
             api);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
@@ -15,6 +15,7 @@ import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import org.apache.hadoop.conf.Configuration;
@@ -51,7 +52,9 @@ class UCGenericCredentialFetcherTest {
 
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
-            new TableCredId("original-table-id", TableOperation.READ.getValue()), api);
+            new TableCredId(
+                CredId.EMPTY_AUTH_UNIQUE_ID, "original-table-id", TableOperation.READ.getValue()),
+            api);
 
     credentialFetcher.createCredential();
 
@@ -70,7 +73,11 @@ class UCGenericCredentialFetcherTest {
 
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
-            new PathCredId("s3://bucket/original-path", PathOperation.PATH_READ.getValue()), api);
+            new PathCredId(
+                CredId.EMPTY_AUTH_UNIQUE_ID,
+                "s3://bucket/original-path",
+                PathOperation.PATH_READ.getValue()),
+            api);
 
     credentialFetcher.createCredential();
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcherTest.java
@@ -53,7 +53,7 @@ class UCGenericCredentialFetcherTest {
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
             new TableCredId(
-                CredId.EMPTY_AUTH_UNIQUE_ID, "original-table-id", TableOperation.READ.getValue()),
+                CredId.EMPTY_CRED_CONTEXT_ID, "original-table-id", TableOperation.READ.getValue()),
             api);
 
     credentialFetcher.createCredential();
@@ -74,7 +74,7 @@ class UCGenericCredentialFetcherTest {
     GenericCredentialFetcher credentialFetcher =
         GenericCredentialFetcher.forUc(
             new PathCredId(
-                CredId.EMPTY_AUTH_UNIQUE_ID,
+                CredId.EMPTY_CRED_CONTEXT_ID,
                 "s3://bucket/original-path",
                 PathOperation.PATH_READ.getValue()),
             api);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.fs;
 
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,7 +41,7 @@ class CredScopedFileSystemCacheTest {
   }
 
   private static Configuration tableConf(String tableId, String op) {
-    return tableConf(tableId, op, CredId.EMPTY_CRED_CONTEXT_ID);
+    return tableConf(tableId, op, EMPTY_CRED_CONTEXT_ID);
   }
 
   private static Configuration tableConf(String tableId, String op, String credContextId) {
@@ -89,7 +90,7 @@ class CredScopedFileSystemCacheTest {
   @Test
   void evictedEntryClosesCachedDelegate() throws Exception {
     FileSystem mockFs = mock(FileSystem.class);
-    CredId key = new TableCredId(CredId.EMPTY_CRED_CONTEXT_ID, "tid-evict", "READ");
+    CredId key = new TableCredId(EMPTY_CRED_CONTEXT_ID, "tid-evict", "READ");
     CredScopedFileSystem.CACHE.put(key, mockFs);
 
     CredScopedFileSystem.clearCacheForTesting();

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.verify;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.net.URI;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.AfterEach;
@@ -21,6 +23,11 @@ import org.junit.jupiter.api.Test;
  */
 class CredScopedFileSystemCacheTest {
 
+  private static final String AUTH_A =
+      MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
+  private static final String AUTH_B =
+      MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
+
   @AfterEach
   void clearCache() {
     CredScopedFileSystem.clearCacheForTesting();
@@ -33,14 +40,17 @@ class CredScopedFileSystemCacheTest {
   }
 
   private static Configuration tableConf(String tableId, String op) {
+    return tableConf(tableId, op, CredId.EMPTY_AUTH_UNIQUE_ID);
+  }
+
+  private static Configuration tableConf(String tableId, String op, String authUniqueId) {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authUniqueId);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
     conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, tableId);
     conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, op);
-    // Disable Hadoop's internal filesystem cache so newFileSystem() creates a fresh instance per
-    // credential scope, making it possible to assert identity inequality across scopes.
     conf.set("fs.file.impl.disable.cache", "true");
     return conf;
   }
@@ -67,13 +77,21 @@ class CredScopedFileSystemCacheTest {
   }
 
   @Test
+  void sameTableDifferentAuthGetsDifferentDelegate() throws Exception {
+    URI uri = new URI("file:///tmp");
+
+    CredScopedFileSystem fsTenantA = init(uri, tableConf("tid-1", "READ", AUTH_A));
+    CredScopedFileSystem fsTenantB = init(uri, tableConf("tid-1", "READ", AUTH_B));
+
+    assertThat(fsTenantA.getDelegate()).isNotSameAs(fsTenantB.getDelegate());
+  }
+
+  @Test
   void evictedEntryClosesCachedDelegate() throws Exception {
-    // Pre-seed the cache with a mock delegate so we can verify close() is called.
     FileSystem mockFs = mock(FileSystem.class);
-    CredId key = new TableCredId("tid-evict", "READ");
+    CredId key = new TableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, "tid-evict", "READ");
     CredScopedFileSystem.CACHE.put(key, mockFs);
 
-    // Invalidate (simulates LRU eviction) and flush the removal listener.
     CredScopedFileSystem.clearCacheForTesting();
 
     verify(mockFs).close();

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
  */
 class CredScopedFileSystemCacheTest {
 
-  private static final String AUTH_A =
+  private static final String CONTEXT_A =
       MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
-  private static final String AUTH_B =
+  private static final String CONTEXT_B =
       MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
 
   @AfterEach
@@ -40,12 +40,12 @@ class CredScopedFileSystemCacheTest {
   }
 
   private static Configuration tableConf(String tableId, String op) {
-    return tableConf(tableId, op, CredId.EMPTY_AUTH_UNIQUE_ID);
+    return tableConf(tableId, op, CredId.EMPTY_CRED_CONTEXT_ID);
   }
 
-  private static Configuration tableConf(String tableId, String op, String authUniqueId) {
+  private static Configuration tableConf(String tableId, String op, String credContextId) {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, authUniqueId);
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, credContextId);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
@@ -77,11 +77,11 @@ class CredScopedFileSystemCacheTest {
   }
 
   @Test
-  void sameTableDifferentAuthGetsDifferentDelegate() throws Exception {
+  void sameTableDifferentCredContextGetsDifferentDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
 
-    CredScopedFileSystem fsTenantA = init(uri, tableConf("tid-1", "READ", AUTH_A));
-    CredScopedFileSystem fsTenantB = init(uri, tableConf("tid-1", "READ", AUTH_B));
+    CredScopedFileSystem fsTenantA = init(uri, tableConf("tid-1", "READ", CONTEXT_A));
+    CredScopedFileSystem fsTenantB = init(uri, tableConf("tid-1", "READ", CONTEXT_B));
 
     assertThat(fsTenantA.getDelegate()).isNotSameAs(fsTenantB.getDelegate());
   }
@@ -89,7 +89,7 @@ class CredScopedFileSystemCacheTest {
   @Test
   void evictedEntryClosesCachedDelegate() throws Exception {
     FileSystem mockFs = mock(FileSystem.class);
-    CredId key = new TableCredId(CredId.EMPTY_AUTH_UNIQUE_ID, "tid-evict", "READ");
+    CredId key = new TableCredId(CredId.EMPTY_CRED_CONTEXT_ID, "tid-evict", "READ");
     CredScopedFileSystem.CACHE.put(key, mockFs);
 
     CredScopedFileSystem.clearCacheForTesting();

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
@@ -81,6 +81,7 @@ class CredIdTest {
   @Test
   void createReturnsTableKey() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
@@ -90,6 +91,20 @@ class CredIdTest {
     assertThat(CredId.create(conf))
         .isInstanceOf(TableCredId.class)
         .isEqualTo(new TableCredId(EMPTY_CRED_CONTEXT_ID, "tid", "READ"));
+  }
+
+  @Test
+  void createThrowsWhenCredContextIdMissing() {
+    Configuration conf = new Configuration();
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+
+    assertThatThrownBy(() -> CredId.create(conf))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY);
   }
 
   @Test
@@ -108,6 +123,7 @@ class CredIdTest {
   @Test
   void createReturnsPathKey() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE);
@@ -174,6 +190,7 @@ class CredIdTest {
   @Test
   void createReturnsDeltaTableKeyWhenDeltaApiEnabled() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
@@ -193,6 +210,7 @@ class CredIdTest {
   @Test
   void createReturnsTableKeyWhenDeltaApiNotEnabled() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
@@ -232,6 +250,7 @@ class CredIdTest {
   @Test
   void createReturnsDeltaStagingTableKey() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "stid-1");
     conf.set(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://b/staging");
 
@@ -243,6 +262,7 @@ class CredIdTest {
   @Test
   void stagingTableKeyTakesPriorityOverTableType() {
     Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
@@ -1,11 +1,13 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.id.CredId.EMPTY_AUTH_UNIQUE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.unitycatalog.hadoop.internal.UCDeltaTableIdentifier;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.net.URI;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -13,35 +15,53 @@ import org.junit.jupiter.api.Test;
 
 class CredIdTest {
 
+  private static final String AUTH_A =
+      MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
+  private static final String AUTH_B =
+      MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
+
   @Test
-  void pathKeyEqualWhenSamePathAndOp() {
-    assertThat(new PathCredId("s3://b/p", "READ"))
-        .isEqualTo(new PathCredId("s3://b/p", "READ"))
-        .hasSameHashCodeAs(new PathCredId("s3://b/p", "READ"));
+  void pathKeyEqualWhenSameAuthPathAndOp() {
+    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
+        .isEqualTo(new PathCredId(AUTH_A, "s3://b/p", "READ"))
+        .hasSameHashCodeAs(new PathCredId(AUTH_A, "s3://b/p", "READ"));
+  }
+
+  @Test
+  void pathKeyNotEqualWhenDifferentAuth() {
+    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
+        .isNotEqualTo(new PathCredId(AUTH_B, "s3://b/p", "READ"));
   }
 
   @Test
   void pathKeyNotEqualWhenDifferentOp() {
-    assertThat(new PathCredId("s3://b/p", "READ"))
-        .isNotEqualTo(new PathCredId("s3://b/p", "WRITE"));
+    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
+        .isNotEqualTo(new PathCredId(AUTH_A, "s3://b/p", "WRITE"));
   }
 
   @Test
   void pathKeyNotEqualWhenDifferentPath() {
-    assertThat(new PathCredId("s3://b/a", "READ")).isNotEqualTo(new PathCredId("s3://b/b", "READ"));
+    assertThat(new PathCredId(AUTH_A, "s3://b/a", "READ"))
+        .isNotEqualTo(new PathCredId(AUTH_A, "s3://b/b", "READ"));
   }
 
   @Test
-  void tableKeyEqualWhenSameIdAndOp() {
-    assertThat(new TableCredId("tid-1", "READ_WRITE"))
-        .isEqualTo(new TableCredId("tid-1", "READ_WRITE"))
-        .hasSameHashCodeAs(new TableCredId("tid-1", "READ_WRITE"));
+  void tableKeyEqualWhenSameAuthIdAndOp() {
+    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
+        .isEqualTo(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
+        .hasSameHashCodeAs(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"));
+  }
+
+  @Test
+  void tableKeyNotEqualWhenDifferentAuth() {
+    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
+        .isNotEqualTo(new TableCredId(AUTH_B, "tid-1", "READ_WRITE"));
   }
 
   @Test
   void tableKeyNotEqualWhenDifferentId() {
-    assertThat(new TableCredId("tid-1", "READ_WRITE"))
-        .isNotEqualTo(new TableCredId("tid-2", "READ_WRITE"));
+    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
+        .isNotEqualTo(new TableCredId(AUTH_A, "tid-2", "READ_WRITE"));
   }
 
   @Test
@@ -69,7 +89,20 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(TableCredId.class)
-        .isEqualTo(new TableCredId("tid", "READ"));
+        .isEqualTo(new TableCredId(EMPTY_AUTH_UNIQUE_ID, "tid", "READ"));
+  }
+
+  @Test
+  void createReturnsTableKeyWithAuthUniqueId() {
+    Configuration conf = new Configuration();
+    conf.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A);
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+
+    assertThat(CredId.create(conf)).isEqualTo(new TableCredId(AUTH_A, "tid", "READ"));
   }
 
   @Test
@@ -83,7 +116,7 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(PathCredId.class)
-        .isEqualTo(new PathCredId("s3://b/p", "WRITE"));
+        .isEqualTo(new PathCredId(EMPTY_AUTH_UNIQUE_ID, "s3://b/p", "WRITE"));
   }
 
   @Test
@@ -102,33 +135,40 @@ class CredIdTest {
   @Test
   void deltaTableKeyEqualWhenSameFields() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(id, "READ_WRITE", "s3://b/t"))
-        .isEqualTo(new DeltaTableCredId(id, "READ_WRITE", "s3://b/t"))
-        .hasSameHashCodeAs(new DeltaTableCredId(id, "READ_WRITE", "s3://b/t"));
+    assertThat(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"))
+        .isEqualTo(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"))
+        .hasSameHashCodeAs(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"));
+  }
+
+  @Test
+  void deltaTableKeyNotEqualWhenDifferentAuth() {
+    UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
+    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t"))
+        .isNotEqualTo(new DeltaTableCredId(AUTH_B, id, "READ", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentCatalog() {
     assertThat(
             new DeltaTableCredId(
-                UCDeltaTableIdentifier.of("cat1", "sch", "tbl"), "READ", "s3://b/t"))
+                AUTH_A, UCDeltaTableIdentifier.of("cat1", "sch", "tbl"), "READ", "s3://b/t"))
         .isNotEqualTo(
             new DeltaTableCredId(
-                UCDeltaTableIdentifier.of("cat2", "sch", "tbl"), "READ", "s3://b/t"));
+                AUTH_A, UCDeltaTableIdentifier.of("cat2", "sch", "tbl"), "READ", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentOperation() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(id, "READ", "s3://b/t"))
-        .isNotEqualTo(new DeltaTableCredId(id, "READ_WRITE", "s3://b/t"));
+    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t"))
+        .isNotEqualTo(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentLocation() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(id, "READ", "s3://b/t1"))
-        .isNotEqualTo(new DeltaTableCredId(id, "READ", "s3://b/t2"));
+    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t1"))
+        .isNotEqualTo(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t2"));
   }
 
   @Test
@@ -147,7 +187,7 @@ class CredIdTest {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
     assertThat(CredId.create(conf))
         .isInstanceOf(DeltaTableCredId.class)
-        .isEqualTo(new DeltaTableCredId(id, "READ_WRITE", "s3://b/tbl"));
+        .isEqualTo(new DeltaTableCredId(EMPTY_AUTH_UNIQUE_ID, id, "READ_WRITE", "s3://b/tbl"));
   }
 
   @Test
@@ -161,26 +201,32 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(TableCredId.class)
-        .isEqualTo(new TableCredId("tid", "READ"));
+        .isEqualTo(new TableCredId(EMPTY_AUTH_UNIQUE_ID, "tid", "READ"));
   }
 
   @Test
   void deltaStagingTableKeyEqualWhenSameFields() {
-    assertThat(new DeltaStagingTableCredId("stid-1", "s3://b/staging"))
-        .isEqualTo(new DeltaStagingTableCredId("stid-1", "s3://b/staging"))
-        .hasSameHashCodeAs(new DeltaStagingTableCredId("stid-1", "s3://b/staging"));
+    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
+        .isEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
+        .hasSameHashCodeAs(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"));
+  }
+
+  @Test
+  void deltaStagingTableKeyNotEqualWhenDifferentAuth() {
+    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
+        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_B, "stid-1", "s3://b/staging"));
   }
 
   @Test
   void deltaStagingTableKeyNotEqualWhenDifferentId() {
-    assertThat(new DeltaStagingTableCredId("stid-1", "s3://b/staging"))
-        .isNotEqualTo(new DeltaStagingTableCredId("stid-2", "s3://b/staging"));
+    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
+        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-2", "s3://b/staging"));
   }
 
   @Test
   void deltaStagingTableKeyNotEqualWhenDifferentLocation() {
-    assertThat(new DeltaStagingTableCredId("stid-1", "s3://b/loc1"))
-        .isNotEqualTo(new DeltaStagingTableCredId("stid-1", "s3://b/loc2"));
+    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/loc1"))
+        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/loc2"));
   }
 
   @Test
@@ -191,7 +237,7 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(DeltaStagingTableCredId.class)
-        .isEqualTo(new DeltaStagingTableCredId("stid-1", "s3://b/staging"));
+        .isEqualTo(new DeltaStagingTableCredId(EMPTY_AUTH_UNIQUE_ID, "stid-1", "s3://b/staging"));
   }
 
   @Test
@@ -210,9 +256,10 @@ class CredIdTest {
 
   @Test
   void pathKeyProps() {
-    CredId key = new PathCredId("s3://b/p", "WRITE");
+    CredId key = new PathCredId(AUTH_A, "s3://b/p", "WRITE");
     assertThat(key.props())
         .containsOnly(
+            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE),
@@ -223,9 +270,10 @@ class CredIdTest {
 
   @Test
   void tableKeyProps() {
-    CredId key = new TableCredId("tid", "READ");
+    CredId key = new TableCredId(AUTH_A, "tid", "READ");
     assertThat(key.props())
         .containsOnly(
+            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE),
@@ -238,9 +286,10 @@ class CredIdTest {
   void deltaTableKeyProps() {
     CredId key =
         new DeltaTableCredId(
-            UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "READ_WRITE", "s3://b/tbl");
+            AUTH_A, UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "READ_WRITE", "s3://b/tbl");
     assertThat(key.props())
         .containsOnly(
+            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
             entry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true"),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
@@ -255,9 +304,10 @@ class CredIdTest {
 
   @Test
   void deltaStagingTableKeyProps() {
-    CredId key = new DeltaStagingTableCredId("stid-1", "s3://b/staging");
+    CredId key = new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging");
     assertThat(key.props())
         .containsOnly(
+            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
             entry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true"),
             entry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "stid-1"),
             entry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://b/staging"));
@@ -266,32 +316,37 @@ class CredIdTest {
 
   @Test
   void defaultKeyPropsAreEmpty() {
-    // The fallback scope carries no credential-request props, so it cannot round-trip via create.
     assertThat(new DefaultCredId(URI.create("s3://b"), new Configuration()).props()).isEmpty();
   }
 
   @Test
   void propsAreUnmodifiable() {
-    Map<String, String> props = new TableCredId("tid", "READ").props();
+    Map<String, String> props = new TableCredId(AUTH_A, "tid", "READ").props();
     assertThatThrownBy(() -> props.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void tableKeyRejectsNullFields() {
-    assertThatThrownBy(() -> new TableCredId(null, "READ"))
+    assertThatThrownBy(() -> new TableCredId(null, "tid", "READ"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("authUniqueId");
+    assertThatThrownBy(() -> new TableCredId(AUTH_A, null, "READ"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableId");
-    assertThatThrownBy(() -> new TableCredId("tid", null))
+    assertThatThrownBy(() -> new TableCredId(AUTH_A, "tid", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableOperation");
   }
 
   @Test
   void pathKeyRejectsNullFields() {
-    assertThatThrownBy(() -> new PathCredId(null, "READ"))
+    assertThatThrownBy(() -> new PathCredId(null, "s3://b/p", "READ"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("authUniqueId");
+    assertThatThrownBy(() -> new PathCredId(AUTH_A, null, "READ"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("path");
-    assertThatThrownBy(() -> new PathCredId("s3://b/p", null))
+    assertThatThrownBy(() -> new PathCredId(AUTH_A, "s3://b/p", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("pathOperation");
   }
@@ -299,28 +354,33 @@ class CredIdTest {
   @Test
   void deltaTableKeyRejectsNullFields() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThatThrownBy(() -> new DeltaTableCredId(null, "READ", "s3://b/t"))
+    assertThatThrownBy(() -> new DeltaTableCredId(null, id, "READ", "s3://b/t"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("authUniqueId");
+    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, null, "READ", "s3://b/t"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("identifier");
-    assertThatThrownBy(() -> new DeltaTableCredId(id, null, "s3://b/t"))
+    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, id, null, "s3://b/t"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableOperation");
-    assertThatThrownBy(() -> new DeltaTableCredId(id, "READ", null))
+    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, id, "READ", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("location");
   }
 
   @Test
   void deltaStagingTableKeyRejectsNullFields() {
-    assertThatThrownBy(() -> new DeltaStagingTableCredId(null, "s3://b/staging"))
+    assertThatThrownBy(() -> new DeltaStagingTableCredId(null, "stid-1", "s3://b/staging"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("authUniqueId");
+    assertThatThrownBy(() -> new DeltaStagingTableCredId(AUTH_A, null, "s3://b/staging"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("stagingTableId");
-    assertThatThrownBy(() -> new DeltaStagingTableCredId("stid-1", null))
+    assertThatThrownBy(() -> new DeltaStagingTableCredId(AUTH_A, "stid-1", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("location");
   }
 
-  /** Asserts that feeding a key's {@code props()} back through {@code create} reconstructs it. */
   private static void assertPropsRoundTrip(CredId key) {
     Configuration conf = new Configuration(false);
     key.props().forEach(conf::set);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
@@ -1,6 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.id.CredId.EMPTY_AUTH_UNIQUE_ID;
+import static io.unitycatalog.hadoop.internal.id.CredId.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -15,53 +15,53 @@ import org.junit.jupiter.api.Test;
 
 class CredIdTest {
 
-  private static final String AUTH_A =
+  private static final String CONTEXT_A =
       MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));
-  private static final String AUTH_B =
+  private static final String CONTEXT_B =
       MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-b"));
 
   @Test
-  void pathKeyEqualWhenSameAuthPathAndOp() {
-    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
-        .isEqualTo(new PathCredId(AUTH_A, "s3://b/p", "READ"))
-        .hasSameHashCodeAs(new PathCredId(AUTH_A, "s3://b/p", "READ"));
+  void pathKeyEqualWhenSameContextPathAndOp() {
+    assertThat(new PathCredId(CONTEXT_A, "s3://b/p", "READ"))
+        .isEqualTo(new PathCredId(CONTEXT_A, "s3://b/p", "READ"))
+        .hasSameHashCodeAs(new PathCredId(CONTEXT_A, "s3://b/p", "READ"));
   }
 
   @Test
-  void pathKeyNotEqualWhenDifferentAuth() {
-    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
-        .isNotEqualTo(new PathCredId(AUTH_B, "s3://b/p", "READ"));
+  void pathKeyNotEqualWhenDifferentContext() {
+    assertThat(new PathCredId(CONTEXT_A, "s3://b/p", "READ"))
+        .isNotEqualTo(new PathCredId(CONTEXT_B, "s3://b/p", "READ"));
   }
 
   @Test
   void pathKeyNotEqualWhenDifferentOp() {
-    assertThat(new PathCredId(AUTH_A, "s3://b/p", "READ"))
-        .isNotEqualTo(new PathCredId(AUTH_A, "s3://b/p", "WRITE"));
+    assertThat(new PathCredId(CONTEXT_A, "s3://b/p", "READ"))
+        .isNotEqualTo(new PathCredId(CONTEXT_A, "s3://b/p", "WRITE"));
   }
 
   @Test
   void pathKeyNotEqualWhenDifferentPath() {
-    assertThat(new PathCredId(AUTH_A, "s3://b/a", "READ"))
-        .isNotEqualTo(new PathCredId(AUTH_A, "s3://b/b", "READ"));
+    assertThat(new PathCredId(CONTEXT_A, "s3://b/a", "READ"))
+        .isNotEqualTo(new PathCredId(CONTEXT_A, "s3://b/b", "READ"));
   }
 
   @Test
-  void tableKeyEqualWhenSameAuthIdAndOp() {
-    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
-        .isEqualTo(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
-        .hasSameHashCodeAs(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"));
+  void tableKeyEqualWhenSameContextIdAndOp() {
+    assertThat(new TableCredId(CONTEXT_A, "tid-1", "READ_WRITE"))
+        .isEqualTo(new TableCredId(CONTEXT_A, "tid-1", "READ_WRITE"))
+        .hasSameHashCodeAs(new TableCredId(CONTEXT_A, "tid-1", "READ_WRITE"));
   }
 
   @Test
-  void tableKeyNotEqualWhenDifferentAuth() {
-    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
-        .isNotEqualTo(new TableCredId(AUTH_B, "tid-1", "READ_WRITE"));
+  void tableKeyNotEqualWhenDifferentContext() {
+    assertThat(new TableCredId(CONTEXT_A, "tid-1", "READ_WRITE"))
+        .isNotEqualTo(new TableCredId(CONTEXT_B, "tid-1", "READ_WRITE"));
   }
 
   @Test
   void tableKeyNotEqualWhenDifferentId() {
-    assertThat(new TableCredId(AUTH_A, "tid-1", "READ_WRITE"))
-        .isNotEqualTo(new TableCredId(AUTH_A, "tid-2", "READ_WRITE"));
+    assertThat(new TableCredId(CONTEXT_A, "tid-1", "READ_WRITE"))
+        .isNotEqualTo(new TableCredId(CONTEXT_A, "tid-2", "READ_WRITE"));
   }
 
   @Test
@@ -89,20 +89,20 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(TableCredId.class)
-        .isEqualTo(new TableCredId(EMPTY_AUTH_UNIQUE_ID, "tid", "READ"));
+        .isEqualTo(new TableCredId(EMPTY_CRED_CONTEXT_ID, "tid", "READ"));
   }
 
   @Test
-  void createReturnsTableKeyWithAuthUniqueId() {
+  void createReturnsTableKeyWithCredContextId() {
     Configuration conf = new Configuration();
-    conf.set(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A);
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A);
     conf.set(
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
         UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
     conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid");
     conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
 
-    assertThat(CredId.create(conf)).isEqualTo(new TableCredId(AUTH_A, "tid", "READ"));
+    assertThat(CredId.create(conf)).isEqualTo(new TableCredId(CONTEXT_A, "tid", "READ"));
   }
 
   @Test
@@ -116,7 +116,7 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(PathCredId.class)
-        .isEqualTo(new PathCredId(EMPTY_AUTH_UNIQUE_ID, "s3://b/p", "WRITE"));
+        .isEqualTo(new PathCredId(EMPTY_CRED_CONTEXT_ID, "s3://b/p", "WRITE"));
   }
 
   @Test
@@ -135,40 +135,40 @@ class CredIdTest {
   @Test
   void deltaTableKeyEqualWhenSameFields() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"))
-        .isEqualTo(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"))
-        .hasSameHashCodeAs(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"));
+    assertThat(new DeltaTableCredId(CONTEXT_A, id, "READ_WRITE", "s3://b/t"))
+        .isEqualTo(new DeltaTableCredId(CONTEXT_A, id, "READ_WRITE", "s3://b/t"))
+        .hasSameHashCodeAs(new DeltaTableCredId(CONTEXT_A, id, "READ_WRITE", "s3://b/t"));
   }
 
   @Test
-  void deltaTableKeyNotEqualWhenDifferentAuth() {
+  void deltaTableKeyNotEqualWhenDifferentContext() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t"))
-        .isNotEqualTo(new DeltaTableCredId(AUTH_B, id, "READ", "s3://b/t"));
+    assertThat(new DeltaTableCredId(CONTEXT_A, id, "READ", "s3://b/t"))
+        .isNotEqualTo(new DeltaTableCredId(CONTEXT_B, id, "READ", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentCatalog() {
     assertThat(
             new DeltaTableCredId(
-                AUTH_A, UCDeltaTableIdentifier.of("cat1", "sch", "tbl"), "READ", "s3://b/t"))
+                CONTEXT_A, UCDeltaTableIdentifier.of("cat1", "sch", "tbl"), "READ", "s3://b/t"))
         .isNotEqualTo(
             new DeltaTableCredId(
-                AUTH_A, UCDeltaTableIdentifier.of("cat2", "sch", "tbl"), "READ", "s3://b/t"));
+                CONTEXT_A, UCDeltaTableIdentifier.of("cat2", "sch", "tbl"), "READ", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentOperation() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t"))
-        .isNotEqualTo(new DeltaTableCredId(AUTH_A, id, "READ_WRITE", "s3://b/t"));
+    assertThat(new DeltaTableCredId(CONTEXT_A, id, "READ", "s3://b/t"))
+        .isNotEqualTo(new DeltaTableCredId(CONTEXT_A, id, "READ_WRITE", "s3://b/t"));
   }
 
   @Test
   void deltaTableKeyNotEqualWhenDifferentLocation() {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
-    assertThat(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t1"))
-        .isNotEqualTo(new DeltaTableCredId(AUTH_A, id, "READ", "s3://b/t2"));
+    assertThat(new DeltaTableCredId(CONTEXT_A, id, "READ", "s3://b/t1"))
+        .isNotEqualTo(new DeltaTableCredId(CONTEXT_A, id, "READ", "s3://b/t2"));
   }
 
   @Test
@@ -187,7 +187,7 @@ class CredIdTest {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
     assertThat(CredId.create(conf))
         .isInstanceOf(DeltaTableCredId.class)
-        .isEqualTo(new DeltaTableCredId(EMPTY_AUTH_UNIQUE_ID, id, "READ_WRITE", "s3://b/tbl"));
+        .isEqualTo(new DeltaTableCredId(EMPTY_CRED_CONTEXT_ID, id, "READ_WRITE", "s3://b/tbl"));
   }
 
   @Test
@@ -201,32 +201,32 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(TableCredId.class)
-        .isEqualTo(new TableCredId(EMPTY_AUTH_UNIQUE_ID, "tid", "READ"));
+        .isEqualTo(new TableCredId(EMPTY_CRED_CONTEXT_ID, "tid", "READ"));
   }
 
   @Test
   void deltaStagingTableKeyEqualWhenSameFields() {
-    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
-        .isEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
-        .hasSameHashCodeAs(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"));
+    assertThat(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging"))
+        .isEqualTo(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging"))
+        .hasSameHashCodeAs(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging"));
   }
 
   @Test
-  void deltaStagingTableKeyNotEqualWhenDifferentAuth() {
-    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
-        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_B, "stid-1", "s3://b/staging"));
+  void deltaStagingTableKeyNotEqualWhenDifferentContext() {
+    assertThat(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging"))
+        .isNotEqualTo(new DeltaStagingTableCredId(CONTEXT_B, "stid-1", "s3://b/staging"));
   }
 
   @Test
   void deltaStagingTableKeyNotEqualWhenDifferentId() {
-    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging"))
-        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-2", "s3://b/staging"));
+    assertThat(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging"))
+        .isNotEqualTo(new DeltaStagingTableCredId(CONTEXT_A, "stid-2", "s3://b/staging"));
   }
 
   @Test
   void deltaStagingTableKeyNotEqualWhenDifferentLocation() {
-    assertThat(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/loc1"))
-        .isNotEqualTo(new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/loc2"));
+    assertThat(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/loc1"))
+        .isNotEqualTo(new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/loc2"));
   }
 
   @Test
@@ -237,7 +237,7 @@ class CredIdTest {
 
     assertThat(CredId.create(conf))
         .isInstanceOf(DeltaStagingTableCredId.class)
-        .isEqualTo(new DeltaStagingTableCredId(EMPTY_AUTH_UNIQUE_ID, "stid-1", "s3://b/staging"));
+        .isEqualTo(new DeltaStagingTableCredId(EMPTY_CRED_CONTEXT_ID, "stid-1", "s3://b/staging"));
   }
 
   @Test
@@ -256,10 +256,10 @@ class CredIdTest {
 
   @Test
   void pathKeyProps() {
-    CredId key = new PathCredId(AUTH_A, "s3://b/p", "WRITE");
+    CredId key = new PathCredId(CONTEXT_A, "s3://b/p", "WRITE");
     assertThat(key.props())
         .containsOnly(
-            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
+            entry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE),
@@ -270,10 +270,10 @@ class CredIdTest {
 
   @Test
   void tableKeyProps() {
-    CredId key = new TableCredId(AUTH_A, "tid", "READ");
+    CredId key = new TableCredId(CONTEXT_A, "tid", "READ");
     assertThat(key.props())
         .containsOnly(
-            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
+            entry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE),
@@ -286,10 +286,10 @@ class CredIdTest {
   void deltaTableKeyProps() {
     CredId key =
         new DeltaTableCredId(
-            AUTH_A, UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "READ_WRITE", "s3://b/tbl");
+            CONTEXT_A, UCDeltaTableIdentifier.of("cat", "sch", "tbl"), "READ_WRITE", "s3://b/tbl");
     assertThat(key.props())
         .containsOnly(
-            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
+            entry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A),
             entry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true"),
             entry(
                 UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
@@ -304,10 +304,10 @@ class CredIdTest {
 
   @Test
   void deltaStagingTableKeyProps() {
-    CredId key = new DeltaStagingTableCredId(AUTH_A, "stid-1", "s3://b/staging");
+    CredId key = new DeltaStagingTableCredId(CONTEXT_A, "stid-1", "s3://b/staging");
     assertThat(key.props())
         .containsOnly(
-            entry(UCHadoopConfConstants.UC_AUTH_UNIQUE_ID_KEY, AUTH_A),
+            entry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A),
             entry(UCHadoopConfConstants.UC_DELTA_CREDENTIALS_API_ENABLED_KEY, "true"),
             entry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY, "stid-1"),
             entry(UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY, "s3://b/staging"));
@@ -321,7 +321,7 @@ class CredIdTest {
 
   @Test
   void propsAreUnmodifiable() {
-    Map<String, String> props = new TableCredId(AUTH_A, "tid", "READ").props();
+    Map<String, String> props = new TableCredId(CONTEXT_A, "tid", "READ").props();
     assertThatThrownBy(() -> props.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -329,11 +329,11 @@ class CredIdTest {
   void tableKeyRejectsNullFields() {
     assertThatThrownBy(() -> new TableCredId(null, "tid", "READ"))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("authUniqueId");
-    assertThatThrownBy(() -> new TableCredId(AUTH_A, null, "READ"))
+        .hasMessageContaining("credContextId");
+    assertThatThrownBy(() -> new TableCredId(CONTEXT_A, null, "READ"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableId");
-    assertThatThrownBy(() -> new TableCredId(AUTH_A, "tid", null))
+    assertThatThrownBy(() -> new TableCredId(CONTEXT_A, "tid", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableOperation");
   }
@@ -342,11 +342,11 @@ class CredIdTest {
   void pathKeyRejectsNullFields() {
     assertThatThrownBy(() -> new PathCredId(null, "s3://b/p", "READ"))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("authUniqueId");
-    assertThatThrownBy(() -> new PathCredId(AUTH_A, null, "READ"))
+        .hasMessageContaining("credContextId");
+    assertThatThrownBy(() -> new PathCredId(CONTEXT_A, null, "READ"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("path");
-    assertThatThrownBy(() -> new PathCredId(AUTH_A, "s3://b/p", null))
+    assertThatThrownBy(() -> new PathCredId(CONTEXT_A, "s3://b/p", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("pathOperation");
   }
@@ -356,14 +356,14 @@ class CredIdTest {
     UCDeltaTableIdentifier id = UCDeltaTableIdentifier.of("cat", "sch", "tbl");
     assertThatThrownBy(() -> new DeltaTableCredId(null, id, "READ", "s3://b/t"))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("authUniqueId");
-    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, null, "READ", "s3://b/t"))
+        .hasMessageContaining("credContextId");
+    assertThatThrownBy(() -> new DeltaTableCredId(CONTEXT_A, null, "READ", "s3://b/t"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("identifier");
-    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, id, null, "s3://b/t"))
+    assertThatThrownBy(() -> new DeltaTableCredId(CONTEXT_A, id, null, "s3://b/t"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("tableOperation");
-    assertThatThrownBy(() -> new DeltaTableCredId(AUTH_A, id, "READ", null))
+    assertThatThrownBy(() -> new DeltaTableCredId(CONTEXT_A, id, "READ", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("location");
   }
@@ -372,11 +372,11 @@ class CredIdTest {
   void deltaStagingTableKeyRejectsNullFields() {
     assertThatThrownBy(() -> new DeltaStagingTableCredId(null, "stid-1", "s3://b/staging"))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("authUniqueId");
-    assertThatThrownBy(() -> new DeltaStagingTableCredId(AUTH_A, null, "s3://b/staging"))
+        .hasMessageContaining("credContextId");
+    assertThatThrownBy(() -> new DeltaStagingTableCredId(CONTEXT_A, null, "s3://b/staging"))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("stagingTableId");
-    assertThatThrownBy(() -> new DeltaStagingTableCredId(AUTH_A, "stid-1", null))
+    assertThatThrownBy(() -> new DeltaStagingTableCredId(CONTEXT_A, "stid-1", null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("location");
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
@@ -1,6 +1,5 @@
 package io.unitycatalog.hadoop.internal.id;
 
-import static io.unitycatalog.hadoop.internal.id.CredId.EMPTY_CRED_CONTEXT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -13,7 +12,10 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
-class CredIdTest {
+public class CredIdTest {
+
+  /** Placeholder context id for tests that don't exercise credential-context isolation. */
+  public static final String EMPTY_CRED_CONTEXT_ID = MapIdGenerator.generateId(Map.of());
 
   private static final String CONTEXT_A =
       MapIdGenerator.generateId(Map.of("type", "static", "token", "tenant-a"));

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/MapIdGeneratorTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/util/MapIdGeneratorTest.java
@@ -1,0 +1,64 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MapIdGeneratorTest {
+
+  @Test
+  void generateIdIsStable64CharLowercaseHex() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("b", "2");
+    first.put("a", "1");
+
+    Map<String, String> second = Map.of("a", "1", "b", "2");
+
+    String id = MapIdGenerator.generateId(first);
+    assertThat(id).isEqualTo(MapIdGenerator.generateId(second));
+    assertThat(id).hasSize(64).matches("[0-9a-f]{64}");
+    assertThat(MapIdGenerator.generateId(Map.of()))
+        .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  }
+
+  @Test
+  void generateIdDiffersAcrossDistinctMaps() {
+    Map<String, String> base = Map.of("a", "1", "b", "2");
+
+    assertThat(MapIdGenerator.generateId(Map.of("a", "1", "b", "3")))
+        .isNotEqualTo(MapIdGenerator.generateId(base));
+    assertThat(MapIdGenerator.generateId(Map.of("a", "1", "c", "2")))
+        .isNotEqualTo(MapIdGenerator.generateId(base));
+    assertThat(MapIdGenerator.generateId(Map.of("a", "1")))
+        .isNotEqualTo(MapIdGenerator.generateId(base));
+    assertThat(MapIdGenerator.generateId(Map.of("a", "b\0c")))
+        .isNotEqualTo(MapIdGenerator.generateId(Map.of("a\0b", "c")));
+    assertThat(MapIdGenerator.generateId(Map.of("k", "café")))
+        .isNotEqualTo(MapIdGenerator.generateId(Map.of("k", "cafe")));
+    assertThat(MapIdGenerator.generateId(Map.of("", "v")))
+        .isNotEqualTo(MapIdGenerator.generateId(Map.of("k", "")));
+  }
+
+  @Test
+  void rejectsNullInputs() {
+    assertThatThrownBy(() -> MapIdGenerator.generateId(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("map cannot be null");
+
+    Map<String, String> nullKey = new HashMap<>();
+    nullKey.put(null, "v");
+    assertThatThrownBy(() -> MapIdGenerator.generateId(nullKey))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("map key cannot be null");
+
+    Map<String, String> nullValue = new HashMap<>();
+    nullValue.put("k", null);
+    assertThatThrownBy(() -> MapIdGenerator.generateId(nullValue))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("map value cannot be null");
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Multi-tenant Spark Connect can route queries from different tenants through the same gateway with different `TokenProvider` auth configs. Previously, `CredId` was keyed only by table/path/operation, so `CredentialCache` and `CredScopedFileSystem` could reuse vended credentials and filesystem delegates across tenants targeting the same resource — a permission leak (e.g. tenant B receiving tenant A's READ_WRITE credential for the same table).

This change keys every credential cache by the full credential-vending *context* rather than the resource alone. A vended credential is a function of the catalog endpoint, the storage scheme, and the caller's auth identity, so all three are hashed into a single `credContextId`:

- Adds `MapIdGenerator`, which derives a stable id from a `Map<String, String>` using an order-independent, length-prefixed SHA-256 digest computed incrementally (no external dependency).
- Adds `credContextId` as the first field on `TableCredId`, `PathCredId`, `DeltaTableCredId`, and `DeltaStagingTableCredId`, computed from `catalogUri`, `scheme`, and `TokenProvider.configs()`.
- Wires `credContextId` generation into all four `CredPropsUtil.create*CredProps` entry points.
- Persists the context id in Hadoop props under `fs.unitycatalog.cred.context.id` and round-trips it via `CredId.create(conf)`. The key is intentionally all-lowercase and dot-separated (matching `table.id`, `staging.table.id`) because these props flow through Spark's case-insensitive table option handling, which lowercases option keys.

Folding `catalogUri` in (not just the auth config) also isolates the case where one identity targets two different catalogs — e.g. cross-catalog data sync — which an auth-only id could not distinguish for `TableCredId`, since it carries no location.

`readCredContextId` fails fast if the context id is absent from the config, rather than falling back to a shared default id that could silently let unrelated sessions reuse each other's credentials. Every `CredId` variant persists the context id via `props()`, so all runtime paths supply it.

**Testing**

`./build/sbt -mem 4096 hadoop/test` (164 tests pass)

- Unit: `MapIdGeneratorTest` (stability, order-independence, boundary/unicode/null cases); `CredIdTest` (context dimension in equals/hashCode/props round-trip for all four variants, plus fast-fail when the context id is missing).
- Driver cache: `CredPropsUtilTest` isolates credentials across auth configs and across catalog URIs (all four `CredId` variants), and verifies `credContextId` varies by catalogUri, scheme, and auth.
- Worker global cache: `BaseTokenProviderTest` across S3/ABFS/GCS providers.
- Delegate cache: `CredScopedFileSystemCacheTest`.
- End-to-end: verified `ParquetExternalTableReadWriteTest` and `DeltaExternalTableReadWriteTest` pass, exercising the context id round-trip through Spark's table option handling for both native Parquet and Delta reads.