### PR TITLE
[0.5][Hadoop] Add the initial credential into the global cache to reuse cred across queries

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -9,12 +9,16 @@ import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +47,8 @@ public class CredPropsUtil {
 
   public static volatile GenericCredentialFetcherFactory genericCredFetcherFactory =
       GenericCredentialFetcher::create;
+
+  static final CredentialCache initialCredCache = CredentialCache.createInitialCredentialCache();
 
   private static final String CRED_SCOPED_FS_CLASS =
       "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";
@@ -221,7 +227,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> s3FixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     return new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
         .set("fs.s3a.access.key", awsCred.getAccessKeyId())
@@ -235,7 +242,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     S3PropsBuilder builder =
         new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -257,7 +265,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> gsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     GcpOauthToken gcpOauthToken = tempCreds.getGcpOauthToken();
     Long expirationTime =
         tempCreds.getExpirationTime() == null ? Long.MAX_VALUE : tempCreds.getExpirationTime();
@@ -272,7 +281,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     GcpOauthToken gcpToken = tempCreds.getGcpOauthToken();
     GcsPropsBuilder builder =
         new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -293,7 +303,8 @@ public class CredPropsUtil {
   }
 
   private static Map<String, String> abfsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, TemporaryCredentials tempCreds) {
+      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     return new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
         .set(ABFS_FIXED_SAS_TOKEN_KEY, azureSas.getSasToken())
@@ -305,7 +316,8 @@ public class CredPropsUtil {
       Configuration hadoopConf,
       String uri,
       TokenProvider tokenProvider,
-      TemporaryCredentials tempCreds) {
+      GenericCredential cred) {
+    TemporaryCredentials tempCreds = cred.temporaryCredentials();
     AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     AbfsPropsBuilder builder =
         new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
@@ -449,46 +461,77 @@ public class CredPropsUtil {
       Map<String, String> appVersions,
       CredId credId)
       throws ApiException {
-    TemporaryCredentials tempCreds =
-        fetchTemporaryCredentials(apiClient, catalogUri, tokenProvider, appVersions, credId);
+    GenericCredential cred =
+        fetchGenericCredential(
+            hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
     switch (scheme) {
       case "s3":
         if (renewCredEnabled) {
           return s3TempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       case "gs":
         if (renewCredEnabled) {
           return gcsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       case "abfss":
       case "abfs":
         if (renewCredEnabled) {
           return abfsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, tempCreds)
+                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
               .credId(credId)
               .appVersions(appVersions)
               .build();
         } else {
-          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, tempCreds);
+          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
       default:
         return Collections.emptyMap();
     }
   }
 
-  private static TemporaryCredentials fetchTemporaryCredentials(
+  private static GenericCredential fetchGenericCredential(
+      Configuration hadoopConf,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions,
+      CredId credId)
+      throws ApiException {
+    boolean credCacheEnabled =
+        hadoopConf.getBoolean(
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY,
+            UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_DEFAULT_VALUE);
+    if (!credCacheEnabled) {
+      return createCredential(apiClient, catalogUri, tokenProvider, appVersions, credId);
+    }
+
+    long renewalLeadTimeMillis =
+        hadoopConf.getLong(
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY,
+            UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_DEFAULT_VALUE);
+
+    return initialCredCache.access(
+        credId,
+        () ->
+            new RenewableCredential(
+                renewalLeadTimeMillis,
+                ClockUtil.resolveClock(hadoopConf),
+                createCredential(apiClient, catalogUri, tokenProvider, appVersions, credId)));
+  }
+
+  private static GenericCredential createCredential(
       ApiClient apiClient,
       String catalogUri,
       TokenProvider tokenProvider,
@@ -497,10 +540,7 @@ public class CredPropsUtil {
       throws ApiException {
     ApiClient client =
         apiClient != null ? apiClient : createApiClient(catalogUri, tokenProvider, appVersions);
-    return genericCredFetcherFactory
-        .create(client, credId)
-        .createCredential()
-        .temporaryCredentials();
+    return genericCredFetcherFactory.create(client, credId).createCredential();
   }
 
   private static ApiClient createApiClient(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialCache.java
@@ -1,0 +1,116 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.internal.Clock;
+import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Caches vended {@link GenericCredential}s keyed by their scope ({@link CredId}). A cached
+ * credential is reused while it is still valid and re-fetched via the supplied factory only once it
+ * is about to expire.
+ */
+public class CredentialCache {
+  private static final int DEFAULT_MAX_SIZE = 1024;
+  private static final String GLOBAL_CACHE_MAX_SIZE_KEY = "unitycatalog.credential.cache.maxSize";
+  private static final String INITIAL_CACHE_MAX_SIZE_KEY =
+      "unitycatalog.initial.credential.cache.maxSize";
+
+  private final BoundedKeyedCache<CredId, RenewableCredential> cache;
+
+  public CredentialCache(int maxSize) {
+    this.cache = new BoundedKeyedCache<>(maxSize);
+  }
+
+  /**
+   * Creates the JVM-wide cache used by the Hadoop token providers to renew and share vended
+   * credentials across requests targeting the same scope, saving QPS to the Unity Catalog server.
+   */
+  public static CredentialCache createGlobalCache() {
+    return new CredentialCache(Integer.getInteger(GLOBAL_CACHE_MAX_SIZE_KEY, DEFAULT_MAX_SIZE));
+  }
+
+  /**
+   * Creates the cache for the initial credential fetched during query planning (e.g. on the Spark
+   * driver) so that different queries targeting the same scope reuse the same vended credential
+   * instead of re-fetching from the Unity Catalog server.
+   */
+  public static CredentialCache createInitialCredentialCache() {
+    return new CredentialCache(Integer.getInteger(INITIAL_CACHE_MAX_SIZE_KEY, DEFAULT_MAX_SIZE));
+  }
+
+  /**
+   * Returns the credential for {@code credId}, handling three cases:
+   *
+   * <ul>
+   *   <li>Cached and still valid: return it as is.
+   *   <li>Cached but about to expire: create a fresh one via {@code factory}, cache it, return it.
+   *   <li>Not cached: create it via {@code factory}, cache it, return it.
+   * </ul>
+   */
+  public GenericCredential access(CredId credId, RenewableCredentialFactory factory)
+      throws ApiException {
+    synchronized (cache) {
+      RenewableCredential cached = cache.getIfPresent(credId);
+      // Reuse the cached credential while it's still valid; otherwise fetch and cache a fresh one.
+      if (cached != null && !cached.readyToRenew()) {
+        return cached.credential();
+      }
+
+      RenewableCredential created = factory.create();
+      cache.put(credId, created);
+      return created.credential();
+    }
+  }
+
+  /** Removes all cached credentials. Public so tests in other packages can reset shared caches. */
+  public void clear() {
+    cache.clear();
+  }
+
+  // Visible for testing only.
+  int size() {
+    return cache.size();
+  }
+
+  // Visible for testing only.
+  List<GenericCredential> credentials() {
+    return cache.values().stream()
+        .map(RenewableCredential::credential)
+        .collect(Collectors.toList());
+  }
+
+  @FunctionalInterface
+  public interface RenewableCredentialFactory {
+    RenewableCredential create() throws ApiException;
+  }
+
+  /**
+   * A cached credential together with the renewal policy ({@code clock} and {@code
+   * renewalLeadTimeMillis}) used to decide when it should be renewed. The policy is captured from
+   * the caller that created the entry; since both are derived from the same Hadoop configuration,
+   * later readers observe the same renewal behavior.
+   */
+  public static class RenewableCredential {
+    private final long renewalLeadTimeMillis;
+    private final Clock clock;
+    private final GenericCredential credential;
+
+    public RenewableCredential(
+        long renewalLeadTimeMillis, Clock clock, GenericCredential credential) {
+      this.renewalLeadTimeMillis = renewalLeadTimeMillis;
+      this.clock = clock;
+      this.credential = credential;
+    }
+
+    public GenericCredential credential() {
+      return credential;
+    }
+
+    public boolean readyToRenew() {
+      return credential.readyToRenew(clock, renewalLeadTimeMillis);
+    }
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -3,8 +3,9 @@ package io.unitycatalog.hadoop.internal.auth;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
 import io.unitycatalog.hadoop.internal.id.CredId;
-import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
+import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -14,18 +15,7 @@ import org.apache.hadoop.conf.Configuration;
  * cache lookup.
  */
 public abstract class GenericCredentialProvider {
-  // The credential cache, for saving QPS to unity catalog server. Keyed by the credential scope
-  // ({@link CredId}) so that requests targeting the same scope can share a vended credential.
-  static final BoundedKeyedCache<CredId, GenericCredential> globalCache;
-  private static final String UC_CREDENTIAL_CACHE_MAX_SIZE =
-      "unitycatalog.credential.cache.maxSize";
-  private static final int UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT = 1024;
-
-  static {
-    int maxSize =
-        Integer.getInteger(UC_CREDENTIAL_CACHE_MAX_SIZE, UC_CREDENTIAL_CACHE_MAX_SIZE_DEFAULT);
-    globalCache = new BoundedKeyedCache<>(maxSize, ignored -> {});
-  }
+  static final CredentialCache globalCache = CredentialCache.createGlobalCache();
 
   private Configuration conf;
   private Clock clock;
@@ -38,10 +28,7 @@ public abstract class GenericCredentialProvider {
 
   protected void initialize(Configuration conf) {
     this.conf = conf;
-
-    // Use the test clock if one is intentionally configured for testing.
-    String clockName = conf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
-    this.clock = clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
+    this.clock = ClockUtil.resolveClock(conf);
 
     this.renewalLeadTimeMillis =
         conf.getLong(
@@ -92,16 +79,11 @@ public abstract class GenericCredentialProvider {
 
   private GenericCredential renewCredential() throws ApiException {
     if (credCacheEnabled) {
-      synchronized (globalCache) {
-        GenericCredential cached = globalCache.getIfPresent(cacheKey);
-        // Use the cached one if existing and valid.
-        if (cached != null && !cached.readyToRenew(clock, renewalLeadTimeMillis)) {
-          return cached;
-        }
-        GenericCredential created = genericCredentialFetcher().createCredential();
-        globalCache.put(cacheKey, created);
-        return created;
-      }
+      return globalCache.access(
+          cacheKey,
+          () ->
+              new RenewableCredential(
+                  renewalLeadTimeMillis, clock, genericCredentialFetcher().createCredential()));
     } else {
       return genericCredentialFetcher().createCredential();
     }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/ClockUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/util/ClockUtil.java
@@ -1,0 +1,14 @@
+package io.unitycatalog.hadoop.internal.util;
+
+import io.unitycatalog.client.internal.Clock;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import org.apache.hadoop.conf.Configuration;
+
+public final class ClockUtil {
+  private ClockUtil() {}
+
+  public static Clock resolveClock(Configuration conf) {
+    String clockName = conf.get(UCHadoopConfConstants.UC_TEST_CLOCK_NAME);
+    return clockName != null ? Clock.getManualClock(clockName) : Clock.systemClock();
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
@@ -15,10 +16,14 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
+import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,6 +38,11 @@ class CredPropsUtilTest {
   private static final String CUSTOM_GS_IMPL = "com.example.CustomGcsFileSystem";
   private static final String CUSTOM_ABFS_IMPL = "com.example.CustomAbfsFileSystem";
   private static final String CUSTOM_ABFSS_IMPL = "com.example.CustomAbfssFileSystem";
+
+  @BeforeEach
+  void clearCredentialCache() {
+    CredPropsUtil.initialCredCache.clear();
+  }
 
   @Test
   void s3OriginalImplPreservedFromExistingProps() throws Exception {
@@ -739,6 +749,107 @@ class CredPropsUtilTest {
   @AfterEach
   void resetFactory() {
     CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
+    CredPropsUtil.initialCredCache.clear();
+  }
+
+  // Driver-side credential cache: different queries reuse the same credential for the same credId.
+
+  @Test
+  void sameCredIdReusesCachedCredentialAcrossQueries() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    Map<String, String> first = createTableCredProps(new Configuration(false));
+    Map<String, String> second = createTableCredProps(new Configuration(false));
+
+    assertThat(fetches.get()).isEqualTo(1);
+    assertThat(first).isEqualTo(second).containsEntry("fs.s3a.access.key", "ak");
+  }
+
+  @Test
+  void differentCredIdsAreCachedSeparately() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+
+    createTableCredProps(new Configuration(false), "tidA");
+    createTableCredProps(new Configuration(false), "tidB");
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
+  @Test
+  void cacheDisabledFetchesForEveryQuery() throws Exception {
+    AtomicInteger fetches = new AtomicInteger();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          fetches.incrementAndGet();
+          return mockGenericCredentialFetcher(s3Creds());
+        };
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+
+    createTableCredProps(conf);
+    createTableCredProps(conf);
+
+    assertThat(fetches.get()).isEqualTo(2);
+  }
+
+  @Test
+  void expiredCachedCredentialIsRefetched() throws Exception {
+    String clockName = UUID.randomUUID().toString();
+    Clock clock = Clock.getManualClock(clockName);
+    try {
+      TemporaryCredentials cred1 = s3CredsExpiringAt("1", clock.now().toEpochMilli() + 2000L);
+      TemporaryCredentials cred2 = s3CredsExpiringAt("2", clock.now().toEpochMilli() + 20000L);
+      AtomicInteger fetches = new AtomicInteger();
+      CredPropsUtil.genericCredFetcherFactory =
+          (apiClient, credId) ->
+              mockGenericCredentialFetcher(fetches.getAndIncrement() == 0 ? cred1 : cred2);
+
+      Configuration conf = new Configuration(false);
+      conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+      conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1000L);
+
+      // 1st query fetches cred1 and caches it.
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st1");
+      // 2nd query reuses cred1 while it is still valid.
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st1");
+      assertThat(fetches.get()).isEqualTo(1);
+
+      // Advance the clock so cred1 is within the renewal lead time; the next query refetches cred2.
+      clock.sleep(Duration.ofMillis(1500));
+      assertThat(createTableCredProps(conf)).containsEntry("fs.s3a.session.token", "st2");
+      assertThat(fetches.get()).isEqualTo(2);
+    } finally {
+      Clock.removeManualClock(clockName);
+    }
+  }
+
+  private static Map<String, String> createTableCredProps(Configuration conf) throws Exception {
+    return createTableCredProps(conf, "tid");
+  }
+
+  private static Map<String, String> createTableCredProps(Configuration conf, String tableId)
+      throws Exception {
+    return CredPropsUtil.createTableCredProps(
+        false,
+        false,
+        conf,
+        "s3",
+        null,
+        "http://uc",
+        tokenProvider(),
+        tableId,
+        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+        Map.of());
   }
 
   @Test
@@ -1014,6 +1125,16 @@ class CredPropsUtilTest {
     return new TemporaryCredentials()
         .awsTempCredentials(
             new AwsCredentials().accessKeyId("ak").secretAccessKey("sk").sessionToken("st"));
+  }
+
+  private static TemporaryCredentials s3CredsExpiringAt(String id, long expirationMillis) {
+    return new TemporaryCredentials()
+        .awsTempCredentials(
+            new AwsCredentials()
+                .accessKeyId("ak" + id)
+                .secretAccessKey("sk" + id)
+                .sessionToken("st" + id))
+        .expirationTime(expirationMillis);
   }
 
   private static TemporaryCredentials gcsCreds() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/BaseTokenProviderTest.java
@@ -323,7 +323,7 @@ public abstract class BaseTokenProviderTest<T extends GenericCredentialProvider>
     assertThat(expectedSize).isEqualTo(creds.length);
     assertThat(GenericCredentialProvider.globalCache.size()).isEqualTo(expectedSize);
     for (TemporaryCredentials cred : creds) {
-      assertThat(GenericCredentialProvider.globalCache.values())
+      assertThat(GenericCredentialProvider.globalCache.credentials())
           .contains(new GenericCredential(cred));
     }
   }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Backport of #1642 to `branch-0.5` (single commit cherry-picked from merge commit `2e08c38c`).

**Test plan**

- [x] `./build/sbt -mem 4096 "project hadoop" "testOnly io.unitycatalog.hadoop.internal.CredPropsUtilTest"` — 41 tests passed
- [x] `./build/sbt -mem 4096 "project hadoop" "testOnly io.unitycatalog.hadoop.internal.auth.*"` — 27 tests passed