### PR TITLE
[0.5][Build] Bump version to 0.5.1

### DIFF
--- a/clients/python/build/pyproject.toml
+++ b/clients/python/build/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unitycatalog-client"
-version = "0.5.0.dev0"
+version = "0.5.1.dev0"
 description = "Official Python SDK for Unity Catalog"
 authors = [
     { name="Unity Catalog Developers", email="dev-feedback@unitycatalog.com" }

--- a/clients/python/build/setup.py
+++ b/clients/python/build/setup.py
@@ -15,7 +15,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="unitycatalog-client",
-    version="0.5.0.dev0",
+    version="0.5.1.dev0",
     description="Official Python SDK for Unity Catalog",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.5.0"
+ThisBuild / version := "0.5.1"


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Prepares the `branch-0.5` release branch for the Unity Catalog 0.5.1 patch release:

- **Set version to `0.5.1`** in `version.sbt` (was `0.5.0`)
- **Bump Python client version to `0.5.1.dev0`** in `clients/python/build/pyproject.toml` and `clients/python/build/setup.py`

After this change, the release will publish artifacts at version 0.5.1, including:

- `unitycatalog-spark_4.0_2.13:0.5.1`
- `unitycatalog-spark_4.1_2.13:0.5.1`
- `unitycatalog-client:0.5.1`
- `unitycatalog-server:0.5.1`