### PR TITLE
Make auth config lookups case-insensitive in TokenProvider.create

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
@@ -2,6 +2,7 @@ package io.unitycatalog.client.auth;
 
 import io.unitycatalog.client.internal.Preconditions;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Interface for providing access tokens to authenticate with Unity Catalog.
@@ -107,7 +108,9 @@ public interface TokenProvider {
    *     not found, no default constructor, or instantiation failure)
    */
   static TokenProvider create(Map<String, String> configs) {
-    String authType = configs.get(AuthConfigs.TYPE);
+    Map<String, String> ci = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    ci.putAll(configs);
+    String authType = ci.get(AuthConfigs.TYPE);
     Preconditions.checkArgument(
         authType != null && !authType.trim().isEmpty(),
         "Required configuration key '%s' is missing or empty. "
@@ -140,7 +143,7 @@ public interface TokenProvider {
     }
 
     // Initialize the TokenProvider with configs.
-    tokenProvider.initialize(configs);
+    tokenProvider.initialize(ci);
     return tokenProvider;
   }
 }

--- a/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
@@ -108,9 +108,11 @@ public interface TokenProvider {
    *     not found, no default constructor, or instantiation failure)
    */
   static TokenProvider create(Map<String, String> configs) {
-    Map<String, String> ci = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    ci.putAll(configs);
-    String authType = ci.get(AuthConfigs.TYPE);
+    // Try normalizing to a case-insensitive view if possible so downstream lookups regardless of
+    // casing
+    Map<String, String> normalizedConfigs = toCaseInsensitiveMap(configs);
+
+    String authType = normalizedConfigs.get(AuthConfigs.TYPE);
     Preconditions.checkArgument(
         authType != null && !authType.trim().isEmpty(),
         "Required configuration key '%s' is missing or empty. "
@@ -143,7 +145,22 @@ public interface TokenProvider {
     }
 
     // Initialize the TokenProvider with configs.
-    tokenProvider.initialize(ci);
+    tokenProvider.initialize(normalizedConfigs);
     return tokenProvider;
+  }
+
+  /**
+   * Returns a case-insensitive view of {@code configs} so key lookups succeed regardless of key
+   * casing (some callers pass keys that were lower-cased upstream). If the map is already
+   * case-insensitive it is returned as-is to avoid an unnecessary copy. The check is by simple
+   * class name.
+   */
+  private static Map<String, String> toCaseInsensitiveMap(Map<String, String> configs) {
+    if (configs == null || configs.getClass().getSimpleName().equals("CaseInsensitiveStringMap")) {
+      return configs;
+    }
+    Map<String, String> caseInsensitive = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    caseInsensitive.putAll(configs);
+    return caseInsensitive;
   }
 }

--- a/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
 public class TokenProviderTest {
@@ -108,6 +109,38 @@ public class TokenProviderTest {
         .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
         .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
         .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  @Test
+  public void testCreatePassesThroughAlreadyCaseInsensitiveMap() {
+    // A map whose simple class name is "CaseInsensitiveStringMap" is treated as already
+    // case-insensitive and passed through as-is. Backing it with a
+    // case-insensitive map and using lower-cased keys verifies lookups still resolve.
+    CaseInsensitiveStringMap configs = new CaseInsensitiveStringMap();
+    configs.put(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE);
+    configs.put("oauth.uri", OAUTH_URI);
+    configs.put("oauth.clientid", CLIENT_ID);
+    configs.put("oauth.clientsecret", CLIENT_SECRET);
+
+    TokenProvider provider = TokenProvider.create(configs);
+
+    assertThat(provider).isInstanceOf(OAuthTokenProvider.class);
+    assertThat(provider.configs())
+        .hasSize(4)
+        .containsEntry(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE)
+        .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  /**
+   * Minimal stand-in named to match the class-simple-name check in {@code TokenProvider.create};
+   * backed by a case-insensitive map so lookups are case-insensitive.
+   */
+  private static class CaseInsensitiveStringMap extends TreeMap<String, String> {
+    CaseInsensitiveStringMap() {
+      super(String.CASE_INSENSITIVE_ORDER);
+    }
   }
 
   @Test

--- a/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
@@ -89,6 +89,28 @@ public class TokenProviderTest {
   }
 
   @Test
+  public void testCreateResolvesOAuthConfigCaseInsensitively() {
+    // Keys can arrive lower-cased when catalog options pass through a
+    // case-insensitive map (e.g. Spark's CaseInsensitiveStringMap in the
+    // Delta UC integration). create() must still resolve them.
+    Map<String, String> lowerCasedConfigs = new HashMap<>();
+    lowerCasedConfigs.put(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE);
+    lowerCasedConfigs.put("oauth.uri", OAUTH_URI);
+    lowerCasedConfigs.put("oauth.clientid", CLIENT_ID); // lower-cased on purpose
+    lowerCasedConfigs.put("oauth.clientsecret", CLIENT_SECRET); // lower-cased on purpose
+
+    TokenProvider provider = TokenProvider.create(lowerCasedConfigs);
+
+    assertThat(provider).isInstanceOf(OAuthTokenProvider.class);
+    assertThat(provider.configs())
+        .hasSize(4)
+        .containsEntry(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE)
+        .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  @Test
   public void testCustomTokenProvider() {
     // Test with custom TokenProvider using fully qualified class name
     Map<String, String> customConfigs = new HashMap<>();


### PR DESCRIPTION
## What
Normalize auth configuration keys to be case-insensitive in `TokenProvider.create`,
so all `TokenProvider` implementations (OAuth, static, custom) resolve their config
keys regardless of key case.

## Why
When the Spark/Delta Unity Catalog integration loads a table, catalog options are
routed through Spark's `CaseInsensitiveStringMap`, which lower-cases all keys. Those
options are then handed to `TokenProvider.create`. Because `OAuthTokenProvider.initialize`
reads keys case-sensitively (`configs.get("oauth.clientId")`), the lower-cased
`oauth.clientid` is not found and OAuth fails with:

    java.lang.IllegalArgumentException: Configuration key 'oauth.clientId' is missing or empty
      at io.unitycatalog.client.auth.OAuthTokenProvider.initialize(OAuthTokenProvider.java:82)
      at io.unitycatalog.client.auth.TokenProvider.create(TokenProvider.java:143)
      at org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory$.createUCClient(...)
      at org.apache.spark.sql.delta.catalog.UCDeltaCatalogClientImpl$.fromCatalogOptions(...)
      ...

Observed with: unitycatalog-spark/client 0.5.0, delta-spark 4.3.0, Apache Spark 4.1.0,
authenticating an external Spark client to Databricks Unity Catalog via OAuth M2M
(client credentials).

Config keys generally should not be case-sensitive, so normalizing once at the factory
fixes this for every provider without changing the public config contract.

## Change
- `TokenProvider.create` normalizes the incoming config map to be case-insensitive
  before dispatching to the provider's `initialize`.

## Tests
- Added `testCreateResolvesOAuthConfigCaseInsensitively` to `TokenProviderTest`:
  passes OAuth keys lower-cased (`oauth.clientid`, `oauth.clientsecret`) and asserts
  `create` builds the `OAuthTokenProvider` and exposes the canonical config keys.
- `build/sbt client/test` and `build/sbt testJavastyle` pass.

## Notes
The root interaction originates in Delta case-folding pass-through auth keys; this PR
hardens the client side so it's robust to that. Happy to also file a Delta-side issue
if useful.
