### PR TITLE
Add configurable expiry for UC access tokens issued by token exchange

### DIFF
--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -28,6 +28,8 @@ server.audiences=
 
 # D-Days H-Hours M-Minutes S-Seconds (P5D = 5 days,PT5H = 5 hours, PT5M = 5 minutes, PT5S = 5 seconds)
 server.cookie-timeout=P5D
+# Lifetime of UC access tokens issued by token exchange. Previously these tokens had no exp claim.
+# Default is 24 hours; increase this value if you need longer-lived sessions during migration.
 server.access-token-timeout=PT24H
 
 # Enable MANAGED table

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -28,6 +28,7 @@ server.audiences=
 
 # D-Days H-Hours M-Minutes S-Seconds (P5D = 5 days,PT5H = 5 hours, PT5M = 5 minutes, PT5S = 5 seconds)
 server.cookie-timeout=P5D
+server.access-token-timeout=PT24H
 
 # Enable MANAGED table
 # Default: true (enabled)

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -28,8 +28,6 @@ server.audiences=
 
 # D-Days H-Hours M-Minutes S-Seconds (P5D = 5 days,PT5H = 5 hours, PT5M = 5 minutes, PT5S = 5 seconds)
 server.cookie-timeout=P5D
-# Lifetime of UC access tokens issued by token exchange. Previously these tokens had no exp claim.
-# Default is 24 hours; increase this value if you need longer-lived sessions during migration.
 server.access-token-timeout=PT24H
 
 # Enable MANAGED table

--- a/helm/README.md
+++ b/helm/README.md
@@ -126,8 +126,6 @@ Example: `P5D` (5 days)
 </td>
 			<td>UC access token lifetime for token exchange
 
-Previously, UC access tokens had no exp claim. Default is 24 hours.
-
 Example: `PT24H` (24 hours), `P7D` (7 days)
 </td>
 		</tr>

--- a/helm/README.md
+++ b/helm/README.md
@@ -118,6 +118,20 @@ Example: `P5D` (5 days)
 </td>
 		</tr>
 		<tr>
+			<td>auth.accessTokenTimeout</td>
+			<td>string</td>
+			<td><pre lang="json">
+"PT24H"
+</pre>
+</td>
+			<td>UC access token lifetime for token exchange
+
+Previously, UC access tokens had no exp claim. Default is 24 hours.
+
+Example: `PT24H` (24 hours), `P7D` (7 days)
+</td>
+		</tr>
+		<tr>
 			<td>auth.enabled</td>
 			<td>bool</td>
 			<td><pre lang="json">

--- a/helm/templates/server/_config.tpl
+++ b/helm/templates/server/_config.tpl
@@ -12,6 +12,7 @@ server.client-id=${OAUTH_CLIENT_ID}
 server.client-secret=${OAUTH_CLIENT_SECRET}
 server.redirect-port={{ .Values.auth.redirectPort }}
 server.cookie-timeout={{ .Values.auth.cookieTimeout }}
+server.access-token-timeout={{ .Values.auth.accessTokenTimeout }}
 server.allowed-issuers={{ .Values.auth.allowedIssuers }}
 server.audiences={{ .Values.auth.audiences }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -150,6 +150,15 @@ auth:
   #
   cookieTimeout: P5D
 
+  # -- (string) UC access token lifetime for token exchange
+  # @default -- PT24H
+  # @raw
+  #
+  # Previously, UC access tokens had no exp claim. Default is 24 hours.
+  # Example: `PT24H` (24 hours), `P7D` (7 days)
+  #
+  accessTokenTimeout: PT24H
+
 server:
   # -- (bool) Enable the server deployment
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -154,7 +154,6 @@ auth:
   # @default -- PT24H
   # @raw
   #
-  # Previously, UC access tokens had no exp claim. Default is 24 hours.
   # Example: `PT24H` (24 hours), `P7D` (7 days)
   #
   accessTokenTimeout: PT24H

--- a/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
+++ b/server/src/main/java/io/unitycatalog/server/security/SecurityContext.java
@@ -8,6 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -69,17 +71,19 @@ public class SecurityContext {
     LOGGER.info(getInternalCertsFile());
   }
 
-  public String createAccessToken(DecodedJWT decodedJWT) {
+  public String createAccessToken(DecodedJWT decodedJWT, Duration ttl) {
     String subject =
         decodedJWT
             .getClaims()
             .getOrDefault(JwtClaim.EMAIL.key(), decodedJWT.getClaim(JwtClaim.SUBJECT.key()))
             .asString();
 
+    Instant expiresAt = Instant.now().plus(ttl);
     return JWT.create()
         .withSubject(serviceName)
         .withIssuer(localIssuer)
         .withIssuedAt(new Date())
+        .withExpiresAt(Date.from(expiresAt))
         .withKeyId(keyId)
         .withJWTId(UUID.randomUUID().toString())
         .withClaim(JwtClaim.TOKEN_TYPE.key(), JwtTokenType.ACCESS.name())

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -41,7 +41,6 @@ import io.unitycatalog.server.security.JwtClaim;
 import io.unitycatalog.server.security.SecurityContext;
 import io.unitycatalog.server.utils.JwksOperations;
 import io.unitycatalog.server.utils.ServerProperties;
-import io.unitycatalog.server.utils.ServerProperties.Property;
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -204,8 +203,7 @@ public class AuthService {
     ext.ifPresent(
         e -> {
           if (e.equals(TokenEndpointExtensionType.COOKIE)) {
-            // Set cookie timeout to 5 days by default if not present in server.properties
-            String cookieTimeout = this.serverProperties.get(Property.COOKIE_TIMEOUT);
+            Duration cookieTimeout = serverProperties.getEffectiveCookieTimeout();
             Cookie cookie =
                 createCookie(AuthDecorator.UC_TOKEN_KEY, accessToken, "/", cookieTimeout);
             responseHeaders.add(HttpHeaderNames.SET_COOKIE, cookie.toSetCookieHeader());
@@ -264,11 +262,12 @@ public class AuthService {
         ErrorCode.INVALID_ARGUMENT, "User not allowed: " + subject);
   }
 
+  private Cookie createCookie(String key, String value, String path, Duration maxAge) {
+    return Cookie.secureBuilder(key, value).path(path).maxAge(maxAge.getSeconds()).build();
+  }
+
   private Cookie createCookie(String key, String value, String path, String maxAge) {
-    return Cookie.secureBuilder(key, value)
-        .path(path)
-        .maxAge(Duration.parse(maxAge).getSeconds())
-        .build();
+    return createCookie(key, value, path, Duration.parse(maxAge));
   }
 
   // NOTE:

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -189,13 +189,15 @@ public class AuthService {
 
     LOGGER.debug("Validated. Creating access token.");
 
-    String accessToken = securityContext.createAccessToken(decodedJWT);
+    Duration accessTokenTimeout = serverProperties.getAccessTokenTimeout();
+    String accessToken = securityContext.createAccessToken(decodedJWT, accessTokenTimeout);
 
     OAuthTokenExchangeInfo tokenExchangeInfo =
         new OAuthTokenExchangeInfo()
             .accessToken(accessToken)
             .issuedTokenType(TokenType.ACCESS_TOKEN)
-            .tokenType(AccessTokenType.BEARER);
+            .tokenType(AccessTokenType.BEARER)
+            .expiresIn(accessTokenTimeout.getSeconds());
 
     // Set token as cookie if ext param is set to cookie
     ResponseHeadersBuilder responseHeaders = ResponseHeaders.builder(HttpStatus.OK);

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -197,6 +197,7 @@ public class ServerProperties {
     CLIENT_SECRET("server.client-secret"),
     REDIRECT_PORT("server.redirect-port", POSITIVE_INTEGER_VALIDATOR),
     COOKIE_TIMEOUT("server.cookie-timeout", "P5D", DURATION_VALIDATOR),
+    ACCESS_TOKEN_TIMEOUT("server.access-token-timeout", "PT24H", DURATION_VALIDATOR),
     MANAGED_TABLE_ENABLED("server.managed-table.enabled", "true", BOOLEAN_VALIDATOR),
     MANAGED_TABLE_USE_DELTA_API_ONLY(
         "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
@@ -443,6 +444,11 @@ public class ServerProperties {
 
   public boolean isIncludeStackTraceInError() {
     return isTrueOrEnable(get(Property.INCLUDE_STACK_TRACE_IN_ERROR));
+  }
+
+  /** Lifetime of UC access tokens issued by token exchange. */
+  public Duration getAccessTokenTimeout() {
+    return Duration.parse(get(Property.ACCESS_TOKEN_TIMEOUT));
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -452,6 +452,16 @@ public class ServerProperties {
   }
 
   /**
+   * Cookie max-age for UC access tokens, capped by {@link #getAccessTokenTimeout()} so the cookie
+   * does not outlive the JWT it contains.
+   */
+  public Duration getEffectiveCookieTimeout() {
+    Duration cookieTimeout = Duration.parse(get(Property.COOKIE_TIMEOUT));
+    Duration accessTokenTimeout = getAccessTokenTimeout();
+    return cookieTimeout.compareTo(accessTokenTimeout) > 0 ? accessTokenTimeout : cookieTimeout;
+  }
+
+  /**
    * Check if experimental MANAGED table feature is enabled. This method throws BaseException with
    * ErrorCode.INVALID_ARGUMENT if it's disabled.
    */

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -446,7 +446,7 @@ public class ServerProperties {
     return isTrueOrEnable(get(Property.INCLUDE_STACK_TRACE_IN_ERROR));
   }
 
-  /** Lifetime of UC access tokens issued by token exchange. */
+  /** Lifetime of UC access tokens issued by token exchange. Defaults to 24 hours. */
   public Duration getAccessTokenTimeout() {
     return Duration.parse(get(Property.ACCESS_TOKEN_TIMEOUT));
   }

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -22,6 +22,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -129,6 +130,8 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     assertThat(body.get("issued_token_type").asText())
         .isEqualTo("urn:ietf:params:oauth:token-type:access_token");
     assertThat(body.get("token_type").asText()).isEqualTo("Bearer");
+    assertThat(body.get("expires_in").asLong()).isEqualTo(Duration.parse("PT24H").getSeconds());
+    assertThat(JWT.decode(body.get("access_token").asText()).getExpiresAt()).isNotNull();
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -1,10 +1,12 @@
 package io.unitycatalog.server.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.client.WebClient;
@@ -23,6 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,8 +133,16 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     assertThat(body.get("issued_token_type").asText())
         .isEqualTo("urn:ietf:params:oauth:token-type:access_token");
     assertThat(body.get("token_type").asText()).isEqualTo("Bearer");
-    assertThat(body.get("expires_in").asLong()).isEqualTo(Duration.parse("PT24H").getSeconds());
-    assertThat(JWT.decode(body.get("access_token").asText()).getExpiresAt()).isNotNull();
+
+    Duration expectedTtl = Duration.parse("PT24H");
+    assertThat(body.get("expires_in").asLong()).isEqualTo(expectedTtl.getSeconds());
+
+    DecodedJWT accessJwt = JWT.decode(body.get("access_token").asText());
+    assertThat(accessJwt.getIssuedAt()).isNotNull();
+    assertThat(accessJwt.getExpiresAt()).isNotNull();
+    assertThat(accessJwt.getExpiresAt().toInstant())
+        .isCloseTo(
+            accessJwt.getIssuedAt().toInstant().plus(expectedTtl), within(2, ChronoUnit.SECONDS));
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.security.SecurityContext.Issuers.INTERNAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,8 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import io.unitycatalog.server.base.auth.BaseAuthCRUDTest;
+import io.unitycatalog.server.security.JwtClaim;
+import io.unitycatalog.server.security.JwtTokenType;
 import java.io.IOException;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -62,6 +65,15 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     assertEquals(HttpStatus.UNAUTHORIZED, response.status());
   }
 
+  @Test
+  public void testExpiredAccessTokenIsRejected() {
+    // Request with expired access token should return 401
+    RequestHeaders headers = buildLogoutRequestHeaderWithToken(createExpiredAccessToken());
+
+    AggregatedHttpResponse response = client.execute(headers).aggregate().join();
+    assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
   private RequestHeaders buildLogoutRequestHeader(boolean includeCookie) {
     RequestHeadersBuilder builder =
         RequestHeaders.builder()
@@ -74,6 +86,31 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     }
 
     return builder.build();
+  }
+
+  private RequestHeaders buildLogoutRequestHeaderWithToken(String token) {
+    return RequestHeaders.builder()
+        .method(HttpMethod.POST)
+        .path(LOGOUT_ENDPOINT)
+        .contentType(MediaType.JSON)
+        .add(HttpHeaderNames.COOKIE, "UC_TOKEN=" + token)
+        .build();
+  }
+
+  private String createExpiredAccessToken() {
+    Date issuedAt = new Date(System.currentTimeMillis() - Duration.ofHours(2).toMillis());
+    Date expiresAt = new Date(System.currentTimeMillis() - Duration.ofHours(1).toMillis());
+
+    return JWT.create()
+        .withSubject(securityContext.getServiceName())
+        .withIssuer(INTERNAL)
+        .withIssuedAt(issuedAt)
+        .withExpiresAt(expiresAt)
+        .withKeyId(securityContext.getKeyId())
+        .withJWTId(UUID.randomUUID().toString())
+        .withClaim(JwtClaim.TOKEN_TYPE.key(), JwtTokenType.ACCESS.name())
+        .withClaim(JwtClaim.SUBJECT.key(), "admin")
+        .sign(securityContext.getAlgorithm());
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -190,12 +190,19 @@ public class ServerPropertiesTest {
     testValidProperty(Property.COOKIE_TIMEOUT, "P5D");
     testValidProperty(Property.COOKIE_TIMEOUT, "PT2H");
     testValidProperty(Property.COOKIE_TIMEOUT, "P1DT12H30M");
+    testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT24H");
+    testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT1H");
 
     // Invalid values
     testInvalidProperty(
         Property.COOKIE_TIMEOUT, "5 days", "Invalid value '5 days'", "server.cookie-timeout");
     testInvalidProperty(
         Property.COOKIE_TIMEOUT, "P5X", "Invalid value 'P5X'", "server.cookie-timeout");
+    testInvalidProperty(
+        Property.ACCESS_TOKEN_TIMEOUT,
+        "24 hours",
+        "Invalid value '24 hours'",
+        "server.access-token-timeout");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.model.TableType;
 import io.unitycatalog.server.utils.ServerProperties.Property;
+import java.time.Duration;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -203,6 +204,18 @@ public class ServerPropertiesTest {
         "24 hours",
         "Invalid value '24 hours'",
         "server.access-token-timeout");
+  }
+
+  @Test
+  public void testEffectiveCookieTimeout() {
+    ServerProperties serverProperties = new ServerProperties();
+    assertThat(serverProperties.getEffectiveCookieTimeout()).isEqualTo(Duration.parse("PT24H"));
+
+    serverProperties.set(Property.COOKIE_TIMEOUT, "PT1H");
+    assertThat(serverProperties.getEffectiveCookieTimeout()).isEqualTo(Duration.parse("PT1H"));
+
+    serverProperties.set(Property.ACCESS_TOKEN_TIMEOUT, "PT48H");
+    assertThat(serverProperties.getEffectiveCookieTimeout()).isEqualTo(Duration.parse("PT1H"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Split from #1661 (PR 1 of 3).

UC access tokens previously had no `exp` claim. This adds:

- `server.access-token-timeout` (default `PT24H`)
- JWT expiration via `withExpiresAt` in `SecurityContext.createAccessToken`
- `expires_in` in the `/auth/tokens` response so clients can cache and refresh correctly
- Cookie max-age capped to `min(server.cookie-timeout, server.access-token-timeout)` when `ext=cookie`
- Helm support via `auth.accessTokenTimeout`

## Behavior change

Previously, UC access tokens issued by `/auth/tokens` had **no `exp` claim** and did not expire.

This PR changes the default lifetime to **24 hours** (`server.access-token-timeout=PT24H`).

**Impact:**
- Clients must re-exchange tokens (or refresh using `expires_in`) at least once per day with default settings.
- Deployments that relied on non-expiring tokens must set `server.access-token-timeout` explicitly (for example to a longer duration) if they need backward-compatible behavior during migration.

**Scope:** Applies only to UC access tokens issued by `/auth/tokens` token exchange (`JwtTokenType.ACCESS`). The bootstrap admin token in `etc/conf/token.txt` (service token, `JwtTokenType.SERVICE`) is unchanged and still does not expire.

## Test plan

- [x] `sbt "server/testOnly io.unitycatalog.server.service.AuthServiceTest, io.unitycatalog.server.utils.ServerPropertiesTest"`
- [x] Token exchange returns `expires_in` matching configured timeout
- [x] Issued UC access token JWT includes valid `exp` claim (`exp ≈ iat + TTL`)
- [x] Expired access tokens are rejected with 401
- [x] Cookie max-age does not exceed access token lifetime