### PR TITLE
fix(server): close InputStream when loading hibernate.properties

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -93,9 +93,7 @@ public class HibernateConfigurator {
           "hibernate.connection.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1");
       hibernateProperties.setProperty("hibernate.hbm2ddl.auto", "update");
     } else {
-      InputStream input;
-      try {
-        input = Files.newInputStream(hibernatePropertiesPath);
+      try (InputStream input = Files.newInputStream(hibernatePropertiesPath)) {
         hibernateProperties.load(input);
       } catch (IOException e) {
         throw new RuntimeException(e);


### PR DESCRIPTION

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`HibernateConfigurator.setupHibernateProperties` loads the on-disk
`etc/conf/hibernate.properties` file like this:

```java
InputStream input;
try {
  input = Files.newInputStream(hibernatePropertiesPath);
  hibernateProperties.load(input);
} catch (IOException e) {
  throw new RuntimeException(e);
}
```

The `InputStream` is opened into a bare local variable and never closed, so the
file descriptor is leaked every time the server starts with a real
`hibernate.properties` file present (the normal path when using an external
database). There is no `finally` and no try-with-resources, so the stream is not
closed on either the success or the exception path.

This change wraps the stream in try-with-resources so it is always closed:

```java
try (InputStream input = Files.newInputStream(hibernatePropertiesPath)) {
  hibernateProperties.load(input);
} catch (IOException e) {
  throw new RuntimeException(e);
}
```

Behavior is otherwise unchanged: an `IOException` is still rethrown as a
`RuntimeException`. This mirrors the existing, correct pattern in the sibling
method `ServerProperties.readPropertiesFromFile`
(`server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java`), which
already uses try-with-resources for the same `Files.newInputStream(...)` +
`properties.load(input)` sequence.

**User-facing impact:** none functionally; this fixes a small file-descriptor leak
at server startup and makes the two properties-loading code paths consistent.
