### PR TITLE
add single source of truth for supported cloud schemes

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CloudType.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CloudType.java
@@ -1,17 +1,34 @@
 package io.unitycatalog.hadoop.internal;
 
-public final class CloudType {
-  private CloudType() {}
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
-  public static boolean isSupportedScheme(String scheme) {
-    switch (scheme) {
-      case "s3":
-      case "gs":
-      case "abfs":
-      case "abfss":
-        return true;
-      default:
-        return false;
+/** The connector's single source of truth for cloud storage types and their schemes. */
+public enum CloudType {
+  S3("s3", "s3a"),
+  GCS("gs"),
+  ABFS("abfs", "abfss");
+
+  private final Set<String> schemes;
+
+  private static final Map<String, CloudType> BY_SCHEME = new HashMap<>();
+
+  static {
+    for (CloudType type : values()) {
+      for (String scheme : type.schemes) {
+        BY_SCHEME.put(scheme, type);
+      }
     }
+  }
+
+  CloudType(String... schemes) {
+    this.schemes = Set.of(schemes);
+  }
+
+  /** Resolves a scheme to its underlying {@link CloudType}. */
+  public static Optional<CloudType> fromScheme(String scheme) {
+    return Optional.ofNullable(BY_SCHEME.get(scheme));
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -466,14 +467,16 @@ public class CredPropsUtil {
       Map<String, String> appVersions,
       CredId credId)
       throws ApiException {
-    if (!CloudType.isSupportedScheme(scheme)) {
+    Optional<CloudType> cloudType = CloudType.fromScheme(scheme);
+    if (cloudType.isEmpty()) {
+      // Unsupported scheme: skip the credential fetch entirely and return no props.
       return Collections.emptyMap();
     }
     GenericCredential cred =
         fetchGenericCredential(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
-    switch (scheme) {
-      case "s3":
+    switch (cloudType.get()) {
+      case S3:
         if (renewCredEnabled) {
           return s3TempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
@@ -483,7 +486,7 @@ public class CredPropsUtil {
         } else {
           return s3FixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
-      case "gs":
+      case GCS:
         if (renewCredEnabled) {
           return gcsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
@@ -493,8 +496,7 @@ public class CredPropsUtil {
         } else {
           return gsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
-      case "abfss":
-      case "abfs":
+      case ABFS:
         if (renewCredEnabled) {
           return abfsTempCredPropsBuilder(
                   credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
@@ -504,9 +506,8 @@ public class CredPropsUtil {
         } else {
           return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
         }
-      default:
-        return Collections.emptyMap();
     }
+    throw new IllegalStateException("Unhandled cloud type: " + cloudType.get());
   }
 
   /**

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CloudTypeTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CloudTypeTest.java
@@ -1,0 +1,28 @@
+package io.unitycatalog.hadoop.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CloudTypeTest {
+
+  @Test
+  void fromSchemeResolvesSupportedSchemes() {
+    assertThat(CloudType.fromScheme("s3")).contains(CloudType.S3);
+    assertThat(CloudType.fromScheme("s3a")).contains(CloudType.S3);
+    assertThat(CloudType.fromScheme("gs")).contains(CloudType.GCS);
+    assertThat(CloudType.fromScheme("abfs")).contains(CloudType.ABFS);
+    assertThat(CloudType.fromScheme("abfss")).contains(CloudType.ABFS);
+  }
+
+  @Test
+  void fromSchemeReturnsEmptyForUnsupportedScheme() {
+    assertThat(CloudType.fromScheme("s3n")).isEmpty(); // unsupported alias
+    assertThat(CloudType.fromScheme("S3")).isEmpty(); // case-sensitive
+    assertThat(CloudType.fromScheme("ABFSS")).isEmpty(); // case-sensitive
+    assertThat(CloudType.fromScheme("hdfs")).isEmpty();
+    assertThat(CloudType.fromScheme("file")).isEmpty();
+    assertThat(CloudType.fromScheme("")).isEmpty();
+    assertThat(CloudType.fromScheme(null)).isEmpty();
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1686/files) to review incremental changes.
- [**stack/cloud-type-source-of-truth**](https://github.com/unitycatalog/unitycatalog/pull/1686) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1686/files)] ← _this PR_
  - [stack/cred-props-util-test-coverage](https://github.com/unitycatalog/unitycatalog/pull/1688) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1688/files/5a0059470fc8e6bc12346347bd14df3baa524c0c..7c744c0a07910093b8b44993e7a28991d807e822)]
    - [stack/credential-property-builders](https://github.com/unitycatalog/unitycatalog/pull/1692) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1692/files/7c744c0a07910093b8b44993e7a28991d807e822..5bb944d59fa406ee2a61194024f27ddc7cadca8f)]
      - [stack/normalize-cloud-storage-prefixes](https://github.com/unitycatalog/unitycatalog/pull/1693) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1693/files/5bb944d59fa406ee2a61194024f27ddc7cadca8f..e6c13c8c8512698151afed957707d8bce1b9415d)]
        - [stack/location-aware-delegate-cache-keys](https://github.com/unitycatalog/unitycatalog/pull/1695) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1695/files/e6c13c8c8512698151afed957707d8bce1b9415d..a2c00f77815aa1a411cb1417395e840d724bcd3e)]
          - [stack/credential-location-identity](https://github.com/unitycatalog/unitycatalog/pull/1699) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1699/files/a2c00f77815aa1a411cb1417395e840d724bcd3e..16cac46532806510568f108b13e866e19f10fa6f)]
            - [stack/select-vended-credential-by-location](https://github.com/unitycatalog/unitycatalog/pull/1701) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1701/files/16cac46532806510568f108b13e866e19f10fa6f..cd348ec20dd49f9e074107b97096c22c0ea71ae3)]
              - [stack/scoped-credential-namespaces](https://github.com/unitycatalog/unitycatalog/pull/1704) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1704/files/cd348ec20dd49f9e074107b97096c22c0ea71ae3..782eb26f0fcc2b52c21aefd3e6dd2b93f0b64bb0)]

---------
## Summary

Refactor cloud-scheme resolution into `CloudType`, the connector's single source of truth for supported cloud types and URI schemes. Route credential-property resolution through this registry, including `s3a` support for S3.

Add unit coverage for every supported scheme and representative unsupported or case-variant schemes.

## Testing

New tests covering supported and unsupported clouds.

## Issue
https://github.com/unitycatalog/unitycatalog/issues/1694