### PR TITLE
fix(server): implement Delta reportMetrics endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -26,6 +26,7 @@ import io.unitycatalog.server.delta.model.DeltaCreateTableRequest;
 import io.unitycatalog.server.delta.model.DeltaCredentialOperation;
 import io.unitycatalog.server.delta.model.DeltaCredentialsResponse;
 import io.unitycatalog.server.delta.model.DeltaLoadTableResponse;
+import io.unitycatalog.server.delta.model.DeltaReportMetricsRequest;
 import io.unitycatalog.server.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.server.delta.model.DeltaTableType;
 import io.unitycatalog.server.delta.model.DeltaUpdateTableRequest;
@@ -263,6 +264,42 @@ public class DeltaApiService extends AuthorizedService {
       @Param("table") @AuthorizeResourceKey(TABLE) String table,
       DeltaUpdateTableRequest request) {
     return tableRepository.updateTableForDelta(catalog, schema, table, request);
+  }
+
+  // ==================== Report Metrics API ====================
+
+  /**
+   * Accept commit metrics (telemetry) reported by Delta clients after a commit (e.g. Delta Spark's
+   * UpdateMetricsHook). Per {@code delta.yaml}, the body's {@code table-id} must identify the same
+   * table as the path; mismatches are rejected. The metrics themselves are currently acknowledged
+   * and discarded -- the endpoint exists so post-commit metrics reporting succeeds instead of
+   * failing writes with 404.
+   */
+  @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics")
+  @AuthorizeExpression(AuthorizeExpressions.UPDATE_TABLE)
+  public HttpResponse reportMetrics(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table,
+      DeltaReportMetricsRequest request) {
+    if (request == null || request.getTableId() == null) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "Must supply table-id in the request body.");
+    }
+    TableInfoDAO tableInfo = tableRepository.findTableOrThrow(catalog, schema, table);
+    if (!tableInfo.getId().equals(request.getTableId())) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "table-id "
+              + request.getTableId()
+              + " does not match table "
+              + catalog
+              + "."
+              + schema
+              + "."
+              + table);
+    }
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   // ==================== Table Credentials API ====================

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -27,6 +27,7 @@ import io.unitycatalog.server.delta.model.DeltaCredentialOperation;
 import io.unitycatalog.server.delta.model.DeltaCredentialsResponse;
 import io.unitycatalog.server.delta.model.DeltaLoadTableResponse;
 import io.unitycatalog.server.delta.model.DeltaRenameTableRequest;
+import io.unitycatalog.server.delta.model.DeltaReportMetricsRequest;
 import io.unitycatalog.server.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.server.delta.model.DeltaTableType;
 import io.unitycatalog.server.delta.model.DeltaUpdateTableRequest;
@@ -284,6 +285,36 @@ public class DeltaApiService extends AuthorizedService {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "New table name is required.");
     }
     tableRepository.renameTable(catalog, schema, table, request.getNewName());
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+
+  // ==================== Report Metrics API ====================
+
+  /**
+   * Accept commit metrics reported by Delta clients after a commit (e.g. Delta Spark's {@code
+   * UpdateMetricsHook}). Per {@code delta.yaml} the body's {@code table-id} must identify the same
+   * table as the path; mismatches are rejected. The metrics are acknowledged and discarded -- UC
+   * does not persist client telemetry today. Authorization mirrors {@link #updateTable}, so a
+   * caller who can commit to the table can report metrics for it.
+   */
+  @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics")
+  @AuthorizeExpression(AuthorizeExpressions.UPDATE_TABLE)
+  public HttpResponse reportMetrics(
+      @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
+      @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
+      @Param("table") @AuthorizeResourceKey(TABLE) String table,
+      DeltaReportMetricsRequest request) {
+    if (request == null || request.getTableId() == null) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "table-id is required.");
+    }
+    TableInfoDAO tableInfo = tableRepository.findTableOrThrow(catalog, schema, table);
+    if (!tableInfo.getId().equals(request.getTableId())) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "table-id %s does not match table %s.%s.%s.",
+              request.getTableId(), catalog, schema, table));
+    }
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkReportMetricsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkReportMetricsTest.java
@@ -1,0 +1,146 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static io.unitycatalog.server.utils.TestUtils.assertApiExceptionStatusOnly;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.ApiResponse;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaErrorType;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequest;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateCatalog;
+import io.unitycatalog.client.model.CreateSchema;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for the UC Delta API reportMetrics endpoint. Regression test for the missing
+ * endpoint (issue #1654): the server advertised {@code POST .../tables/{table}/metrics} in its
+ * config endpoint list but did not implement it, so every post-commit metrics report from Delta
+ * clients failed with 404 and surfaced as a failed write.
+ */
+public class SdkReportMetricsTest extends BaseServerTest {
+
+  private static final String TABLE_NAME = "metrics_test_table";
+
+  private CatalogOperations catalogOps;
+  private SchemaOperations schemaOps;
+  private TableOperations tableOps;
+  private DeltaTablesApi deltaTablesApi;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    var apiClient = TestUtils.createApiClient(serverConfig);
+    catalogOps = new SdkCatalogOperations(apiClient);
+    schemaOps = new SdkSchemaOperations(apiClient);
+    tableOps = new SdkTableOperations(apiClient);
+    deltaTablesApi = new DeltaTablesApi(apiClient);
+    cleanUp();
+    createCatalogAndSchema();
+  }
+
+  private void cleanUp() {
+    try {
+      catalogOps.deleteCatalog(TestUtils.CATALOG_NAME, Optional.of(true));
+    } catch (Exception e) {
+      // Ignore
+    }
+  }
+
+  private void createCatalogAndSchema() {
+    try {
+      catalogOps.createCatalog(new CreateCatalog().name(TestUtils.CATALOG_NAME).comment("test"));
+      schemaOps.createSchema(
+          new CreateSchema().name(TestUtils.SCHEMA_NAME).catalogName(TestUtils.CATALOG_NAME));
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private UUID createTable() throws ApiException, IOException {
+    TableInfo table =
+        tableOps.createTable(
+            new CreateTable()
+                .name(TABLE_NAME)
+                .catalogName(TestUtils.CATALOG_NAME)
+                .schemaName(TestUtils.SCHEMA_NAME)
+                .tableType(TableType.EXTERNAL)
+                .dataSourceFormat(DataSourceFormat.DELTA)
+                .storageLocation("file:///tmp/uc_test/" + TABLE_NAME)
+                .columns(
+                    List.of(
+                        new ColumnInfo()
+                            .name("id")
+                            .typeName(ColumnTypeName.LONG)
+                            .typeText("bigint")
+                            .typeJson(
+                                "{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}")
+                            .position(0))));
+    return UUID.fromString(table.getTableId());
+  }
+
+  @Test
+  public void testReportMetrics() throws Exception {
+    UUID tableId = createTable();
+
+    // Success: matching table-id is acknowledged with 204 No Content
+    ApiResponse<Void> response =
+        deltaTablesApi.reportMetricsWithHttpInfo(
+            TestUtils.CATALOG_NAME,
+            TestUtils.SCHEMA_NAME,
+            TABLE_NAME,
+            new DeltaReportMetricsRequest().tableId(tableId));
+    assertThat(response.getStatusCode()).isEqualTo(204);
+
+    // Error: table-id not matching the path table returns 400
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                TABLE_NAME,
+                new DeltaReportMetricsRequest().tableId(UUID.randomUUID())),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "does not match");
+
+    // Error: missing table-id returns 400
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                TABLE_NAME,
+                new DeltaReportMetricsRequest()),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "table-id");
+
+    // Error: nonexistent table returns 404
+    assertApiExceptionStatusOnly(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                "nonexistent_table",
+                new DeltaReportMetricsRequest().tableId(tableId)),
+        404);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkReportMetricsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkReportMetricsTest.java
@@ -1,0 +1,82 @@
+package io.unitycatalog.server.sdk.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiResponse;
+import io.unitycatalog.client.delta.model.DeltaErrorType;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequest;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.delta.DeltaBaseTableCRUDTestEnv;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * E2E tests for the Delta REST Catalog {@code POST .../metrics} endpoint (204 on success, 400 when
+ * the body {@code table-id} is missing or does not match the path table, 404 when the table is
+ * missing).
+ */
+public class SdkReportMetricsTest extends DeltaBaseTableCRUDTestEnv {
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig serverConfig) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Test
+  public void testReportMetricsEndpoint() throws Exception {
+    Handle table = createDeltaManaged("metricsTable", Map.of());
+
+    // A matching table-id is acknowledged with 204 No Content.
+    ApiResponse<Void> response =
+        deltaTablesApi.reportMetricsWithHttpInfo(
+            TestUtils.CATALOG_NAME,
+            TestUtils.SCHEMA_NAME,
+            table.name(),
+            new DeltaReportMetricsRequest().tableId(table.tableId()));
+    assertThat(response.getStatusCode()).isEqualTo(204);
+
+    // A missing table-id is rejected before the table is looked up.
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                table.name(),
+                new DeltaReportMetricsRequest()),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "table-id is required");
+
+    // A table-id that resolves to a different table than the path is rejected.
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                table.name(),
+                new DeltaReportMetricsRequest().tableId(UUID.randomUUID())),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "does not match table");
+
+    // A missing table returns 404 even when the table-id is well-formed.
+    TestUtils.assertDeltaApiException(
+        () ->
+            deltaTablesApi.reportMetrics(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                "missingTable",
+                new DeltaReportMetricsRequest().tableId(table.tableId())),
+        DeltaErrorType.NO_SUCH_TABLE_EXCEPTION,
+        "Table not found");
+  }
+}


### PR DESCRIPTION
## Summary

Implements the missing `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics` (`reportMetrics`) endpoint in `DeltaApiService`.

The operation is fully specified in `api/delta.yaml` and advertised in the server's own `GET /delta/v1/config` endpoint list, but had no server-side handler. Delta clients (e.g. Delta Spark's `UpdateMetricsHook` via `UCDeltaTokenBasedRestClient`) report commit metrics after every commit, so on 0.5.0 the **second write to any table fails** with `IOException: Failed to report metrics ... (HTTP 404)`.

Behavior per spec:

| Case | Response |
|---|---|
| `table-id` matches the path table | `204 No Content` |
| `table-id` missing from the body | `400 INVALID_PARAMETER_VALUE` |
| `table-id` does not identify the path table (the spec explicitly requires this validation) | `400 INVALID_PARAMETER_VALUE` |
| Three-part table name does not resolve | `404 NO_SUCH_TABLE` |

Authorization mirrors the commit/`updateTable` path (`AuthorizeExpressions.UPDATE_TABLE`): a caller who can commit to the table can report metrics for it.

The metrics payload is acknowledged and discarded — UC does not persist client telemetry today, and deciding what to store/expose is a separate product decision. This PR unblocks the write path.

Fixes #1654.

## How we tested

New E2E test `SdkReportMetricsTest`, built on the `DeltaBaseTableCRUDTestEnv` scaffolding and shaped after `SdkRenameTableTest`: happy path asserts 204 via `reportMetricsWithHttpInfo`, plus missing `table-id` → 400, mismatched `table-id` → 400, and nonexistent table → 404.

TDD verification — the test was first run with the handler removed and reproduces the exact failure from the issue:

```
[error] Test io.unitycatalog.server.sdk.delta.SdkReportMetricsTest.testReportMetricsEndpoint failed:
        io.unitycatalog.client.ApiException: reportMetrics call failed with: 404 - Status: 404
[info] Test run finished: 1 failed, 0 ignored, 1 total
```

With the handler in place:

```
build/sbt "server/testOnly io.unitycatalog.server.sdk.delta.*"
[info] Passed: Total 11, Failed 0, Errors 0, Passed 11
```

All 11 Delta SDK test classes pass, including `SdkDeltaConfigTest`, which pins the advertised endpoint list.
