### PR TITLE
refactor(hadoop): extract cloud credential property builders

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -5,11 +5,8 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
-import io.unitycatalog.hadoop.internal.auth.AwsCredential;
-import io.unitycatalog.hadoop.internal.auth.AzureCredential;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
-import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
@@ -17,6 +14,7 @@ import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.hadoop.internal.props.CredPropsBuilder;
 import io.unitycatalog.hadoop.internal.util.ClockUtil;
 import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.net.URI;
@@ -52,291 +50,9 @@ public class CredPropsUtil {
 
   static final CredentialCache initialCredCache = CredentialCache.createInitialCredentialCache();
 
-  private static final String CRED_SCOPED_FS_CLASS =
-      "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";
-  private static final String CRED_SCOPED_AFS_CLASS =
-      "io.unitycatalog.hadoop.internal.fs.CredScopedFs";
-  private static final String AWS_VENDED_TOKEN_PROVIDER_CLASS =
-      "io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider";
-  private static final String GCS_VENDED_TOKEN_PROVIDER_CLASS =
-      "io.unitycatalog.hadoop.internal.auth.GcsVendedTokenProvider";
-  private static final String ABFS_VENDED_TOKEN_PROVIDER_CLASS =
-      "io.unitycatalog.hadoop.internal.auth.AbfsVendedTokenProvider";
-  private static final String GCS_ACCESS_TOKEN_KEY = "fs.gs.auth.access.token.credential";
-  private static final String GCS_ACCESS_TOKEN_EXPIRATION_KEY =
-      "fs.gs.auth.access.token.expiration";
-  private static final String GCS_CONFLICT_CHECK_KEY = "fs.gs.create.items.conflict.check.enable";
-  private static final String ABFS_FIXED_SAS_TOKEN_KEY = "fs.azure.sas.fixed.token";
-
   // Keys used to build the credential-context id (see #credContextId).
   private static final String CRED_CONTEXT_CATALOG_URI_KEY = "catalogUri";
   private static final String CRED_CONTEXT_SCHEME_KEY = "scheme";
-
-  private abstract static class PropsBuilder<T extends PropsBuilder<T>> {
-    private final HashMap<String, String> builder = new HashMap<>();
-
-    public T set(String key, String value) {
-      builder.put(key, value);
-      return self();
-    }
-
-    public T uri(String uri) {
-      builder.put(UCHadoopConfConstants.UC_URI_KEY, uri);
-      return self();
-    }
-
-    public T tokenProvider(TokenProvider tokenProvider) {
-      // As we can only propagate the properties with prefix 'fs.*' to the FileSystem
-      // implementation. So let's add the prefix here.
-      tokenProvider
-          .configs()
-          .forEach((key, value) -> builder.put(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
-      return self();
-    }
-
-    /** Applies the credential-scope identity properties carried by {@code credId}. */
-    public T credId(CredId credId) {
-      credId.props().forEach(this::set);
-      return self();
-    }
-
-    public T appVersions(Map<String, String> appVersions) {
-      appVersions.forEach(
-          (k, v) -> builder.put(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + k, v));
-      return self();
-    }
-
-    /**
-     * Saves the current value of {@code key} from {@code hadoopProps} (falling back to {@code
-     * defaultOriginal}) under {@code key + ".original"}, then overrides {@code key} with {@code
-     * newValue}. This lets CredScopedFileSystem#newFileSystem restore the real delegate
-     * implementation after the wrapper has been installed.
-     */
-    public T saveAndOverride(
-        Configuration hadoopConf, String key, String defaultOriginal, String newValue) {
-      builder.put(key + ".original", hadoopConf.get(key, defaultOriginal));
-      builder.put(key, newValue);
-      return self();
-    }
-
-    protected abstract T self();
-
-    public Map<String, String> build() {
-      return Collections.unmodifiableMap(new HashMap<>(builder));
-    }
-  }
-
-  static class S3PropsBuilder extends PropsBuilder<S3PropsBuilder> {
-
-    S3PropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
-      // Common properties for S3.
-      set("fs.s3a.path.style.access", "true");
-      set("fs.s3.impl.disable.cache", "true");
-      set("fs.s3a.impl.disable.cache", "true");
-
-      if (credScopedFsEnabled) {
-        saveAndOverride(
-            hadoopConf,
-            "fs.s3.impl",
-            "org.apache.hadoop.fs.s3a.S3AFileSystem",
-            CRED_SCOPED_FS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.s3a.impl",
-            "org.apache.hadoop.fs.s3a.S3AFileSystem",
-            CRED_SCOPED_FS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.AbstractFileSystem.s3.impl",
-            "org.apache.hadoop.fs.s3a.S3A",
-            CRED_SCOPED_AFS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.AbstractFileSystem.s3a.impl",
-            "org.apache.hadoop.fs.s3a.S3A",
-            CRED_SCOPED_AFS_CLASS);
-      }
-    }
-
-    @Override
-    protected S3PropsBuilder self() {
-      return this;
-    }
-  }
-
-  private static class GcsPropsBuilder extends PropsBuilder<GcsPropsBuilder> {
-
-    GcsPropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
-      // The upstream GCS connector defaults this to true which causes the connector to
-      // stat every ancestor directory on file creation. With UC-vended downscoped tokens
-      // (scoped to a table's path prefix) these ancestor stats return 403. Default to
-      // false; users with broader credentials can opt back in via Hadoop/Spark config.
-      set(GCS_CONFLICT_CHECK_KEY, hadoopConf.get(GCS_CONFLICT_CHECK_KEY, "false"));
-      set("fs.gs.impl.disable.cache", "true");
-
-      if (credScopedFsEnabled) {
-        saveAndOverride(
-            hadoopConf,
-            "fs.gs.impl",
-            "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
-            CRED_SCOPED_FS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.AbstractFileSystem.gs.impl",
-            "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS",
-            CRED_SCOPED_AFS_CLASS);
-      }
-    }
-
-    @Override
-    protected GcsPropsBuilder self() {
-      return this;
-    }
-  }
-
-  private static class AbfsPropsBuilder extends PropsBuilder<AbfsPropsBuilder> {
-
-    AbfsPropsBuilder(boolean credScopedFsEnabled, Configuration hadoopConf) {
-      set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, "SAS");
-      set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_IS_HNS_ENABLED, "true");
-      set("fs.abfs.impl.disable.cache", "true");
-      set("fs.abfss.impl.disable.cache", "true");
-
-      if (credScopedFsEnabled) {
-        saveAndOverride(
-            hadoopConf,
-            "fs.abfs.impl",
-            "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem",
-            CRED_SCOPED_FS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.abfss.impl",
-            "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem",
-            CRED_SCOPED_FS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.AbstractFileSystem.abfs.impl",
-            "org.apache.hadoop.fs.azurebfs.Abfs",
-            CRED_SCOPED_AFS_CLASS);
-        saveAndOverride(
-            hadoopConf,
-            "fs.AbstractFileSystem.abfss.impl",
-            "org.apache.hadoop.fs.azurebfs.Abfss",
-            CRED_SCOPED_AFS_CLASS);
-      }
-    }
-
-    @Override
-    protected AbfsPropsBuilder self() {
-      return this;
-    }
-  }
-
-  private static Map<String, String> s3FixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    AwsCredential aws = (AwsCredential) cred;
-    return new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set("fs.s3a.access.key", aws.accessKeyId())
-        .set("fs.s3a.secret.key", aws.secretAccessKey())
-        .set("fs.s3a.session.token", aws.sessionToken())
-        .build();
-  }
-
-  private static S3PropsBuilder s3TempCredPropsBuilder(
-      boolean credScopedFsEnabled,
-      Configuration hadoopConf,
-      String uri,
-      TokenProvider tokenProvider,
-      GenericCredential cred) {
-    AwsCredential aws = (AwsCredential) cred;
-    S3PropsBuilder builder =
-        new S3PropsBuilder(credScopedFsEnabled, hadoopConf)
-            .set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS)
-            .uri(uri)
-            .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, aws.accessKeyId())
-            .set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, aws.secretAccessKey())
-            .set(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, aws.sessionToken());
-
-    // For the static credential case, nullable expiration time is possible.
-    if (cred.expirationTimeMillis() != null) {
-      builder.set(
-          UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME,
-          String.valueOf(cred.expirationTimeMillis()));
-    }
-
-    return builder;
-  }
-
-  private static Map<String, String> gsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    GcsCredential gcs = (GcsCredential) cred;
-    Long expirationTime =
-        gcs.expirationTimeMillis() == null ? Long.MAX_VALUE : gcs.expirationTimeMillis();
-    return new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set(GCS_ACCESS_TOKEN_KEY, gcs.oauthToken())
-        .set(GCS_ACCESS_TOKEN_EXPIRATION_KEY, String.valueOf(expirationTime))
-        .build();
-  }
-
-  private static GcsPropsBuilder gcsTempCredPropsBuilder(
-      boolean credScopedFsEnabled,
-      Configuration hadoopConf,
-      String uri,
-      TokenProvider tokenProvider,
-      GenericCredential cred) {
-    GcsCredential gcs = (GcsCredential) cred;
-    GcsPropsBuilder builder =
-        new GcsPropsBuilder(credScopedFsEnabled, hadoopConf)
-            .set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
-            .set("fs.gs.auth.access.token.provider", GCS_VENDED_TOKEN_PROVIDER_CLASS)
-            .uri(uri)
-            .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, gcs.oauthToken());
-
-    // For the static credential case, nullable expiration time is possible.
-    if (gcs.expirationTimeMillis() != null) {
-      builder.set(
-          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
-          String.valueOf(gcs.expirationTimeMillis()));
-    }
-
-    return builder;
-  }
-
-  private static Map<String, String> abfsFixedCredProps(
-      boolean credScopedFsEnabled, Configuration hadoopConf, GenericCredential cred) {
-    AzureCredential azure = (AzureCredential) cred;
-    return new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
-        .set(ABFS_FIXED_SAS_TOKEN_KEY, azure.sasToken())
-        .build();
-  }
-
-  private static AbfsPropsBuilder abfsTempCredPropsBuilder(
-      boolean credScopedFsEnabled,
-      Configuration hadoopConf,
-      String uri,
-      TokenProvider tokenProvider,
-      GenericCredential cred) {
-    AzureCredential azure = (AzureCredential) cred;
-    AbfsPropsBuilder builder =
-        new AbfsPropsBuilder(credScopedFsEnabled, hadoopConf)
-            .set(
-                UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE,
-                ABFS_VENDED_TOKEN_PROVIDER_CLASS)
-            .uri(uri)
-            .tokenProvider(tokenProvider)
-            .set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, azure.sasToken());
-
-    // For the static credential case, nullable expiration time is possible.
-    if (azure.expirationTimeMillis() != null) {
-      builder.set(
-          UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
-          String.valueOf(azure.expirationTimeMillis()));
-    }
-
-    return builder;
-  }
 
   /** Fetches table credentials from the UC REST API and builds Hadoop configuration properties. */
   public static Map<String, String> createTableCredProps(
@@ -475,39 +191,11 @@ public class CredPropsUtil {
     GenericCredential cred =
         fetchGenericCredential(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
-    switch (cloudType.get()) {
-      case S3:
-        if (renewCredEnabled) {
-          return s3TempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
-              .credId(credId)
-              .appVersions(appVersions)
-              .build();
-        } else {
-          return s3FixedCredProps(credScopedFsEnabled, hadoopConf, cred);
-        }
-      case GCS:
-        if (renewCredEnabled) {
-          return gcsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
-              .credId(credId)
-              .appVersions(appVersions)
-              .build();
-        } else {
-          return gsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
-        }
-      case ABFS:
-        if (renewCredEnabled) {
-          return abfsTempCredPropsBuilder(
-                  credScopedFsEnabled, hadoopConf, catalogUri, tokenProvider, cred)
-              .credId(credId)
-              .appVersions(appVersions)
-              .build();
-        } else {
-          return abfsFixedCredProps(credScopedFsEnabled, hadoopConf, cred);
-        }
-    }
-    throw new IllegalStateException("Unhandled cloud type: " + cloudType.get());
+    return CredPropsBuilder.forCloud(cloudType.get(), hadoopConf)
+        .renewCredEnabled(renewCredEnabled, catalogUri, tokenProvider, credId, appVersions)
+        .credScopedFsEnabled(credScopedFsEnabled)
+        .initialCredential(cred)
+        .build();
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -191,11 +191,14 @@ public class CredPropsUtil {
     GenericCredential cred =
         fetchGenericCredential(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
-    return CredPropsBuilder.forCloud(cloudType.get(), hadoopConf)
-        .renewCredEnabled(renewCredEnabled, catalogUri, tokenProvider, credId, appVersions)
-        .credScopedFsEnabled(credScopedFsEnabled)
-        .initialCredential(cred)
-        .build();
+    CredPropsBuilder builder =
+        CredPropsBuilder.forCloud(cloudType.get(), hadoopConf)
+            .credScopedFsEnabled(credScopedFsEnabled)
+            .initialCredential(cred);
+    if (renewCredEnabled) {
+      builder.enableRenewCred(catalogUri, tokenProvider, credId, appVersions);
+    }
+    return builder.build();
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.props;
 
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AzureCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
@@ -44,6 +45,10 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeRenewableCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof AzureCredential,
+        "Expected AzureCredential, but got %s",
+        cred.getClass().getSimpleName());
     AzureCredential azure = (AzureCredential) cred;
     set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, azure.sasToken());
     // Expiration may be absent (e.g. a static token provider), so write the key only when set.
@@ -56,6 +61,10 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeFixedCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof AzureCredential,
+        "Expected AzureCredential, but got %s",
+        cred.getClass().getSimpleName());
     AzureCredential azure = (AzureCredential) cred;
     set(ABFS_FIXED_SAS_TOKEN_KEY, azure.sasToken());
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -21,7 +21,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFsImplKeys() {
+  protected void setCredScopedFsKeys() {
     saveAndOverride(
         "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -38,7 +38,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void applyVendedProviderKeys() {
+  protected void writeVendedProviderKeys() {
     set(UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, ABFS_VENDED_TOKEN_PROVIDER_CLASS);
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -1,0 +1,62 @@
+package io.unitycatalog.hadoop.internal.props;
+
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.AzureCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import org.apache.hadoop.conf.Configuration;
+
+/** Builds ABFS credential properties. */
+final class AbfsCredPropsBuilder extends CredPropsBuilder {
+  private static final String ABFS_VENDED_TOKEN_PROVIDER_CLASS =
+      "io.unitycatalog.hadoop.internal.auth.AbfsVendedTokenProvider";
+  private static final String ABFS_FIXED_SAS_TOKEN_KEY = "fs.azure.sas.fixed.token";
+
+  AbfsCredPropsBuilder(Configuration hadoopConf) {
+    super(hadoopConf);
+    set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, "SAS");
+    set(UCHadoopConfConstants.FS_AZURE_ACCOUNT_IS_HNS_ENABLED, "true");
+    set("fs.abfs.impl.disable.cache", "true");
+    set("fs.abfss.impl.disable.cache", "true");
+  }
+
+  @Override
+  protected void writeImplOverrides() {
+    saveAndOverride(
+        "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem", CRED_SCOPED_FS_CLASS);
+    saveAndOverride(
+        "fs.abfss.impl",
+        "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem",
+        CRED_SCOPED_FS_CLASS);
+    saveAndOverride(
+        "fs.AbstractFileSystem.abfs.impl",
+        "org.apache.hadoop.fs.azurebfs.Abfs",
+        CRED_SCOPED_AFS_CLASS);
+    saveAndOverride(
+        "fs.AbstractFileSystem.abfss.impl",
+        "org.apache.hadoop.fs.azurebfs.Abfss",
+        CRED_SCOPED_AFS_CLASS);
+  }
+
+  @Override
+  protected void applyVendedProviderKeys() {
+    set(UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, ABFS_VENDED_TOKEN_PROVIDER_CLASS);
+  }
+
+  @Override
+  protected void writeRenewableCredKeys(GenericCredential cred) {
+    AzureCredential azure = (AzureCredential) cred;
+    set(UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN, azure.sasToken());
+    // Expiration may be absent (e.g. a static token provider), so write the key only when set.
+    if (azure.expirationTimeMillis() != null) {
+      set(
+          UCHadoopConfConstants.AZURE_INIT_SAS_TOKEN_EXPIRED_TIME,
+          String.valueOf(azure.expirationTimeMillis()));
+    }
+  }
+
+  @Override
+  protected void writeFixedCredKeys(GenericCredential cred) {
+    AzureCredential azure = (AzureCredential) cred;
+    set(ABFS_FIXED_SAS_TOKEN_KEY, azure.sasToken());
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -21,7 +21,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeImplOverrides() {
+  protected void setFsImplKeys() {
     saveAndOverride(
         "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride(
@@ -39,12 +39,12 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeVendedProviderKeys() {
+  protected void setVendedProviderKeys() {
     set(UCHadoopConfConstants.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE, ABFS_VENDED_TOKEN_PROVIDER_CLASS);
   }
 
   @Override
-  protected void writeRenewableCredKeys(GenericCredential cred) {
+  protected void setRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AzureCredential,
         "Expected AzureCredential, but got %s",
@@ -60,7 +60,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeFixedCredKeys(GenericCredential cred) {
+  protected void setFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AzureCredential,
         "Expected AzureCredential, but got %s",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -5,6 +5,8 @@ import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.CloudType;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem;
+import io.unitycatalog.hadoop.internal.fs.CredScopedFs;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,11 +16,9 @@ import org.apache.hadoop.conf.Configuration;
 /** Builds the cloud-provider specific Hadoop configuration credential properties. */
 public abstract class CredPropsBuilder {
   /** CredScopedFileSystem implementation classes, swapped in when cred-scoped FS is enabled. */
-  protected static final String CRED_SCOPED_FS_CLASS =
-      "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";
+  protected static final String CRED_SCOPED_FS_CLASS = CredScopedFileSystem.class.getName();
 
-  protected static final String CRED_SCOPED_AFS_CLASS =
-      "io.unitycatalog.hadoop.internal.fs.CredScopedFs";
+  protected static final String CRED_SCOPED_AFS_CLASS = CredScopedFs.class.getName();
 
   private final Configuration hadoopConf;
   private final HashMap<String, String> props = new HashMap<>();

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -1,0 +1,125 @@
+package io.unitycatalog.hadoop.internal.props;
+
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.CloudType;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import io.unitycatalog.hadoop.internal.id.CredId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+
+/** Builds the cloud-provider specific Hadoop configuration credential properties. */
+public abstract class CredPropsBuilder {
+  /** CredScopedFileSystem implementation classes, swapped in when cred-scoped FS is enabled. */
+  protected static final String CRED_SCOPED_FS_CLASS =
+      "io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem";
+
+  protected static final String CRED_SCOPED_AFS_CLASS =
+      "io.unitycatalog.hadoop.internal.fs.CredScopedFs";
+
+  private final Configuration hadoopConf;
+  private final HashMap<String, String> props = new HashMap<>();
+
+  private boolean renewCredEnabled;
+  private GenericCredential initialCredential;
+
+  protected CredPropsBuilder(Configuration hadoopConf) {
+    Preconditions.checkNotNull(hadoopConf, "hadoopConf is required");
+    this.hadoopConf = hadoopConf;
+  }
+
+  /** Returns a builder for {@code cloudType}, seeded with that cloud's static base properties. */
+  public static CredPropsBuilder forCloud(CloudType cloudType, Configuration hadoopConf) {
+    switch (cloudType) {
+      case S3:
+        return new S3CredPropsBuilder(hadoopConf);
+      case GCS:
+        return new GcsCredPropsBuilder(hadoopConf);
+      case ABFS:
+        return new AbfsCredPropsBuilder(hadoopConf);
+    }
+    throw new IllegalStateException("Unhandled cloud type: " + cloudType);
+  }
+
+  /**
+   * Records whether renewal is enabled and, when it is, writes the wiring the vended token provider
+   * needs to renew the credential: the provider-class keys, the catalog uri, the auth configs, the
+   * credential-scope identity, and the engine versions. The fixed path writes none of this.
+   */
+  public CredPropsBuilder renewCredEnabled(
+      boolean renewCredEnabled,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      CredId credId,
+      Map<String, String> appVersions) {
+    this.renewCredEnabled = renewCredEnabled;
+    if (renewCredEnabled) {
+      applyVendedProviderKeys();
+      set(UCHadoopConfConstants.UC_URI_KEY, catalogUri);
+      // Only 'fs.*' properties propagate to the FileSystem, so prefix the auth configs.
+      tokenProvider
+          .configs()
+          .forEach((key, value) -> set(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
+      credId.props().forEach(this::set);
+      appVersions.forEach(
+          (key, value) -> set(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + key, value));
+    }
+    return this;
+  }
+
+  /** When enabled, writes the cloud filesystem-impl overrides that install CredScopedFileSystem. */
+  public CredPropsBuilder credScopedFsEnabled(boolean credScopedFsEnabled) {
+    if (credScopedFsEnabled) {
+      writeImplOverrides();
+    }
+    return this;
+  }
+
+  /** Records the fetched credential whose secrets are written by {@link #build()}. */
+  public CredPropsBuilder initialCredential(GenericCredential initialCredential) {
+    this.initialCredential = initialCredential;
+    return this;
+  }
+
+  public Map<String, String> build() {
+    Preconditions.checkNotNull(initialCredential, "initialCredential is required");
+    if (renewCredEnabled) {
+      writeRenewableCredKeys(initialCredential);
+    } else {
+      writeFixedCredKeys(initialCredential);
+    }
+    return Collections.unmodifiableMap(new HashMap<>(props));
+  }
+
+  protected CredPropsBuilder set(String key, String value) {
+    props.put(key, value);
+    return this;
+  }
+
+  /**
+   * Saves the current value of {@code key} from the Hadoop conf (falling back to {@code
+   * defaultOriginal}) under {@code key + ".original"}, then overrides {@code key} with {@code
+   * newValue}. The saved {@code .original} value is the side channel a reader uses to restore the
+   * real delegate implementation after the wrapper has been installed.
+   */
+  protected CredPropsBuilder saveAndOverride(String key, String defaultOriginal, String newValue) {
+    props.put(key + ".original", hadoopConf.get(key, defaultOriginal));
+    props.put(key, newValue);
+    return this;
+  }
+
+  /** Cloud-specific filesystem-impl overrides that install CredScopedFileSystem. */
+  protected abstract void writeImplOverrides();
+
+  /** Cloud-specific key naming the vended token provider (renewable path only). */
+  protected abstract void applyVendedProviderKeys();
+
+  /** Writes the renewable-path credential secrets (the {@code init.*} keys) for this cloud. */
+  protected abstract void writeRenewableCredKeys(GenericCredential cred);
+
+  /** Writes the fixed-path credential secrets for this cloud. */
+  protected abstract void writeFixedCredKeys(GenericCredential cred);
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -82,7 +82,7 @@ public abstract class CredPropsBuilder {
   public Map<String, String> build() {
     Preconditions.checkNotNull(initialCredential, "initialCredential is required");
     if (credScopedFsEnabled) {
-      setFsImplKeys();
+      setCredScopedFsKeys();
     }
     if (renewCredEnabled) {
       setVendedProviderKeys();
@@ -119,7 +119,7 @@ public abstract class CredPropsBuilder {
   }
 
   /** Cloud-specific filesystem-impl overrides that install CredScopedFileSystem. */
-  protected abstract void setFsImplKeys();
+  protected abstract void setCredScopedFsKeys();
 
   /** Cloud-specific key naming the vended token provider (renewable path only). */
   protected abstract void setVendedProviderKeys();

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -57,7 +57,7 @@ public abstract class CredPropsBuilder {
       Map<String, String> appVersions) {
     this.renewCredEnabled = renewCredEnabled;
     if (renewCredEnabled) {
-      applyVendedProviderKeys();
+      writeVendedProviderKeys();
       set(UCHadoopConfConstants.UC_URI_KEY, catalogUri);
       // Only 'fs.*' properties propagate to the FileSystem, so prefix the auth configs.
       tokenProvider
@@ -115,7 +115,7 @@ public abstract class CredPropsBuilder {
   protected abstract void writeImplOverrides();
 
   /** Cloud-specific key naming the vended token provider (renewable path only). */
-  protected abstract void applyVendedProviderKeys();
+  protected abstract void writeVendedProviderKeys();
 
   /** Writes the renewable-path credential secrets (the {@code init.*} keys) for this cloud. */
   protected abstract void writeRenewableCredKeys(GenericCredential cred);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -24,6 +24,11 @@ public abstract class CredPropsBuilder {
   private final HashMap<String, String> props = new HashMap<>();
 
   private boolean renewCredEnabled;
+  private boolean credScopedFsEnabled;
+  private String catalogUri;
+  private TokenProvider tokenProvider;
+  private CredId credId;
+  private Map<String, String> appVersions;
   private GenericCredential initialCredential;
 
   protected CredPropsBuilder(Configuration hadoopConf) {
@@ -44,37 +49,27 @@ public abstract class CredPropsBuilder {
     throw new IllegalStateException("Unhandled cloud type: " + cloudType);
   }
 
-  /**
-   * Records whether renewal is enabled and, when it is, writes the wiring the vended token provider
-   * needs to renew the credential: the provider-class keys, the catalog uri, the auth configs, the
-   * credential-scope identity, and the engine versions. The fixed path writes none of this.
-   */
-  public CredPropsBuilder renewCredEnabled(
-      boolean renewCredEnabled,
+  /** Records the configuration needed to enable credential renewal. */
+  public CredPropsBuilder enableRenewCred(
       String catalogUri,
       TokenProvider tokenProvider,
       CredId credId,
       Map<String, String> appVersions) {
-    this.renewCredEnabled = renewCredEnabled;
-    if (renewCredEnabled) {
-      writeVendedProviderKeys();
-      set(UCHadoopConfConstants.UC_URI_KEY, catalogUri);
-      // Only 'fs.*' properties propagate to the FileSystem, so prefix the auth configs.
-      tokenProvider
-          .configs()
-          .forEach((key, value) -> set(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
-      credId.props().forEach(this::set);
-      appVersions.forEach(
-          (key, value) -> set(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + key, value));
-    }
+    Preconditions.checkNotNull(catalogUri, "catalogUri is required");
+    Preconditions.checkNotNull(tokenProvider, "tokenProvider is required");
+    Preconditions.checkNotNull(credId, "credId is required");
+    Preconditions.checkNotNull(appVersions, "appVersions is required");
+    this.renewCredEnabled = true;
+    this.catalogUri = catalogUri;
+    this.tokenProvider = tokenProvider;
+    this.credId = credId;
+    this.appVersions = appVersions;
     return this;
   }
 
-  /** When enabled, writes the cloud filesystem-impl overrides that install CredScopedFileSystem. */
+  /** Records whether the cloud filesystem implementation overrides should be enabled. */
   public CredPropsBuilder credScopedFsEnabled(boolean credScopedFsEnabled) {
-    if (credScopedFsEnabled) {
-      writeImplOverrides();
-    }
+    this.credScopedFsEnabled = credScopedFsEnabled;
     return this;
   }
 
@@ -86,10 +81,22 @@ public abstract class CredPropsBuilder {
 
   public Map<String, String> build() {
     Preconditions.checkNotNull(initialCredential, "initialCredential is required");
+    if (credScopedFsEnabled) {
+      setFsImplKeys();
+    }
     if (renewCredEnabled) {
-      writeRenewableCredKeys(initialCredential);
+      setVendedProviderKeys();
+      set(UCHadoopConfConstants.UC_URI_KEY, catalogUri);
+      // Only 'fs.*' properties propagate to the FileSystem, so prefix the auth configs.
+      tokenProvider
+          .configs()
+          .forEach((key, value) -> set(UCHadoopConfConstants.UC_AUTH_PREFIX + key, value));
+      credId.props().forEach(this::set);
+      appVersions.forEach(
+          (key, value) -> set(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + key, value));
+      setRenewableCredKeys(initialCredential);
     } else {
-      writeFixedCredKeys(initialCredential);
+      setFixedCredKeys(initialCredential);
     }
     return Collections.unmodifiableMap(new HashMap<>(props));
   }
@@ -112,14 +119,14 @@ public abstract class CredPropsBuilder {
   }
 
   /** Cloud-specific filesystem-impl overrides that install CredScopedFileSystem. */
-  protected abstract void writeImplOverrides();
+  protected abstract void setFsImplKeys();
 
   /** Cloud-specific key naming the vended token provider (renewable path only). */
-  protected abstract void writeVendedProviderKeys();
+  protected abstract void setVendedProviderKeys();
 
   /** Writes the renewable-path credential secrets (the {@code init.*} keys) for this cloud. */
-  protected abstract void writeRenewableCredKeys(GenericCredential cred);
+  protected abstract void setRenewableCredKeys(GenericCredential cred);
 
   /** Writes the fixed-path credential secrets for this cloud. */
-  protected abstract void writeFixedCredKeys(GenericCredential cred);
+  protected abstract void setFixedCredKeys(GenericCredential cred);
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -26,7 +26,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFsImplKeys() {
+  protected void setCredScopedFsKeys() {
     saveAndOverride(
         "fs.gs.impl",
         "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -1,0 +1,65 @@
+package io.unitycatalog.hadoop.internal.props;
+
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.GcsCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import org.apache.hadoop.conf.Configuration;
+
+/** Builds GCS credential properties. */
+final class GcsCredPropsBuilder extends CredPropsBuilder {
+  private static final String GCS_VENDED_TOKEN_PROVIDER_CLASS =
+      "io.unitycatalog.hadoop.internal.auth.GcsVendedTokenProvider";
+  private static final String GCS_ACCESS_TOKEN_KEY = "fs.gs.auth.access.token.credential";
+  private static final String GCS_ACCESS_TOKEN_EXPIRATION_KEY =
+      "fs.gs.auth.access.token.expiration";
+  private static final String GCS_CONFLICT_CHECK_KEY = "fs.gs.create.items.conflict.check.enable";
+
+  GcsCredPropsBuilder(Configuration conf) {
+    super(conf);
+    set("fs.gs.impl.disable.cache", "true");
+    // The upstream GCS connector defaults this to true which causes the connector to
+    // stat every ancestor directory on file creation. With UC-vended downscoped tokens
+    // (scoped to a table's path prefix) these ancestor stats return 403. Default to
+    // false; users with broader credentials can opt back in via Hadoop/Spark config.
+    set(GCS_CONFLICT_CHECK_KEY, conf.get(GCS_CONFLICT_CHECK_KEY, "false"));
+  }
+
+  @Override
+  protected void writeImplOverrides() {
+    saveAndOverride(
+        "fs.gs.impl",
+        "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
+        CRED_SCOPED_FS_CLASS);
+    saveAndOverride(
+        "fs.AbstractFileSystem.gs.impl",
+        "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS",
+        CRED_SCOPED_AFS_CLASS);
+  }
+
+  @Override
+  protected void applyVendedProviderKeys() {
+    set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER");
+    set("fs.gs.auth.access.token.provider", GCS_VENDED_TOKEN_PROVIDER_CLASS);
+  }
+
+  @Override
+  protected void writeRenewableCredKeys(GenericCredential cred) {
+    GcsCredential gcs = (GcsCredential) cred;
+    set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, gcs.oauthToken());
+    // Expiration may be absent (e.g. a static token provider), so write the key only when set.
+    if (gcs.expirationTimeMillis() != null) {
+      set(
+          UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN_EXPIRATION_TIME,
+          String.valueOf(gcs.expirationTimeMillis()));
+    }
+  }
+
+  @Override
+  protected void writeFixedCredKeys(GenericCredential cred) {
+    GcsCredential gcs = (GcsCredential) cred;
+    Long expirationTime =
+        gcs.expirationTimeMillis() == null ? Long.MAX_VALUE : gcs.expirationTimeMillis();
+    set(GCS_ACCESS_TOKEN_KEY, gcs.oauthToken());
+    set(GCS_ACCESS_TOKEN_EXPIRATION_KEY, String.valueOf(expirationTime));
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -37,7 +37,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void applyVendedProviderKeys() {
+  protected void writeVendedProviderKeys() {
     set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER");
     set("fs.gs.auth.access.token.provider", GCS_VENDED_TOKEN_PROVIDER_CLASS);
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.props;
 
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
@@ -44,6 +45,10 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeRenewableCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof GcsCredential,
+        "Expected GcsCredential, but got %s",
+        cred.getClass().getSimpleName());
     GcsCredential gcs = (GcsCredential) cred;
     set(UCHadoopConfConstants.GCS_INIT_OAUTH_TOKEN, gcs.oauthToken());
     // Expiration may be absent (e.g. a static token provider), so write the key only when set.
@@ -56,6 +61,10 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeFixedCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof GcsCredential,
+        "Expected GcsCredential, but got %s",
+        cred.getClass().getSimpleName());
     GcsCredential gcs = (GcsCredential) cred;
     Long expirationTime =
         gcs.expirationTimeMillis() == null ? Long.MAX_VALUE : gcs.expirationTimeMillis();

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -26,7 +26,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeImplOverrides() {
+  protected void setFsImplKeys() {
     saveAndOverride(
         "fs.gs.impl",
         "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
@@ -38,13 +38,13 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeVendedProviderKeys() {
+  protected void setVendedProviderKeys() {
     set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER");
     set("fs.gs.auth.access.token.provider", GCS_VENDED_TOKEN_PROVIDER_CLASS);
   }
 
   @Override
-  protected void writeRenewableCredKeys(GenericCredential cred) {
+  protected void setRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof GcsCredential,
         "Expected GcsCredential, but got %s",
@@ -60,7 +60,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeFixedCredKeys(GenericCredential cred) {
+  protected void setFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof GcsCredential,
         "Expected GcsCredential, but got %s",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.props;
 
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
@@ -37,6 +38,10 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeRenewableCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof AwsCredential,
+        "Expected AwsCredential, but got %s",
+        cred.getClass().getSimpleName());
     AwsCredential aws = (AwsCredential) cred;
     set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, aws.accessKeyId());
     set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, aws.secretAccessKey());
@@ -51,6 +56,10 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
 
   @Override
   protected void writeFixedCredKeys(GenericCredential cred) {
+    Preconditions.checkArgument(
+        cred instanceof AwsCredential,
+        "Expected AwsCredential, but got %s",
+        cred.getClass().getSimpleName());
     AwsCredential aws = (AwsCredential) cred;
     set(S3A_ACCESS_KEY, aws.accessKeyId());
     set(S3A_SECRET_KEY, aws.secretAccessKey());

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -22,7 +22,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeImplOverrides() {
+  protected void setFsImplKeys() {
     saveAndOverride("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride(
@@ -32,12 +32,12 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeVendedProviderKeys() {
+  protected void setVendedProviderKeys() {
     set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS);
   }
 
   @Override
-  protected void writeRenewableCredKeys(GenericCredential cred) {
+  protected void setRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AwsCredential,
         "Expected AwsCredential, but got %s",
@@ -55,7 +55,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void writeFixedCredKeys(GenericCredential cred) {
+  protected void setFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AwsCredential,
         "Expected AwsCredential, but got %s",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -1,0 +1,56 @@
+package io.unitycatalog.hadoop.internal.props;
+
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import org.apache.hadoop.conf.Configuration;
+
+/** Builds S3 credential properties. */
+final class S3CredPropsBuilder extends CredPropsBuilder {
+  private static final String AWS_VENDED_TOKEN_PROVIDER_CLASS =
+      "io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider";
+
+  S3CredPropsBuilder(Configuration hadoopConf) {
+    super(hadoopConf);
+    set("fs.s3a.path.style.access", "true");
+    set("fs.s3.impl.disable.cache", "true");
+    set("fs.s3a.impl.disable.cache", "true");
+  }
+
+  @Override
+  protected void writeImplOverrides() {
+    saveAndOverride("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
+    saveAndOverride("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
+    saveAndOverride(
+        "fs.AbstractFileSystem.s3.impl", "org.apache.hadoop.fs.s3a.S3A", CRED_SCOPED_AFS_CLASS);
+    saveAndOverride(
+        "fs.AbstractFileSystem.s3a.impl", "org.apache.hadoop.fs.s3a.S3A", CRED_SCOPED_AFS_CLASS);
+  }
+
+  @Override
+  protected void applyVendedProviderKeys() {
+    set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS);
+  }
+
+  @Override
+  protected void writeRenewableCredKeys(GenericCredential cred) {
+    AwsCredential aws = (AwsCredential) cred;
+    set(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, aws.accessKeyId());
+    set(UCHadoopConfConstants.S3A_INIT_SECRET_KEY, aws.secretAccessKey());
+    set(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, aws.sessionToken());
+    // Expiration may be absent (e.g. a static token provider), so write the key only when set.
+    if (aws.expirationTimeMillis() != null) {
+      set(
+          UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME,
+          String.valueOf(aws.expirationTimeMillis()));
+    }
+  }
+
+  @Override
+  protected void writeFixedCredKeys(GenericCredential cred) {
+    AwsCredential aws = (AwsCredential) cred;
+    set("fs.s3a.access.key", aws.accessKeyId());
+    set("fs.s3a.secret.key", aws.secretAccessKey());
+    set("fs.s3a.session.token", aws.sessionToken());
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -28,7 +28,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void applyVendedProviderKeys() {
+  protected void writeVendedProviderKeys() {
     set(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER, AWS_VENDED_TOKEN_PROVIDER_CLASS);
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -9,6 +9,9 @@ import org.apache.hadoop.conf.Configuration;
 final class S3CredPropsBuilder extends CredPropsBuilder {
   private static final String AWS_VENDED_TOKEN_PROVIDER_CLASS =
       "io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider";
+  private static final String S3A_ACCESS_KEY = "fs.s3a.access.key";
+  private static final String S3A_SECRET_KEY = "fs.s3a.secret.key";
+  private static final String S3A_SESSION_TOKEN = "fs.s3a.session.token";
 
   S3CredPropsBuilder(Configuration hadoopConf) {
     super(hadoopConf);
@@ -49,8 +52,8 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   @Override
   protected void writeFixedCredKeys(GenericCredential cred) {
     AwsCredential aws = (AwsCredential) cred;
-    set("fs.s3a.access.key", aws.accessKeyId());
-    set("fs.s3a.secret.key", aws.secretAccessKey());
-    set("fs.s3a.session.token", aws.sessionToken());
+    set(S3A_ACCESS_KEY, aws.accessKeyId());
+    set(S3A_SECRET_KEY, aws.secretAccessKey());
+    set(S3A_SESSION_TOKEN, aws.sessionToken());
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -22,7 +22,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFsImplKeys() {
+  protected void setCredScopedFsKeys() {
     saveAndOverride("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem", CRED_SCOPED_FS_CLASS);
     saveAndOverride(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1692/files) to review incremental changes.
- [**stack/credential-property-builders**](https://github.com/unitycatalog/unitycatalog/pull/1692) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1692/files)] ← _this PR_
  - [stack/normalize-cloud-storage-prefixes](https://github.com/unitycatalog/unitycatalog/pull/1693) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1693/files/082ff24468a7a1440012466f717219832a012c36..607ecf0161b3c1289ab89c48d4bd4587e1df1075)]
    - [stack/location-aware-delegate-cache-keys](https://github.com/unitycatalog/unitycatalog/pull/1695) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1695/files/607ecf0161b3c1289ab89c48d4bd4587e1df1075..8ea3692a327ccb67f7f380ef8a2e57a4984dc8d4)]
      - [stack/credential-location-identity](https://github.com/unitycatalog/unitycatalog/pull/1699) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1699/files/8ea3692a327ccb67f7f380ef8a2e57a4984dc8d4..9678b39a8b80f2cc49c501862f2a588465841d98)]
        - [stack/select-vended-credential-by-location](https://github.com/unitycatalog/unitycatalog/pull/1701) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1701/files/9678b39a8b80f2cc49c501862f2a588465841d98..aca6d1deba11a8e63a91443c7802dc9404d7b488)]
          - [stack/scoped-credential-namespaces](https://github.com/unitycatalog/unitycatalog/pull/1704) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1704/files/aca6d1deba11a8e63a91443c7802dc9404d7b488..03a9c5a58b4c484148abce4151a08679c00f9da7)]
            - [stack/encode-scoped-vended-credentials](https://github.com/unitycatalog/unitycatalog/pull/1705) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1705/files/03a9c5a58b4c484148abce4151a08679c00f9da7..775af5e9e15df81804d7575994444222ef44a9d3)]

---------
## Summary

- Extract provider-specific Hadoop credential-property construction from `CredPropsUtil` into dedicated S3, GCS, and ABFS builders.
- Select the builder through `CloudType` while preserving static and renewable credential wiring, credential-scoped filesystem overrides, and GCS configuration behavior.

## Issue
https://github.com/unitycatalog/unitycatalog/issues/1694