### PR TITLE
[WIP] hadoop: normalize GenericCredential storage values

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -4,13 +4,10 @@ import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
-import io.unitycatalog.client.model.AwsCredentials;
-import io.unitycatalog.client.model.AzureUserDelegationSAS;
-import io.unitycatalog.client.model.GcpOauthToken;
-import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
+import io.unitycatalog.hadoop.internal.auth.CredentialResolver;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
@@ -234,12 +231,10 @@ public class CredPropsUtil {
 
   private static Map<String, String> s3FixedCredProps(
       boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     return new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set("fs.s3a.access.key", awsCred.getAccessKeyId())
-        .set("fs.s3a.secret.key", awsCred.getSecretAccessKey())
-        .set("fs.s3a.session.token", awsCred.getSessionToken())
+        .set("fs.s3a.access.key", cred.awsAccessKeyId())
+        .set("fs.s3a.secret.key", cred.awsSecretAccessKey())
+        .set("fs.s3a.session.token", cred.awsSessionToken())
         .build();
   }
 
@@ -249,22 +244,20 @@ public class CredPropsUtil {
       String uri,
       TokenProvider tokenProvider,
       GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    AwsCredentials awsCred = tempCreds.getAwsTempCredentials();
     S3PropsBuilder builder =
         new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
             .set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS)
             .uri(uri)
             .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, awsCred.getAccessKeyId())
-            .set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, awsCred.getSecretAccessKey())
-            .set(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, awsCred.getSessionToken());
+            .set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, cred.awsAccessKeyId())
+            .set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, cred.awsSecretAccessKey())
+            .set(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, cred.awsSessionToken());
 
     // For the static credential case, nullable expiration time is possible.
-    if (tempCreds.getExpirationTime() != null) {
+    if (cred.expirationTimeMillis() != null) {
       builder.set(
           UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME,
-          String.valueOf(tempCreds.getExpirationTime()));
+          String.valueOf(cred.expirationTimeMillis()));
     }
 
     return builder;
@@ -272,12 +265,10 @@ public class CredPropsUtil {
 
   private static Map<String, String> gsFixedCredProps(
       boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    GcpOauthToken gcpOauthToken = tempCreds.getGcpOauthToken();
     Long expirationTime =
-        tempCreds.getExpirationTime() == null ? Long.MAX_VALUE : tempCreds.getExpirationTime();
+        cred.expirationTimeMillis() == null ? Long.MAX_VALUE : cred.expirationTimeMillis();
     return new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set(GCS_ACCESS_TOKEN_KEY, gcpOauthToken.getOauthToken())
+        .set(GCS_ACCESS_TOKEN_KEY, cred.gcsOauthToken())
         .set(GCS_ACCESS_TOKEN_EXPIRATION_KEY, String.valueOf(expirationTime))
         .build();
   }
@@ -288,21 +279,19 @@ public class CredPropsUtil {
       String uri,
       TokenProvider tokenProvider,
       GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    GcpOauthToken gcpToken = tempCreds.getGcpOauthToken();
     GcsPropsBuilder builder =
         new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
             .set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
             .set("fs.gs.auth.access.token.provider", GCS_VENDED_TOKEN_PROVIDER_CLASS)
             .uri(uri)
             .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, gcpToken.getOauthToken());
+            .set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, cred.gcsOauthToken());
 
     // For the static credential case, nullable expiration time is possible.
-    if (tempCreds.getExpirationTime() != null) {
+    if (cred.expirationTimeMillis() != null) {
       builder.set(
           UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
-          String.valueOf(tempCreds.getExpirationTime()));
+          String.valueOf(cred.expirationTimeMillis()));
     }
 
     return builder;
@@ -310,10 +299,8 @@ public class CredPropsUtil {
 
   private static Map<String, String> abfsFixedCredProps(
       boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     return new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set(ABFS_FIXED_SAS_TOKEN_KEY, azureSas.getSasToken())
+        .set(ABFS_FIXED_SAS_TOKEN_KEY, cred.azureSasToken())
         .build();
   }
 
@@ -323,8 +310,6 @@ public class CredPropsUtil {
       String uri,
       TokenProvider tokenProvider,
       GenericCredential cred) {
-    TemporaryCredentials tempCreds = cred.temporaryCredentials();
-    AzureUserDelegationSAS azureSas = tempCreds.getAzureUserDelegationSas();
     AbfsPropsBuilder builder =
         new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
             .set(
@@ -332,13 +317,13 @@ public class CredPropsUtil {
                 ABFS_VENDED_TOKEN_PROVIDER_CLASS)
             .uri(uri)
             .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, azureSas.getSasToken());
+            .set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, cred.azureSasToken());
 
     // For the static credential case, nullable expiration time is possible.
-    if (tempCreds.getExpirationTime() != null) {
+    if (cred.expirationTimeMillis() != null) {
       builder.set(
           UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
-          String.valueOf(tempCreds.getExpirationTime()));
+          String.valueOf(cred.expirationTimeMillis()));
     }
 
     return builder;
@@ -569,7 +554,8 @@ public class CredPropsUtil {
       throws ApiException {
     ApiClient client =
         apiClient != null ? apiClient : createApiClient(catalogUri, tokenProvider, appVersions);
-    return genericCredFetcherFactory.create(client, credId).createCredential();
+    return CredentialResolver.create(genericCredFetcherFactory.create(client, credId))
+        .select(credId);
   }
 
   private static ApiClient createApiClient(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/DeltaStorageCredentialUtil.java
@@ -3,81 +3,57 @@ package io.unitycatalog.hadoop.internal;
 import io.unitycatalog.client.delta.model.DeltaStorageCredential;
 import io.unitycatalog.client.delta.model.DeltaStorageCredentialConfig;
 import io.unitycatalog.client.internal.Preconditions;
-import io.unitycatalog.client.model.AwsCredentials;
-import io.unitycatalog.client.model.AzureUserDelegationSAS;
-import io.unitycatalog.client.model.GcpOauthToken;
-import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.auth.CredentialBundle;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Internal utility for UC Delta storage credentials. */
 public final class DeltaStorageCredentialUtil {
   private DeltaStorageCredentialUtil() {}
 
-  /** Converts one UC Delta storage credential into standard UC temporary credentials. */
-  public static TemporaryCredentials toTemporaryCredentials(DeltaStorageCredential cred) {
+  /**
+   * Maps every storage credential in a UC Delta response into a {@link CredentialBundle},
+   * preserving order.
+   */
+  public static CredentialBundle toCredentialBundle(List<DeltaStorageCredential> creds) {
+    Preconditions.checkArgument(
+        creds != null && !creds.isEmpty(), "UC Delta API response has no storage credentials.");
+    List<GenericCredential> out = new ArrayList<>(creds.size());
+    for (DeltaStorageCredential cred : creds) {
+      Preconditions.checkNotNull(cred, "UC Delta API response contains a null storage credential.");
+      out.add(toGenericCredential(cred));
+    }
+    return CredentialBundle.of(out);
+  }
+
+  /**
+   * Converts one UC Delta storage credential into a {@link GenericCredential} scoped to its prefix.
+   *
+   * <p>The credential's config must contain exactly one cloud's values; a missing config, multiple
+   * clouds, or a partially-populated cloud is rejected.
+   */
+  public static GenericCredential toGenericCredential(DeltaStorageCredential cred) {
     DeltaStorageCredentialConfig config = requireSingleCloudConfig(cred);
     long expiry = cred.getExpirationTimeMs() == null ? Long.MAX_VALUE : cred.getExpirationTimeMs();
-    TemporaryCredentials out = new TemporaryCredentials().expirationTime(expiry);
+    GenericCredential result;
     if (isS3Config(config)) {
-      out.awsTempCredentials(
-          new AwsCredentials()
-              .accessKeyId(field(config.getS3AccessKeyId(), cred, "S3 access key"))
-              .secretAccessKey(field(config.getS3SecretAccessKey(), cred, "S3 secret key"))
-              .sessionToken(field(config.getS3SessionToken(), cred, "S3 session token")));
+      result =
+          GenericCredential.forAws(
+              field(config.getS3AccessKeyId(), cred, "S3 access key"),
+              field(config.getS3SecretAccessKey(), cred, "S3 secret key"),
+              field(config.getS3SessionToken(), cred, "S3 session token"),
+              expiry);
     } else if (isAzureConfig(config)) {
-      out.azureUserDelegationSas(
-          new AzureUserDelegationSAS()
-              .sasToken(field(config.getAzureSasToken(), cred, "Azure SAS token")));
+      result =
+          GenericCredential.forAzure(
+              field(config.getAzureSasToken(), cred, "Azure SAS token"), expiry);
     } else {
-      out.gcpOauthToken(
-          new GcpOauthToken()
-              .oauthToken(field(config.getGcsOauthToken(), cred, "GCS OAuth token")));
+      result =
+          GenericCredential.forGcs(
+              field(config.getGcsOauthToken(), cred, "GCS OAuth token"), expiry);
     }
-    return out;
-  }
-
-  /** Selects the credential whose prefix covers the requested location. */
-  public static DeltaStorageCredential selectForLocation(
-      String location, List<DeltaStorageCredential> creds) {
-    Preconditions.checkArgument(
-        creds != null && !creds.isEmpty(),
-        "UC Delta API response for '%s' has no storage credentials.",
-        location);
-    if (creds.size() == 1) {
-      Preconditions.checkNotNull(
-          creds.get(0), "UC Delta API response for '%s' contains null.", location);
-    }
-    DeltaStorageCredential best = null;
-    int bestLen = -1;
-    for (DeltaStorageCredential c : creds) {
-      if (c == null || c.getPrefix() == null || !prefixCovers(location, c.getPrefix())) {
-        continue;
-      }
-      int len = stripTrailingSlashes(c.getPrefix()).length();
-      if (len > bestLen) {
-        best = c;
-        bestLen = len;
-      }
-    }
-    Preconditions.checkArgument(
-        best != null, "No UC Delta credential matched location '%s'.", location);
-    return best;
-  }
-
-  static boolean prefixCovers(String location, String prefix) {
-    String l = stripTrailingSlashes(location);
-    String p = stripTrailingSlashes(prefix);
-    return !p.isEmpty() && (l.equals(p) || (l.startsWith(p) && l.charAt(p.length()) == '/'));
-  }
-
-  private static String stripTrailingSlashes(String value) {
-    int end = value.length();
-    int min = value.indexOf("://");
-    min = min >= 0 ? min + 3 : 1;
-    while (end > min && value.charAt(end - 1) == '/') {
-      end--;
-    }
-    return value.substring(0, end);
+    return result.withPrefix(cred.getPrefix());
   }
 
   private static DeltaStorageCredentialConfig requireSingleCloudConfig(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/StorageLocationUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/StorageLocationUtil.java
@@ -1,0 +1,50 @@
+package io.unitycatalog.hadoop.internal;
+
+import java.util.List;
+import java.util.function.Function;
+
+/** Internal helpers for reasoning about storage locations and their path prefixes. */
+public final class StorageLocationUtil {
+  private StorageLocationUtil() {}
+
+  /**
+   * Returns true if {@code prefix} covers {@code location}: they are equal (ignoring trailing
+   * slashes) or {@code location} is a path-boundary descendant of {@code prefix}.
+   */
+  public static boolean covers(String location, String prefix) {
+    String l = stripTrailingSlashes(location);
+    String p = stripTrailingSlashes(prefix);
+    return !p.isEmpty() && (l.equals(p) || (l.startsWith(p) && l.charAt(p.length()) == '/'));
+  }
+
+  /**
+   * Returns the item whose prefix (via {@code prefixOf}) covers {@code location} with the longest
+   * match, or null if none cover it. Items with a null prefix are skipped.
+   */
+  public static <T> T longestCovering(
+      String location, List<T> items, Function<T, String> prefixOf) {
+    T best = null;
+    int bestLen = -1;
+    for (T item : items) {
+      String prefix = prefixOf.apply(item);
+      if (prefix == null || !covers(location, prefix)) {
+        continue;
+      }
+      if (prefix.length() > bestLen) {
+        best = item;
+        bestLen = prefix.length();
+      }
+    }
+    return best;
+  }
+
+  private static String stripTrailingSlashes(String value) {
+    int end = value.length();
+    int min = value.indexOf("://");
+    min = min >= 0 ? min + 3 : 1;
+    while (end > min && value.charAt(end - 1) == '/') {
+      end--;
+    }
+    return value.substring(0, end);
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCStorageCredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCStorageCredentialUtil.java
@@ -1,0 +1,42 @@
+package io.unitycatalog.hadoop.internal;
+
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.client.model.AwsCredentials;
+import io.unitycatalog.client.model.AzureUserDelegationSAS;
+import io.unitycatalog.client.model.GcpOauthToken;
+import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+
+/** Internal utility for standard UC temporary credentials. */
+public final class UCStorageCredentialUtil {
+  private UCStorageCredentialUtil() {}
+
+  /**
+   * Converts standard UC {@link TemporaryCredentials} into a {@link GenericCredential}.
+   *
+   * <p>Exactly one cloud sub-model must be present; the credential is not scoped to a prefix (the
+   * UC temporary-credentials model carries none).
+   */
+  public static GenericCredential toGenericCredential(TemporaryCredentials tempCred) {
+    Preconditions.checkNotNull(tempCred, "temporaryCredentials cannot be null");
+    Long expiry = tempCred.getExpirationTime();
+    AwsCredentials aws = tempCred.getAwsTempCredentials();
+    AzureUserDelegationSAS azure = tempCred.getAzureUserDelegationSas();
+    GcpOauthToken gcp = tempCred.getGcpOauthToken();
+    if (aws != null) {
+      return GenericCredential.forAws(
+          aws.getAccessKeyId(),
+          aws.getSecretAccessKey(),
+          aws.getSessionToken(),
+          expiry == null ? Long.MAX_VALUE : expiry);
+    } else if (azure != null) {
+      return GenericCredential.forAzure(
+          azure.getSasToken(), expiry == null ? Long.MAX_VALUE : expiry);
+    } else if (gcp != null) {
+      return GenericCredential.forGcs(
+          gcp.getOauthToken(), expiry == null ? Long.MAX_VALUE : expiry);
+    }
+    throw new IllegalArgumentException(
+        "UC temporary credentials contain no cloud credential values.");
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AbfsVendedTokenProvider.java
@@ -1,6 +1,5 @@
 package io.unitycatalog.hadoop.internal.auth;
 
-import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
@@ -46,9 +45,9 @@ public class AbfsVendedTokenProvider extends GenericCredentialProvider implement
   public String getSASToken(String account, String fileSystem, String path, String operation) {
     GenericCredential generic = accessCredentials();
 
-    AzureUserDelegationSAS azureSAS = generic.temporaryCredentials().getAzureUserDelegationSas();
-    Preconditions.checkNotNull(azureSAS, "Azure SAS of generic credential cannot be null");
+    String sasToken = generic.azureSasToken();
+    Preconditions.checkNotNull(sasToken, "Azure SAS of generic credential cannot be null");
 
-    return azureSAS.getSasToken();
+    return sasToken;
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/AwsVendedTokenProvider.java
@@ -47,15 +47,13 @@ public class AwsVendedTokenProvider extends GenericCredentialProvider
     GenericCredential generic = accessCredentials();
 
     // Wrap the GenericCredential as an AwsCredentials.
-    io.unitycatalog.client.model.AwsCredentials awsTempCred =
-        generic.temporaryCredentials().getAwsTempCredentials();
     Preconditions.checkNotNull(
-        awsTempCred, "AWS temp credential of generic credentials cannot be null");
+        generic.awsAccessKeyId(), "AWS temp credential of generic credentials cannot be null");
 
     return AwsSessionCredentials.builder()
-        .accessKeyId(awsTempCred.getAccessKeyId())
-        .secretAccessKey(awsTempCred.getSecretAccessKey())
-        .sessionToken(awsTempCred.getSessionToken())
+        .accessKeyId(generic.awsAccessKeyId())
+        .secretAccessKey(generic.awsSecretAccessKey())
+        .sessionToken(generic.awsSessionToken())
         .build();
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialBundle.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialBundle.java
@@ -1,0 +1,52 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.internal.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** An immutable list of {@link GenericCredential}s. */
+public final class CredentialBundle {
+  private final List<GenericCredential> credentials;
+
+  private CredentialBundle(List<GenericCredential> credentials) {
+    this.credentials = credentials;
+  }
+
+  public static CredentialBundle of(List<GenericCredential> creds) {
+    Preconditions.checkNotNull(creds, "credentials is required");
+    Preconditions.checkArgument(!creds.isEmpty(), "credentials must not be empty");
+    for (GenericCredential cred : creds) {
+      Preconditions.checkNotNull(cred, "credentials must not contain null");
+    }
+    return new CredentialBundle(Collections.unmodifiableList(new ArrayList<>(creds)));
+  }
+
+  /** Creates a bundle holding a single credential. */
+  public static CredentialBundle of(GenericCredential cred) {
+    Preconditions.checkNotNull(cred, "credential is required");
+    return new CredentialBundle(Collections.singletonList(cred));
+  }
+
+  /** All credentials in the batch, in fetch order. Never empty. */
+  public List<GenericCredential> all() {
+    return credentials;
+  }
+
+  /**
+   * Returns the sole credential.
+   *
+   * @throws IllegalArgumentException if the batch holds more than one credential.
+   */
+  public GenericCredential single() {
+    Preconditions.checkArgument(
+        credentials.size() == 1,
+        "Expected exactly one credential but found %s.",
+        credentials.size());
+    return credentials.get(0);
+  }
+
+  public boolean isEmpty() {
+    return credentials.isEmpty();
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialResolver.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialResolver.java
@@ -1,0 +1,31 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.hadoop.internal.id.CredId;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Resolves the {@link GenericCredential} that applies to a credential scope.
+ */
+public final class CredentialResolver {
+  private final GenericCredentialFetcher fetcher;
+
+  private CredentialResolver(GenericCredentialFetcher fetcher) {
+    this.fetcher = fetcher;
+  }
+
+  /** Builds a resolver over the given fetcher. */
+  public static CredentialResolver create(GenericCredentialFetcher fetcher) {
+    return new CredentialResolver(fetcher);
+  }
+
+  /** Builds a resolver from Hadoop configuration via {@link GenericCredentialFetcher#create}. */
+  public static CredentialResolver create(Configuration conf) {
+    return new CredentialResolver(GenericCredentialFetcher.create(conf));
+  }
+
+  /** Fetches credentials and returns the single one that applies to {@code credId}. */
+  public GenericCredential select(CredId credId) throws ApiException {
+    return CredentialSelector.forCredId(credId).select(fetcher.fetch(), credId);
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialSelector.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/CredentialSelector.java
@@ -1,0 +1,22 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.hadoop.internal.id.CredId;
+import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
+import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+
+/**
+ * Selects the {@link GenericCredential} from a {@link CredentialBundle} that applies to a given
+ * credential scope. Behavior depends on the credential type {@link CredId}.
+ */
+public interface CredentialSelector {
+
+  GenericCredential select(CredentialBundle bundle, CredId credId);
+
+  /** Returns the selection policy that applies to {@code credId}'s type. */
+  static CredentialSelector forCredId(CredId credId) {
+    if (credId instanceof DeltaTableCredId || credId instanceof DeltaStagingTableCredId) {
+      return new PrefixCredentialSelector();
+    }
+    return new SingleCredentialSelector();
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GcsVendedTokenProvider.java
@@ -1,7 +1,6 @@
 package io.unitycatalog.hadoop.internal.auth;
 
 import com.google.cloud.hadoop.util.AccessTokenProvider;
-import io.unitycatalog.client.model.GcpOauthToken;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.io.IOException;
 import java.time.Instant;
@@ -45,13 +44,10 @@ public class GcsVendedTokenProvider extends GenericCredentialProvider
   public AccessToken getAccessToken() {
     GenericCredential generic = accessCredentials();
 
-    GcpOauthToken gcpToken = generic.temporaryCredentials().getGcpOauthToken();
-    Preconditions.checkNotNull(gcpToken, "GCS OAuth token of generic credential cannot be null");
-
-    String tokenValue = gcpToken.getOauthToken();
+    String tokenValue = generic.gcsOauthToken();
     Preconditions.checkNotNull(tokenValue, "GCS OAuth token value cannot be null");
 
-    Long expirationMillis = generic.temporaryCredentials().getExpirationTime();
+    Long expirationMillis = generic.expirationTimeMillis();
     Instant expirationInstant =
         expirationMillis == null ? null : Instant.ofEpochMilli(expirationMillis);
     return new AccessToken(tokenValue, expirationInstant);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredential.java
@@ -1,64 +1,94 @@
 package io.unitycatalog.hadoop.internal.auth;
 
 import io.unitycatalog.client.internal.Clock;
-import io.unitycatalog.client.model.AwsCredentials;
-import io.unitycatalog.client.model.AzureUserDelegationSAS;
-import io.unitycatalog.client.model.GcpOauthToken;
-import io.unitycatalog.client.model.TemporaryCredentials;
 import java.util.Objects;
 
 /**
- * Internal credential wrapper used by Hadoop token providers.
+ * Internal credential model used by Hadoop token providers.
  *
- * <p>This class normalizes UC SDK temporary credentials into cloud-specific credential values.
+ * <p>A plain, cloud-agnostic value type: it holds one cloud's credential values (AWS, Azure, or
+ * GCS), an optional scope {@code prefix}, and an optional expiration.
  */
-public class GenericCredential {
-  private final TemporaryCredentials tempCred;
+public final class GenericCredential {
 
-  public GenericCredential(TemporaryCredentials tempCred) {
-    this.tempCred = tempCred;
+  private final String awsAccessKeyId;
+  private final String awsSecretAccessKey;
+  private final String awsSessionToken;
+  private final String azureSasToken;
+  private final String gcsOauthToken;
+  private final String prefix;
+  private final Long expirationTimeMillis;
+
+  private GenericCredential(
+      String awsAccessKeyId,
+      String awsSecretAccessKey,
+      String awsSessionToken,
+      String azureSasToken,
+      String gcsOauthToken,
+      String prefix,
+      Long expirationTimeMillis) {
+    this.awsAccessKeyId = awsAccessKeyId;
+    this.awsSecretAccessKey = awsSecretAccessKey;
+    this.awsSessionToken = awsSessionToken;
+    this.azureSasToken = azureSasToken;
+    this.gcsOauthToken = gcsOauthToken;
+    this.prefix = prefix;
+    this.expirationTimeMillis = expirationTimeMillis;
   }
 
   public static GenericCredential forAws(
       String accessKey, String secretKey, String sessionToken, long expiredTimeMillis) {
-    // Initialize the aws credentials.
-    AwsCredentials awsCredentials = new AwsCredentials();
-    awsCredentials.setAccessKeyId(accessKey);
-    awsCredentials.setSecretAccessKey(secretKey);
-    awsCredentials.setSessionToken(sessionToken);
-
-    // Initialize the unity catalog's temporary credentials.
-    TemporaryCredentials tempCred = new TemporaryCredentials();
-    tempCred.setAwsTempCredentials(awsCredentials);
-    tempCred.setExpirationTime(expiredTimeMillis);
-
-    return new GenericCredential(tempCred);
+    return new GenericCredential(
+        accessKey, secretKey, sessionToken, null, null, null, expiredTimeMillis);
   }
 
   public static GenericCredential forAzure(String sasToken, long expiredTimeMillis) {
-    AzureUserDelegationSAS azureSAS = new AzureUserDelegationSAS();
-    azureSAS.setSasToken(sasToken);
-
-    TemporaryCredentials tempCred = new TemporaryCredentials();
-    tempCred.setAzureUserDelegationSas(azureSAS);
-    tempCred.setExpirationTime(expiredTimeMillis);
-
-    return new GenericCredential(tempCred);
+    return new GenericCredential(null, null, null, sasToken, null, null, expiredTimeMillis);
   }
 
   public static GenericCredential forGcs(String oauthToken, long expiredTimeMillis) {
-    GcpOauthToken gcpOauthToken = new GcpOauthToken();
-    gcpOauthToken.setOauthToken(oauthToken);
-
-    TemporaryCredentials tempCred = new TemporaryCredentials();
-    tempCred.setGcpOauthToken(gcpOauthToken);
-    tempCred.setExpirationTime(expiredTimeMillis);
-
-    return new GenericCredential(tempCred);
+    return new GenericCredential(null, null, null, null, oauthToken, null, expiredTimeMillis);
   }
 
-  public TemporaryCredentials temporaryCredentials() {
-    return tempCred;
+  /** Returns a copy of this credential scoped to {@code prefix}. */
+  public GenericCredential withPrefix(String prefix) {
+    return new GenericCredential(
+        awsAccessKeyId,
+        awsSecretAccessKey,
+        awsSessionToken,
+        azureSasToken,
+        gcsOauthToken,
+        prefix,
+        expirationTimeMillis);
+  }
+
+  public String awsAccessKeyId() {
+    return awsAccessKeyId;
+  }
+
+  public String awsSecretAccessKey() {
+    return awsSecretAccessKey;
+  }
+
+  public String awsSessionToken() {
+    return awsSessionToken;
+  }
+
+  public String azureSasToken() {
+    return azureSasToken;
+  }
+
+  public String gcsOauthToken() {
+    return gcsOauthToken;
+  }
+
+  public Long expirationTimeMillis() {
+    return expirationTimeMillis;
+  }
+
+  /** The storage path prefix this credential is scoped to, or null if not scoped. */
+  public String prefix() {
+    return prefix;
   }
 
   /**
@@ -70,13 +100,20 @@ public class GenericCredential {
    * @return true if it's ready to renew.
    */
   public boolean readyToRenew(Clock clock, long renewalLeadTimeMillis) {
-    return tempCred.getExpirationTime() != null
-        && tempCred.getExpirationTime() <= clock.now().toEpochMilli() + renewalLeadTimeMillis;
+    return expirationTimeMillis != null
+        && expirationTimeMillis <= clock.now().toEpochMilli() + renewalLeadTimeMillis;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(tempCred);
+    return Objects.hash(
+        awsAccessKeyId,
+        awsSecretAccessKey,
+        awsSessionToken,
+        azureSasToken,
+        gcsOauthToken,
+        prefix,
+        expirationTimeMillis);
   }
 
   @Override
@@ -90,6 +127,12 @@ public class GenericCredential {
     }
 
     GenericCredential that = (GenericCredential) o;
-    return Objects.equals(tempCred, that.tempCred);
+    return Objects.equals(awsAccessKeyId, that.awsAccessKeyId)
+        && Objects.equals(awsSecretAccessKey, that.awsSecretAccessKey)
+        && Objects.equals(awsSessionToken, that.awsSessionToken)
+        && Objects.equals(azureSasToken, that.azureSasToken)
+        && Objects.equals(gcsOauthToken, that.gcsOauthToken)
+        && Objects.equals(prefix, that.prefix)
+        && Objects.equals(expirationTimeMillis, that.expirationTimeMillis);
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.conf.Configuration;
  * <p><b>Internal API — not for external use. May change without notice.</b>
  */
 public interface GenericCredentialFetcher {
-  GenericCredential createCredential() throws ApiException;
+  CredentialBundle fetch() throws ApiException;
 
   /** Creates a fetcher backed by the standard UC temporary credentials API for a table. */
   static GenericCredentialFetcher forUc(TableCredId credId, TemporaryCredentialsApi api) {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialProvider.java
@@ -20,11 +20,11 @@ public abstract class GenericCredentialProvider {
   private Configuration conf;
   private Clock clock;
   private long renewalLeadTimeMillis;
-  private CredId cacheKey;
+  private CredId credId;
   private boolean credCacheEnabled;
 
   private volatile GenericCredential credential;
-  private volatile GenericCredentialFetcher credentialFetcher;
+  private volatile CredentialResolver credentialResolver;
 
   protected void initialize(Configuration conf) {
     this.conf = conf;
@@ -37,7 +37,7 @@ public abstract class GenericCredentialProvider {
 
     // Identify the credential scope; used as the global cache key so that requests targeting the
     // same scope can share a vended credential.
-    this.cacheKey = CredId.create(conf);
+    this.credId = CredId.create(conf);
 
     this.credCacheEnabled =
         conf.getBoolean(
@@ -66,26 +66,26 @@ public abstract class GenericCredentialProvider {
     return credential;
   }
 
-  GenericCredentialFetcher genericCredentialFetcher() {
-    if (credentialFetcher == null) {
+  CredentialResolver credentialResolver() {
+    if (credentialResolver == null) {
       synchronized (this) {
-        if (credentialFetcher == null) {
-          credentialFetcher = GenericCredentialFetcher.create(conf);
+        if (credentialResolver == null) {
+          credentialResolver = CredentialResolver.create(conf);
         }
       }
     }
-    return credentialFetcher;
+    return credentialResolver;
   }
 
   private GenericCredential renewCredential() throws ApiException {
     if (credCacheEnabled) {
       return globalCache.access(
-          cacheKey,
+          credId,
           () ->
               new RenewableCredential(
-                  renewalLeadTimeMillis, clock, genericCredentialFetcher().createCredential()));
+                  renewalLeadTimeMillis, clock, credentialResolver().select(credId)));
     } else {
-      return genericCredentialFetcher().createCredential();
+      return credentialResolver().select(credId);
     }
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/PrefixCredentialSelector.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/PrefixCredentialSelector.java
@@ -1,0 +1,27 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.StorageLocationUtil;
+import io.unitycatalog.hadoop.internal.id.CredId;
+
+/**
+ * Selection policy for prefix-scoped credentials. A response may carry several credentials each
+ * scoped to a storage-path prefix; this selects the one whose prefix covers the requested location,
+ * preferring the longest match. Coverage is always validated, even when the bundle holds a single
+ * credential.
+ */
+final class PrefixCredentialSelector implements CredentialSelector {
+
+  @Override
+  public GenericCredential select(CredentialBundle bundle, CredId credId) {
+    String location = credId.location();
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(),
+        "Prefix-scoped credential selection requires a location, but the credId has none.");
+
+    GenericCredential best =
+        StorageLocationUtil.longestCovering(location, bundle.all(), GenericCredential::prefix);
+    Preconditions.checkArgument(best != null, "No credential matched location '%s'.", location);
+    return best;
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/SingleCredentialSelector.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/SingleCredentialSelector.java
@@ -1,0 +1,12 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import io.unitycatalog.hadoop.internal.id.CredId;
+
+/** Selection policy for single credential sources. Returns the sole credential in the bundle. */
+final class SingleCredentialSelector implements CredentialSelector {
+
+  @Override
+  public GenericCredential select(CredentialBundle bundle, CredId credId) {
+    return bundle.single();
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaGenericCredentialFetcher.java
@@ -29,7 +29,7 @@ final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher 
   }
 
   @Override
-  public GenericCredential createCredential() throws ApiException {
+  public CredentialBundle fetch() throws ApiException {
     UCDeltaTableIdentifier id = credId.identifier();
     DeltaCredentialsResponse response =
         api.getTableCredentials(operation, id.catalog(), id.schema(), id.table());
@@ -39,9 +39,6 @@ final class UCDeltaGenericCredentialFetcher implements GenericCredentialFetcher 
         id.catalog(),
         id.schema(),
         id.table());
-    return new GenericCredential(
-        DeltaStorageCredentialUtil.toTemporaryCredentials(
-            DeltaStorageCredentialUtil.selectForLocation(
-                credId.location(), response.getStorageCredentials())));
+    return DeltaStorageCredentialUtil.toCredentialBundle(response.getStorageCredentials());
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCDeltaStagingTableCredentialFetcher.java
@@ -13,7 +13,6 @@ final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFet
 
   private final DeltaTemporaryCredentialsApi api;
   private final UUID stagingTableId;
-  private final String stagingTableLocation;
 
   UCDeltaStagingTableCredentialFetcher(
       DeltaStagingTableCredId credId, DeltaTemporaryCredentialsApi api) {
@@ -22,20 +21,16 @@ final class UCDeltaStagingTableCredentialFetcher implements GenericCredentialFet
 
     this.api = api;
     this.stagingTableId = UUID.fromString(credId.stagingTableId());
-    this.stagingTableLocation = credId.location();
   }
 
   @Override
-  public GenericCredential createCredential() throws ApiException {
+  public CredentialBundle fetch() throws ApiException {
     DeltaCredentialsResponse response = api.getStagingTableCredentials(stagingTableId);
     Preconditions.checkNotNull(
         response,
         "UC Delta API returned no credentials response for staging table '%s'.",
         stagingTableId);
 
-    return new GenericCredential(
-        DeltaStorageCredentialUtil.toTemporaryCredentials(
-            DeltaStorageCredentialUtil.selectForLocation(
-                stagingTableLocation, response.getStorageCredentials())));
+    return DeltaStorageCredentialUtil.toCredentialBundle(response.getStorageCredentials());
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/UCGenericCredentialFetcher.java
@@ -8,6 +8,7 @@ import io.unitycatalog.client.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.client.model.PathOperation;
 import io.unitycatalog.client.model.TableOperation;
 import io.unitycatalog.client.model.TemporaryCredentials;
+import io.unitycatalog.hadoop.internal.UCStorageCredentialUtil;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 
@@ -38,8 +39,8 @@ final class UCGenericCredentialFetcher implements GenericCredentialFetcher {
   }
 
   @Override
-  public GenericCredential createCredential() throws ApiException {
-    return new GenericCredential(credentialCaller.get());
+  public CredentialBundle fetch() throws ApiException {
+    return CredentialBundle.of(UCStorageCredentialUtil.toGenericCredential(credentialCaller.get()));
   }
 
   /** Supplies temporary credentials from a pre-built request, bound at construction time. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -137,4 +137,13 @@ public interface CredId {
         credContextId, "Missing required config '%s'", UC_CRED_CONTEXT_ID_KEY);
     return credContextId;
   }
+
+  /**
+   * The storage location this credential scope targets.
+   *
+   * @return the target storage location, or null when this scope carries no location.
+   */
+  default String location() {
+    return null;
+  }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaStagingTableCredId.java
@@ -31,6 +31,7 @@ public class DeltaStagingTableCredId implements CredId {
     return stagingTableId;
   }
 
+  @Override
   public String location() {
     return location;
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/DeltaTableCredId.java
@@ -48,6 +48,7 @@ public class DeltaTableCredId implements CredId {
     return tableOperation;
   }
 
+  @Override
   public String location() {
     return location;
   }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1676/files) to review incremental changes.
- [stack/credential-model](https://github.com/unitycatalog/unitycatalog/pull/1676) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1676/files)]

---------
Signed-off-by: foss-contributor <282724952+foss-contributor@users.noreply.github.com>

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you have fixed a bug or added code that should be tested, add tests!
- [ ] If you have added or modified a feature, documentation in `docs` is updated

**Description of changes**

## Summary
Normalize `GenericCredential` storage values and migrate its consumers while preserving the existing single-credential fetcher behavior.
No behavioral changes; this simply normalizes storage values.

## Testing
Not run (deferred by request).
