### PR TITLE
fix(server): close Hibernate SessionFactory when the server is disposed

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -66,7 +66,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UnityCatalogServer {
+public class UnityCatalogServer implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(UnityCatalogServer.class);
   private static final String BASE_PATH = "/api/2.1/unity-catalog/";
   private static final String CONTROL_PATH = "/api/1.0/unity-control/";
@@ -75,6 +75,9 @@ public class UnityCatalogServer {
   private final Server server;
   private final ServerProperties serverProperties;
   private final SecurityContext securityContext;
+  private final HibernateConfigurator hibernateConfigurator;
+  /** True when this server built the configurator itself and must therefore close it. */
+  private final boolean ownsHibernateConfigurator;
 
   static {
     System.setProperty("log4j.configurationFile", "etc/conf/server.log4j2.properties");
@@ -89,7 +92,36 @@ public class UnityCatalogServer {
     this.securityContext =
         new SecurityContext(configurationFolder, securityConfiguration, "server", INTERNAL);
     this.serverProperties = unityCatalogServerBuilder.serverProperties;
-    this.server = initializeServer(unityCatalogServerBuilder);
+    // An injected configurator stays the caller's to close; only a self-built one is ours.
+    this.ownsHibernateConfigurator = unityCatalogServerBuilder.hibernateConfigurator == null;
+    this.hibernateConfigurator =
+        ownsHibernateConfigurator
+            ? new HibernateConfigurator(serverProperties)
+            : unityCatalogServerBuilder.hibernateConfigurator;
+    try {
+      this.server = initializeServer(unityCatalogServerBuilder);
+    } catch (Throwable t) {
+      // Construction failed after the SessionFactory was built; close it so a failed boot does
+      // not leak its connection pool. Errors matter as much as RuntimeExceptions here: a
+      // NoClassDefFoundError out of initializeServer() would leak the pool just the same.
+      closeOwnedSessionFactory(t);
+      throw t;
+    }
+  }
+
+  /**
+   * Closes the SessionFactory if this server created it, leaving an injected one to its owner. A
+   * failure to close is attached to {@code primaryFailure} so it cannot mask the original error.
+   */
+  private void closeOwnedSessionFactory(Throwable primaryFailure) {
+    if (!ownsHibernateConfigurator) {
+      return;
+    }
+    try {
+      hibernateConfigurator.getSessionFactory().close();
+    } catch (Throwable closeFailure) {
+      primaryFailure.addSuppressed(closeFailure);
+    }
   }
 
   private void setDefaults(UnityCatalogServer.Builder unityCatalogServerBuilder) {
@@ -107,11 +139,6 @@ public class UnityCatalogServer {
             .http(unityCatalogServerBuilder.port)
             .serviceUnder("/docs", new DocService());
 
-    // Init hibernate
-    HibernateConfigurator hibernateConfigurator =
-        unityCatalogServerBuilder.hibernateConfigurator != null
-            ? unityCatalogServerBuilder.hibernateConfigurator
-            : new HibernateConfigurator(unityCatalogServerBuilder.serverProperties);
     // Init all repositories
     Repositories repositories =
         new Repositories(hibernateConfigurator.getSessionFactory(), serverProperties);
@@ -369,9 +396,29 @@ public class UnityCatalogServer {
     LOGGER.info("Unity Catalog server started.");
   }
 
+  /** Stops the HTTP server. The server can be restarted afterwards with {@link #start()}. */
   public void stop() {
     server.stop().join();
     LOGGER.info("Unity Catalog server stopped.");
+  }
+
+  /**
+   * Stops the server and closes the Hibernate SessionFactory it created, releasing its pooled
+   * database connections, which the Armeria shutdown does not touch and which would otherwise stay
+   * open until the JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is
+   * left open — the caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its
+   * SessionFactory must not be restarted after this call: the factory is closed, so all persistence
+   * operations would fail. Safe to call more than once and safe to call before {@link #start()}.
+   */
+  @Override
+  public void close() {
+    try {
+      stop();
+    } finally {
+      if (ownsHibernateConfigurator) {
+        hibernateConfigurator.getSessionFactory().close();
+      }
+    }
   }
 
   private void printArt() {

--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -136,7 +136,16 @@ public abstract class BaseServerTest {
       tx.commit();
       session.close();
 
-      unityCatalogServer.stop();
+      // close() rather than stop() so a server that built its own SessionFactory releases it;
+      // this harness injects one, so the server leaves it open and we close it below.
+      unityCatalogServer.close();
+      // Release the factory this harness built and injected in setUp(). setUp() builds a fresh
+      // one per test, so leaked factories would otherwise accumulate for the whole JVM run. In
+      // test env hbm2ddl is create-drop, so closing also drops the schema — keep this after the
+      // cleanup queries above.
+      sessionFactory.close();
+      // Null out so tearDown is idempotent if a subclass @AfterEach also invokes it.
+      unityCatalogServer = null;
     }
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/base/access/BaseAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/access/BaseAccessControlCRUDTest.java
@@ -40,16 +40,23 @@ public abstract class BaseAccessControlCRUDTest extends BaseCRUDTest {
         new SecurityContext(configurationFolder, securityConfiguration, "server", INTERNAL);
   }
 
+  // Part of the tearDown() override chain (not a separate @AfterEach) so the casbin cleanup is
+  // guaranteed to run before super.tearDown() closes the SessionFactory. casbin_rule is created
+  // by the casbin JDBCAdapter outside Hibernate's create-drop, so it survives across tests and
+  // must be cleared explicitly.
   @AfterEach
-  public void cleanUp() {
+  @Override
+  public void tearDown() {
     System.clearProperty("server.authorization");
 
-    SessionFactory sessionFactory = hibernateConfigurator.getSessionFactory();
-    Session session = sessionFactory.openSession();
-    Transaction tx = session.beginTransaction();
-    session.createNativeMutationQuery("delete from casbin_rule").executeUpdate();
-    tx.commit();
-    session.close();
+    if (unityCatalogServer != null) {
+      SessionFactory sessionFactory = hibernateConfigurator.getSessionFactory();
+      Session session = sessionFactory.openSession();
+      Transaction tx = session.beginTransaction();
+      session.createNativeMutationQuery("delete from casbin_rule").executeUpdate();
+      tx.commit();
+      session.close();
+    }
 
     super.tearDown();
   }


### PR DESCRIPTION
## Summary

`UnityCatalogServer` creates a `HibernateConfigurator` — and therefore a Hibernate `SessionFactory` with a JDBC connection pool — internally, but nothing ever closes it. `stop()` only shuts down the Armeria HTTP server, so the pooled physical database connections stay open until the JVM exits.

This is invisible with the default in-memory H2, but against a real database every discarded server instance leaks its pool. The sharpest case is the test suite: `BaseServerTest` boots a fresh server per test method, so a test JVM accumulates leaked pools and can eventually exhaust the database's connection limit (e.g. PostgreSQL `max_connections`).

## Stress test — reproducing the leak and proving the fix

A throwaway harness boots a `UnityCatalogServer` and immediately discards it, 40 times in a row, against a real PostgreSQL 16 instance (Testcontainers) started with `max_connections=40`, while a separate probe connection watches `SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()` after each iteration. The dispose step calls `close()` when the server implements `AutoCloseable` (fix applied) and `stop()` otherwise, so the identical harness demonstrates both sides.

**Before (dispose via `stop()`)** — exactly one leaked connection per discarded server, then hard failure:

```
[stress] mode=stop() [unfixed] max_connections=40 baseline connections=1
[stress] iteration 1:  connections=2
[stress] iteration 2:  connections=3
...
[stress] iteration 38: connections=39
[stress] iteration 39: connections=40
[stress] FAILED at iteration 40 (connections=40): PSQLException: FATAL: sorry, too many clients already
```

**After (dispose via `close()`)** — flat at the probe's single connection for all 40 iterations:

```
[stress] mode=close() [fix applied] max_connections=40 baseline connections=1
[stress] iteration 1:  connections=1
...
[stress] iteration 40: connections=1
[stress] COMPLETED 40 iterations; final connections=1
```

This is also the trajectory of the real test suite: one server per test method means a same-JVM run against a default PostgreSQL (`max_connections=100`) dies at roughly the 100th test without this fix.

## Changes

- `UnityCatalogServer` implements `AutoCloseable`; the `HibernateConfigurator` is promoted from a local in `initializeServer()` to a field so its lifecycle can be managed (same single instance as before — previously the reference was simply unreachable after construction, which is why nothing could ever close it).
- `stop()` is unchanged and stays restartable — `BaseMetastoreSummaryTest` exercises `stop()` → `start()` on the same instance (closing the factory in `stop()` fails that test with `EntityManagerFactory is closed`).
- New `close()` stops the server and closes the `SessionFactory` in a `finally` block, so a failing `stop()` cannot leak the pool. Idempotent, and safe before `start()` (Armeria's `stop()` no-ops when not started; Hibernate's native `SessionFactory.close()` tolerates repeat calls).
- The constructor closes the factory if `initializeServer()` throws after the factory was built (e.g. `initMetastoreIfNeeded()` failing on a broken schema), so a failed boot does not leak.
- `BaseServerTest.tearDown()` disposes the per-test server with `close()`, also closes the test harness's own factory, and nulls the server so tearDown is idempotent.
- `BaseAccessControlCRUDTest`'s casbin cleanup moved from a separate `@AfterEach` (`cleanUp()`) into the `tearDown()` override chain. JUnit runs the most-derived `tearDown` override (e.g. `SdkAccessControlBaseCRUDTest`) before less-derived `@AfterEach` methods, so once tearDown closes the factory, the old `cleanUp()` failed with `EntityManagerFactory is closed`. `casbin_rule` is created by casbin's `JDBCAdapter` outside Hibernate's `create-drop`, so it must still be cleared before the factory closes.

## Known adjacent gaps (intentionally out of scope)

- `JCasbinAuthorizer` opens its own raw `DriverManager` connection via casbin's `JDBCAdapter`; it is not covered by `close()` and still leaks one connection per auth-enabled server instance. Fixing it needs a lifecycle method on `UnityCatalogAuthorizer` — happy to do as a follow-up.
- The server does not configure Armeria's `gracefulShutdownTimeout`, so `stop()` does not formally wait for in-flight handlers. Safe today because all DB-touching services are synchronous event-loop handlers, but worth revisiting if async/`@Blocking` services are added.

## How we tested

```
build/sbt "server/testOnly *SdkDeltaCommitsCRUDTest *MetastoreSummaryTest *AccessControl* *AuthCRUD*"
Passed: Total 26, Failed 0, Errors 0, Passed 26
```

Covers the per-test boot/dispose cycle, the stop/start restart path, and the auth-enabled hierarchy with the double-teardown pattern — plus the connection-exhaustion stress test above.

## PR Checklist

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)