### PR TITLE
fix(server): reject ADLS location with missing authority instead of NPE

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/azure/ADLSLocationUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/azure/ADLSLocationUtils.java
@@ -1,5 +1,7 @@
 package io.unitycatalog.server.service.credential.azure;
 
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.net.URI;
 
@@ -10,7 +12,12 @@ public class ADLSLocationUtils {
   public static ADLSLocationParts parseLocation(NormalizedURL location) {
     URI locationUri = location.toUri();
 
-    String[] authorityParts = locationUri.getAuthority().split("@");
+    String authority = locationUri.getAuthority();
+    if (authority == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "Invalid ADLS location, missing authority: " + location);
+    }
+    String[] authorityParts = authority.split("@");
     if (authorityParts.length > 1) {
       return new ADLSLocationParts(
           locationUri.getScheme(),

--- a/server/src/test/java/io/unitycatalog/server/service/credential/azure/ADLSLocationUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/azure/ADLSLocationUtilsTest.java
@@ -2,7 +2,10 @@ package io.unitycatalog.server.service.credential.azure;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.utils.NormalizedURL;
 import org.junit.jupiter.api.Test;
 
@@ -39,5 +42,19 @@ public class ADLSLocationUtilsTest {
     assertThat(parts.accountName()).isEqualTo(TEST_STORAGE_ACCOUNT);
     assertThat(parts.account()).isEqualTo(format("%s.dfs.core.windows.net", TEST_STORAGE_ACCOUNT));
     assertThat(parts.scheme()).isEqualTo("abfs");
+  }
+
+  @Test
+  public void testMissingAuthorityRejected() {
+    // An abfs URL with no authority (e.g. "abfs:///path") is accepted by NormalizedURL but has a
+    // null URI authority. parseLocation must reject it with a clean INVALID_ARGUMENT rather than
+    // throwing a raw NullPointerException.
+    NormalizedURL location = NormalizedURL.from("abfs:///path/to/files");
+
+    assertThatThrownBy(() -> ADLSLocationUtils.parseLocation(location))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("missing authority")
+        .extracting(e -> ((BaseException) e).getErrorCode())
+        .isEqualTo(ErrorCode.INVALID_ARGUMENT);
   }
 }


### PR DESCRIPTION

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`ADLSLocationUtils.parseLocation` dereferenced `URI.getAuthority()` directly before
calling `.split("@")`:

```java
String[] authorityParts = locationUri.getAuthority().split("@");
```

For an `abfs`/`abfss` location whose URI has no authority (for example
`abfs:///path`), `URI.getAuthority()` returns `null`, so this threw a raw
`NullPointerException`. `NormalizedURL` accepts authority-less `abfs` URLs (it
validates the scheme but does not require an authority), so such a location can be
stored and later reaches `parseLocation` on the credential-vending path
(`FileIOFactory.getADLSFileIO` and `TableConfigService`), where the NPE surfaces to
the client as an opaque HTTP 500.

This change reads the authority once and, when it is `null`, throws
`BaseException(ErrorCode.INVALID_ARGUMENT, ...)` with a clear message, so the caller
gets a clean `400 INVALID_ARGUMENT` instead of a 500. This matches the existing
validation idiom in the same package (`NormalizedURL.normalize`). Behavior for
authority-present locations is unchanged.

Added a regression test (`ADLSLocationUtilsTest.testMissingAuthorityRejected`) that
asserts an authority-less `abfs` URL produces a `BaseException`
(`INVALID_ARGUMENT`, message contains "missing authority") rather than an NPE.

**User-facing impact:** requests that supply an ADLS location with no authority now
receive a clear `400` validation error naming the problem, instead of an opaque
`500`. No change for valid ADLS locations.
