### PR TITLE
[server] Add temporary credential URL

### DIFF
--- a/api/Models/TemporaryCredentials.md
+++ b/api/Models/TemporaryCredentials.md
@@ -7,6 +7,7 @@
 | **azure\_user\_delegation\_sas** | [**AzureUserDelegationSAS**](AzureUserDelegationSAS.md) |  | [optional] [default to null] |
 | **gcp\_oauth\_token** | [**GcpOauthToken**](GcpOauthToken.md) |  | [optional] [default to null] |
 | **expiration\_time** | **Long** | Server time when the credential will expire, in epoch milliseconds. The API client is advised to cache the credential given this expiration time.  | [optional] [default to null] |
+| **url** | **String** | The normalized URL of the storage path the temporary credential was generated for. | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/all.yaml
+++ b/api/all.yaml
@@ -2657,6 +2657,9 @@ components:
             The API client is advised to cache the credential given this expiration time.
           type: integer
           format: int64
+        url:
+          description: The normalized URL of the storage path the temporary credential was generated for.
+          type: string
     PathOperation:
       enum:
         - UNKNOWN_PATH_OPERATION

--- a/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
@@ -52,6 +52,6 @@ public class StorageCredentialVendor {
     Optional<CredentialDAO> credentialDAO =
         externalLocationUtils.getExternalLocationCredentialDaoForPath(path);
     CredentialContext credentialContext = CredentialContext.create(path, privileges, credentialDAO);
-    return cloudCredentialVendor.vendCredential(credentialContext);
+    return cloudCredentialVendor.vendCredential(credentialContext).url(path.toString());
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -284,8 +284,7 @@ public class DeltaApiService extends AuthorizedService {
     NormalizedURL storageLocation = tableRepository.getTableStorageLocation(catalog, schema, table);
     TemporaryCredentials credentials =
         storageCredentialVendor.vendCredential(storageLocation, toPrivileges(operation));
-    return DeltaCredentialsMapper.toCredentialsResponse(
-        storageLocation.toString(), credentials, operation);
+    return DeltaCredentialsMapper.toCredentialsResponse(credentials, operation);
   }
 
   /**
@@ -305,7 +304,7 @@ public class DeltaApiService extends AuthorizedService {
             storageLocation,
             Set.of(CredentialContext.Privilege.SELECT, CredentialContext.Privilege.UPDATE));
     return DeltaCredentialsMapper.toCredentialsResponse(
-        storageLocation.toString(), credentials, DeltaCredentialOperation.READ_WRITE);
+        credentials, DeltaCredentialOperation.READ_WRITE);
   }
 
   private static Set<CredentialContext.Privilege> toPrivileges(DeltaCredentialOperation operation) {

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCredentialsMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCredentialsMapper.java
@@ -22,16 +22,17 @@ public final class DeltaCredentialsMapper {
 
   /**
    * Build a {@link DeltaCredentialsResponse} from UC {@link TemporaryCredentials} for a given
-   * storage prefix and operation.
+   * operation. The storage prefix is taken from the credential's own {@code url}, which the
+   * credential vendor scopes to the requested location.
    */
   public static DeltaCredentialsResponse toCredentialsResponse(
-      String prefix, TemporaryCredentials credentials, DeltaCredentialOperation operation) {
+      TemporaryCredentials credentials, DeltaCredentialOperation operation) {
     return new DeltaCredentialsResponse()
-        .storageCredentials(List.of(toStorageCredential(prefix, credentials, operation)));
+        .storageCredentials(List.of(toStorageCredential(credentials, operation)));
   }
 
   private static DeltaStorageCredential toStorageCredential(
-      String prefix, TemporaryCredentials credentials, DeltaCredentialOperation operation) {
+      TemporaryCredentials credentials, DeltaCredentialOperation operation) {
     DeltaStorageCredentialConfig config = new DeltaStorageCredentialConfig();
     var aws = credentials.getAwsTempCredentials();
     if (aws != null) {
@@ -49,7 +50,7 @@ public final class DeltaCredentialsMapper {
     }
 
     return new DeltaStorageCredential()
-        .prefix(prefix)
+        .prefix(credentials.getUrl())
         .operation(operation)
         .config(config)
         .expirationTimeMs(credentials.getExpirationTime());

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaStagingTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaStagingTableMapper.java
@@ -30,7 +30,7 @@ public final class DeltaStagingTableMapper {
       StagingTableInfo info, TemporaryCredentials credentials) {
     var creds =
         DeltaCredentialsMapper.toCredentialsResponse(
-            info.getStagingLocation(), credentials, DeltaCredentialOperation.READ_WRITE);
+            credentials, DeltaCredentialOperation.READ_WRITE);
 
     Map<String, String> requiredProperties =
         new HashMap<>(UcManagedDeltaContract.REQUIRED_FIXED_PROPERTIES);

--- a/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
@@ -214,7 +214,10 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
     };
   }
 
-  protected void assertTemporaryCredentials(TemporaryCredentials tempCredentials, String scheme) {
+  protected void assertTemporaryCredentials(
+      TemporaryCredentials tempCredentials, String scheme, String requestedLocation) {
+    // requestedLocation must be passed in already-normalized form
+    assertThat(tempCredentials.getUrl()).isEqualTo(requestedLocation);
     switch (scheme) {
       case "s3":
         AwsCredentials awsCredentials = tempCredentials.getAwsTempCredentials();

--- a/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryModelVersionCredentialTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryModelVersionCredentialTest.java
@@ -273,7 +273,7 @@ public class SdkTemporaryModelVersionCredentialTest extends BaseCRUDTestWithMock
     if (isConfiguredPath) {
       TemporaryCredentials temporaryCredentials =
           temporaryCredentialsApi.generateTemporaryModelVersionCredentials(generateCloudReadyCreds);
-      assertTemporaryCredentials(temporaryCredentials, scheme);
+      assertTemporaryCredentials(temporaryCredentials, scheme, url);
     } else {
       assertThatThrownBy(
               () ->

--- a/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryPathCredentialTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryPathCredentialTest.java
@@ -51,7 +51,7 @@ public class SdkTemporaryPathCredentialTest extends BaseCRUDTestWithMockCredenti
     if (isConfiguredPath) {
       TemporaryCredentials temporaryCredentials =
           temporaryCredentialsApi.generateTemporaryPathCredentials(generateTemporaryPathCredential);
-      assertTemporaryCredentials(temporaryCredentials, scheme);
+      assertTemporaryCredentials(temporaryCredentials, scheme, url);
     } else {
       assertThatThrownBy(
               () ->

--- a/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryTableCredentialTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryTableCredentialTest.java
@@ -59,9 +59,10 @@ public class SdkTemporaryTableCredentialTest extends BaseCRUDTestWithMockCredent
     String url = getTestCloudPath(scheme, isConfiguredPath);
     URI uri = URI.create(url);
     String tableName = "testtable-" + uri.getScheme();
+    String tableLocation = url + "/" + tableName;
     TableInfo tableInfo =
         BaseTableCRUDTest.createTestingTable(
-            tableName, TableType.EXTERNAL, Optional.of(url + "/" + tableName), tableOperations);
+            tableName, TableType.EXTERNAL, Optional.of(tableLocation), tableOperations);
 
     GenerateTemporaryTableCredential generateTemporaryTableCredential =
         new GenerateTemporaryTableCredential()
@@ -71,7 +72,7 @@ public class SdkTemporaryTableCredentialTest extends BaseCRUDTestWithMockCredent
       TemporaryCredentials temporaryCredentials =
           temporaryCredentialsApi.generateTemporaryTableCredentials(
               generateTemporaryTableCredential);
-      assertTemporaryCredentials(temporaryCredentials, scheme);
+      assertTemporaryCredentials(temporaryCredentials, scheme, tableLocation);
     } else {
       assertThatThrownBy(
               () ->

--- a/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryVolumeCredentialTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tempcredential/SdkTemporaryVolumeCredentialTest.java
@@ -80,7 +80,7 @@ public class SdkTemporaryVolumeCredentialTest extends BaseCRUDTestWithMockCreden
       TemporaryCredentials temporaryCredentials =
           temporaryCredentialsApi.generateTemporaryVolumeCredentials(
               generateTemporaryVolumeCredential);
-      assertTemporaryCredentials(temporaryCredentials, scheme);
+      assertTemporaryCredentials(temporaryCredentials, scheme, url);
     } else {
       assertThatThrownBy(
               () ->

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -93,6 +93,12 @@ public class CloudCredentialVendorTest {
                 .accessKeyId(ACCESS_KEY)
                 .secretAccessKey(SECRET_KEY)
                 .sessionToken(SESSION_TOKEN));
+    // The vended url is the normalized path, not the raw request: a trailing slash is stripped.
+    // This fails if the vendor ever echoes the caller-supplied string verbatim.
+    assertThat(
+            vendCredential("s3://storageBase/abc/", Set.of(CredentialContext.Privilege.SELECT))
+                .getUrl())
+        .isEqualTo("s3://storageBase/abc");
 
     // Test when sts client is called
     when(serverProperties.getS3Configurations())

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCredentialsMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaCredentialsMapperTest.java
@@ -19,6 +19,7 @@ public class DeltaCredentialsMapperTest {
   public void testAwsCredentials() {
     TemporaryCredentials uc =
         new TemporaryCredentials()
+            .url("s3://bucket/path")
             .awsTempCredentials(
                 new AwsCredentials()
                     .accessKeyId("AKIA123")
@@ -27,8 +28,7 @@ public class DeltaCredentialsMapperTest {
             .expirationTime(1700000000000L);
 
     DeltaCredentialsResponse resp =
-        DeltaCredentialsMapper.toCredentialsResponse(
-            "s3://bucket/path", uc, DeltaCredentialOperation.READ);
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ);
 
     assertThat(resp.getStorageCredentials()).hasSize(1);
     DeltaStorageCredential sc = resp.getStorageCredentials().get(0);
@@ -47,14 +47,12 @@ public class DeltaCredentialsMapperTest {
   public void testAzureCredentials() {
     TemporaryCredentials uc =
         new TemporaryCredentials()
+            .url("abfss://container@acct.dfs.core.windows.net/path")
             .azureUserDelegationSas(new AzureUserDelegationSAS().sasToken("sv=..."))
             .expirationTime(1700000000000L);
 
     DeltaCredentialsResponse resp =
-        DeltaCredentialsMapper.toCredentialsResponse(
-            "abfss://container@acct.dfs.core.windows.net/path",
-            uc,
-            DeltaCredentialOperation.READ_WRITE);
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ_WRITE);
 
     DeltaStorageCredential sc = resp.getStorageCredentials().get(0);
     assertThat(sc.getOperation()).isEqualTo(DeltaCredentialOperation.READ_WRITE);
@@ -66,12 +64,12 @@ public class DeltaCredentialsMapperTest {
   public void testGcpCredentials() {
     TemporaryCredentials uc =
         new TemporaryCredentials()
+            .url("gs://bucket/path")
             .gcpOauthToken(new GcpOauthToken().oauthToken("ya29..."))
             .expirationTime(1700000000000L);
 
     DeltaCredentialsResponse resp =
-        DeltaCredentialsMapper.toCredentialsResponse(
-            "gs://bucket/path", uc, DeltaCredentialOperation.READ);
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ);
 
     DeltaStorageCredential sc = resp.getStorageCredentials().get(0);
     assertThat(sc.getConfig().getGcsOauthToken()).isEqualTo("ya29...");
@@ -83,13 +81,13 @@ public class DeltaCredentialsMapperTest {
     // Only access key + secret, no session token (permanent credentials case)
     TemporaryCredentials uc =
         new TemporaryCredentials()
+            .url("s3://bucket/path")
             .awsTempCredentials(
                 new AwsCredentials().accessKeyId("AKIA123").secretAccessKey("secret"))
             .expirationTime(1700000000000L);
 
     DeltaStorageCredential sc =
-        DeltaCredentialsMapper.toCredentialsResponse(
-                "s3://bucket/path", uc, DeltaCredentialOperation.READ)
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ)
             .getStorageCredentials()
             .get(0);
 
@@ -100,15 +98,16 @@ public class DeltaCredentialsMapperTest {
 
   @Test
   public void testNullProviderCredentials() {
-    // No provider creds at all (shouldn't happen in prod but guards against NPE)
+    // No provider creds or url at all (shouldn't happen in prod but guards against NPE)
     TemporaryCredentials uc = new TemporaryCredentials().expirationTime(1700000000000L);
 
     DeltaStorageCredential sc =
-        DeltaCredentialsMapper.toCredentialsResponse(
-                "s3://bucket/path", uc, DeltaCredentialOperation.READ)
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ)
             .getStorageCredentials()
             .get(0);
 
+    // A null url maps straight through to a null prefix.
+    assertThat(sc.getPrefix()).isNull();
     DeltaStorageCredentialConfig config = sc.getConfig();
     assertThat(config.getS3AccessKeyId()).isNull();
     assertThat(config.getS3SecretAccessKey()).isNull();
@@ -129,6 +128,7 @@ public class DeltaCredentialsMapperTest {
   public void testSparseJsonOmitsUnpopulatedKeys() throws Exception {
     TemporaryCredentials uc =
         new TemporaryCredentials()
+            .url("s3://bucket/path")
             .awsTempCredentials(
                 new AwsCredentials()
                     .accessKeyId("AKIA123")
@@ -136,8 +136,7 @@ public class DeltaCredentialsMapperTest {
                     .sessionToken("token"))
             .expirationTime(1700000000000L);
     DeltaStorageCredentialConfig config =
-        DeltaCredentialsMapper.toCredentialsResponse(
-                "s3://bucket/path", uc, DeltaCredentialOperation.READ)
+        DeltaCredentialsMapper.toCredentialsResponse(uc, DeltaCredentialOperation.READ)
             .getStorageCredentials()
             .get(0)
             .getConfig();

--- a/ui/src/types/api/catalog.gen.ts
+++ b/ui/src/types/api/catalog.gen.ts
@@ -1315,6 +1315,8 @@ export interface components {
        *
        */
       expiration_time?: number;
+      /** @description The normalized URL of the storage path the temporary credential was generated for. */
+      url?: string;
     };
     /** @enum {string} */
     PathOperation: PathOperation;


### PR DESCRIPTION
## Summary
Add the normalized URL to temporary credentials and use it for Delta credential prefixes. Matches the URL location field currently used by the Delta REST API.

## Tests
Updated existing SDK tests to verify URL field. Also added to API test. 