### PR TITLE
docs: fix unterminated f-string in get_function_as_callable AI client example

### DIFF
--- a/docs/ai/client.md
+++ b/docs/ai/client.md
@@ -510,7 +510,7 @@ def sample_python_func(a: int, b: int) -> int:
 # Create the function within Unity Catalog
 client.create_python_function(catalog=CATALOG, schema=SCHEMA, func=sample_python_func, replace=True)
 
-my_callable = client.get_function_as_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_func)
+my_callable = client.get_function_as_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_func")
 
 # Use the callable directly
 my_callable(2, 4)


### PR DESCRIPTION

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
      (Docs-only fix to Markdown code blocks; the repo runs no docs-snippet test
      harness, so there is no test to add. Correctness is shown below by parsing
      the snippet.)
- [x] If you've added or modified a feature, documentation in `docs` is updated
      (this change is in the docs).

**Description of changes**

The runnable Python example under "Retrieving a function as a callable" is
missing the closing double-quote on the `get_function_as_callable`
`function_name` f-string argument. The same broken snippet appears in two docs
files, `docs/ai/client.md` and `ai/core/README.md`:

```python
# before
my_callable = client.get_function_as_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_func)
```

Copy-pasting either documented snippet as-is raises
`SyntaxError: unterminated string literal`, so the example cannot run. This adds
the missing quote in both files so each block is valid Python and matches the
parallel `get_function_source` example a few lines below (which already closes
the quote correctly):

```python
# after
my_callable = client.get_function_as_callable(function_name=f"{CATALOG}.{SCHEMA}.sample_python_func")
```

User impact: readers who copy the AI client "callable" example (from either the
docs site page or the `ai/core` README) can now run it without hitting a syntax
error. No code or behavior change.

Verified locally that each corrected line parses and the full code block
compiles:

```
$ python3 -c 'import ast; ast.parse("my_callable = client.get_function_as_callable(function_name=f\"{CATALOG}.{SCHEMA}.sample_python_func\")"); print("parse OK")'
parse OK
```
