### PR TITLE
[AI] Fix list[str] environment variables splitting into single characters

### DIFF
--- a/ai/core/src/unitycatalog/ai/core/envs/base.py
+++ b/ai/core/src/unitycatalog/ai/core/envs/base.py
@@ -1,5 +1,6 @@
 import json
 import os
+import typing
 
 
 class _EnvironmentVariable:
@@ -12,6 +13,17 @@ class _EnvironmentVariable:
         element_type: type = str,
     ):
         self.name = name
+        # Support parameterized generics such as ``list[str]``: normalize to the
+        # origin type (``list``) so the ``is list`` checks below work, and infer
+        # the element type from the type arguments when present. Without this,
+        # ``list[str] is list`` is False and a list-valued variable falls through
+        # to ``list[str](raw_value)``, splitting the string into single characters.
+        origin = typing.get_origin(type_)
+        if origin is not None:
+            args = typing.get_args(type_)
+            if args:
+                element_type = args[0]
+            type_ = origin
         self.type = type_
         self.description = description
         self.element_type = element_type

--- a/ai/core/tests/core/test_envs.py
+++ b/ai/core/tests/core/test_envs.py
@@ -70,6 +70,57 @@ def test_list_env_var_json(monkeypatch):
     assert var.get() == ["p", "q", "r"]
 
 
+def test_parameterized_list_env_var(monkeypatch):
+    # ``list[str]`` must behave the same as ``list`` with ``element_type=str``:
+    # the origin type drives the list handling and the type argument the element
+    # type. Before the generic was normalized, ``list[str] is list`` was False,
+    # so ``get()`` fell through to ``list[str](raw_value)`` and split the string
+    # into individual characters.
+    var = _EnvironmentVariable(
+        "TEST_LIST_STR",
+        list[str],
+        ["a", "b"],
+        "Test list[str] environment variable.",
+    )
+    assert var.type is list
+    assert var.element_type is str
+    assert var.get() == ["a", "b"]
+
+    monkeypatch.setenv("TEST_LIST_STR", "sys, socket, os")
+    assert var.get() == ["sys", "socket", "os"]
+
+    monkeypatch.setenv("TEST_LIST_STR", '["numpy", "pandas"]')
+    assert var.get() == ["numpy", "pandas"]
+
+    var.set(["json", "typing"])
+    assert var.get() == ["json", "typing"]
+
+    # The type argument overrides the element type for casting.
+    int_var = _EnvironmentVariable(
+        "TEST_LIST_INT",
+        list[int],
+        [1, 2, 3],
+        "Test list[int] environment variable.",
+    )
+    assert int_var.type is list
+    assert int_var.element_type is int
+    assert int_var.get() == [1, 2, 3]
+
+    monkeypatch.setenv("TEST_LIST_INT", "4, 5, 6")
+    assert int_var.get() == [4, 5, 6]
+
+
+def test_executor_disallowed_modules_returns_full_module_names(monkeypatch):
+    from unitycatalog.ai.core.envs.executor_env_vars import EXECUTOR_DISALLOWED_MODULES
+
+    monkeypatch.setenv("EXECUTOR_DISALLOWED_MODULES", "sys, socket, os")
+    modules = EXECUTOR_DISALLOWED_MODULES.get()
+    # Membership checks in the executor sandbox rely on whole module names; a
+    # character-split list (["s", "y", "s", ...]) would never match "os".
+    assert modules == ["sys", "socket", "os"]
+    assert "os" in modules
+
+
 def test_set_and_remove(monkeypatch):
     var = _EnvironmentVariable("TEST_ENV", int, 0, "Test set and remove operations.")
     assert var.get() == 0


### PR DESCRIPTION
No linked issue — found by reading the code.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`_EnvironmentVariable` decides whether to parse an environment value as a list by checking `self.type is list`, but the type is stored exactly as passed in. A parameterized generic like `list[str]` is not the `list` object itself — `list[str] is list` is `False` — so a variable declared with `list[str]` skips the list branch in `get()` and falls through to `self.type(raw_value)`:

```python
>>> list[str]("sys,socket,os")
['s', 'y', 's', ',', 's', 'o', 'c', 'k', 'e', 't', ',', 'o', 's']
```

`EXECUTOR_DISALLOWED_MODULES` is declared as `list[str]`:

```python
# ai/core/src/unitycatalog/ai/core/envs/executor_env_vars.py
EXECUTOR_DISALLOWED_MODULES = _EnvironmentVariable(
    "EXECUTOR_DISALLOWED_MODULES",
    list[str],
    DISALLOWED_MODULES,
    ...
)
```

So overriding it through the environment produces a list of single characters instead of module names. The local executor sandbox then checks membership against whole module names:

```python
# ai/core/src/unitycatalog/ai/core/execution/local.py
if name in EXECUTOR_DISALLOWED_MODULES.get():
    raise ...
```

Because `"os"` is never in `['o', 's', ...]`, a user-configured module blocklist is silently ignored — a function can import a module the operator intended to block.

**Fix**

Normalize parameterized generics in `__init__` with `typing.get_origin`/`typing.get_args`: the origin (`list`) drives the existing list handling, and the type argument (`str`) becomes the element type used for casting. This fixes the whole class of `list[...]` declarations rather than just the one variable; plain `list` declarations (with an explicit `element_type`) are unchanged.

**Testing**

Added `test_parameterized_list_env_var` (covers `list[str]` and `list[int]`: default value, comma-separated parsing, JSON parsing, and set/get round-trip) and `test_executor_disallowed_modules_returns_full_module_names` (regression guard asserting the blocklist resolves to whole module names). Both fail before the change and pass after. `ruff check` / `ruff format --check` are clean.