### PR TITLE
UUID-based commit idempotency for CCv2

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1464,6 +1464,8 @@ paths:
         most cases the number of unbackfilled commits should be close to zero or one. But if
         clients misbehave and unbackfilled commits accumulate beyond the limit, server will
         reject further commits until more backfill is done.
+        Replaying an already-accepted commit (same version and file-name) is an idempotent no-op
+        that returns 200, so a client that lost the response can safely resend.
         WARNING: This API is experimental and may change in future versions.
       operationId: commit
       requestBody:
@@ -1491,7 +1493,7 @@ paths:
         '404':
           description: Not Found. The specified table does not exist.
         '409':
-          description: Conflict. Indicates that a commit with the same version already exists.
+          description: Conflict. Indicates that a different commit with the same version already exists.
         '429':
           description: The maximum number of unbackfilled commits per table has been reached. Please backfill some commits before retrying.
         '500':

--- a/api/delta.yaml
+++ b/api/delta.yaml
@@ -269,6 +269,8 @@ paths:
         Update table properties, columns, or commit Delta changes. Unlike IRC, this endpoint
         does not support table creation. This endpoint also covers the coordinated commit flow
         described in the Unity Catalog Managed Tables Specification.
+        Replaying an already-accepted add-commit (same version and file-name) is an idempotent
+        whole-request no-op that returns 200, so a client that lost the response can safely resend.
       requestBody:
         required: true
         content:

--- a/server/src/main/java/io/unitycatalog/server/exception/TransactionRollbackException.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/TransactionRollbackException.java
@@ -1,0 +1,14 @@
+package io.unitycatalog.server.exception;
+
+/**
+ * Base for an exception a {@code TransactionManager} operation throws purely to roll its
+ * transaction back, not to report an error. {@code TransactionManager} rolls back and rethrows such
+ * an exception as-is (rather than wrapping it into an {@code INTERNAL} error), so the caller can
+ * catch its specific type and translate it into a normal outcome.
+ *
+ * <p>Unchecked so it propagates through the (undeclared) operation call chain, and an exception
+ * base class rather than a marker interface so {@code TransactionManager} can rethrow it
+ * type-safely without an unchecked cast. Subclasses must be caught by their originating caller;
+ * they are never meant to reach the HTTP layer.
+ */
+public abstract class TransactionRollbackException extends RuntimeException {}

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -765,6 +765,9 @@ public class DeltaCommitRepository {
    * conservatively reported as not-a-replay. The caller must hold the table lock (see {@link
    * #lockTableForCommit}).
    *
+   * <p>Filename with the client-generated, per-commit-unique UUID (or file content, if filename is
+   * no longer tracked in DB) is used for dedup.
+   *
    * @return {@code true} only if this matches an already-accepted commit; {@code false} for a fresh
    *     version, a genuine conflict, or a purged version
    */

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -4,6 +4,7 @@ import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.TransactionRollbackException;
 import io.unitycatalog.server.model.ColumnInfos;
 import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.DeltaCommit;
@@ -25,6 +26,7 @@ import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
+import jakarta.persistence.PessimisticLockException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -34,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.NativeQuery;
@@ -65,6 +68,20 @@ import org.slf4j.LoggerFactory;
  * </ol>
  */
 public class DeltaCommitRepository {
+
+  /**
+   * Thrown when a commit request is recognized as an idempotent replay of an already-accepted
+   * commit, to roll the whole transaction back so nothing the request applied (the commit, and on
+   * the Delta path any sibling metadata) is persisted; the commit entry point then catches it and
+   * reports a no-op success.
+   *
+   * <p>Not a client-facing error, so it deliberately does not extend {@link BaseException}. As a
+   * {@link TransactionRollbackException}, {@code TransactionManager} rolls back and rethrows it
+   * as-is instead of wrapping it into an {@code INTERNAL} error; it is always caught within {@link
+   * #postCommit} / {@link io.unitycatalog.server.persist.TableRepository#updateTableForDelta} and
+   * never reaches the HTTP layer.
+   */
+  static class CommitAlreadyAcceptedException extends TransactionRollbackException {}
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DeltaCommitRepository.class);
 
@@ -231,11 +248,23 @@ public class DeltaCommitRepository {
    * <p>The method validates the commit, ensures the table is a managed Delta table, and performs
    * the appropriate commit operation within a transaction.
    *
+   * <p>Replaying a commit already accepted for this table is an idempotent no-op success (not a
+   * conflict), so a client that lost the response can safely resend. See {@link
+   * #isAcceptedCommitReplay}.
+   *
    * @param commit the commit request containing version info, metadata, and backfill information
    * @throws BaseException if the commit is invalid, table is not found, or commit limits are
    *     exceeded
    */
   public void postCommit(DeltaCommit commit) {
+    try {
+      postCommitInTransaction(commit);
+    } catch (CommitAlreadyAcceptedException e) {
+      // Idempotent replay: the transaction rolled back to a no-op. Report success.
+    }
+  }
+
+  private void postCommitInTransaction(DeltaCommit commit) {
     serverProperties.checkManagedTableEnabled();
     validateCommit(commit);
     // Extract + shape-validate uniform fields outside the transaction. The subpath check (which
@@ -252,6 +281,10 @@ public class DeltaCommitRepository {
             throw new BaseException(
                 ErrorCode.TABLE_NOT_FOUND, "Table not found: " + commit.getTableId());
           }
+          // Serialize all commit/backfill mutations on this table by write-locking its uc_tables
+          // row, matching the Delta update path. This makes the commit-log reads and writes below
+          // atomic against a concurrent commit or backfill.
+          lockTableForCommit(session, tableInfoDAO, tableId);
           validateTableForCommit(session, commit, tableInfoDAO, uniformFields);
           postCommitCore(session, tableId, tableInfoDAO, commit, uniformFields);
           return null;
@@ -261,11 +294,36 @@ public class DeltaCommitRepository {
   }
 
   /**
+   * Acquire a {@code PESSIMISTIC_WRITE} lock on the table's {@code uc_tables} row so concurrent
+   * CCv2 commit/backfill transactions on the same table serialize. Shared by both commit entry
+   * points: UC REST {@code postCommit} and the Delta update path.
+   *
+   * <p>Call this before reading or mutating commit-log state (and, on the Delta path, before
+   * snapshotting the etag): {@code session.refresh} reloads the row, so calling it after in-memory
+   * DAO mutations would discard them.
+   *
+   * <p>A lock-wait timeout or deadlock surfaces as {@code UPDATE_REQUIREMENT_CONFLICT} (409) so the
+   * client retries, rather than as a generic 500.
+   */
+  public static void lockTableForCommit(Session session, TableInfoDAO dao, UUID tableId) {
+    try {
+      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
+    } catch (PessimisticLockException e) {
+      throw new BaseException(
+          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+          "Concurrent commit in progress on table " + tableId + "; retry the request.");
+    }
+  }
+
+  /**
    * Shared core of {@link #postCommit} and {@link #applyCommitAndBackfillInSession}: read the
    * first/last commits and route to {@link #handleOnboardingCommit} (no prior commits + commit info
    * present), {@link #handleBackfillOnlyCommit} (prior commits + commit info absent), or {@link
    * #handleNormalCommit} (prior commits + commit info present). A backfill-only request against an
    * empty commit log is rejected here directly with a caller-aware message.
+   *
+   * <p>An idempotent replay is detected within {@link #handleNormalCommit}, which throws {@link
+   * CommitAlreadyAcceptedException}.
    */
   private void postCommitCore(
       Session session,
@@ -455,12 +513,17 @@ public class DeltaCommitRepository {
    *   <li>Adding the new commit won't exceed the maximum commits per table limit
    * </ul>
    *
+   * <p>A resend of an already-accepted commit is detected here (see {@link
+   * CommitAlreadyAcceptedException}); a non-matching commit at an already-taken version is a
+   * genuine conflict.
+   *
    * @param session the Hibernate session for database operations
    * @param tableId the unique identifier of the table
    * @param tableInfoDAO the table information data access object
    * @param commit the commit request containing version info, optional backfill, and metadata
    * @param firstCommitDAO the first commit already in the database
    * @param lastCommitDAO the last commit already in the database
+   * @throws CommitAlreadyAcceptedException if this is an idempotent replay of an accepted commit
    * @throws BaseException if the commit version is invalid, already exists, or violates constraints
    */
   private static void handleNormalCommit(
@@ -476,6 +539,17 @@ public class DeltaCommitRepository {
     long lastCommitVersion = lastCommitDAO.getCommitVersion();
     long newCommitVersion = commitInfo.getVersion();
     if (newCommitVersion <= lastCommitVersion) {
+      if (isAcceptedCommitReplay(
+          session,
+          tableId,
+          newCommitVersion,
+          commitInfo.getFileName(),
+          firstCommitDAO,
+          lastCommitDAO)) {
+        // A replay of an already-accepted commit.
+        throw new CommitAlreadyAcceptedException();
+      }
+      // A non-matching commit at an already-taken version is a genuine conflict.
       throw new BaseException(
           ErrorCode.COMMIT_VERSION_CONFLICT,
           "Commit version already accepted. Current table version is " + lastCommitVersion);
@@ -679,6 +753,78 @@ public class DeltaCommitRepository {
   private static void saveCommit(Session session, UUID tableId, DeltaCommitInfo commitInfo) {
     DeltaCommitDAO deltaCommitDAO = DeltaCommitDAO.from(tableId, commitInfo);
     session.persist(deltaCommitDAO);
+  }
+
+  /**
+   * Whether this {@code add-commit} at {@code version} is a replay of a commit already accepted for
+   * this table, rather than a fresh commit or a genuine conflict at an already-taken version. A
+   * client that lost the response to an accepted commit may safely resend the whole request;
+   * recognizing the replay lets the server report success instead of a spurious conflict.
+   *
+   * <p>Covers only versions still tracked in the DB; a replay of a backfilled-and-purged version is
+   * conservatively reported as not-a-replay. The caller must hold the table lock (see {@link
+   * #lockTableForCommit}).
+   *
+   * @return {@code true} only if this matches an already-accepted commit; {@code false} for a fresh
+   *     version, a genuine conflict, or a purged version
+   */
+  private static boolean isAcceptedCommitReplay(
+      Session session,
+      UUID tableId,
+      long version,
+      String fileName,
+      DeltaCommitDAO firstCommitDAO,
+      DeltaCommitDAO lastCommitDAO) {
+    // Resolve the commit tracked at `version` against the caller's already-read boundary commits,
+    // querying the DB only for a version strictly between them (never re-reading the whole log).
+    DeltaCommitDAO existing;
+    if (version == lastCommitDAO.getCommitVersion()) {
+      existing = lastCommitDAO;
+    } else if (version == firstCommitDAO.getCommitVersion()) {
+      existing = firstCommitDAO;
+    } else if (version > firstCommitDAO.getCommitVersion()
+        && version < lastCommitDAO.getCommitVersion()) {
+      // Tracked commit versions are contiguous between the boundaries. The caller holds the table
+      // write lock, so no concurrent backfill can purge this version between reading the boundaries
+      // and this lookup; an in-range version must therefore have a row. A missing row means the
+      // uc_delta_commits table is internally inconsistent (a gap in the tracked range).
+      existing =
+          findCommitByVersion(session, tableId, version)
+              .orElseThrow(
+                  () ->
+                      new BaseException(
+                          ErrorCode.INTERNAL,
+                          "Inconsistent uc_delta_commits table for table "
+                              + tableId
+                              + ": no row tracked at in-range commit version "
+                              + version));
+    } else {
+      // Below the oldest tracked version, i.e. backfilled and purged. This could be a genuine
+      // replay, but the file name is no longer stored, so we can't confirm it. Conservatively
+      // treat it as a conflict.
+      // TODO: close this gap by comparing the incoming staged file against the published
+      // _delta_log/<v>.json.
+      return false;
+    }
+    // The file name embeds a client-generated, per-commit-unique UUID, used as the dedup handle: a
+    // match means the same commit replayed; a difference means another writer won that version.
+    return existing.getCommitFilename().equals(fileName);
+  }
+
+  /**
+   * Looks up the commit tracked at a specific version of a table, or empty if none. At most one row
+   * can match, per the {@code (table_id, commit_version)} unique constraint on {@link
+   * DeltaCommitDAO}.
+   */
+  private static Optional<DeltaCommitDAO> findCommitByVersion(
+      Session session, UUID tableId, long commitVersion) {
+    Query<DeltaCommitDAO> query =
+        session.createQuery(
+            "FROM DeltaCommitDAO WHERE tableId = :tableId AND commitVersion = :commitVersion",
+            DeltaCommitDAO.class);
+    query.setParameter("tableId", tableId);
+    query.setParameter("commitVersion", commitVersion);
+    return query.uniqueResultOptional();
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -284,7 +284,7 @@ public class DeltaCommitRepository {
           // Serialize all commit/backfill mutations on this table by write-locking its uc_tables
           // row, matching the Delta update path. This makes the commit-log reads and writes below
           // atomic against a concurrent commit or backfill.
-          lockTableForCommit(session, tableInfoDAO, tableId);
+          lockTableForCommit(session, tableInfoDAO, tableId, Optional.empty());
           validateTableForCommit(session, commit, tableInfoDAO, uniformFields);
           postCommitCore(session, tableId, tableInfoDAO, commit, uniformFields);
           return null;
@@ -305,13 +305,16 @@ public class DeltaCommitRepository {
    * <p>A lock-wait timeout or deadlock surfaces as {@code UPDATE_REQUIREMENT_CONFLICT} (409) so the
    * client retries, rather than as a generic 500.
    */
-  public static void lockTableForCommit(Session session, TableInfoDAO dao, UUID tableId) {
+  public static void lockTableForCommit(
+      Session session, TableInfoDAO dao, UUID tableId, Optional<String> tableFullNameForLogging) {
     try {
       session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
     } catch (PessimisticLockException e) {
       throw new BaseException(
           ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "Concurrent commit in progress on table " + tableId + "; retry the request.");
+          "Concurrent commit in progress on table "
+              + tableFullNameForLogging.orElseGet(tableId::toString)
+              + "; retry the request.");
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -768,8 +768,7 @@ public class DeltaCommitRepository {
    * conservatively reported as not-a-replay. The caller must hold the table lock (see {@link
    * #lockTableForCommit}).
    *
-   * <p>Filename with the client-generated, per-commit-unique UUID (or file content, if filename is
-   * no longer tracked in DB) is used for dedup.
+   * <p>Filename with the client-generated, per-commit-unique UUID is used for dedup.
    *
    * @return {@code true} only if this matches an already-accepted commit; {@code false} for a fresh
    *     version, a genuine conflict, or a purged version

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -40,7 +40,6 @@ import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
-import jakarta.persistence.PessimisticLockException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -52,7 +51,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
-import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -292,13 +290,31 @@ public class TableRepository {
    * <p>The transaction makes exactly one {@code uc_properties} read (via {@link
    * MutablePropertyMap#load}): all property-touching actions mutate the in-memory map, and a single
    * diff-flush at the end applies only the keys that actually changed. Request classification runs
-   * before opening the transaction (see {@link DeltaUpdateTableMapper#collectRequest}); inside,
-   * requirement checks run first so a stale-snapshot conflict short-circuits before any write is
-   * persisted. The DAO's {@code updatedAt}/{@code updatedBy} advance at the end only when the
-   * request changes catalog-visible metadata; data-only commits and backfill notifications leave
-   * them untouched.
+   * before opening the transaction (see {@link DeltaUpdateTableMapper#collectRequest}).
+   *
+   * <p>Requirement checks straddle the apply: {@code assert-table-uuid} up front, then the request
+   * is applied, then {@code assert-etag} (against the pre-apply etag). A resend of an
+   * already-accepted commit throws {@link DeltaCommitRepository.CommitAlreadyAcceptedException}
+   * from within the apply, which rolls the transaction back to a no-op; it is caught here and the
+   * current table state is returned as success. Because the throw unwinds before the {@code
+   * assert-etag} check, a replay carrying a now-stale etag still succeeds.
+   *
+   * <p>The DAO's {@code updatedAt}/{@code updatedBy} advance at the end only when the request
+   * changes catalog-visible metadata; data-only commits and backfill notifications leave them
+   * untouched.
    */
   public DeltaLoadTableResponse updateTableForDelta(
+      String catalog, String schema, String table, DeltaUpdateTableRequest request) {
+    try {
+      return updateTableForDeltaInTransaction(catalog, schema, table, request);
+    } catch (DeltaCommitRepository.CommitAlreadyAcceptedException e) {
+      // Idempotent replay: the transaction rolled back to a no-op. Return the current table state
+      // (a fresh read, since the rolled-back transaction produced no response).
+      return loadTableForDelta(catalog, schema, table);
+    }
+  }
+
+  private DeltaLoadTableResponse updateTableForDeltaInTransaction(
       String catalog, String schema, String table, DeltaUpdateTableRequest request) {
     DeltaUpdateTableMapper.CollectedRequest collected =
         DeltaUpdateTableMapper.collectRequest(request);
@@ -308,9 +324,16 @@ public class TableRepository {
         session -> {
           TableInfoDAO dao = findTableOrThrow(session, catalog, schema, table);
           requireDeltaTable(dao, catalog, schema, table);
-          lockTableForDeltaUpdate(session, dao, catalog, schema, table);
-          DeltaUpdateTableMapper.checkRequirements(dao, collected);
+          DeltaCommitRepository.lockTableForCommit(session, dao, dao.getId());
+          // assert-table-uuid is stable identity, so check it up front. assert-etag is deferred to
+          // after the apply, captured here against pre-apply state: a commit advances the etag, and
+          // an idempotent replay must bypass the etag entirely (it throws mid-apply and rolls back
+          // before the deferred check runs).
+          DeltaUpdateTableMapper.checkTableUuidRequirement(dao, collected);
+          String preApplyEtag = DeltaUpdateTableMapper.computeEtag(dao);
           MutablePropertyMap properties = MutablePropertyMap.load(session, dao.getId());
+          // The commit path throws CommitAlreadyAcceptedException on an idempotent replay (caught
+          // in updateTableForDelta); everything applied above is rolled back with it.
           DeltaUpdateTableMapper.applyUpdates(session, dao, properties, collected, serverProperties)
               .ifPresent(
                   d ->
@@ -322,6 +345,9 @@ public class TableRepository {
                               d.commit(),
                               d.uniformFields(),
                               d.latestBackfilledVersion()));
+          // Non-replay only (a replay already threw out): enforce assert-etag against pre-apply
+          // state, rolling back the applied changes on mismatch.
+          DeltaUpdateTableMapper.checkEtagRequirement(preApplyEtag, collected);
           properties.flush(session, dao.getId());
           // updatedAt/updatedBy track the last change to the table's catalog-visible metadata.
           // Data-only add-commit and backfill-only requests change no metadata, so they must
@@ -352,28 +378,6 @@ public class TableRepository {
       throw new BaseException(
           ErrorCode.UNSUPPORTED_TABLE_FORMAT,
           "Table is not a Delta table: " + catalog + "." + schema + "." + table);
-    }
-  }
-
-  /**
-   * Acquire {@code SELECT ... FOR UPDATE} on the table row and refresh in-memory state, so two
-   * concurrent {@link #updateTableForDelta} calls serialize. Lock-wait timeouts and deadlock
-   * victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
-   */
-  private static void lockTableForDeltaUpdate(
-      Session session, TableInfoDAO dao, String catalog, String schema, String table) {
-    try {
-      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
-    } catch (PessimisticLockException e) {
-      throw new BaseException(
-          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "Concurrent update in progress on "
-              + catalog
-              + "."
-              + schema
-              + "."
-              + table
-              + "; retry the request.");
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -319,12 +319,14 @@ public class TableRepository {
     DeltaUpdateTableMapper.CollectedRequest collected =
         DeltaUpdateTableMapper.collectRequest(request);
     String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String tableFullName = catalog + "." + schema + "." + table;
     return TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
           TableInfoDAO dao = findTableOrThrow(session, catalog, schema, table);
           requireDeltaTable(dao, catalog, schema, table);
-          DeltaCommitRepository.lockTableForCommit(session, dao, dao.getId());
+          DeltaCommitRepository.lockTableForCommit(
+              session, dao, dao.getId(), Optional.of(tableFullName));
           // assert-table-uuid is stable identity, so check it up front. assert-etag is deferred to
           // after the apply, captured here against pre-apply state: a commit advances the etag, and
           // an idempotent replay must bypass the etag entirely (it throws mid-apply and rolls back
@@ -361,7 +363,7 @@ public class TableRepository {
           return buildLoadTableResponse(
               session, dao, Optional.of(properties.asMap()), catalog, schema, table);
         },
-        "Failed to update table " + catalog + "." + schema + "." + table,
+        "Failed to update table " + tableFullName,
         /* readOnly = */ false);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
@@ -2,6 +2,7 @@ package io.unitycatalog.server.persist.utils;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.TransactionRollbackException;
 import java.util.Optional;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -90,6 +91,12 @@ public class TransactionManager {
         return result;
       } catch (Exception e) {
         tx.rollback();
+        // A control-flow signal (e.g. an idempotent-replay short-circuit) is not an error: rethrow
+        // it as-is, without error logging, so the caller can catch its specific type. The rollback
+        // above has already undone its work.
+        if (e instanceof TransactionRollbackException) {
+          throw (TransactionRollbackException) e;
+        }
         LOGGER.debug(errorMessage, e);
         if (e instanceof BaseException) {
           throw (BaseException) e;

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -55,7 +55,8 @@ import org.hibernate.Session;
  *
  * <ol>
  *   <li>{@link #collectRequest} -- pre-transaction shape checks; classify by subtype.
- *   <li>{@link #checkRequirements} -- {@code assert-*} requirements against the loaded DAO.
+ *   <li>{@link #checkTableUuidRequirement} / {@link #checkEtagRequirement} -- {@code assert-*}
+ *       requirements against the loaded DAO.
  *   <li>{@link #applyUpdates} -- dispatch each action onto the DAO and property map.
  * </ol>
  *
@@ -287,27 +288,34 @@ public final class DeltaUpdateTableMapper {
 
   // ---------------------------------------------------------------------- requirements check
 
-  /** Failures raise {@link ErrorCode#UPDATE_REQUIREMENT_CONFLICT} so the client retries. */
-  public static void checkRequirements(TableInfoDAO dao, CollectedRequest collected) {
-    CollectedRequirements r = collected.requirements();
-    r.assertTableUuid.ifPresent(u -> checkAssertTableUuid(dao, u));
-    r.assertEtag.ifPresent(e -> checkAssertEtag(dao, e));
-  }
-
-  private static void checkAssertTableUuid(TableInfoDAO dao, DeltaAssertTableUUID u) {
-    if (!Objects.equals(u.getUuid(), dao.getId())) {
+  /**
+   * Checks the {@code assert-table-uuid} requirement, if present, raising {@link
+   * ErrorCode#UPDATE_REQUIREMENT_CONFLICT} on mismatch.
+   */
+  public static void checkTableUuidRequirement(TableInfoDAO dao, CollectedRequest collected) {
+    Optional<UUID> assertUuid =
+        collected.requirements().assertTableUuid.map(DeltaAssertTableUUID::getUuid);
+    UUID tableUuid = dao.getId();
+    if (assertUuid.isPresent() && !Objects.equals(assertUuid.get(), tableUuid)) {
       throw new BaseException(
           ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "assert-table-uuid failed: expected " + u.getUuid() + " but table has " + dao.getId());
+          "assert-table-uuid failed: expected " + assertUuid.get() + " but table has " + tableUuid);
     }
   }
 
-  private static void checkAssertEtag(TableInfoDAO dao, DeltaAssertEtag e) {
-    String currentEtag = computeEtag(dao);
-    if (!Objects.equals(currentEtag, e.getEtag())) {
+  /**
+   * Checks the {@code assert-etag} requirement, if present, against {@code preApplyEtag}, raising
+   * {@link ErrorCode#UPDATE_REQUIREMENT_CONFLICT} on mismatch. The caller passes the pre-apply etag
+   * because applying a commit can advance {@code updatedAt} (and the etag), so recomputing here
+   * would compare against post-mutation state.
+   */
+  public static void checkEtagRequirement(String preApplyEtag, CollectedRequest collected) {
+    Optional<String> assertEtag =
+        collected.requirements().assertEtag.map(DeltaAssertEtag::getEtag);
+    if (assertEtag.isPresent() && !Objects.equals(preApplyEtag, assertEtag.get())) {
       throw new BaseException(
           ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "assert-etag failed: expected " + e.getEtag() + " but table has " + currentEtag);
+          "assert-etag failed: expected " + assertEtag.get() + " but table has " + preApplyEtag);
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.exception.TransactionRollbackException;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.sql.Connection;
@@ -116,6 +117,28 @@ public class TransactionManagerTest {
           .isInstanceOf(BaseException.class)
           .hasMessageContaining(errorMessage)
           .hasMessageContaining(testException.getMessage());
+
+      verify(transaction).rollback();
+      verify(transaction, never()).commit();
+    }
+
+    @Test
+    public void testTransactionRollbackExceptionIsRethrownAsIsNotWrapped() {
+      // A TransactionRollbackException signals rollback, not an error, so it is rethrown by
+      // identity for the caller to catch, not wrapped into a BaseException/INTERNAL.
+      class SignalException extends TransactionRollbackException {}
+      SignalException signal = new SignalException();
+
+      assertThatThrownBy(
+              () ->
+                  TransactionManager.executeWithTransaction(
+                      sessionFactory,
+                      session -> {
+                        throw signal;
+                      },
+                      "Error executing operation",
+                      false))
+          .isSameAs(signal);
 
       verify(transaction).rollback();
       verify(transaction, never()).commit();

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -422,7 +422,7 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
           DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
           "assert-table-uuid requirement is required");
 
-      // assert-table-uuid mismatch: rejected during checkRequirements.
+      // assert-table-uuid mismatch: rejected during checkTableUuidRequirement.
       TestUtils.assertDeltaApiException(
           () -> updateTable(h.name(), requestWith(UUID.randomUUID(), setKv)),
           DeltaErrorType.UPDATE_REQUIREMENT_CONFLICT_EXCEPTION,
@@ -605,9 +605,31 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(r1.getMetadata().getUpdatedTime()).isEqualTo(t0);
       assertThat(r1.getMetadata().getEtag()).isEqualTo(h.etag());
 
-      // Replaying v1 should surface as a CommitVersionConflict (409). Pin assert-etag against
-      // the post-r1 etag so the conflict comes from the version check, not from assert-etag.
       Handle h1 = h.withEtag(r1.getMetadata().getEtag());
+
+      // UUID-based idempotency: replaying the identical v1 add-commit (same file name / UUID)
+      // must succeed as a no-op rather than conflict, so a client that lost the original response
+      // is not misled into rebasing and duplicating the commit. The table state is unchanged.
+      DeltaLoadTableResponse rReplay =
+          updateTable(
+              h1,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(1L)
+                          .timestamp(1700000001L)
+                          .fileName("00000001.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000001L)));
+      assertThat(rReplay.getCommits()).hasSize(1);
+      assertThat(rReplay.getCommits().get(0).getVersion()).isEqualTo(1L);
+      assertThat(rReplay.getCommits().get(0).getFileName()).isEqualTo("00000001.json");
+      assertThat(rReplay.getLatestTableVersion()).isEqualTo(1L);
+      assertThat(rReplay.getMetadata().getEtag()).isEqualTo(r1.getMetadata().getEtag());
+
+      // Replaying v1 with a DIFFERENT file name means another writer won that version: this must
+      // surface as a CommitVersionConflict (409). Pin assert-etag against the post-r1 etag so the
+      // conflict comes from the version check, not from assert-etag.
       TestUtils.assertDeltaApiException(
           () ->
               updateTable(
@@ -638,6 +660,201 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
                               .fileModificationTimestamp(1700000003L))),
           DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
           "next version");
+    }
+
+    // -------- idempotent replay of non-newest tracked versions (first-DAO + DB-lookup branches) --
+    {
+      Handle h = createDeltaManaged("tbl_commit_idempotent_multi", Map.of());
+      Handle cur = h;
+      // Build up three tracked, unbackfilled commits: v1, v2, v3.
+      for (long v = 1; v <= 3; v++) {
+        DeltaLoadTableResponse r =
+            updateTable(
+                cur,
+                new DeltaAddCommitUpdate()
+                    .commit(
+                        new DeltaCommit()
+                            .version(v)
+                            .timestamp(1700000000L + v)
+                            .fileName(String.format("%08d.json", v))
+                            .fileSize(1024L)
+                            .fileModificationTimestamp(1700000000L + v)));
+        cur = cur.withEtag(r.getMetadata().getEtag());
+      }
+      final Handle h3 = cur;
+
+      // Replay the OLDEST tracked version (v1) with its original file name -> idempotent 200.
+      DeltaLoadTableResponse replayFirst =
+          updateTable(
+              h3,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(1L)
+                          .timestamp(1700000001L)
+                          .fileName("00000001.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000001L)));
+      assertThat(replayFirst.getLatestTableVersion()).isEqualTo(3L);
+      assertThat(replayFirst.getCommits()).hasSize(3);
+
+      // Replay a MIDDLE tracked version (v2) with its original file name -> idempotent 200. This
+      // is the branch that resolves the existing commit via a DB lookup rather than a boundary DAO.
+      DeltaLoadTableResponse replayMiddle =
+          updateTable(
+              h3,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(2L)
+                          .timestamp(1700000002L)
+                          .fileName("00000002.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000002L)));
+      assertThat(replayMiddle.getLatestTableVersion()).isEqualTo(3L);
+      assertThat(replayMiddle.getCommits()).hasSize(3);
+
+      // A middle version with a DIFFERENT file name is still a genuine conflict.
+      TestUtils.assertDeltaApiException(
+          () ->
+              updateTable(
+                  h3,
+                  new DeltaAddCommitUpdate()
+                      .commit(
+                          new DeltaCommit()
+                              .version(2L)
+                              .timestamp(1700000002L)
+                              .fileName("00000002_other.json")
+                              .fileSize(1024L)
+                              .fileModificationTimestamp(1700000002L))),
+          DeltaErrorType.COMMIT_VERSION_CONFLICT_EXCEPTION,
+          "already accepted");
+    }
+
+    // -------- assert-etag is skipped for a verified commit replay, enforced otherwise --------
+    {
+      Handle h = createDeltaManaged("tbl_commit_idempotent_meta", Map.of());
+      DeltaLoadTableResponse r1 =
+          updateTable(
+              h,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(1L)
+                          .timestamp(1700000001L)
+                          .fileName("00000001.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000001L)),
+              new DeltaSetPropertiesUpdate().updates(Map.of("k", "v")));
+      // The metadata change rolled the etag, so h.etag() is now stale.
+      assertThat(r1.getMetadata().getEtag()).isNotEqualTo(h.etag());
+      Handle hStale = h; // pins the stale (pre-commit) etag
+
+      // Verified replay with the STALE etag pinned: recognized as an already-accepted commit, so
+      // the whole request is a 200 no-op (the stale etag does not conflict) and the table is
+      // unchanged.
+      DeltaLoadTableResponse replayStaleEtag =
+          updateTable(
+              hStale,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(1L)
+                          .timestamp(1700000001L)
+                          .fileName("00000001.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000001L)),
+              new DeltaSetPropertiesUpdate().updates(Map.of("k", "v")));
+      assertThat(replayStaleEtag.getLatestTableVersion()).isEqualTo(1L);
+      assertThat(replayStaleEtag.getCommits()).hasSize(1);
+      assertThat(replayStaleEtag.getMetadata().getProperties()).containsEntry("k", "v");
+
+      // A genuine NEW commit (v2) with the STALE etag is NOT a replay, so assert-etag is enforced
+      // and the stale etag correctly fails -- optimistic concurrency still protects real writes.
+      TestUtils.assertDeltaApiException(
+          () ->
+              updateTable(
+                  hStale,
+                  new DeltaAddCommitUpdate()
+                      .commit(
+                          new DeltaCommit()
+                              .version(2L)
+                              .timestamp(1700000002L)
+                              .fileName("00000002.json")
+                              .fileSize(1024L)
+                              .fileModificationTimestamp(1700000002L))),
+          DeltaErrorType.UPDATE_REQUIREMENT_CONFLICT_EXCEPTION,
+          "assert-etag failed");
+
+      // The same NEW v2 commit with the CURRENT etag proceeds normally (table still at v1). The
+      // replay above was a no-op, so the etag is unchanged from r1.
+      Handle hFresh = h.withEtag(replayStaleEtag.getMetadata().getEtag());
+      DeltaLoadTableResponse rNext =
+          updateTable(
+              hFresh,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(2L)
+                          .timestamp(1700000002L)
+                          .fileName("00000002.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000002L)));
+      assertThat(rNext.getLatestTableVersion()).isEqualTo(2L);
+    }
+
+    // -------- a commit replay is a whole-request no-op, even with a stale etag and extra actions
+    // --
+    // The client's original v2 attempt (commit-only) landed but the response was lost. The retry
+    // resends the identical v2 commit, pins the now-stale (pre-v2) etag, and folds in a new
+    // backfill
+    // of v1. Because the commit is a recognized replay, the whole request is a no-op success: the
+    // stale etag does not conflict, and the extra backfill is NOT applied (v1 is retained). To
+    // report backfill after a lost response, the client sends a standalone
+    // set-latest-backfilled-version.
+    {
+      Handle h = createDeltaManaged("tbl_replay_whole_request_noop", Map.of());
+      DeltaLoadTableResponse r1 =
+          updateTable(
+              h,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(1L)
+                          .timestamp(1700000001L)
+                          .fileName("00000001.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000001L)));
+      // Data-only commit does not roll the etag.
+      Handle afterV1 = h.withEtag(r1.getMetadata().getEtag());
+      updateTable(
+          afterV1,
+          new DeltaAddCommitUpdate()
+              .commit(
+                  new DeltaCommit()
+                      .version(2L)
+                      .timestamp(1700000002L)
+                      .fileName("00000002.json")
+                      .fileSize(1024L)
+                      .fileModificationTimestamp(1700000002L)));
+
+      // Replay v2 (same file name) + report backfill of v1, pinning the now-stale afterV1 etag.
+      DeltaLoadTableResponse replay =
+          updateTable(
+              afterV1,
+              new DeltaAddCommitUpdate()
+                  .commit(
+                      new DeltaCommit()
+                          .version(2L)
+                          .timestamp(1700000002L)
+                          .fileName("00000002.json")
+                          .fileSize(1024L)
+                          .fileModificationTimestamp(1700000002L)),
+              new DeltaSetLatestBackfilledVersionUpdate().latestPublishedVersion(1L));
+      // Whole-request no-op: no conflict from the stale etag, and the backfill did NOT run, so both
+      // v1 and v2 remain unbackfilled.
+      assertThat(replay.getLatestTableVersion()).isEqualTo(2L);
+      assertThat(replay.getCommits()).hasSize(2);
     }
 
     // -------- add-commit + set-latest-backfilled-version in one request --------
@@ -811,11 +1028,10 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
     }
 
     // -------- set-latest-backfilled-version alone on a table with prior commits --------
-    // Exercises the standalone backfill branch (handleBackfillOnlyCommit) that the combined
-    // add-commit + backfill test doesn't reach (that one goes through handleNormalCommit). The
-    // post-backfill commits list isn't asserted: markCommitAsLatestBackfilled issues a native
-    // SQL UPDATE that the session cache doesn't reflect in the same-transaction read used to
-    // build the response.
+    // Exercises the standalone backfill-only branch that the combined add-commit + backfill test
+    // doesn't reach (that one goes through handleNormalCommit). The post-backfill commits list
+    // isn't asserted: markCommitAsLatestBackfilled issues a native SQL UPDATE that the session
+    // cache doesn't reflect in the same-transaction read used to build the response.
     {
       Handle h = createDeltaManaged("tbl_backfill_only", Map.of());
       DeltaLoadTableResponse r1 =

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -803,15 +803,13 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(rNext.getLatestTableVersion()).isEqualTo(2L);
     }
 
-    // -------- a commit replay is a whole-request no-op, even with a stale etag and extra actions
-    // --
+    // ------- a commit replay is a whole-request no-op, even with a stale etag and extra actions --
     // The client's original v2 attempt (commit-only) landed but the response was lost. The retry
     // resends the identical v2 commit, pins the now-stale (pre-v2) etag, and folds in a new
-    // backfill
-    // of v1. Because the commit is a recognized replay, the whole request is a no-op success: the
-    // stale etag does not conflict, and the extra backfill is NOT applied (v1 is retained). To
-    // report backfill after a lost response, the client sends a standalone
-    // set-latest-backfilled-version.
+    // backfill of v1.
+    // Because the commit is a recognized replay, the whole request is a no-op success: the stale
+    // etag does not conflict, and the extra backfill is NOT applied (v1 is retained). To report
+    // backfill after a lost response, the client sends a standalone set-latest-backfilled-version.
     {
       Handle h = createDeltaManaged("tbl_replay_whole_request_noop", Map.of());
       DeltaLoadTableResponse r1 =

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -255,13 +255,14 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation());
     deltaCommitsApi.commit(commit1);
 
-    // Commit the same version again, and it would fail
-    assertApiException(
-        () -> deltaCommitsApi.commit(commit1),
-        ErrorCode.ALREADY_EXISTS,
-        "Commit version already accepted.");
+    // UUID-based idempotency: replaying the identical commit (same version + same file name) is a
+    // no-op success, not a conflict, so a client that lost the response is not misled into
+    // rebasing and duplicating the commit. The table state is unchanged.
+    deltaCommitsApi.commit(commit1);
+    verifyDeltaCommits(
+        /* expectedLatestTableVersion= */ 1, /* expectedCommits= */ commit1);
 
-    // Commit the same version again with a different filename: the same failure
+    // Committing the same version with a DIFFERENT filename means another writer won it: conflict.
     DeltaCommit commit1_other_filename =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation());
     commit1_other_filename.getCommitInfo().setFileName("some_other_filename_" + UUID.randomUUID());
@@ -287,9 +288,12 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Then we can commit 3
     deltaCommitsApi.commit(commit3);
 
-    // Commit the old version 1 again, and it would fail
+    // Replay the old version 1 again (still unbackfilled, so still tracked): identical file name
+    // -> idempotent no-op success even though it is no longer the latest version.
+    deltaCommitsApi.commit(commit1);
+    // Replay old version 1 with a different file name -> genuine conflict.
     assertApiException(
-        () -> deltaCommitsApi.commit(commit1),
+        () -> deltaCommitsApi.commit(commit1_other_filename),
         ErrorCode.ALREADY_EXISTS,
         "Commit version already accepted.");
 
@@ -335,6 +339,22 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaCommits(
         /* expectedLatestTableVersion= */ 4);
 
+    // The latest backfilled version (v4) is retained as a marker row that keeps its file name (it
+    // is flagged, not purged), so an identical replay of that commit is still recognized as an
+    // idempotent no-op success rather than a conflict.
+    deltaCommitsApi.commit(commit4);
+    verifyDeltaCommits(
+        /* expectedLatestTableVersion= */ 4);
+
+    // Known limitation (see DeltaCommitRepository idempotency TODO): once a version is backfilled
+    // and purged, its file name is no longer tracked, so an idempotent replay of that same commit
+    // can no longer be recognized and surfaces as a conflict. Here versions 2 and 3 were purged by
+    // the backfill above, so replaying the identical commit2 conflicts rather than no-op'ing.
+    assertApiException(
+        () -> deltaCommitsApi.commit(commit2),
+        ErrorCode.ALREADY_EXISTS,
+        "Commit version already accepted.");
+
     // Commit one more version before deleting the table
     DeltaCommit commit5 =
         createCommitObject(tableInfo.getTableId(), 5L, tableInfo.getStorageLocation());
@@ -354,6 +374,27 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         "Table not found");
     List<DeltaCommitDAO> commitDAOs = getCommitDAOs(UUID.fromString(tableInfo.getTableId()));
     assertThat(commitDAOs.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testCommitReplayIsWholeRequestNoOp() throws ApiException {
+    // Commit v1 and v2 (commit-only, no backfill): DB tracks [v1, v2].
+    DeltaCommit commit1 =
+        createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation());
+    DeltaCommit commit2 =
+        createCommitObject(tableInfo.getTableId(), 2L, tableInfo.getStorageLocation());
+    deltaCommitsApi.commit(commit1);
+    deltaCommitsApi.commit(commit2);
+    assertThat(getCommitDAOs(UUID.fromString(tableInfo.getTableId())).size()).isEqualTo(2);
+
+    // Replay v2 (identical file name -> recognized replay) but now ALSO folding in a backfill of
+    // v1. A commit replay is a whole-request no-op success: the request already landed once, so the
+    // extra backfill is NOT applied. Both v1 and v2 remain. (To report backfill after a lost
+    // response, the client sends a standalone set-latest-backfilled-version.)
+    deltaCommitsApi.commit(commit2.latestBackfilledVersion(1L));
+    List<DeltaCommitDAO> remaining = getCommitDAOs(UUID.fromString(tableInfo.getTableId()));
+    assertThat(remaining.size()).isEqualTo(2);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 2, /* expectedCommits= */ 2L, 1L);
   }
 
   private void checkCommitInvalidParameter(

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapperTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapperTest.java
@@ -201,7 +201,7 @@ public class DeltaUpdateTableMapperTest {
 
     assertThatCode(
             () ->
-                DeltaUpdateTableMapper.checkRequirements(
+                DeltaUpdateTableMapper.checkTableUuidRequirement(
                     dao,
                     collectRequestFor(
                         new DeltaAssertTableUUID().uuid(id).type("assert-table-uuid"))))
@@ -216,7 +216,7 @@ public class DeltaUpdateTableMapperTest {
 
     assertThatThrownBy(
             () ->
-                DeltaUpdateTableMapper.checkRequirements(
+                DeltaUpdateTableMapper.checkTableUuidRequirement(
                     dao,
                     collectRequestFor(
                         new DeltaAssertTableUUID()
@@ -228,34 +228,30 @@ public class DeltaUpdateTableMapperTest {
 
   @Test
   public void assertEtagHappyPath() {
-    TableInfoDAO dao = new TableInfoDAO();
-    dao.setId(UUID.randomUUID());
-    Date updatedAt = new Date();
-    dao.setUpdatedAt(updatedAt);
-
-    String expectedEtag = "etag-" + updatedAt.getTime();
+    // The client's assert-etag matches the pre-apply etag, so the check passes.
+    String preApplyEtag = "etag-1700000000000";
     assertThatCode(
             () ->
-                DeltaUpdateTableMapper.checkRequirements(
-                    dao,
+                DeltaUpdateTableMapper.checkEtagRequirement(
+                    preApplyEtag,
                     collectRequestFor(
-                        new DeltaAssertTableUUID().uuid(dao.getId()).type("assert-table-uuid"),
-                        new DeltaAssertEtag().etag(expectedEtag).type("assert-etag"))))
+                        new DeltaAssertTableUUID()
+                            .uuid(UUID.randomUUID())
+                            .type("assert-table-uuid"),
+                        new DeltaAssertEtag().etag(preApplyEtag).type("assert-etag"))))
         .doesNotThrowAnyException();
   }
 
   @Test
   public void assertEtagMismatchSurfacesUpdateRequirementConflict() {
-    TableInfoDAO dao = new TableInfoDAO();
-    dao.setId(UUID.randomUUID());
-    dao.setUpdatedAt(new Date());
-
     assertThatThrownBy(
             () ->
-                DeltaUpdateTableMapper.checkRequirements(
-                    dao,
+                DeltaUpdateTableMapper.checkEtagRequirement(
+                    "etag-current",
                     collectRequestFor(
-                        new DeltaAssertTableUUID().uuid(dao.getId()).type("assert-table-uuid"),
+                        new DeltaAssertTableUUID()
+                            .uuid(UUID.randomUUID())
+                            .type("assert-table-uuid"),
                         new DeltaAssertEtag().etag("etag-stale").type("assert-etag"))))
         .isInstanceOf(BaseException.class)
         .hasMessageContaining("assert-etag failed");


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1685/files) to review incremental changes.
- [stack/ccv2_idempotency_uuid](https://github.com/unitycatalog/unitycatalog/pull/1685) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1685/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

UUID-based commit idempotency for CCv2

Replaying a commit already accepted for a table is now an idempotent no-op success instead of a 409 conflict, so a client that lost the response to an accepted commit can safely resend.

- Detect replays via the per-commit UUID in the commit file name.
- Serialize per-table commit/backfill with a `PESSIMISTIC_WRITE` lock on the `uc_tables` row, shared by the REST and Delta paths.
- Short-circuit a replay with `CommitAlreadyAcceptedException` to roll the transaction back to a no-op; defer `assert-etag` past the apply so a stale-etag replay still succeeds.

Tested on both entry points, with full branch coverage of the replay check.