### PR TITLE
Wildcard issuer/audience matching and subject-token principal resolution

### DIFF
--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -56,7 +56,7 @@ server.audiences=<Client ID provided earlier>
 When authorization is enabled, the server validates incoming identity tokens against configured issuers and audiences:
 
 - **server.allowed-issuers**: Comma-separated list of allowed token issuers (exact match). Tokens from issuers not in this list will be rejected. This prevents attackers from using their own identity provider to forge tokens.
-- **server.audiences**: Comma-separated list of expected JWT audience values. Tokens must contain one of these audience values. This is typically your application's client ID.
+- **server.audiences**: Comma-separated list of expected JWT audience values. Tokens must contain an `aud` value matching one of these entries (exact match or wildcard with `*`). A single value of `*` disables audience validation (issuer and user checks still apply); that sentinel cannot be combined with other values.
 
 #### Multiple Identity Providers
 
@@ -65,6 +65,23 @@ You can configure multiple issuers and audiences by separating them with commas:
 ```properties
 server.allowed-issuers=https://accounts.google.com,https://login.microsoftonline.com/{tenant-id}/v2.0
 server.audiences=your-google-client-id,your-azure-client-id
+```
+
+Wildcard audience patterns match a single DNS label per `*`. For example, `https://*.dev.example.com`
+accepts tokens whose `aud` includes `https://dev.dev.example.com` or
+`https://backend.dev.example.com`:
+
+```properties
+server.audiences=unity-catalog-local,https://*.dev.example.com
+```
+
+When the identity provider issues per-client UUID audiences that cannot be pre-listed (for example
+dynamic OAuth client IDs in `id_token.aud`), use `*` alone to skip audience validation while still
+enforcing issuer and user checks:
+
+```properties
+server.audiences=*
+server.allowed-issuers=https://*.dev.example.com
 ```
 
 ### Restart the UC Server

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -55,8 +55,19 @@ server.audiences=<Client ID provided earlier>
 
 When authorization is enabled, the server validates incoming identity tokens against configured issuers and audiences:
 
-- **server.allowed-issuers**: Comma-separated list of allowed token issuers (exact match). Tokens from issuers not in this list will be rejected. This prevents attackers from using their own identity provider to forge tokens.
-- **server.audiences**: Comma-separated list of expected JWT audience values. Tokens must contain an `aud` value matching one of these entries (exact match or wildcard with `*`). A single value of `*` disables audience validation (issuer and user checks still apply); that sentinel cannot be combined with other values.
+- **server.allowed-issuers**: Comma-separated list of allowed token issuers (exact match or wildcard with `*`). Tokens from issuers not in this list will be rejected. This prevents attackers from using their own identity provider to forge tokens.
+- **server.audiences**: Comma-separated list of expected JWT audience values. Tokens must match the allowlist unless the signed subject token carries an OAuth client id in `azp` or a non-URL `aud` value (used for programmatic `externalId` resolution).
+
+#### Programmatic exchange (service principals)
+
+Service integrations exchange an upstream OAuth access token on `POST /auth/tokens` without client credentials on the UC request. UC resolves the principal in two steps:
+
+1. **Email mode** — look up the user by the token `email` claim (or `sub` fallback for `id_token`).
+2. **External id mode** — look up the user by OAuth client id from the subject token (`azp`, or the first non-URL `aud` value) mapped to `externalId`. For `access_token` subjects without an `email` claim, this is tried before `sub`.
+
+Create UC users with a human-readable `email` for grants and set `externalId` to the OAuth client id for programmatic exchange. The issued UC access token always uses the resolved user's `email`.
+
+CLI and browser login flows use email mode only.
 
 #### Multiple Identity Providers
 
@@ -67,7 +78,13 @@ server.allowed-issuers=https://accounts.google.com,https://login.microsoftonline
 server.audiences=your-google-client-id,your-azure-client-id
 ```
 
-Wildcard audience patterns match a single DNS label per `*`. For example, `https://*.dev.example.com`
+Wildcard issuers match a single DNS label per `*`:
+
+```properties
+server.allowed-issuers=https://*.dev.example.com
+```
+
+Wildcard audience patterns use the same `*` rules. For example, `https://*.dev.example.com`
 accepts tokens whose `aud` includes `https://dev.dev.example.com` or
 `https://backend.dev.example.com`:
 
@@ -75,14 +92,17 @@ accepts tokens whose `aud` includes `https://dev.dev.example.com` or
 server.audiences=unity-catalog-local,https://*.dev.example.com
 ```
 
-When the identity provider issues per-client UUID audiences that cannot be pre-listed (for example
-dynamic OAuth client IDs in `id_token.aud`), use `*` alone to skip audience validation while still
-enforcing issuer and user checks:
+When email-based exchange cannot list dynamic OAuth client UUID audiences, tokens whose `azp` or
+non-URL `aud` matches a registered UC user's `externalId` are accepted even when the client UUID is
+not listed in `server.audiences`. As a fallback for human login only, `*` alone skips audience
+allowlist validation:
 
 ```properties
 server.audiences=*
 server.allowed-issuers=https://*.dev.example.com
 ```
+
+Prefer the subject-token `externalId` flow for per-tenant service principals instead of `audiences=*`.
 
 ### Restart the UC Server
 

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -28,6 +28,7 @@ server.audiences=
 
 # D-Days H-Hours M-Minutes S-Seconds (P5D = 5 days,PT5H = 5 hours, PT5M = 5 minutes, PT5S = 5 seconds)
 server.cookie-timeout=P5D
+server.access-token-timeout=PT24H
 
 # Enable MANAGED table
 # Default: true (enabled)

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,9 +133,9 @@ auth:
   # @default -- not set
   # @raw
   #
-  # When authorization is enabled, tokens must contain one of these audience values.
-  # This ensures tokens are intended for this Unity Catalog instance.
-  # Typically your application's client ID or API identifier.
+  # When authorization is enabled, tokens must contain an aud value matching one of these entries.
+  # Supports exact match or wildcard patterns with * (same rules as allowedIssuers).
+  # Use "*" alone to disable audience validation (issuer and user checks still apply).
   #
   audiences:
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -183,9 +183,10 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
         // This code block is not called immediately. It is called later as part of delegate.serve()
         LOGGER.debug("Authorization peekData invoked.");
 
-        peekDataHandler.processPeekData(data);
-        Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
-        evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
+        if (peekDataHandler.processPeekData(data)) {
+          Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
+          evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
+        }
       });
     }
 
@@ -426,7 +427,8 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
         // Unfortunately we don't appear to get a signal that we've got all the data, so we have to
         // resort to attempting to parse the data whenever it _looks_ complete.
         // TODO: try to optimize this using Jackson streaming or something else.
-        if (data.array()[data.array().length - 1] == '}') {
+        byte[] accumulated = dataStream.toByteArray();
+        if (accumulated.length > 0 && accumulated[accumulated.length - 1] == '}') {
           try {
             Map<String, Object> payload = MAPPER.readValue(
                 dataStream.toByteArray(),

--- a/server/src/main/java/io/unitycatalog/server/persist/UserRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/UserRepository.java
@@ -44,11 +44,15 @@ public class UserRepository {
     return TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
-          if (getUserByEmail(session, user.getEmail()) != null
-              || (user.getExternalId() != null
-                  && getUserByExternalId(session, user.getExternalId()) != null)) {
+          if (getUserByEmail(session, user.getEmail()) != null) {
             throw new BaseException(
                 ErrorCode.ALREADY_EXISTS, "User already exists: " + user.getEmail());
+          }
+          if (user.getExternalId() != null
+              && getUserByExternalId(session, user.getExternalId()) != null) {
+            throw new BaseException(
+                ErrorCode.ALREADY_EXISTS,
+                "User already exists with external id: " + user.getExternalId());
           }
           session.persist(UserDAO.from(user));
           return user;
@@ -136,6 +140,20 @@ public class UserRepository {
         /* readOnly = */ true);
   }
 
+  public User getUserByExternalId(String externalId) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UserDAO userDAO = getUserByExternalId(session, externalId);
+          if (userDAO == null) {
+            throw new BaseException(ErrorCode.NOT_FOUND, "User not found: " + externalId);
+          }
+          return userDAO.toUser();
+        },
+        "Failed to get user by external id",
+        /* readOnly = */ true);
+  }
+
   public UserDAO getUserByEmail(Session session, String email) {
     Query<UserDAO> query = session.createQuery("FROM UserDAO WHERE email = :email", UserDAO.class);
     query.setParameter("email", email);
@@ -169,6 +187,14 @@ public class UserRepository {
                     : User.StateEnum.DISABLED.toString());
           }
           if (updateUser.getExternalId() != null) {
+            UserDAO existingExternalIdUser =
+                getUserByExternalId(session, updateUser.getExternalId());
+            if (existingExternalIdUser != null
+                && !existingExternalIdUser.getId().equals(userDAO.getId())) {
+              throw new BaseException(
+                  ErrorCode.ALREADY_EXISTS,
+                  "User already exists with external id: " + updateUser.getExternalId());
+            }
             userDAO.setExternalId(updateUser.getExternalId());
           }
           session.merge(userDAO);

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/UserDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/UserDAO.java
@@ -4,6 +4,7 @@ import io.unitycatalog.control.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -14,7 +15,11 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "uc_users")
+@Table(
+    name = "uc_users",
+    uniqueConstraints = {
+      @UniqueConstraint(name = "uc_users_external_id_key", columnNames = "external_id")
+    })
 // Lombok annotations
 @Getter
 @Setter

--- a/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
+++ b/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
@@ -2,12 +2,13 @@ package io.unitycatalog.server.security;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -69,20 +70,13 @@ public class SecurityContext {
     LOGGER.info(getInternalCertsFile());
   }
 
-  public String createAccessToken(DecodedJWT decodedJWT) {
-    String subject =
-        decodedJWT
-            .getClaims()
-            .getOrDefault(JwtClaim.EMAIL.key(), decodedJWT.getClaim(JwtClaim.SUBJECT.key()))
-            .asString();
-    return createAccessToken(subject);
-  }
-
-  public String createAccessToken(String principalEmail) {
+  public String createAccessToken(String principalEmail, Duration ttl) {
+    Instant expiresAt = Instant.now().plus(ttl);
     return JWT.create()
         .withSubject(serviceName)
         .withIssuer(localIssuer)
         .withIssuedAt(new Date())
+        .withExpiresAt(Date.from(expiresAt))
         .withKeyId(keyId)
         .withJWTId(UUID.randomUUID().toString())
         .withClaim(JwtClaim.TOKEN_TYPE.key(), JwtTokenType.ACCESS.name())

--- a/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
+++ b/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
@@ -75,7 +75,10 @@ public class SecurityContext {
             .getClaims()
             .getOrDefault(JwtClaim.EMAIL.key(), decodedJWT.getClaim(JwtClaim.SUBJECT.key()))
             .asString();
+    return createAccessToken(subject);
+  }
 
+  public String createAccessToken(String principalEmail) {
     return JWT.create()
         .withSubject(serviceName)
         .withIssuer(localIssuer)
@@ -83,7 +86,7 @@ public class SecurityContext {
         .withKeyId(keyId)
         .withJWTId(UUID.randomUUID().toString())
         .withClaim(JwtClaim.TOKEN_TYPE.key(), JwtTokenType.ACCESS.name())
-        .withClaim(JwtClaim.SUBJECT.key(), subject)
+        .withClaim(JwtClaim.SUBJECT.key(), principalEmail)
         .sign(algorithm);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -186,13 +186,15 @@ public class AuthService {
 
     LOGGER.debug("Validated. Creating access token for principal {}.", principalEmail);
 
-    String accessToken = securityContext.createAccessToken(principalEmail);
+    Duration accessTokenTimeout = serverProperties.getAccessTokenTimeout();
+    String accessToken = securityContext.createAccessToken(principalEmail, accessTokenTimeout);
 
     OAuthTokenExchangeInfo tokenExchangeInfo =
         new OAuthTokenExchangeInfo()
             .accessToken(accessToken)
             .issuedTokenType(TokenType.ACCESS_TOKEN)
-            .tokenType(AccessTokenType.BEARER);
+            .tokenType(AccessTokenType.BEARER)
+            .expiresIn(accessTokenTimeout.getSeconds());
 
     // Set token as cookie if ext param is set to cookie
     ResponseHeadersBuilder responseHeaders = ResponseHeaders.builder(HttpStatus.OK);

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -39,6 +39,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.security.SecurityContext;
+import io.unitycatalog.server.utils.AudienceAllowlist;
 import io.unitycatalog.server.utils.JwksOperations;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ServerProperties.Property;
@@ -96,8 +97,9 @@ public class AuthService {
    *
    * <p>The issuer of the incoming token must be in the configured allowlist
    * (server.allowed-issuers) and the token must contain a valid audience claim matching the
-   * configured audiences (server.audiences). Both configurations are required when authorization is
-   * enabled.
+   * configured audiences (server.audiences). Audience entries support exact match or wildcard
+   * patterns with {@code *} (same rules as server.allowed-issuers). A single value of {@code *}
+   * disables audience validation. Both configurations are required when authorization is enabled.
    *
    * @param ext Specifies whether the issued token should be set as a cookie.
    * @param form The OAuth 2.0 token exchange request form.
@@ -177,12 +179,18 @@ public class AuthService {
 
     try {
       JWTVerifier jwtVerifier =
-          jwksOperations.verifierForIssuerAndKey(issuer, keyId, alg, audiences);
+          jwksOperations.verifierForIssuerAndKey(issuer, keyId, alg, List.of());
       decodedJWT = jwtVerifier.verify(decodedJWT);
     } catch (JWTVerificationException e) {
       LOGGER.debug("Token rejected: verification failed", e);
       throw new OAuthInvalidRequestException(
           ErrorCode.UNAUTHENTICATED, "Token verification failed: " + e.getMessage(), e);
+    }
+
+    if (!serverProperties.isAudienceValidationDisabled()
+        && !AudienceAllowlist.isAllowed(decodedJWT.getAudience(), audiences)) {
+      LOGGER.debug("Token rejected: audience not in allowlist");
+      throw new OAuthInvalidRequestException(ErrorCode.UNAUTHENTICATED, "Invalid audience");
     }
 
     verifyPrincipal(decodedJWT);

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -30,16 +30,14 @@ import io.unitycatalog.control.model.OAuthTokenExchangeForm;
 import io.unitycatalog.control.model.OAuthTokenExchangeInfo;
 import io.unitycatalog.control.model.TokenEndpointExtensionType;
 import io.unitycatalog.control.model.TokenType;
-import io.unitycatalog.control.model.User;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.OAuthInvalidRequestException;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
-import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.security.SecurityContext;
-import io.unitycatalog.server.utils.AudienceAllowlist;
+import io.unitycatalog.server.utils.IssuerAllowlist;
 import io.unitycatalog.server.utils.JwksOperations;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ServerProperties.Property;
@@ -58,6 +56,7 @@ public class AuthService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthService.class);
   private final UserRepository userRepository;
+  private final TokenExchangePrincipalResolver tokenExchangePrincipalResolver;
 
   private final SecurityContext securityContext;
   private final JwksOperations jwksOperations;
@@ -73,6 +72,8 @@ public class AuthService {
     this.jwksOperations = new JwksOperations(securityContext);
     this.serverProperties = serverProperties;
     this.userRepository = repositories.getUserRepository();
+    this.tokenExchangePrincipalResolver =
+        new TokenExchangePrincipalResolver(serverProperties, userRepository);
   }
 
   /**
@@ -95,11 +96,11 @@ public class AuthService {
    *   <li>scope: Not supported
    * </ul>
    *
-   * <p>The issuer of the incoming token must be in the configured allowlist
-   * (server.allowed-issuers) and the token must contain a valid audience claim matching the
-   * configured audiences (server.audiences). Audience entries support exact match or wildcard
-   * patterns with {@code *} (same rules as server.allowed-issuers). A single value of {@code *}
-   * disables audience validation. Both configurations are required when authorization is enabled.
+   * <p>Principal resolution tries email mode first ({@code email} claim or {@code sub} fallback),
+   * then external id mode when email resolution fails. External id mode reads the OAuth client id
+   * from the subject token ({@code azp}, or a non-URL {@code aud} value) and looks up the UC user
+   * by {@code externalId}. Audience validation uses {@code server.audiences}, with additional
+   * acceptance when the signed subject token carries an OAuth client id.
    *
    * @param ext Specifies whether the issued token should be set as a cookie.
    * @param form The OAuth 2.0 token exchange request form.
@@ -147,14 +148,6 @@ public class AuthService {
           "No allowed issuers configured. Set server.allowed-issuers in server.properties");
     }
 
-    List<String> audiences = serverProperties.getAudiences();
-    if (audiences.isEmpty()) {
-      LOGGER.error("No audiences configured");
-      throw new OAuthInvalidRequestException(
-          ErrorCode.INVALID_ARGUMENT,
-          "No audiences configured. Set server.audiences in server.properties");
-    }
-
     DecodedJWT decodedJWT;
     try {
       decodedJWT = JWT.decode(form.getSubjectToken());
@@ -167,7 +160,7 @@ public class AuthService {
     String issuer = decodedJWT.getIssuer();
 
     // Validate issuer is in allowlist BEFORE fetching JWKS
-    if (!allowedIssuers.contains(issuer)) {
+    if (!IssuerAllowlist.isAllowed(issuer, allowedIssuers)) {
       LOGGER.debug("Token rejected: invalid issuer '{}'", issuer);
       throw new OAuthInvalidRequestException(ErrorCode.UNAUTHENTICATED, "Invalid issuer");
     }
@@ -187,17 +180,13 @@ public class AuthService {
           ErrorCode.UNAUTHENTICATED, "Token verification failed: " + e.getMessage(), e);
     }
 
-    if (!serverProperties.isAudienceValidationDisabled()
-        && !AudienceAllowlist.isAllowed(decodedJWT.getAudience(), audiences)) {
-      LOGGER.debug("Token rejected: audience not in allowlist");
-      throw new OAuthInvalidRequestException(ErrorCode.UNAUTHENTICATED, "Invalid audience");
-    }
+    String principalEmail =
+        tokenExchangePrincipalResolver.resolvePrincipalEmail(
+            form.getSubjectTokenType(), decodedJWT);
 
-    verifyPrincipal(decodedJWT);
+    LOGGER.debug("Validated. Creating access token for principal {}.", principalEmail);
 
-    LOGGER.debug("Validated. Creating access token.");
-
-    String accessToken = securityContext.createAccessToken(decodedJWT);
+    String accessToken = securityContext.createAccessToken(principalEmail);
 
     OAuthTokenExchangeInfo tokenExchangeInfo =
         new OAuthTokenExchangeInfo()
@@ -240,34 +229,6 @@ public class AuthService {
               return HttpResponse.of(headers, HttpData.ofUtf8(EMPTY_RESPONSE));
             })
         .orElse(HttpResponse.of(HttpStatus.OK, MediaType.JSON, EMPTY_RESPONSE));
-  }
-
-  private void verifyPrincipal(DecodedJWT decodedJWT) {
-    String subject =
-        decodedJWT
-            .getClaims()
-            .getOrDefault(JwtClaim.EMAIL.key(), decodedJWT.getClaim(JwtClaim.SUBJECT.key()))
-            .asString();
-
-    LOGGER.debug("Validating principal: {}", subject);
-
-    if (subject.equals("admin")) {
-      LOGGER.debug("admin always allowed");
-      return;
-    }
-
-    try {
-      User user = userRepository.getUserByEmail(subject);
-      if (user != null && user.getState() == User.StateEnum.ENABLED) {
-        LOGGER.debug("Principal {} is enabled", subject);
-        return;
-      }
-    } catch (Exception e) {
-      // IGNORE
-    }
-
-    throw new OAuthInvalidRequestException(
-        ErrorCode.INVALID_ARGUMENT, "User not allowed: " + subject);
   }
 
   private Cookie createCookie(String key, String value, String path, String maxAge) {

--- a/server/src/main/java/io/unitycatalog/server/service/TokenExchangePrincipalResolver.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TokenExchangePrincipalResolver.java
@@ -1,0 +1,222 @@
+package io.unitycatalog.server.service;
+
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.unitycatalog.control.model.TokenType;
+import io.unitycatalog.control.model.User;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.OAuthInvalidRequestException;
+import io.unitycatalog.server.persist.UserRepository;
+import io.unitycatalog.server.security.JwtClaim;
+import io.unitycatalog.server.utils.AudienceAllowlist;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Resolves UC principals and validates subject token audiences during token exchange. */
+public class TokenExchangePrincipalResolver {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(TokenExchangePrincipalResolver.class);
+
+  private final ServerProperties serverProperties;
+  private final UserRepository userRepository;
+
+  public TokenExchangePrincipalResolver(
+      ServerProperties serverProperties, UserRepository userRepository) {
+    this.serverProperties = serverProperties;
+    this.userRepository = userRepository;
+  }
+
+  /**
+   * Validates audience rules and returns the UC principal email for the issued access token.
+   *
+   * <p>For {@code id_token} subjects, resolution order is email (or {@code sub}) then OAuth client
+   * id from {@code azp} or non-URL {@code aud} mapped to {@code externalId}. For {@code
+   * access_token} subjects without an {@code email} claim, {@code externalId} is tried before
+   * {@code sub}.
+   */
+  public String resolvePrincipalEmail(TokenType subjectTokenType, DecodedJWT decodedJWT) {
+    validateAudience(subjectTokenType, decodedJWT);
+
+    if (subjectTokenType == TokenType.ACCESS_TOKEN && !hasEmailClaim(decodedJWT)) {
+      Optional<String> clientPrincipal = tryResolvePrincipalEmailForClient(decodedJWT);
+      if (clientPrincipal.isPresent()) {
+        return clientPrincipal.get();
+      }
+
+      Optional<String> principalEmail = tryResolvePrincipalEmailFromTokenClaims(decodedJWT);
+      if (principalEmail.isPresent()) {
+        return principalEmail.get();
+      }
+
+      throw new OAuthInvalidRequestException(ErrorCode.INVALID_ARGUMENT, "User not allowed");
+    }
+
+    Optional<String> principalEmail = tryResolvePrincipalEmailFromTokenClaims(decodedJWT);
+    if (principalEmail.isPresent()) {
+      return principalEmail.get();
+    }
+
+    Optional<String> clientPrincipal = tryResolvePrincipalEmailForClient(decodedJWT);
+    if (clientPrincipal.isPresent()) {
+      return clientPrincipal.get();
+    }
+
+    throw new OAuthInvalidRequestException(ErrorCode.INVALID_ARGUMENT, "User not allowed");
+  }
+
+  private Optional<String> tryResolvePrincipalEmailForClient(DecodedJWT decodedJWT) {
+    Optional<String> clientId = extractOAuthClientId(decodedJWT);
+    if (clientId.isEmpty()) {
+      return Optional.empty();
+    }
+    return tryResolvePrincipalEmailForClient(clientId.get());
+  }
+
+  static boolean hasEmailClaim(DecodedJWT decodedJWT) {
+    Claim email = decodedJWT.getClaim(JwtClaim.EMAIL.key());
+    return !email.isNull() && email.asString() != null && !email.asString().isBlank();
+  }
+
+  /**
+   * Returns the OAuth client id from the subject token, preferring {@code azp} over {@code aud}.
+   *
+   * <p>URL-like audience values are skipped so realm-wide {@code aud} entries do not shadow the
+   * per-client id.
+   */
+  static Optional<String> extractOAuthClientId(DecodedJWT decodedJWT) {
+    Claim azp = decodedJWT.getClaim("azp");
+    if (!azp.isNull()) {
+      String authorizedParty = azp.asString();
+      if (authorizedParty != null && !authorizedParty.isBlank()) {
+        return Optional.of(authorizedParty);
+      }
+    }
+
+    List<String> audiences = decodedJWT.getAudience();
+    if (audiences == null) {
+      return Optional.empty();
+    }
+
+    return audiences.stream()
+        .filter(TokenExchangePrincipalResolver::isOAuthClientIdAudience)
+        .findFirst();
+  }
+
+  private static boolean isOAuthClientIdAudience(String audience) {
+    if (audience == null || audience.isBlank()) {
+      return false;
+    }
+    return !audience.contains("://");
+  }
+
+  private void validateAudience(TokenType subjectTokenType, DecodedJWT decodedJWT) {
+    List<String> audiences = serverProperties.getAudiences();
+    Optional<String> tokenClientId = extractOAuthClientId(decodedJWT);
+
+    if (audiences.isEmpty() && tokenClientId.isEmpty()) {
+      LOGGER.error("No audiences configured");
+      throw new OAuthInvalidRequestException(
+          ErrorCode.INVALID_ARGUMENT,
+          "No audiences configured. Set server.audiences in server.properties");
+    }
+
+    if (audiences.isEmpty()) {
+      if (tokenClientId.isPresent() && hasEnabledUserForExternalId(tokenClientId.get())) {
+        return;
+      }
+      throw new OAuthInvalidRequestException(
+          ErrorCode.INVALID_ARGUMENT,
+          "No audiences configured. Set server.audiences in server.properties");
+    }
+
+    if (serverProperties.isAudienceValidationDisabled()) {
+      return;
+    }
+
+    if (AudienceAllowlist.isAllowed(decodedJWT.getAudience(), audiences)) {
+      return;
+    }
+
+    if (subjectTokenType == TokenType.ID_TOKEN) {
+      String configuredClientId = serverProperties.get(ServerProperties.Property.CLIENT_ID);
+      if (configuredClientId != null
+          && subjectTokenReferencesClient(decodedJWT, configuredClientId)) {
+        return;
+      }
+    }
+
+    if (tokenClientId.isPresent() && hasEnabledUserForExternalId(tokenClientId.get())) {
+      return;
+    }
+
+    LOGGER.debug("Token rejected: audience not in allowlist");
+    throw new OAuthInvalidRequestException(ErrorCode.UNAUTHENTICATED, "Invalid audience");
+  }
+
+  private boolean hasEnabledUserForExternalId(String externalId) {
+    try {
+      User user = userRepository.getUserByExternalId(externalId);
+      return user != null && user.getState() == User.StateEnum.ENABLED;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean subjectTokenReferencesClient(DecodedJWT decodedJWT, String clientId) {
+    Claim azp = decodedJWT.getClaim("azp");
+    if (!azp.isNull() && clientId.equals(azp.asString())) {
+      return true;
+    }
+    List<String> audiences = decodedJWT.getAudience();
+    return audiences != null && audiences.contains(clientId);
+  }
+
+  private Optional<String> tryResolvePrincipalEmailForClient(String clientId) {
+    LOGGER.debug("Resolving principal for OAuth client id {}", clientId);
+    try {
+      User user = userRepository.getUserByExternalId(clientId);
+      if (user != null && user.getState() == User.StateEnum.ENABLED) {
+        LOGGER.debug("Principal for client {} resolved to {}", clientId, user.getEmail());
+        return Optional.of(user.getEmail());
+      }
+    } catch (Exception e) {
+      // IGNORE
+    }
+    return Optional.empty();
+  }
+
+  private Optional<String> tryResolvePrincipalEmailFromTokenClaims(DecodedJWT decodedJWT) {
+    String subject =
+        decodedJWT
+            .getClaims()
+            .getOrDefault(JwtClaim.EMAIL.key(), decodedJWT.getClaim(JwtClaim.SUBJECT.key()))
+            .asString();
+
+    if (subject == null || subject.isBlank()) {
+      return Optional.empty();
+    }
+
+    LOGGER.debug("Trying principal resolution from token claims: {}", subject);
+
+    if ("admin".equals(subject)) {
+      LOGGER.debug("admin always allowed");
+      return Optional.of(subject);
+    }
+
+    try {
+      User user = userRepository.getUserByEmail(subject);
+      if (user != null && user.getState() == User.StateEnum.ENABLED) {
+        LOGGER.debug("Principal {} resolved from token email", subject);
+        return Optional.of(user.getEmail());
+      }
+    } catch (Exception e) {
+      // IGNORE
+    }
+
+    return Optional.empty();
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/AudienceAllowlist.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/AudienceAllowlist.java
@@ -1,7 +1,6 @@
 package io.unitycatalog.server.utils;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 /** Matches JWT {@code aud} claim values against configured audience entries (exact or wildcard). */
 public final class AudienceAllowlist {
@@ -13,53 +12,17 @@ public final class AudienceAllowlist {
    * allowedAudiences}.
    *
    * <p>Entries without {@code *} require an exact match. Entries with {@code *} match a single DNS
-   * label at each wildcard position (e.g. {@code https://*.dev.example.com} matches {@code
-   * https://acme.dev.example.com}).
+   * label at each wildcard position (same rules as {@link IssuerAllowlist}).
    */
   public static boolean isAllowed(List<String> tokenAudiences, List<String> allowedAudiences) {
     if (tokenAudiences == null || tokenAudiences.isEmpty()) {
       return false;
     }
     for (String audience : tokenAudiences) {
-      if (matchesEntry(audience, allowedAudiences)) {
+      if (IssuerAllowlist.isAllowed(audience, allowedAudiences)) {
         return true;
       }
     }
     return false;
-  }
-
-  private static boolean matchesEntry(String value, List<String> patterns) {
-    if (value == null || value.isBlank()) {
-      return false;
-    }
-    for (String pattern : patterns) {
-      if (pattern == null || pattern.isBlank()) {
-        continue;
-      }
-      if (pattern.indexOf('*') >= 0) {
-        if (toRegex(pattern).matcher(value).matches()) {
-          return true;
-        }
-      } else if (pattern.equals(value)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static Pattern toRegex(String pattern) {
-    StringBuilder regex = new StringBuilder("^");
-    for (int i = 0; i < pattern.length(); i++) {
-      char c = pattern.charAt(i);
-      if (c == '*') {
-        regex.append("[^./]+");
-      } else if ("\\.[]{}()+-^$|?".indexOf(c) >= 0) {
-        regex.append('\\').append(c);
-      } else {
-        regex.append(c);
-      }
-    }
-    regex.append('$');
-    return Pattern.compile(regex.toString());
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/AudienceAllowlist.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/AudienceAllowlist.java
@@ -1,0 +1,65 @@
+package io.unitycatalog.server.utils;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Matches JWT {@code aud} claim values against configured audience entries (exact or wildcard). */
+public final class AudienceAllowlist {
+
+  private AudienceAllowlist() {}
+
+  /**
+   * Returns true if any value in {@code tokenAudiences} matches an entry in {@code
+   * allowedAudiences}.
+   *
+   * <p>Entries without {@code *} require an exact match. Entries with {@code *} match a single DNS
+   * label at each wildcard position (e.g. {@code https://*.dev.example.com} matches {@code
+   * https://acme.dev.example.com}).
+   */
+  public static boolean isAllowed(List<String> tokenAudiences, List<String> allowedAudiences) {
+    if (tokenAudiences == null || tokenAudiences.isEmpty()) {
+      return false;
+    }
+    for (String audience : tokenAudiences) {
+      if (matchesEntry(audience, allowedAudiences)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean matchesEntry(String value, List<String> patterns) {
+    if (value == null || value.isBlank()) {
+      return false;
+    }
+    for (String pattern : patterns) {
+      if (pattern == null || pattern.isBlank()) {
+        continue;
+      }
+      if (pattern.indexOf('*') >= 0) {
+        if (toRegex(pattern).matcher(value).matches()) {
+          return true;
+        }
+      } else if (pattern.equals(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Pattern toRegex(String pattern) {
+    StringBuilder regex = new StringBuilder("^");
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      if (c == '*') {
+        regex.append("[^./]+");
+      } else if ("\\.[]{}()+-^$|?".indexOf(c) >= 0) {
+        regex.append('\\').append(c);
+      } else {
+        regex.append(c);
+      }
+    }
+    regex.append('$');
+    return Pattern.compile(regex.toString());
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/IssuerAllowlist.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/IssuerAllowlist.java
@@ -1,0 +1,52 @@
+package io.unitycatalog.server.utils;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Matches token issuers against configured allowlist entries (exact or wildcard). */
+public final class IssuerAllowlist {
+
+  private IssuerAllowlist() {}
+
+  /**
+   * Returns true if {@code issuer} matches any entry in {@code allowedIssuers}.
+   *
+   * <p>Entries without {@code *} require an exact match. Entries with {@code *} match a single DNS
+   * label at each wildcard position (e.g. {@code https://*.dev.example.com} matches {@code
+   * https://acme.dev.example.com}).
+   */
+  public static boolean isAllowed(String issuer, List<String> allowedIssuers) {
+    if (issuer == null || issuer.isBlank()) {
+      return false;
+    }
+    for (String pattern : allowedIssuers) {
+      if (pattern == null || pattern.isBlank()) {
+        continue;
+      }
+      if (pattern.indexOf('*') >= 0) {
+        if (toRegex(pattern).matcher(issuer).matches()) {
+          return true;
+        }
+      } else if (pattern.equals(issuer)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Pattern toRegex(String pattern) {
+    StringBuilder regex = new StringBuilder("^");
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      if (c == '*') {
+        regex.append("[^./]+");
+      } else if ("\\.[]{}()+-^$|?".indexOf(c) >= 0) {
+        regex.append('\\').append(c);
+      } else {
+        regex.append(c);
+      }
+    }
+    regex.append('$');
+    return Pattern.compile(regex.toString());
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -197,6 +197,7 @@ public class ServerProperties {
     CLIENT_SECRET("server.client-secret"),
     REDIRECT_PORT("server.redirect-port", POSITIVE_INTEGER_VALIDATOR),
     COOKIE_TIMEOUT("server.cookie-timeout", "P5D", DURATION_VALIDATOR),
+    ACCESS_TOKEN_TIMEOUT("server.access-token-timeout", "PT24H", DURATION_VALIDATOR),
     MANAGED_TABLE_ENABLED("server.managed-table.enabled", "true", BOOLEAN_VALIDATOR),
     MANAGED_TABLE_USE_DELTA_API_ONLY(
         "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
@@ -454,6 +455,11 @@ public class ServerProperties {
 
   public boolean isIncludeStackTraceInError() {
     return isTrueOrEnable(get(Property.INCLUDE_STACK_TRACE_IN_ERROR));
+  }
+
+  /** Lifetime of UC access tokens issued by token exchange. */
+  public Duration getAccessTokenTimeout() {
+    return Duration.parse(get(Property.ACCESS_TOKEN_TIMEOUT));
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -268,6 +268,17 @@ public class ServerProperties {
       }
       property.validator.validate(property.key, value);
     }
+    validateAudienceConfiguration();
+  }
+
+  private void validateAudienceConfiguration() {
+    List<String> audiences = getAudiences();
+    if (audiences.contains("*") && audiences.size() > 1) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "server.audiences cannot combine '*' with other values; use '*' alone to disable"
+              + " audience validation");
+    }
   }
 
   // Load properties from a configuration file
@@ -517,7 +528,7 @@ public class ServerProperties {
    * <p>When authorization is enabled, tokens will only be accepted from issuers in this list. This
    * prevents attackers from using their own identity provider to forge tokens.
    *
-   * @return List of allowed issuer URLs (exact match required)
+   * @return List of allowed issuer URLs (exact match or wildcard with {@code *})
    */
   public List<String> getAllowedIssuers() {
     return getCommaSeparatedList("server.allowed-issuers");
@@ -526,13 +537,26 @@ public class ServerProperties {
   /**
    * Get the list of expected JWT audience values.
    *
-   * <p>When authorization is enabled, tokens must contain one of these audience values. This
-   * ensures tokens are intended for this Unity Catalog instance.
+   * <p>When authorization is enabled, tokens must contain an {@code aud} value matching one of
+   * these entries (exact match or wildcard with {@code *}, same rules as {@link
+   * #getAllowedIssuers()}).
+   *
+   * <p>A single entry of {@code *} disables audience validation (issuer and user checks still
+   * apply). That sentinel cannot be combined with other values.
    *
    * @return List of expected audience values
    */
   public List<String> getAudiences() {
     return getCommaSeparatedList("server.audiences");
+  }
+
+  /**
+   * Returns true when {@code server.audiences} is exactly {@code *}, disabling JWT audience checks
+   * during token exchange.
+   */
+  public boolean isAudienceValidationDisabled() {
+    List<String> audiences = getAudiences();
+    return audiences.size() == 1 && "*".equals(audiences.get(0));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/base/auth/BaseAuthCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/auth/BaseAuthCRUDTest.java
@@ -47,6 +47,8 @@ public abstract class BaseAuthCRUDTest extends BaseServerTest {
 
     serverProperties.setProperty("server.allowed-issuers", testIssuer);
     serverProperties.setProperty("server.audiences", TEST_AUDIENCE);
+    serverProperties.setProperty("server.client-id", TEST_AUDIENCE);
+    serverProperties.setProperty("server.client-secret", "test-client-secret");
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/persist/UserRepositoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/UserRepositoryTest.java
@@ -1,0 +1,97 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.persist.model.CreateUser;
+import io.unitycatalog.server.persist.model.UpdateUser;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Properties;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class UserRepositoryTest {
+
+  private static SessionFactory sessionFactory;
+  private static UserRepository userRepository;
+
+  @BeforeAll
+  static void setUp() {
+    Properties properties = new Properties();
+    properties.setProperty("server.env", "test");
+    HibernateConfigurator hibernateConfigurator =
+        new HibernateConfigurator(new ServerProperties(properties));
+    sessionFactory = hibernateConfigurator.getSessionFactory();
+    userRepository = new UserRepository(null, sessionFactory);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (sessionFactory != null) {
+      sessionFactory.close();
+    }
+  }
+
+  @Test
+  void createUserRejectsDuplicateExternalId() {
+    userRepository.createUser(
+        CreateUser.builder()
+            .name("Service A")
+            .email("service-a@example.com")
+            .externalId("oauth-client-a")
+            .build());
+
+    assertThatThrownBy(
+            () ->
+                userRepository.createUser(
+                    CreateUser.builder()
+                        .name("Service B")
+                        .email("service-b@example.com")
+                        .externalId("oauth-client-a")
+                        .build()))
+        .isInstanceOf(BaseException.class)
+        .satisfies(
+            e ->
+                assertThat(((BaseException) e).getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS));
+  }
+
+  @Test
+  void createUserAllowsMultipleNullExternalIds() {
+    userRepository.createUser(
+        CreateUser.builder().name("Human A").email("human-a@example.com").build());
+    userRepository.createUser(
+        CreateUser.builder().name("Human B").email("human-b@example.com").build());
+  }
+
+  @Test
+  void updateUserRejectsDuplicateExternalIdOnAnotherUser() {
+    var first =
+        userRepository.createUser(
+            CreateUser.builder()
+                .name("Service A")
+                .email("update-a@example.com")
+                .externalId("oauth-client-update-a")
+                .build());
+    userRepository.createUser(
+        CreateUser.builder()
+            .name("Service B")
+            .email("update-b@example.com")
+            .externalId("oauth-client-update-b")
+            .build());
+
+    assertThatThrownBy(
+            () ->
+                userRepository.updateUser(
+                    first.getId(),
+                    UpdateUser.builder().externalId("oauth-client-update-b").build()))
+        .isInstanceOf(BaseException.class)
+        .satisfies(
+            e ->
+                assertThat(((BaseException) e).getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS));
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceClientPrincipalTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceClientPrincipalTest.java
@@ -1,0 +1,239 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import io.unitycatalog.server.security.JwtClaim;
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Token exchange tests for email-first and subject-token externalId principal resolution. */
+public class AuthServiceClientPrincipalTest extends BaseAuthCRUDTest {
+
+  private static final String TOKEN_ENDPOINT = "/api/1.0/unity-control/auth/tokens";
+  private static final String SCIM_USERS_PATH = "/api/1.0/unity-control/scim2/Users";
+  private static final String OAUTH_CLIENT_ID = "oauth-client-uuid";
+  private static final String SERVICE_EMAIL = "storium-uc-test@example.com";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private WebClient client;
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    client = WebClient.builder(serverConfig.getServerUrl()).build();
+    createServiceUser();
+  }
+
+  @Test
+  public void testIdTokenExchangeResolvesPrincipalByEmailBeforeExternalId() throws IOException {
+    String token =
+        createIdentityToken(
+            testIssuer, OAUTH_CLIENT_ID, SERVICE_EMAIL, testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:id_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertIssuedUcTokenSubject(body, SERVICE_EMAIL);
+  }
+
+  @Test
+  public void testIdTokenExchangeResolvesPrincipalByExternalId() throws IOException {
+    String token =
+        createIdentityToken(
+            testIssuer,
+            OAUTH_CLIENT_ID,
+            "wrong-email@example.com",
+            testIssuerAlgorithm,
+            testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:id_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertIssuedUcTokenSubject(body, SERVICE_EMAIL);
+  }
+
+  @Test
+  public void testAccessTokenExchangeResolvesPrincipalByExternalId() throws IOException {
+    String token =
+        createAccessTokenSubject(testIssuer, OAUTH_CLIENT_ID, testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:access_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertIssuedUcTokenSubject(body, SERVICE_EMAIL);
+  }
+
+  @Test
+  public void testAccessTokenExchangePrefersExternalIdWhenEmailClaimMissing() throws IOException {
+    String token =
+        createAccessTokenSubjectWithoutEmail(
+            testIssuer,
+            OAUTH_CLIENT_ID,
+            "wrong-email@example.com",
+            testIssuerAlgorithm,
+            testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:access_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertIssuedUcTokenSubject(body, SERVICE_EMAIL);
+  }
+
+  @Test
+  public void testSubjectTokenRejectsUnknownExternalId() {
+    String token =
+        createIdentityToken(
+            testIssuer,
+            "unknown-client-id",
+            "unknown-email@example.com",
+            testIssuerAlgorithm,
+            testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:id_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.contentUtf8()).contains("Invalid audience");
+  }
+
+  @Test
+  public void testSubjectTokenRejectsAudienceOutsideAllowlistWithoutClientId() {
+    String token =
+        createRealmOnlyAccessToken(
+            testIssuer, "https://unknown.example.com", testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response =
+        exchangeToken(token, "urn:ietf:params:oauth:token-type:access_token");
+
+    assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.contentUtf8()).contains("Invalid audience");
+  }
+
+  private static void assertIssuedUcTokenSubject(JsonNode body, String expectedSubject) {
+    assertThat(body.has("access_token")).isTrue();
+    String accessToken = body.get("access_token").asText();
+    String subject = JWT.decode(accessToken).getClaim(JwtClaim.SUBJECT.key()).asString();
+    assertThat(subject).isEqualTo(expectedSubject);
+  }
+
+  private void createServiceUser() {
+    String userJson =
+        "{"
+            + "\"displayName\":\"Storium UC test\","
+            + "\"externalId\":\""
+            + OAUTH_CLIENT_ID
+            + "\","
+            + "\"emails\":[{\"value\":\""
+            + SERVICE_EMAIL
+            + "\",\"primary\":true}]"
+            + "}";
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(SCIM_USERS_PATH)
+            .contentType(MediaType.JSON)
+            .add(HttpHeaderNames.COOKIE, "UC_TOKEN=" + securityContext.getServiceToken())
+            .build();
+    AggregatedHttpResponse response =
+        client.execute(headers, HttpData.ofUtf8(userJson)).aggregate().join();
+    assertThat(response.status().code()).isEqualTo(201);
+  }
+
+  private static String createIdentityToken(
+      String issuer, String audience, String email, Algorithm algorithm, String keyId) {
+    var builder =
+        JWT.create()
+            .withSubject("subject-uuid")
+            .withClaim("email", email)
+            .withIssuer(issuer)
+            .withIssuedAt(new Date())
+            .withKeyId(keyId)
+            .withJWTId(UUID.randomUUID().toString());
+    if (audience != null) {
+      builder.withAudience(audience);
+    }
+    return builder.sign(algorithm);
+  }
+
+  private static String createAccessTokenSubject(
+      String issuer, String clientId, Algorithm algorithm, String keyId) {
+    return JWT.create()
+        .withSubject("subject-uuid")
+        .withClaim("azp", clientId)
+        .withAudience(clientId, "https://dev.dev.example.com")
+        .withIssuer(issuer)
+        .withIssuedAt(new Date())
+        .withKeyId(keyId)
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(algorithm);
+  }
+
+  private static String createAccessTokenSubjectWithoutEmail(
+      String issuer, String clientId, String subject, Algorithm algorithm, String keyId) {
+    return JWT.create()
+        .withSubject(subject)
+        .withClaim("azp", clientId)
+        .withAudience(clientId, "https://dev.dev.example.com")
+        .withIssuer(issuer)
+        .withIssuedAt(new Date())
+        .withKeyId(keyId)
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(algorithm);
+  }
+
+  private static String createRealmOnlyAccessToken(
+      String issuer, String realmAudience, Algorithm algorithm, String keyId) {
+    return JWT.create()
+        .withSubject("subject-uuid")
+        .withAudience(realmAudience)
+        .withIssuer(issuer)
+        .withIssuedAt(new Date())
+        .withKeyId(keyId)
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(algorithm);
+  }
+
+  private AggregatedHttpResponse exchangeToken(String subjectToken, String subjectTokenType) {
+    String formBody =
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+            + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+            + "&subject_token_type="
+            + subjectTokenType
+            + "&subject_token="
+            + subjectToken;
+
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(TOKEN_ENDPOINT)
+            .contentType(MediaType.FORM_DATA)
+            .build();
+
+    return client.execute(headers, HttpData.ofUtf8(formBody)).aggregate().join();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -17,6 +17,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import io.unitycatalog.server.security.JwtClaim;
 import java.io.IOException;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -126,6 +127,11 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     JsonNode body = MAPPER.readTree(response.contentUtf8());
     assertThat(body.has("access_token")).isTrue();
     assertThat(body.get("access_token").asText()).isNotEmpty();
+    assertThat(
+            JWT.decode(body.get("access_token").asText())
+                .getClaim(JwtClaim.SUBJECT.key())
+                .asString())
+        .isEqualTo("admin");
     assertThat(body.get("issued_token_type").asText())
         .isEqualTo("urn:ietf:params:oauth:token-type:access_token");
     assertThat(body.get("token_type").asText()).isEqualTo("Bearer");

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -23,6 +23,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -135,6 +136,8 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     assertThat(body.get("issued_token_type").asText())
         .isEqualTo("urn:ietf:params:oauth:token-type:access_token");
     assertThat(body.get("token_type").asText()).isEqualTo("Bearer");
+    assertThat(body.get("expires_in").asLong()).isEqualTo(Duration.parse("PT24H").getSeconds());
+    assertThat(JWT.decode(body.get("access_token").asText()).getExpiresAt()).isNotNull();
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudiencePatternTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudiencePatternTest.java
@@ -14,13 +14,14 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import io.unitycatalog.server.security.JwtClaim;
 import java.io.IOException;
 import java.util.Date;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Integration tests for wildcard audience patterns in server.audiences. */
+/** Integration tests for wildcard audience patterns on access-token subject exchange. */
 public class AuthServiceWildcardAudiencePatternTest extends BaseAuthCRUDTest {
 
   private static final String TOKEN_ENDPOINT = "/api/1.0/unity-control/auth/tokens";
@@ -43,33 +44,42 @@ public class AuthServiceWildcardAudiencePatternTest extends BaseAuthCRUDTest {
   }
 
   @Test
-  public void testTokenExchangeAcceptsExactConfiguredAudience() throws IOException {
+  public void testAccessTokenExchangeAcceptsExactConfiguredAudience() throws IOException {
     String token =
-        createIdentityToken(
-            testIssuer, "unity-catalog-local", testIssuerAlgorithm, testIssuerKeyId);
+        createAccessToken(testIssuer, "unity-catalog-local", testIssuerAlgorithm, testIssuerKeyId);
 
     AggregatedHttpResponse response = exchangeToken(token);
 
     assertThat(response.status()).isEqualTo(HttpStatus.OK);
     JsonNode body = MAPPER.readTree(response.contentUtf8());
-    assertThat(body.has("access_token")).isTrue();
+    assertThat(
+            JWT.decode(body.get("access_token").asText())
+                .getClaim(JwtClaim.SUBJECT.key())
+                .asString())
+        .isEqualTo("admin");
   }
 
   @Test
-  public void testTokenExchangeAcceptsWildcardAudienceMatch() throws IOException {
+  public void testAccessTokenExchangeAcceptsWildcardAudienceMatch() throws IOException {
     String token =
-        createIdentityToken(
+        createAccessToken(
             testIssuer, "https://dev.dev.example.com", testIssuerAlgorithm, testIssuerKeyId);
 
     AggregatedHttpResponse response = exchangeToken(token);
 
     assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertThat(
+            JWT.decode(body.get("access_token").asText())
+                .getClaim(JwtClaim.SUBJECT.key())
+                .asString())
+        .isEqualTo("admin");
   }
 
   @Test
-  public void testTokenExchangeRejectsAudienceOutsideAllowlist() {
+  public void testAccessTokenExchangeRejectsAudienceOutsideAllowlist() {
     String token =
-        createIdentityToken(
+        createAccessToken(
             testIssuer, "dynamic-oauth-client-uuid", testIssuerAlgorithm, testIssuerKeyId);
 
     AggregatedHttpResponse response = exchangeToken(token);
@@ -78,7 +88,7 @@ public class AuthServiceWildcardAudiencePatternTest extends BaseAuthCRUDTest {
     assertThat(response.contentUtf8()).contains("Invalid audience");
   }
 
-  private String createIdentityToken(
+  private String createAccessToken(
       String issuer, String audience, Algorithm algorithm, String keyId) {
     var builder =
         JWT.create()
@@ -93,13 +103,13 @@ public class AuthServiceWildcardAudiencePatternTest extends BaseAuthCRUDTest {
     return builder.sign(algorithm);
   }
 
-  private AggregatedHttpResponse exchangeToken(String identityToken) {
+  private AggregatedHttpResponse exchangeToken(String accessToken) {
     String formBody =
         "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
             + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
-            + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token"
+            + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
             + "&subject_token="
-            + identityToken;
+            + accessToken;
 
     RequestHeaders headers =
         RequestHeaders.builder()

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudiencePatternTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudiencePatternTest.java
@@ -1,0 +1,113 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Integration tests for wildcard audience patterns in server.audiences. */
+public class AuthServiceWildcardAudiencePatternTest extends BaseAuthCRUDTest {
+
+  private static final String TOKEN_ENDPOINT = "/api/1.0/unity-control/auth/tokens";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private WebClient client;
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    serverProperties.setProperty(
+        "server.audiences", "unity-catalog-local,https://*.dev.example.com");
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    client = WebClient.builder(serverConfig.getServerUrl()).build();
+  }
+
+  @Test
+  public void testTokenExchangeAcceptsExactConfiguredAudience() throws IOException {
+    String token =
+        createIdentityToken(
+            testIssuer, "unity-catalog-local", testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response = exchangeToken(token);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertThat(body.has("access_token")).isTrue();
+  }
+
+  @Test
+  public void testTokenExchangeAcceptsWildcardAudienceMatch() throws IOException {
+    String token =
+        createIdentityToken(
+            testIssuer, "https://dev.dev.example.com", testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response = exchangeToken(token);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void testTokenExchangeRejectsAudienceOutsideAllowlist() {
+    String token =
+        createIdentityToken(
+            testIssuer, "dynamic-oauth-client-uuid", testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response = exchangeToken(token);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.contentUtf8()).contains("Invalid audience");
+  }
+
+  private String createIdentityToken(
+      String issuer, String audience, Algorithm algorithm, String keyId) {
+    var builder =
+        JWT.create()
+            .withSubject("admin")
+            .withIssuer(issuer)
+            .withIssuedAt(new Date())
+            .withKeyId(keyId)
+            .withJWTId(UUID.randomUUID().toString());
+    if (audience != null) {
+      builder.withAudience(audience);
+    }
+    return builder.sign(algorithm);
+  }
+
+  private AggregatedHttpResponse exchangeToken(String identityToken) {
+    String formBody =
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+            + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+            + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token"
+            + "&subject_token="
+            + identityToken;
+
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(TOKEN_ENDPOINT)
+            .contentType(MediaType.FORM_DATA)
+            .build();
+
+    return client.execute(headers, HttpData.ofUtf8(formBody)).aggregate().join();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudienceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudienceTest.java
@@ -1,0 +1,110 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AuthServiceWildcardAudienceTest extends BaseAuthCRUDTest {
+
+  private static final String TOKEN_ENDPOINT = "/api/1.0/unity-control/auth/tokens";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private WebClient client;
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    serverProperties.setProperty("server.audiences", "*");
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    client = WebClient.builder(serverConfig.getServerUrl()).build();
+  }
+
+  @Test
+  public void testTokenExchangeWithWildcardAudiencesAcceptsWrongAudience() throws IOException {
+    String token =
+        createIdentityToken(
+            testIssuer, "dynamic-oauth-client-uuid", testIssuerAlgorithm, testIssuerKeyId);
+
+    AggregatedHttpResponse response = exchangeToken(token);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    JsonNode body = MAPPER.readTree(response.contentUtf8());
+    assertThat(body.has("access_token")).isTrue();
+    assertThat(body.get("access_token").asText()).isNotEmpty();
+  }
+
+  @Test
+  public void testTokenExchangeWithWildcardAudiencesRejectsUnknownUser() {
+    String token =
+        createIdentityTokenForSubject(
+            testIssuer,
+            "any-audience",
+            "unknown-user@example.com",
+            testIssuerAlgorithm,
+            testIssuerKeyId);
+
+    AggregatedHttpResponse response = exchangeToken(token);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.contentUtf8()).contains("User not allowed");
+  }
+
+  private String createIdentityToken(
+      String issuer, String audience, Algorithm algorithm, String keyId) {
+    return createIdentityTokenForSubject(issuer, audience, "admin", algorithm, keyId);
+  }
+
+  private String createIdentityTokenForSubject(
+      String issuer, String audience, String subject, Algorithm algorithm, String keyId) {
+    var builder =
+        JWT.create()
+            .withSubject(subject)
+            .withIssuer(issuer)
+            .withIssuedAt(new Date())
+            .withKeyId(keyId)
+            .withJWTId(UUID.randomUUID().toString());
+    if (audience != null) {
+      builder.withAudience(audience);
+    }
+    return builder.sign(algorithm);
+  }
+
+  private AggregatedHttpResponse exchangeToken(String identityToken) {
+    String formBody =
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+            + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+            + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token"
+            + "&subject_token="
+            + identityToken;
+
+    RequestHeaders headers =
+        RequestHeaders.builder()
+            .method(HttpMethod.POST)
+            .path(TOKEN_ENDPOINT)
+            .contentType(MediaType.FORM_DATA)
+            .build();
+
+    return client.execute(headers, HttpData.ofUtf8(formBody)).aggregate().join();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudienceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceWildcardAudienceTest.java
@@ -14,12 +14,14 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import io.unitycatalog.server.security.JwtClaim;
 import java.io.IOException;
 import java.util.Date;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/** Integration tests for audiences=* on email-based token exchange. */
 public class AuthServiceWildcardAudienceTest extends BaseAuthCRUDTest {
 
   private static final String TOKEN_ENDPOINT = "/api/1.0/unity-control/auth/tokens";
@@ -51,7 +53,11 @@ public class AuthServiceWildcardAudienceTest extends BaseAuthCRUDTest {
     assertThat(response.status()).isEqualTo(HttpStatus.OK);
     JsonNode body = MAPPER.readTree(response.contentUtf8());
     assertThat(body.has("access_token")).isTrue();
-    assertThat(body.get("access_token").asText()).isNotEmpty();
+    assertThat(
+            JWT.decode(body.get("access_token").asText())
+                .getClaim(JwtClaim.SUBJECT.key())
+                .asString())
+        .isEqualTo("admin");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/TokenExchangePrincipalResolverTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/TokenExchangePrincipalResolverTest.java
@@ -1,0 +1,68 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class TokenExchangePrincipalResolverTest {
+
+  private static final String CLIENT_ID = "6e8bc60c-5e4d-4cd8-93ce-0b7c02b32499";
+
+  @Test
+  void hasEmailClaimDetectsMissingEmailClaim() {
+    DecodedJWT jwt = decode(tokenWithAzpAndAud(CLIENT_ID, "https://dev.dev.example.com"));
+
+    assertThat(TokenExchangePrincipalResolver.hasEmailClaim(jwt)).isFalse();
+  }
+
+  @Test
+  void extractOAuthClientIdPrefersAzp() {
+    DecodedJWT jwt = decode(tokenWithAzpAndAud(CLIENT_ID, "https://dev.dev.example.com"));
+
+    assertThat(TokenExchangePrincipalResolver.extractOAuthClientId(jwt)).contains(CLIENT_ID);
+  }
+
+  @Test
+  void extractOAuthClientIdFallsBackToNonUrlAudience() {
+    DecodedJWT jwt = decode(tokenWithAudOnly(CLIENT_ID, "https://dev.dev.example.com"));
+
+    assertThat(TokenExchangePrincipalResolver.extractOAuthClientId(jwt)).contains(CLIENT_ID);
+  }
+
+  @Test
+  void extractOAuthClientIdSkipsUrlOnlyAudiences() {
+    DecodedJWT jwt = decode(tokenWithAudOnly("https://dev.dev.example.com"));
+
+    assertThat(TokenExchangePrincipalResolver.extractOAuthClientId(jwt)).isEmpty();
+  }
+
+  private static DecodedJWT decode(String token) {
+    return JWT.decode(token);
+  }
+
+  private static String tokenWithAzpAndAud(String clientId, String realmAudience) {
+    return JWT.create()
+        .withSubject("subject")
+        .withClaim("azp", clientId)
+        .withAudience(clientId, realmAudience)
+        .withIssuer("https://issuer.example.com")
+        .withIssuedAt(new Date())
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(Algorithm.none());
+  }
+
+  private static String tokenWithAudOnly(String... audiences) {
+    return JWT.create()
+        .withSubject("subject")
+        .withAudience(audiences)
+        .withIssuer("https://issuer.example.com")
+        .withIssuedAt(new Date())
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(Algorithm.none());
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/AudienceAllowlistTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/AudienceAllowlistTest.java
@@ -1,0 +1,62 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AudienceAllowlistTest {
+
+  @Test
+  void exactMatch() {
+    assertThat(
+            AudienceAllowlist.isAllowed(
+                List.of("unity-catalog-local"), List.of("unity-catalog-local")))
+        .isTrue();
+    assertThat(
+            AudienceAllowlist.isAllowed(List.of("wrong-audience"), List.of("unity-catalog-local")))
+        .isFalse();
+  }
+
+  @Test
+  void anyTokenAudienceMayMatch() {
+    List<String> patterns = List.of("unity-catalog-local");
+    assertThat(
+            AudienceAllowlist.isAllowed(
+                List.of("oauth-client-uuid", "unity-catalog-local"), patterns))
+        .isTrue();
+    assertThat(AudienceAllowlist.isAllowed(List.of("oauth-client-uuid"), patterns)).isFalse();
+  }
+
+  @Test
+  void wildcardMatchesRealmHostAudience() {
+    String pattern = "https://*.dev.example.com";
+    assertThat(
+            AudienceAllowlist.isAllowed(List.of("https://dev.dev.example.com"), List.of(pattern)))
+        .isTrue();
+    assertThat(
+            AudienceAllowlist.isAllowed(
+                List.of("oauth-client-uuid", "https://backend.dev.example.com"),
+                List.of(pattern)))
+        .isTrue();
+    assertThat(
+            AudienceAllowlist.isAllowed(List.of("https://acme.eu.example.com"), List.of(pattern)))
+        .isFalse();
+  }
+
+  @Test
+  void mixedExactAndWildcard() {
+    List<String> patterns = List.of("unity-catalog-local", "https://*.dev.example.com");
+    assertThat(AudienceAllowlist.isAllowed(List.of("unity-catalog-local"), patterns)).isTrue();
+    assertThat(AudienceAllowlist.isAllowed(List.of("https://team.dev.example.com"), patterns))
+        .isTrue();
+    assertThat(AudienceAllowlist.isAllowed(List.of("https://other.example.com"), patterns))
+        .isFalse();
+  }
+
+  @Test
+  void rejectsNullOrEmptyTokenAudiences() {
+    assertThat(AudienceAllowlist.isAllowed(null, List.of("unity-catalog-local"))).isFalse();
+    assertThat(AudienceAllowlist.isAllowed(List.of(), List.of("unity-catalog-local"))).isFalse();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/AudienceAllowlistTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/AudienceAllowlistTest.java
@@ -36,8 +36,7 @@ class AudienceAllowlistTest {
         .isTrue();
     assertThat(
             AudienceAllowlist.isAllowed(
-                List.of("oauth-client-uuid", "https://backend.dev.example.com"),
-                List.of(pattern)))
+                List.of("oauth-client-uuid", "https://backend.dev.example.com"), List.of(pattern)))
         .isTrue();
     assertThat(
             AudienceAllowlist.isAllowed(List.of("https://acme.eu.example.com"), List.of(pattern)))

--- a/server/src/test/java/io/unitycatalog/server/utils/IssuerAllowlistTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/IssuerAllowlistTest.java
@@ -1,0 +1,50 @@
+package io.unitycatalog.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IssuerAllowlistTest {
+
+  @Test
+  void exactMatch() {
+    assertThat(
+            IssuerAllowlist.isAllowed(
+                "https://dev.dev.example.com", List.of("https://dev.dev.example.com")))
+        .isTrue();
+    assertThat(
+            IssuerAllowlist.isAllowed(
+                "https://backend.dev.example.com", List.of("https://dev.dev.example.com")))
+        .isFalse();
+  }
+
+  @Test
+  void wildcardMatchesAnyTeamOnRealm() {
+    String pattern = "https://*.dev.example.com";
+    assertThat(IssuerAllowlist.isAllowed("https://dev.dev.example.com", List.of(pattern)))
+        .isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://backend.dev.example.com", List.of(pattern)))
+        .isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://acme.dev.example.com", List.of(pattern)))
+        .isTrue();
+  }
+
+  @Test
+  void wildcardRejectsOtherRealmsAndMalformedIssuers() {
+    String pattern = "https://*.dev.example.com";
+    assertThat(IssuerAllowlist.isAllowed("https://acme.eu.example.com", List.of(pattern)))
+        .isFalse();
+    assertThat(IssuerAllowlist.isAllowed("https://evil.com", List.of(pattern))).isFalse();
+    assertThat(IssuerAllowlist.isAllowed("https://foo.bar.dev.example.com", List.of(pattern)))
+        .isFalse();
+  }
+
+  @Test
+  void mixedExactAndWildcard() {
+    List<String> patterns = List.of("https://accounts.google.com", "https://*.dev.example.com");
+    assertThat(IssuerAllowlist.isAllowed("https://accounts.google.com", patterns)).isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://team.dev.example.com", patterns)).isTrue();
+    assertThat(IssuerAllowlist.isAllowed("https://other.example.com", patterns)).isFalse();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -190,12 +190,19 @@ public class ServerPropertiesTest {
     testValidProperty(Property.COOKIE_TIMEOUT, "P5D");
     testValidProperty(Property.COOKIE_TIMEOUT, "PT2H");
     testValidProperty(Property.COOKIE_TIMEOUT, "P1DT12H30M");
+    testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT24H");
+    testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT1H");
 
     // Invalid values
     testInvalidProperty(
         Property.COOKIE_TIMEOUT, "5 days", "Invalid value '5 days'", "server.cookie-timeout");
     testInvalidProperty(
         Property.COOKIE_TIMEOUT, "P5X", "Invalid value 'P5X'", "server.cookie-timeout");
+    testInvalidProperty(
+        Property.ACCESS_TOKEN_TIMEOUT,
+        "24 hours",
+        "Invalid value '24 hours'",
+        "server.access-token-timeout");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -243,4 +243,18 @@ public class ServerPropertiesTest {
         .isInstanceOf(BaseException.class)
         .hasMessageContaining("endpoint is disabled when");
   }
+
+  @Test
+  public void testWildcardAudienceConfiguration() {
+    Properties wildcardOnly = new Properties();
+    wildcardOnly.setProperty("server.audiences", "*");
+    ServerProperties props = new ServerProperties(wildcardOnly);
+    assertThat(props.isAudienceValidationDisabled()).isTrue();
+
+    Properties mixed = new Properties();
+    mixed.setProperty("server.audiences", "*,unity-catalog-local");
+    assertThatThrownBy(() -> new ServerProperties(mixed))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("cannot combine '*' with other values");
+  }
 }


### PR DESCRIPTION
## Summary

Extends token exchange for multi-tenant OAuth deployments with four related changes:

### Wildcard `server.allowed-issuers` ([supersedes #1657](https://github.com/unitycatalog/unitycatalog/pull/1657))
- Add `IssuerAllowlist` for single-DNS-label wildcard issuer patterns (e.g. `https://*.dev.example.com`)
- Reuse the same matcher in `AudienceAllowlist`

### Wildcard `server.audiences`
- Validate JWT `aud` after signature verification (any token audience may match any configured entry)
- Support `server.audiences=*` alone to disable audience checks for dynamic OAuth client UUID audiences

### Subject-token principal resolution (service principals)
UC resolves the principal from the **subject token** on `POST /auth/tokens` — no OAuth client credentials on the UC request:

1. **`id_token`** (CLI/browser): `email` claim or `sub` → `getUserByEmail`, then `externalId` fallback via `azp`/non-URL `aud`
2. **`access_token`** (M2M): if no `email` claim, `externalId` via `azp`/non-URL `aud` first, then `sub`; otherwise same as `id_token`

The issued UC access token always uses the resolved user's **email** as `sub` (for grants/authorization).

Additional behavior:
- **Audience bypass**: signed subject tokens whose `azp` or non-URL `aud` matches a registered UC user `externalId` are accepted even when the client UUID is not in `server.audiences`
- **Unique index** on `uc_users.external_id` (multiple `NULL` values still allowed)
- Prefer the `externalId` flow over `server.audiences=*` for per-tenant service principals

### UC access token expiry
- Add `server.access-token-timeout` (default `PT24H`) for access tokens issued by token exchange
- Set JWT `exp` via `withExpiresAt` in `SecurityContext.createAccessToken`
- Return `expires_in` in the `/auth/tokens` response so clients can cache and refresh correctly

### Chunked JSON payload authorization
`UnityAccessDecorator` previously ran `beforeRequest` on every `peekData` chunk, before the full JSON body was buffered and parsed. For chunked `POST` requests (e.g. `POST /schemas`), authorization could run on a partial payload and fail to resolve payload-derived resource keys such as `catalog_name`, causing:

```
Cannot invoke "java.util.UUID.toString()" because "resource" is null
```

This fix:
- Defers authorization until `processPeekData` has successfully parsed the complete JSON payload
- Checks the accumulated payload buffer (not the current chunk) for JSON completion

Example multi-tenant configuration:

```properties
server.allowed-issuers=https://*.dev.example.com
server.audiences=unity-catalog-local,*.dev.example.com
server.access-token-timeout=PT24H
```

Bootstrap UC users with `email` for grants and `externalId` = OAuth `client_id`.