### PR TITLE
[spark] Avoid duplicate UC getTable call during view relation fallback

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
@@ -1,6 +1,5 @@
 package io.unitycatalog.spark
 
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, NoSuchViewException}
 import org.apache.spark.sql.connector.catalog.{
   Identifier,
   Relation,
@@ -41,24 +40,21 @@ trait UCSingleCatalogViewSupport extends RelationCatalog { self: UCSingleCatalog
     ucProxy.renameView(oldIdent, newIdent)
 
   /**
-   * Keep normal table loading on the delegate path. If the delegate rejects the identifier as
-   * a table, try the UC view path with any view row from that load memoized.
+   * Keep normal table loading on the delegate path. If the UC table-only path finds a view, reuse
+   * the view metadata carried by its `NoSuchTableException` instead of issuing another UC lookup.
    */
   override def loadRelation(ident: Identifier): Relation = {
-    ucProxy.memoizeViewOnLoadTable(ident)
     try {
-      try {
-        delegate.loadTable(ident)
-      } catch {
-        case tableNotFound: NoSuchTableException =>
-          try {
-            ucProxy.loadView(ident)
-          } catch {
-            case _: NoSuchViewException => throw tableNotFound
-          }
-      }
-    } finally {
-      ucProxy.clearViewMemo()
+      delegate.loadTable(ident)
+    } catch {
+      case viewFound: ViewFoundDuringTableLoadException =>
+        val t = viewFound.tableInfo
+        if (UCViewTypes.isViewCommandsSupportedTableType(t.getTableType)) {
+          ucProxy.toView(t)
+        } else {
+          throw new UnsupportedOperationException(
+            s"Loading a ${t.getTableType} view is not supported yet")
+        }
     }
   }
 }

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
@@ -42,18 +42,23 @@ trait UCSingleCatalogViewSupport extends RelationCatalog { self: UCSingleCatalog
 
   /**
    * Keep normal table loading on the delegate path. If the delegate rejects the identifier as
-   * a table, try the UC view path.
+   * a table, try the UC view path with any view row from that load memoized.
    */
   override def loadRelation(ident: Identifier): Relation = {
+    ucProxy.memoizeViewOnLoadTable(ident)
     try {
-      delegate.loadTable(ident)
-    } catch {
-      case tableNotFound: NoSuchTableException =>
-        try {
-          ucProxy.loadView(ident)
-        } catch {
-          case _: NoSuchViewException => throw tableNotFound
-        }
+      try {
+        delegate.loadTable(ident)
+      } catch {
+        case tableNotFound: NoSuchTableException =>
+          try {
+            ucProxy.loadView(ident)
+          } catch {
+            case _: NoSuchViewException => throw tableNotFound
+          }
+      }
+    } finally {
+      ucProxy.clearViewMemo()
     }
   }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -635,6 +635,17 @@ private[spark] class UCProxy(
   with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
+  private[this] val viewMemo: ThreadLocal[(String, UCTableInfo)] =
+    new ThreadLocal[(String, UCTableInfo)]()
+  private[this] val memoizeView: ThreadLocal[String] = new ThreadLocal[String]()
+
+  private[spark] def memoizeViewOnLoadTable(ident: Identifier): Unit =
+    memoizeView.set(UCSingleCatalog.fullTableNameForApi(this.name, ident))
+
+  private[spark] def clearViewMemo(): Unit = {
+    memoizeView.remove()
+    viewMemo.remove()
+  }
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name
@@ -675,6 +686,11 @@ private[spark] class UCProxy(
   // own not-found result.
   private[spark] def getUCTableLike(ident: Identifier): Option[UCTableInfo] = {
     val fullName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
+    val memoized = viewMemo.get()
+    if (memoized != null && memoized._1 == fullName) {
+      viewMemo.remove()
+      return Some(memoized._2)
+    }
     try {
       Some(tablesApi.getTable(
         fullName,
@@ -686,10 +702,15 @@ private[spark] class UCProxy(
   }
 
   // Single-RPC table path. Calls UC `getTable` once and rejects view-like rows from the
-  // table-only surface by throwing `NoSuchTableException`.
+  // table-only surface by throwing `NoSuchTableException`. On Spark 4.2+, `loadRelation`
+  // catches that exception and falls back to `loadView` using the memoized view row.
   override def loadTable(ident: Identifier): Table = {
     val t = getUCTableLike(ident).getOrElse(throw new NoSuchTableException(ident))
     if (UCViewTypes.isViewLikeTableType(t.getTableType)) {
+      val fullName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
+      if (memoizeView.get() == fullName) {
+        viewMemo.set((fullName, t))
+      }
       throw new NoSuchTableException(ident)
     } else {
       loadV1Table(t)

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -620,6 +620,12 @@ object UCSingleCatalog {
 
 }
 
+/** Internal signal that preserves a view row rejected by the table-only catalog surface. */
+private[spark] final class ViewFoundDuringTableLoadException(
+    ident: Identifier,
+    val tableInfo: UCTableInfo)
+  extends NoSuchTableException(ident)
+
 // An internal proxy to talk to the UC client.
 private[spark] class UCProxy(
     uri: URI,
@@ -635,17 +641,6 @@ private[spark] class UCProxy(
   with Logging {
   private[this] var name: String = null
   private[this] var schemasApi: SchemasApi = null
-  private[this] val viewMemo: ThreadLocal[(String, UCTableInfo)] =
-    new ThreadLocal[(String, UCTableInfo)]()
-  private[this] val memoizeView: ThreadLocal[String] = new ThreadLocal[String]()
-
-  private[spark] def memoizeViewOnLoadTable(ident: Identifier): Unit =
-    memoizeView.set(UCSingleCatalog.fullTableNameForApi(this.name, ident))
-
-  private[spark] def clearViewMemo(): Unit = {
-    memoizeView.remove()
-    viewMemo.remove()
-  }
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     this.name = name
@@ -686,11 +681,6 @@ private[spark] class UCProxy(
   // own not-found result.
   private[spark] def getUCTableLike(ident: Identifier): Option[UCTableInfo] = {
     val fullName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
-    val memoized = viewMemo.get()
-    if (memoized != null && memoized._1 == fullName) {
-      viewMemo.remove()
-      return Some(memoized._2)
-    }
     try {
       Some(tablesApi.getTable(
         fullName,
@@ -702,16 +692,11 @@ private[spark] class UCProxy(
   }
 
   // Single-RPC table path. Calls UC `getTable` once and rejects view-like rows from the
-  // table-only surface by throwing `NoSuchTableException`. On Spark 4.2+, `loadRelation`
-  // catches that exception and falls back to `loadView` using the memoized view row.
+  // table-only surface by throwing `NoSuchTableException`.
   override def loadTable(ident: Identifier): Table = {
     val t = getUCTableLike(ident).getOrElse(throw new NoSuchTableException(ident))
     if (UCViewTypes.isViewLikeTableType(t.getTableType)) {
-      val fullName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
-      if (memoizeView.get() == fullName) {
-        viewMemo.set((fullName, t))
-      }
-      throw new NoSuchTableException(ident)
+      throw new ViewFoundDuringTableLoadException(ident, t)
     } else {
       loadV1Table(t)
     }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -337,6 +337,34 @@ public class UCViewProxySuite {
   }
 
   @Test
+  public void testUCSingleCatalogLoadRelationReusesViewFromDelegateLoadTable() throws Exception {
+    TableInfo ucMetricView =
+        new TableInfo()
+            .catalogName(CATALOG_NAME)
+            .schemaName(SCHEMA_NAME)
+            .name("mv1")
+            .tableType(TableType.METRIC_VIEW)
+            .viewDefinition("version: \"0.1\"");
+    when(mockTablesApi.getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true)))
+        .thenReturn(ucMetricView);
+
+    Identifier ident = Identifier.of(NAMESPACE, "mv1");
+    TableCatalog delegate = org.mockito.Mockito.mock(TableCatalog.class);
+    when(delegate.loadTable(eq(ident))).thenAnswer(invocation -> proxy.loadTable(ident));
+
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    setCatalogField(catalog, "delegate", delegate);
+    setCatalogField(catalog, "ucProxy", proxyRelations);
+
+    Relation relation = ((RelationCatalog) catalog).loadRelation(ident);
+
+    assertThat(relation).isInstanceOf(View.class);
+    verify(delegate).loadTable(eq(ident));
+    verify(mockTablesApi, org.mockito.Mockito.times(1))
+        .getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true));
+  }
+
+  @Test
   public void testLoadViewThrowsNoSuchViewForRegularTable() throws Exception {
     TableInfo ucTable =
         new TableInfo()

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -256,7 +256,7 @@ public class UCViewProxySuite {
   }
 
   @Test
-  public void testUCSingleCatalogLoadRelationFallsBackToLoadView() throws Exception {
+  public void testUCSingleCatalogLoadRelationReusesViewFromDelegate() throws Exception {
     TableInfo ucMetricView =
         new TableInfo()
             .catalogName(CATALOG_NAME)
@@ -269,7 +269,7 @@ public class UCViewProxySuite {
 
     Identifier ident = Identifier.of(NAMESPACE, "mv1");
     TableCatalog delegate = org.mockito.Mockito.mock(TableCatalog.class);
-    when(delegate.loadTable(eq(ident))).thenThrow(new NoSuchTableException(ident));
+    when(delegate.loadTable(eq(ident))).thenAnswer(invocation -> proxy.loadTable(ident));
 
     UCSingleCatalog catalog = new UCSingleCatalog();
     setCatalogField(catalog, "delegate", delegate);
@@ -279,7 +279,8 @@ public class UCViewProxySuite {
 
     assertThat(relation).isInstanceOf(View.class);
     verify(delegate).loadTable(eq(ident));
-    verify(mockTablesApi).getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true));
+    verify(mockTablesApi, org.mockito.Mockito.times(1))
+        .getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true));
   }
 
   @Test
@@ -312,6 +313,8 @@ public class UCViewProxySuite {
     assertThatThrownBy(() -> ((RelationCatalog) catalog).loadRelation(ident))
         .isSameAs(delegateError);
     verify(delegate).loadTable(eq(ident));
+    verify(mockTablesApi, org.mockito.Mockito.never())
+        .getTable(eq("test_catalog.test_schema.t1"), eq(true), eq(true));
   }
 
   @Test
@@ -334,34 +337,6 @@ public class UCViewProxySuite {
     assertThatThrownBy(() -> ((RelationCatalog) catalog).loadRelation(ident))
         .isSameAs(delegateError);
     verify(delegate).loadTable(eq(ident));
-  }
-
-  @Test
-  public void testUCSingleCatalogLoadRelationReusesViewFromDelegateLoadTable() throws Exception {
-    TableInfo ucMetricView =
-        new TableInfo()
-            .catalogName(CATALOG_NAME)
-            .schemaName(SCHEMA_NAME)
-            .name("mv1")
-            .tableType(TableType.METRIC_VIEW)
-            .viewDefinition("version: \"0.1\"");
-    when(mockTablesApi.getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true)))
-        .thenReturn(ucMetricView);
-
-    Identifier ident = Identifier.of(NAMESPACE, "mv1");
-    TableCatalog delegate = org.mockito.Mockito.mock(TableCatalog.class);
-    when(delegate.loadTable(eq(ident))).thenAnswer(invocation -> proxy.loadTable(ident));
-
-    UCSingleCatalog catalog = new UCSingleCatalog();
-    setCatalogField(catalog, "delegate", delegate);
-    setCatalogField(catalog, "ucProxy", proxyRelations);
-
-    Relation relation = ((RelationCatalog) catalog).loadRelation(ident);
-
-    assertThat(relation).isInstanceOf(View.class);
-    verify(delegate).loadTable(eq(ident));
-    verify(mockTablesApi, org.mockito.Mockito.times(1))
-        .getTable(eq("test_catalog.test_schema.mv1"), eq(true), eq(true));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This is stacked on #1675's commit which will be removed prior to merging. Please just review commit https://github.com/unitycatalog/unitycatalog/pull/1680/commits/469e3ac10616954a8dc6f561f23c9fcbc46c47ea

It adds one optimization commit on top of the Spark 4.2 upgrade. When Spark 4.2 loadRelation first tries delegate.loadTable and that path discovers the identifier is a view, UCProxy.loadTable temporarily saves that UC row. The fallback loadView then reuses the saved row instead of calling UC getTable a second time.

## Testing

- build/sbt -J-Xmx3G -DsparkVersion=4.2 -DskipDeltaSpark=true "spark/Compile/compile"
- Focused local invocation of UCViewProxySuite.testUCSingleCatalogLoadRelationReusesViewFromDelegateLoadTable: passed

Depends on #1675.
