### PR TITLE
Support wildcard patterns in server.allowed-issuers

### DIFF
--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -55,7 +55,7 @@ server.audiences=<Client ID provided earlier>
 
 When authorization is enabled, the server validates incoming identity tokens against configured issuers and audiences:
 
-- **server.allowed-issuers**: Comma-separated list of allowed token issuers (exact match). Tokens from issuers not in this list will be rejected. This prevents attackers from using their own identity provider to forge tokens.
+- **server.allowed-issuers**: Comma-separated list of allowed token issuers (exact match or wildcard with `*`). Tokens from issuers not in this list will be rejected. This prevents attackers from using their own identity provider to forge tokens.
 - **server.audiences**: Comma-separated list of expected JWT audience values. Tokens must contain one of these audience values. This is typically your application's client ID.
 
 #### Multiple Identity Providers
@@ -65,6 +65,12 @@ You can configure multiple issuers and audiences by separating them with commas:
 ```properties
 server.allowed-issuers=https://accounts.google.com,https://login.microsoftonline.com/{tenant-id}/v2.0
 server.audiences=your-google-client-id,your-azure-client-id
+```
+
+Wildcard issuers match a single DNS label per `*` (useful for multi-tenant deployments):
+
+```properties
+server.allowed-issuers=https://*.dev.example.com
 ```
 
 ### Restart the UC Server

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -39,6 +39,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.security.SecurityContext;
+import io.unitycatalog.server.utils.IssuerAllowlist;
 import io.unitycatalog.server.utils.JwksOperations;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ServerProperties.Property;
@@ -165,7 +166,7 @@ public class AuthService {
     String issuer = decodedJWT.getIssuer();
 
     // Validate issuer is in allowlist BEFORE fetching JWKS
-    if (!allowedIssuers.contains(issuer)) {
+    if (!IssuerAllowlist.isAllowed(issuer, allowedIssuers)) {
       LOGGER.debug("Token rejected: invalid issuer '{}'", issuer);
       throw new OAuthInvalidRequestException(ErrorCode.UNAUTHENTICATED, "Invalid issuer");
     }

--- a/server/src/main/java/io/unitycatalog/server/utils/IssuerAllowlist.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/IssuerAllowlist.java
@@ -1,0 +1,52 @@
+package io.unitycatalog.server.utils;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Matches token issuers against configured allowlist entries (exact or wildcard). */
+public final class IssuerAllowlist {
+
+  private IssuerAllowlist() {}
+
+  /**
+   * Returns true if {@code issuer} matches any entry in {@code allowedIssuers}.
+   *
+   * <p>Entries without {@code *} require an exact match. Entries with {@code *} match a single DNS
+   * label at each wildcard position (e.g. {@code https://*.dev.example.com} matches {@code
+   * https://acme.dev.example.com}).
+   */
+  public static boolean isAllowed(String issuer, List<String> allowedIssuers) {
+    if (issuer == null || issuer.isBlank()) {
+      return false;
+    }
+    for (String pattern : allowedIssuers) {
+      if (pattern == null || pattern.isBlank()) {
+        continue;
+      }
+      if (pattern.indexOf('*') >= 0) {
+        if (toRegex(pattern).matcher(issuer).matches()) {
+          return true;
+        }
+      } else if (pattern.equals(issuer)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Pattern toRegex(String pattern) {
+    StringBuilder regex = new StringBuilder("^");
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      if (c == '*') {
+        regex.append("[^./]+");
+      } else if ("\\.[]{}()+-^$|?".indexOf(c) >= 0) {
+        regex.append('\\').append(c);
+      } else {
+        regex.append(c);
+      }
+    }
+    regex.append('$');
+    return Pattern.compile(regex.toString());
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -517,7 +517,7 @@ public class ServerProperties {
    * <p>When authorization is enabled, tokens will only be accepted from issuers in this list. This
    * prevents attackers from using their own identity provider to forge tokens.
    *
-   * @return List of allowed issuer URLs (exact match required)
+   * @return List of allowed issuer URLs (exact match or wildcard with {@code *})
    */
   public List<String> getAllowedIssuers() {
     return getCommaSeparatedList("server.allowed-issuers");

--- a/server/src/test/java/io/unitycatalog/server/utils/IssuerAllowlistTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/IssuerAllowlistTest.java
@@ -1,0 +1,50 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IssuerAllowlistTest {
+
+  @Test
+  void exactMatch() {
+    assertThat(
+            IssuerAllowlist.isAllowed(
+                "https://dev.dev.example.com", List.of("https://dev.dev.example.com")))
+        .isTrue();
+    assertThat(
+            IssuerAllowlist.isAllowed(
+                "https://backend.dev.example.com", List.of("https://dev.dev.example.com")))
+        .isFalse();
+  }
+
+  @Test
+  void wildcardMatchesAnyTeamOnRealm() {
+    String pattern = "https://*.dev.example.com";
+    assertThat(IssuerAllowlist.isAllowed("https://dev.dev.example.com", List.of(pattern)))
+        .isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://backend.dev.example.com", List.of(pattern)))
+        .isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://acme.dev.example.com", List.of(pattern)))
+        .isTrue();
+  }
+
+  @Test
+  void wildcardRejectsOtherRealmsAndMalformedIssuers() {
+    String pattern = "https://*.dev.example.com";
+    assertThat(IssuerAllowlist.isAllowed("https://acme.eu.example.com", List.of(pattern)))
+        .isFalse();
+    assertThat(IssuerAllowlist.isAllowed("https://evil.com", List.of(pattern))).isFalse();
+    assertThat(IssuerAllowlist.isAllowed("https://foo.bar.dev.example.com", List.of(pattern)))
+        .isFalse();
+  }
+
+  @Test
+  void mixedExactAndWildcard() {
+    List<String> patterns = List.of("https://accounts.google.com", "https://*.dev.example.com");
+    assertThat(IssuerAllowlist.isAllowed("https://accounts.google.com", patterns)).isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://team.dev.example.com", patterns)).isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://other.example.com", patterns)).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary
- Add `IssuerAllowlist` to match `server.allowed-issuers` entries with `*` (single DNS label)
- Use wildcard matching in `AuthService` token exchange issuer validation
- Document wildcard usage in `docs/server/auth.md`

Example: `server.allowed-issuers=https://*.dev.example.com` accepts tokens from `https://dev.dev.example.com`, `https://backend.dev.example.com`, etc.

## Test plan
- [x] `IssuerAllowlistTest` unit tests (exact, wildcard, mixed patterns)


Made with [Cursor](https://cursor.com)