### PR TITLE
Implement native Iceberg REST catalog write endpoints

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1688,6 +1688,7 @@ components:
       type: string
       enum:
         - DELTA
+        - ICEBERG
         - CSV
         - JSON
         - AVRO

--- a/clients/java/src/test/java/io/unitycatalog/client/EnumDeserializationTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/EnumDeserializationTest.java
@@ -55,8 +55,7 @@ public class EnumDeserializationTest {
   @Test
   public void testDataSourceFormatUnknownValueDeserialization() {
     // Test that an unknown DataSourceFormat value deserializes to UNKNOWN
-    // Using ICEBERG as an example of a format not in the current API spec
-    String unknownFormat = "\"ICEBERG\"";
+    String unknownFormat = "\"NEW_FUTURE_FORMAT\"";
     assertThatCode(
             () -> {
               DataSourceFormat format =
@@ -194,7 +193,7 @@ public class EnumDeserializationTest {
             + "\"table_type\": \"TEMPORARY_VIEW\","
             + "\"catalog_name\": \"main\","
             + "\"schema_name\": \"default\","
-            + "\"data_source_format\": \"ICEBERG\","
+            + "\"data_source_format\": \"NEW_FUTURE_FORMAT\","
             + "\"created_at\": 1234567890"
             + "}";
 

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -37,6 +37,8 @@ server.access-token-timeout=PT24H
 # Enable MANAGED table
 # Default: true (enabled)
 # server.managed-table.enabled=true
+# Native Iceberg REST table writes are experimental and disabled by default.
+# server.iceberg-table.enabled=false
 
 #### AWS credential configs
 

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -217,16 +217,18 @@ public class UnityCatalogServer implements AutoCloseable {
         .annotateUc(
             "external-locations",
             new ExternalLocationService(authorizer, repositories, serverProperties));
-    addIcebergApiServices(armeriaServerBuilder, schemaService, repositories, fileOperations);
+    addIcebergApiServices(
+        armeriaServerBuilder, authorizer, repositories, fileOperations, serverProperties);
     addDeltaApiServices(
         armeriaServerBuilder, authorizer, repositories, serverProperties, storageCredentialVendor);
   }
 
   private void addIcebergApiServices(
       ArmeriaServerBuilder armeriaServerBuilder,
-      SchemaService schemaService,
+      UnityCatalogAuthorizer authorizer,
       Repositories repositories,
-      FileOperations fileOperations) {
+      FileOperations fileOperations,
+      ServerProperties serverProperties) {
     LOGGER.info("Adding Iceberg services...");
 
     // Add support for Iceberg REST APIs
@@ -236,7 +238,7 @@ public class UnityCatalogServer implements AutoCloseable {
     armeriaServerBuilder.annotateIceberg(
         "iceberg",
         new IcebergRestCatalogService(
-            schemaService, tableConfigService, metadataService, repositories));
+            authorizer, tableConfigService, metadataService, repositories, serverProperties));
   }
 
   private void addDeltaApiServices(

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -36,6 +36,31 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
 
   @Override
   protected BaseException toBaseException(Throwable cause) {
+    if (cause instanceof BaseException baseException) {
+      return switch (baseException.getErrorCode()) {
+        case SCHEMA_NOT_FOUND ->
+            wrapException(
+                ErrorCode.NOT_FOUND,
+                baseException.getErrorMessage(),
+                new NoSuchNamespaceException("%s", baseException.getErrorMessage()));
+        case TABLE_NOT_FOUND ->
+            wrapException(
+                ErrorCode.NOT_FOUND,
+                baseException.getErrorMessage(),
+                new NoSuchTableException("%s", baseException.getErrorMessage()));
+        case SCHEMA_ALREADY_EXISTS, TABLE_ALREADY_EXISTS ->
+            wrapException(
+                ErrorCode.ALREADY_EXISTS,
+                baseException.getErrorMessage(),
+                new AlreadyExistsException("%s", baseException.getErrorMessage()));
+        case UPDATE_REQUIREMENT_CONFLICT ->
+            wrapException(
+                ErrorCode.ALREADY_EXISTS,
+                baseException.getErrorMessage(),
+                new CommitFailedException("%s", baseException.getErrorMessage()));
+        default -> baseException;
+      };
+    }
     if (cause instanceof NoSuchNamespaceException
         || cause instanceof NoSuchTableException
         || cause instanceof NoSuchViewException) {

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -18,6 +18,7 @@ import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.RepositoryUtils;
 import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.service.delta.DeltaUniformUtils;
 import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
@@ -26,7 +27,6 @@ import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
-import jakarta.persistence.PessimisticLockException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -36,7 +36,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.NativeQuery;
@@ -284,38 +283,13 @@ public class DeltaCommitRepository {
           // Serialize all commit/backfill mutations on this table by write-locking its uc_tables
           // row, matching the Delta update path. This makes the commit-log reads and writes below
           // atomic against a concurrent commit or backfill.
-          lockTableForCommit(session, tableInfoDAO, tableId, Optional.empty());
+          RepositoryUtils.lockTableForCommit(session, tableInfoDAO, tableId, Optional.empty());
           validateTableForCommit(session, commit, tableInfoDAO, uniformFields);
           postCommitCore(session, tableId, tableInfoDAO, commit, uniformFields);
           return null;
         },
         "Error committing to table: " + commit.getTableId(),
         /* readOnly = */ false);
-  }
-
-  /**
-   * Acquire a {@code PESSIMISTIC_WRITE} lock on the table's {@code uc_tables} row so concurrent
-   * CCv2 commit/backfill transactions on the same table serialize. Shared by both commit entry
-   * points: UC REST {@code postCommit} and the Delta update path.
-   *
-   * <p>Call this before reading or mutating commit-log state (and, on the Delta path, before
-   * snapshotting the etag): {@code session.refresh} reloads the row, so calling it after in-memory
-   * DAO mutations would discard them.
-   *
-   * <p>A lock-wait timeout or deadlock surfaces as {@code UPDATE_REQUIREMENT_CONFLICT} (409) so the
-   * client retries, rather than as a generic 500.
-   */
-  public static void lockTableForCommit(
-      Session session, TableInfoDAO dao, UUID tableId, Optional<String> tableFullNameForLogging) {
-    try {
-      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
-    } catch (PessimisticLockException e) {
-      throw new BaseException(
-          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "Concurrent commit in progress on table "
-              + tableFullNameForLogging.orElseGet(tableId::toString)
-              + "; retry the request.");
-    }
   }
 
   /**
@@ -766,7 +740,7 @@ public class DeltaCommitRepository {
    *
    * <p>Covers only versions still tracked in the DB; a replay of a backfilled-and-purged version is
    * conservatively reported as not-a-replay. The caller must hold the table lock (see {@link
-   * #lockTableForCommit}).
+   * RepositoryUtils#lockTableForCommit}).
    *
    * <p>Filename with the client-generated, per-commit-unique UUID is used for dedup.
    *

--- a/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
@@ -40,6 +40,17 @@ public class StagingTableRepository {
     return query.uniqueResult(); // Returns null if no result is found
   }
 
+  public boolean isUncommittedStagingLocation(NormalizedURL stagingLocation) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          StagingTableDAO stagingTable = findByStagingLocation(session, stagingLocation);
+          return stagingTable != null && !stagingTable.isStageCommitted();
+        },
+        "Failed to look up staging table at " + stagingLocation,
+        /* readOnly = */ true);
+  }
+
   private void validateIfAlreadyExists(
       Session session, UUID schemaId, String tableName, NormalizedURL stagingLocation) {
     // Check if table by the same name already exists. It's OK if a staging table with the same name

--- a/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
@@ -40,17 +40,6 @@ public class StagingTableRepository {
     return query.uniqueResult(); // Returns null if no result is found
   }
 
-  public boolean isUncommittedStagingLocation(NormalizedURL stagingLocation) {
-    return TransactionManager.executeWithTransaction(
-        sessionFactory,
-        session -> {
-          StagingTableDAO stagingTable = findByStagingLocation(session, stagingLocation);
-          return stagingTable != null && !stagingTable.isStageCommitted();
-        },
-        "Failed to look up staging table at " + stagingLocation,
-        /* readOnly = */ true);
-  }
-
   private void validateIfAlreadyExists(
       Session session, UUID schemaId, String tableName, NormalizedURL stagingLocation) {
     // Check if table by the same name already exists. It's OK if a staging table with the same name

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -52,9 +52,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.LockMode;
+import org.hibernate.PessimisticLockException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.PessimisticLockException;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +80,10 @@ public class TableRepository {
    * always finalize to MANAGED Delta.
    */
   public record TableStorageLocationInfo(NormalizedURL url, TableType tableType) {}
+
+  /** Detached catalog state needed to load or commit an Iceberg metadata file. */
+  public record IcebergTableState(
+      UUID tableId, DataSourceFormat dataSourceFormat, String metadataLocation) {}
 
   /**
    * Retrieves the storage location for a table or staging table by its ID, plus the table type.
@@ -385,8 +389,8 @@ public class TableRepository {
 
   /**
    * Acquire {@code SELECT ... FOR UPDATE} on the table row and refresh in-memory state, so two
-   * concurrent Iceberg REST commits serialize. Lock-wait timeouts and deadlock
-   * victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
+   * concurrent Iceberg REST commits serialize. Lock-wait timeouts and deadlock victims surface as
+   * {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
    */
   private static void lockTableForUpdate(
       Session session, TableInfoDAO dao, String catalog, String schema, String table) {
@@ -588,25 +592,62 @@ public class TableRepository {
     return dao.getUniformIcebergMetadataLocation();
   }
 
+  public IcebergTableState getIcebergTableState(
+      String catalogName, String schemaName, String tableName) {
+    return getIcebergTableState(catalogName, schemaName, tableName, false);
+  }
+
+  public IcebergTableState getNativeIcebergTableState(
+      String catalogName, String schemaName, String tableName) {
+    return getIcebergTableState(catalogName, schemaName, tableName, true);
+  }
+
+  private IcebergTableState getIcebergTableState(
+      String catalogName, String schemaName, String tableName, boolean requireNativeIceberg) {
+    String fullName = catalogName + "." + schemaName + "." + tableName;
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
+          DataSourceFormat dataSourceFormat =
+              dao.getDataSourceFormat() == null
+                  ? null
+                  : DataSourceFormat.fromValue(dao.getDataSourceFormat());
+          if (requireNativeIceberg && dataSourceFormat != DataSourceFormat.ICEBERG) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Table is not a native Iceberg table and cannot be committed to via the Iceberg"
+                    + " REST catalog: "
+                    + fullName);
+          }
+          return new IcebergTableState(
+              dao.getId(), dataSourceFormat, dao.getUniformIcebergMetadataLocation());
+        },
+        "Failed to load Iceberg table state for " + fullName,
+        /* readOnly = */ true);
+  }
+
   /**
-   * Compare-and-swap the Iceberg metadata location of a native Iceberg table (created through the
-   * Iceberg REST catalog). This is the linearization point of an Iceberg REST commit: the metadata
-   * file for {@code newMetadataLocation} is written by the caller before this method runs, and the
-   * swap only succeeds when the stored location still matches {@code expectedMetadataLocation}
-   * ({@code null} for a freshly created table). A mismatch means a concurrent commit won and
-   * surfaces as {@link ErrorCode#UPDATE_REQUIREMENT_CONFLICT} so the caller can translate it into
-   * an Iceberg {@code CommitFailedException}.
+   * Commits a native Iceberg table's metadata pointer, UC columns, and UC properties in one locked
+   * transaction. This is the linearization point of an Iceberg REST commit: the metadata file for
+   * {@code newMetadataLocation} is written by the caller before this method runs, and the update
+   * only succeeds when the stored location still matches {@code expectedMetadataLocation}. A
+   * mismatch means a concurrent commit won and surfaces as {@link
+   * ErrorCode#UPDATE_REQUIREMENT_CONFLICT} so the caller can translate it into an Iceberg {@code
+   * CommitFailedException}.
    *
    * <p>Only tables with {@link DataSourceFormat#ICEBERG} can be committed to: UniForm-enabled Delta
    * tables also carry a uniform metadata location, but their Iceberg metadata is derived from the
    * Delta log and stays read-only through this API.
    */
-  public void setIcebergMetadataLocation(
+  public void commitIcebergTable(
       String catalogName,
       String schemaName,
       String tableName,
       String expectedMetadataLocation,
-      String newMetadataLocation) {
+      NormalizedURL newMetadataLocation,
+      List<ColumnInfo> columns,
+      Map<String, String> tableProperties) {
     String callerId = IdentityUtils.findPrincipalEmailAddress();
     String fullName = catalogName + "." + schemaName + "." + tableName;
     TransactionManager.executeWithTransaction(
@@ -631,7 +672,23 @@ public class TableRepository {
                     + " but found "
                     + dao.getUniformIcebergMetadataLocation());
           }
-          dao.setUniformIcebergMetadataLocation(newMetadataLocation);
+          List<ColumnInfoDAO> newColumns = ColumnInfoDAO.fromList(columns);
+          newColumns.forEach(
+              column -> {
+                column.setId(UUID.randomUUID());
+                column.setTable(dao);
+              });
+          dao.getColumns().clear();
+          session.flush();
+          dao.getColumns().addAll(newColumns);
+          dao.setColumnCount(newColumns.size());
+
+          MutablePropertyMap properties = MutablePropertyMap.load(session, dao.getId());
+          properties.removeAll(new ArrayList<>(properties.asMap().keySet()));
+          properties.putAll(tableProperties);
+          properties.flush(session, dao.getId());
+
+          dao.setUniformIcebergMetadataLocation(newMetadataLocation.toString());
           dao.setUpdatedAt(new Date());
           dao.setUpdatedBy(callerId);
           session.merge(dao);
@@ -655,7 +712,20 @@ public class TableRepository {
   }
 
   public TableInfo createTable(CreateTable createTable) {
-    return createTableImpl(createTable, Optional.empty(), (session, dao, tableInfo) -> tableInfo);
+    return createTableImpl(
+        createTable, Optional.empty(), Optional.empty(), (session, dao, tableInfo) -> tableInfo);
+  }
+
+  public TableInfo createTableForIceberg(CreateTable createTable, NormalizedURL metadataLocation) {
+    if (createTable.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "createTableForIceberg requires ICEBERG format.");
+    }
+    return createTableImpl(
+        createTable,
+        Optional.empty(),
+        Optional.of(metadataLocation),
+        (session, dao, tableInfo) -> tableInfo);
   }
 
   /**
@@ -674,6 +744,7 @@ public class TableRepository {
     return createTableImpl(
         createTable,
         uniformFields,
+        Optional.empty(),
         (session, dao, tableInfo) ->
             buildLoadTableResponse(
                 session,
@@ -685,16 +756,17 @@ public class TableRepository {
   }
 
   /**
-   * Shared implementation for the two {@code create} entry points. Validates the name, opens a
+   * Shared implementation for the table {@code create} entry points. Validates the name, opens a
    * write transaction, builds the new {@link TableInfoDAO} (row, columns, properties), applies
-   * UniForm Iceberg metadata when {@code uniformFields} is non-empty, persists the DAO, then hands
-   * it and the built {@link TableInfo} to {@code mapper} which picks the return shape each caller
-   * needs. Keeps the create path as a single operation, and pins all DAO setters before {@code
-   * session.persist} so the create lands as a single INSERT.
+   * UniForm or native Iceberg metadata when supplied, persists the DAO, then hands it and the built
+   * {@link TableInfo} to {@code mapper} which picks the return shape each caller needs. Keeps the
+   * create path as a single operation, and pins all DAO setters before {@code session.persist} so
+   * the create lands as a single INSERT.
    */
   private <T> T createTableImpl(
       CreateTable createTable,
       Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields,
+      Optional<NormalizedURL> nativeIcebergMetadataLocation,
       CreateResultMapper<T> mapper) {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
@@ -746,24 +818,26 @@ public class TableRepository {
           } else if (tableType == TableType.MANAGED) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             serverProperties.checkManagedTableEnabled();
-            if (createTable.getDataSourceFormat() != DataSourceFormat.DELTA) {
+            if (createTable.getDataSourceFormat() != DataSourceFormat.DELTA
+                && createTable.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
               throw new BaseException(
                   ErrorCode.INVALID_ARGUMENT,
-                  "Managed table creation is only supported for Delta format.");
+                  "Managed table creation is only supported for Delta and Iceberg formats.");
             }
-            // Find and commit staging table with the same staging location
             StagingTableDAO stagingTableDAO =
                 repositories
                     .getStagingTableRepository()
                     .commitStagingTable(session, callerId, storageLocation);
             tableUUID = stagingTableDAO.getId();
-            // MANAGED tables (created via either UC REST or Delta REST) must carry UC_TABLE_ID in
-            // their properties, matching the staging UUID. UC has the staging UUID as the source of
-            // truth; a request with a missing or mismatched UC_TABLE_ID gets rejected here
-            // instead of producing an internally-inconsistent UC table that subsequent commits
-            // would fail on.
-            UcManagedDeltaContract.validateTableIdProperty(
-                createTable.getProperties(), tableUUID.toString());
+            if (createTable.getDataSourceFormat() == DataSourceFormat.DELTA) {
+              // MANAGED tables (created via either UC REST or Delta REST) must carry UC_TABLE_ID
+              // in their properties, matching the staging UUID. UC has the staging UUID as the
+              // source of truth; a request with a missing or mismatched UC_TABLE_ID gets rejected
+              // here instead of producing an internally-inconsistent UC table that subsequent
+              // commits would fail on.
+              UcManagedDeltaContract.validateTableIdProperty(
+                  createTable.getProperties(), tableUUID.toString());
+            }
           } else if (tableType == TableType.METRIC_VIEW) {
             storageLocation = null;
             validateMetricView(session, createTable);
@@ -817,6 +891,8 @@ public class TableRepository {
           // UniForm Iceberg fields (when supplied by the Delta create path) are written while the
           // entity is still transient so they're folded into the single INSERT below.
           DeltaUniformUtils.applyToDao(tableInfoDAO, uniformFields);
+          nativeIcebergMetadataLocation.ifPresent(
+              location -> tableInfoDAO.setUniformIcebergMetadataLocation(location.toString()));
           session.persist(tableInfoDAO);
           if (RepositoryUtils.isViewLike(tableType.getValue())) {
             DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
@@ -1041,43 +1117,5 @@ public class TableRepository {
         .forEach(session::remove);
     session.remove(tableInfoDAO);
     return tableInfoDAO;
-  }
-
-  /**
-   * Renames a table within the same schema. Looks up the source table by its three-part name
-   * (throwing {@link ErrorCode#TABLE_NOT_FOUND} if absent) and rejects a collision with an existing
-   * table of the target name in the same schema (throwing {@link ErrorCode#TABLE_ALREADY_EXISTS}).
-   * Renaming a table to its current name is an idempotent no-op. Metadata-only: the table UUID,
-   * schema, and storage location are all unchanged.
-   */
-  public void renameTable(String catalog, String schema, String table, String newName) {
-    ValidationUtils.validateSqlObjectName(newName);
-    String callerId = IdentityUtils.findPrincipalEmailAddress();
-    TransactionManager.executeWithTransaction(
-        sessionFactory,
-        session -> {
-          UUID schemaId =
-              repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
-          TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, table);
-          if (tableInfoDAO == null) {
-            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + table);
-          }
-          // Do the no-op check after the table lookup. A missing table must still return
-          // TABLE_NOT_FOUND rather than succeed as a no-op.
-          if (table.equals(newName)) {
-            return null;
-          }
-          if (findBySchemaIdAndName(session, schemaId, newName) != null) {
-            throw new BaseException(
-                ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + newName);
-          }
-          tableInfoDAO.setName(newName);
-          tableInfoDAO.setUpdatedAt(new Date());
-          tableInfoDAO.setUpdatedBy(callerId);
-          session.merge(tableInfoDAO);
-          return null;
-        },
-        "Failed to rename table " + catalog + "." + schema + "." + table,
-        /* readOnly = */ false);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -51,8 +51,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
-import org.hibernate.LockMode;
-import org.hibernate.PessimisticLockException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -83,7 +81,10 @@ public class TableRepository {
 
   /** Detached catalog state needed to load or commit an Iceberg metadata file. */
   public record IcebergTableState(
-      UUID tableId, DataSourceFormat dataSourceFormat, String metadataLocation) {}
+      UUID tableId,
+      DataSourceFormat dataSourceFormat,
+      String metadataLocation,
+      String storageLocation) {}
 
   /**
    * Retrieves the storage location for a table or staging table by its ID, plus the table type.
@@ -329,8 +330,7 @@ public class TableRepository {
         session -> {
           TableInfoDAO dao = findTableOrThrow(session, catalog, schema, table);
           requireDeltaTable(dao, catalog, schema, table);
-          DeltaCommitRepository.lockTableForCommit(
-              session, dao, dao.getId(), Optional.of(tableFullName));
+          RepositoryUtils.lockTableForCommit(session, dao, dao.getId(), Optional.of(tableFullName));
           // assert-table-uuid is stable identity, so check it up front. assert-etag is deferred to
           // after the apply, captured here against pre-apply state: a commit advances the etag, and
           // an idempotent replay must bypass the etag entirely (it throws mid-apply and rolls back
@@ -384,28 +384,6 @@ public class TableRepository {
       throw new BaseException(
           ErrorCode.UNSUPPORTED_TABLE_FORMAT,
           "Table is not a Delta table: " + catalog + "." + schema + "." + table);
-    }
-  }
-
-  /**
-   * Acquire {@code SELECT ... FOR UPDATE} on the table row and refresh in-memory state, so two
-   * concurrent Iceberg REST commits serialize. Lock-wait timeouts and deadlock victims surface as
-   * {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
-   */
-  private static void lockTableForUpdate(
-      Session session, TableInfoDAO dao, String catalog, String schema, String table) {
-    try {
-      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
-    } catch (PessimisticLockException e) {
-      throw new BaseException(
-          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
-          "Concurrent update in progress on "
-              + catalog
-              + "."
-              + schema
-              + "."
-              + table
-              + "; retry the request.");
     }
   }
 
@@ -621,7 +599,7 @@ public class TableRepository {
                     + fullName);
           }
           return new IcebergTableState(
-              dao.getId(), dataSourceFormat, dao.getUniformIcebergMetadataLocation());
+              dao.getId(), dataSourceFormat, dao.getUniformIcebergMetadataLocation(), dao.getUrl());
         },
         "Failed to load Iceberg table state for " + fullName,
         /* readOnly = */ true);
@@ -661,7 +639,7 @@ public class TableRepository {
                     + " REST catalog: "
                     + fullName);
           }
-          lockTableForUpdate(session, dao, catalogName, schemaName, tableName);
+          RepositoryUtils.lockTableForCommit(session, dao, dao.getId(), Optional.of(fullName));
           if (!Objects.equals(dao.getUniformIcebergMetadataLocation(), expectedMetadataLocation)) {
             throw new BaseException(
                 ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
@@ -684,6 +662,9 @@ public class TableRepository {
           dao.setColumnCount(newColumns.size());
 
           MutablePropertyMap properties = MutablePropertyMap.load(session, dao.getId());
+          // Native Iceberg metadata is the authoritative projection of UC-visible properties. A
+          // commit therefore replaces the complete property set; server-owned properties must not
+          // be persisted here because the next client snapshot would intentionally erase them.
           properties.removeAll(new ArrayList<>(properties.asMap().keySet()));
           properties.putAll(tableProperties);
           properties.flush(session, dao.getId());
@@ -712,14 +693,52 @@ public class TableRepository {
   }
 
   public TableInfo createTable(CreateTable createTable) {
+    requireNonIcebergFormat(createTable, "createTable");
     return createTableImpl(
         createTable, Optional.empty(), Optional.empty(), (session, dao, tableInfo) -> tableInfo);
   }
 
+  /**
+   * Renames a table within its schema. Looks up the source table first (throwing {@link
+   * ErrorCode#TABLE_NOT_FOUND} if absent) and rejects a collision with an existing table of the
+   * target name in the same schema (throwing {@link ErrorCode#TABLE_ALREADY_EXISTS}). Renaming a
+   * table to its current name is an idempotent no-op. Metadata-only: the table UUID, schema, and
+   * storage location are all unchanged.
+   */
+  public void renameTable(String catalog, String schema, String table, String newName) {
+    ValidationUtils.validateSqlObjectName(newName);
+    String callerId = IdentityUtils.findPrincipalEmailAddress();
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
+          TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, table);
+          if (tableInfoDAO == null) {
+            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + table);
+          }
+          // Do the no-op check after the table lookup. A missing table must still return
+          // TABLE_NOT_FOUND rather than succeed as a no-op.
+          if (table.equals(newName)) {
+            return null;
+          }
+          if (findBySchemaIdAndName(session, schemaId, newName) != null) {
+            throw new BaseException(
+                ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + newName);
+          }
+          tableInfoDAO.setName(newName);
+          tableInfoDAO.setUpdatedAt(new Date());
+          tableInfoDAO.setUpdatedBy(callerId);
+          session.merge(tableInfoDAO);
+          return null;
+        },
+        "Failed to rename table " + catalog + "." + schema + "." + table,
+        /* readOnly = */ false);
+  }
+
   public TableInfo createTableForIceberg(CreateTable createTable, NormalizedURL metadataLocation) {
     if (createTable.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "createTableForIceberg requires ICEBERG format.");
+      throw new BaseException(ErrorCode.INTERNAL, "createTableForIceberg requires ICEBERG format.");
     }
     return createTableImpl(
         createTable,
@@ -741,6 +760,7 @@ public class TableRepository {
    */
   public DeltaLoadTableResponse createTableForDelta(
       CreateTable createTable, Optional<DeltaUniformUtils.UniformIcebergFields> uniformFields) {
+    requireNonIcebergFormat(createTable, "createTableForDelta");
     return createTableImpl(
         createTable,
         uniformFields,
@@ -753,6 +773,14 @@ public class TableRepository {
                 createTable.getCatalogName(),
                 createTable.getSchemaName(),
                 createTable.getName()));
+  }
+
+  private static void requireNonIcebergFormat(CreateTable createTable, String caller) {
+    if (createTable.getDataSourceFormat() == DataSourceFormat.ICEBERG) {
+      throw new BaseException(
+          ErrorCode.UNSUPPORTED_TABLE_FORMAT,
+          caller + " cannot create native ICEBERG tables; use createTableForIceberg instead.");
+    }
   }
 
   /**
@@ -824,6 +852,8 @@ public class TableRepository {
                   ErrorCode.INVALID_ARGUMENT,
                   "Managed table creation is only supported for Delta and Iceberg formats.");
             }
+            // Find and commit the staging table with the same staging location. This single
+            // transaction validates ownership and prevents a staging location from being reused.
             StagingTableDAO stagingTableDAO =
                 repositories
                     .getStagingTableRepository()

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -698,44 +698,6 @@ public class TableRepository {
         createTable, Optional.empty(), Optional.empty(), (session, dao, tableInfo) -> tableInfo);
   }
 
-  /**
-   * Renames a table within its schema. Looks up the source table first (throwing {@link
-   * ErrorCode#TABLE_NOT_FOUND} if absent) and rejects a collision with an existing table of the
-   * target name in the same schema (throwing {@link ErrorCode#TABLE_ALREADY_EXISTS}). Renaming a
-   * table to its current name is an idempotent no-op. Metadata-only: the table UUID, schema, and
-   * storage location are all unchanged.
-   */
-  public void renameTable(String catalog, String schema, String table, String newName) {
-    ValidationUtils.validateSqlObjectName(newName);
-    String callerId = IdentityUtils.findPrincipalEmailAddress();
-    TransactionManager.executeWithTransaction(
-        sessionFactory,
-        session -> {
-          UUID schemaId =
-              repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
-          TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, table);
-          if (tableInfoDAO == null) {
-            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + table);
-          }
-          // Do the no-op check after the table lookup. A missing table must still return
-          // TABLE_NOT_FOUND rather than succeed as a no-op.
-          if (table.equals(newName)) {
-            return null;
-          }
-          if (findBySchemaIdAndName(session, schemaId, newName) != null) {
-            throw new BaseException(
-                ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + newName);
-          }
-          tableInfoDAO.setName(newName);
-          tableInfoDAO.setUpdatedAt(new Date());
-          tableInfoDAO.setUpdatedBy(callerId);
-          session.merge(tableInfoDAO);
-          return null;
-        },
-        "Failed to rename table " + catalog + "." + schema + "." + table,
-        /* readOnly = */ false);
-  }
-
   public TableInfo createTableForIceberg(CreateTable createTable, NormalizedURL metadataLocation) {
     if (createTable.getDataSourceFormat() != DataSourceFormat.ICEBERG) {
       throw new BaseException(ErrorCode.INTERNAL, "createTableForIceberg requires ICEBERG format.");
@@ -779,7 +741,9 @@ public class TableRepository {
     if (createTable.getDataSourceFormat() == DataSourceFormat.ICEBERG) {
       throw new BaseException(
           ErrorCode.UNSUPPORTED_TABLE_FORMAT,
-          caller + " cannot create native ICEBERG tables; use createTableForIceberg instead.");
+          caller
+              + " cannot create native ICEBERG tables; use the Iceberg REST catalog endpoints"
+              + " instead.");
     }
   }
 
@@ -1147,5 +1111,43 @@ public class TableRepository {
         .forEach(session::remove);
     session.remove(tableInfoDAO);
     return tableInfoDAO;
+  }
+
+  /**
+   * Renames a table within the same schema. Looks up the source table by its three-part name
+   * (throwing {@link ErrorCode#TABLE_NOT_FOUND} if absent) and rejects a collision with an existing
+   * table of the target name in the same schema (throwing {@link ErrorCode#TABLE_ALREADY_EXISTS}).
+   * Renaming a table to its current name is an idempotent no-op. Metadata-only: the table UUID,
+   * schema, and storage location are all unchanged.
+   */
+  public void renameTable(String catalog, String schema, String table, String newName) {
+    ValidationUtils.validateSqlObjectName(newName);
+    String callerId = IdentityUtils.findPrincipalEmailAddress();
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
+          TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, table);
+          if (tableInfoDAO == null) {
+            throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + table);
+          }
+          // Do the no-op check after the table lookup. A missing table must still return
+          // TABLE_NOT_FOUND rather than succeed as a no-op.
+          if (table.equals(newName)) {
+            return null;
+          }
+          if (findBySchemaIdAndName(session, schemaId, newName) != null) {
+            throw new BaseException(
+                ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + newName);
+          }
+          tableInfoDAO.setName(newName);
+          tableInfoDAO.setUpdatedAt(new Date());
+          tableInfoDAO.setUpdatedBy(callerId);
+          session.merge(tableInfoDAO);
+          return null;
+        },
+        "Failed to rename table " + catalog + "." + schema + "." + table,
+        /* readOnly = */ false);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -51,8 +51,10 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.PessimisticLockException;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -382,6 +384,28 @@ public class TableRepository {
   }
 
   /**
+   * Acquire {@code SELECT ... FOR UPDATE} on the table row and refresh in-memory state, so two
+   * concurrent Iceberg REST commits serialize. Lock-wait timeouts and deadlock
+   * victims surface as {@code UPDATE_REQUIREMENT_CONFLICT} (409) instead of a generic 500.
+   */
+  private static void lockTableForUpdate(
+      Session session, TableInfoDAO dao, String catalog, String schema, String table) {
+    try {
+      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
+    } catch (PessimisticLockException e) {
+      throw new BaseException(
+          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+          "Concurrent update in progress on "
+              + catalog
+              + "."
+              + schema
+              + "."
+              + table
+              + "; retry the request.");
+    }
+  }
+
+  /**
    * Build a {@link DeltaLoadTableResponse} from an already-loaded {@link TableInfoDAO}. Shared by
    * {@link #loadTableForDelta}, {@link #createTableForDelta}, and {@link #updateTableForDelta} so
    * the post-mutation DAO → response assembly stays in one place.
@@ -562,6 +586,59 @@ public class TableRepository {
       Session session, String catalogName, String schemaName, String tableName) {
     TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
     return dao.getUniformIcebergMetadataLocation();
+  }
+
+  /**
+   * Compare-and-swap the Iceberg metadata location of a native Iceberg table (created through the
+   * Iceberg REST catalog). This is the linearization point of an Iceberg REST commit: the metadata
+   * file for {@code newMetadataLocation} is written by the caller before this method runs, and the
+   * swap only succeeds when the stored location still matches {@code expectedMetadataLocation}
+   * ({@code null} for a freshly created table). A mismatch means a concurrent commit won and
+   * surfaces as {@link ErrorCode#UPDATE_REQUIREMENT_CONFLICT} so the caller can translate it into
+   * an Iceberg {@code CommitFailedException}.
+   *
+   * <p>Only tables with {@link DataSourceFormat#ICEBERG} can be committed to: UniForm-enabled Delta
+   * tables also carry a uniform metadata location, but their Iceberg metadata is derived from the
+   * Delta log and stays read-only through this API.
+   */
+  public void setIcebergMetadataLocation(
+      String catalogName,
+      String schemaName,
+      String tableName,
+      String expectedMetadataLocation,
+      String newMetadataLocation) {
+    String callerId = IdentityUtils.findPrincipalEmailAddress();
+    String fullName = catalogName + "." + schemaName + "." + tableName;
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
+          if (!DataSourceFormat.ICEBERG.toString().equals(dao.getDataSourceFormat())) {
+            throw new BaseException(
+                ErrorCode.INVALID_ARGUMENT,
+                "Table is not a native Iceberg table and cannot be committed to via the Iceberg"
+                    + " REST catalog: "
+                    + fullName);
+          }
+          lockTableForUpdate(session, dao, catalogName, schemaName, tableName);
+          if (!Objects.equals(dao.getUniformIcebergMetadataLocation(), expectedMetadataLocation)) {
+            throw new BaseException(
+                ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+                "Metadata location for "
+                    + fullName
+                    + " changed concurrently: expected "
+                    + expectedMetadataLocation
+                    + " but found "
+                    + dao.getUniformIcebergMetadataLocation());
+          }
+          dao.setUniformIcebergMetadataLocation(newMetadataLocation);
+          dao.setUpdatedAt(new Date());
+          dao.setUpdatedBy(callerId);
+          session.merge(dao);
+          return null;
+        },
+        "Failed to update Iceberg metadata location for " + fullName,
+        /* readOnly = */ false);
   }
 
   private TableInfoDAO findTableOrThrow(

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -81,6 +81,11 @@ public class TableInfoDAO extends IdentifiableDAO {
   @Column(name = "view_definition", length = 16777215)
   private String viewDefinition;
 
+  /**
+   * Iceberg metadata pointer for either a Delta UniForm projection or a native Iceberg table. The
+   * meaning is distinguished by {@link #dataSourceFormat}: Delta is authoritative for UniForm;
+   * Iceberg is authoritative for native Iceberg tables.
+   */
   @Column(name = "uniform_iceberg_metadata_location", length = 65535)
   private String uniformIcebergMetadataLocation;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
@@ -90,6 +90,12 @@ public class FileOperations {
    */
   // TODO: Cache fileIOs
   public FileIO getFileIO(NormalizedURL path) {
+    return getFileIO(path, CredentialContext.READ_ONLY);
+  }
+
+  /** Returns a FileIO configured for the requested storage privileges. */
+  public FileIO getFileIO(
+      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
     return switch (UriScheme.fromURI(path.toUri())) {
       // Local paths are served by SimpleLocalFileIO (backed by java.nio + iceberg-core). We
       // deliberately do NOT route these through ResolvingFileIO: it resolves the file:// scheme to
@@ -99,7 +105,7 @@ public class FileOperations {
       case FILE, NULL -> new SimpleLocalFileIO();
       case S3, GS, ABFS, ABFSS -> {
         ResolvingFileIO fileio = new ResolvingFileIO();
-        fileio.initialize(getFileIOConfig(path));
+        fileio.initialize(getFileIOConfig(path, privileges));
         yield fileio;
       }
     };
@@ -113,6 +119,12 @@ public class FileOperations {
    * @param path the normalized storage location to vend credentials and build config for
    */
   public Map<String, String> getFileIOConfig(NormalizedURL path) {
+    return getFileIOConfig(path, CredentialContext.READ_ONLY);
+  }
+
+  /** Builds FileIO configuration using the requested storage privileges. */
+  public Map<String, String> getFileIOConfig(
+      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
     UriScheme scheme = UriScheme.fromURI(path.toUri());
     if (scheme == UriScheme.FILE || scheme == UriScheme.NULL) {
       // Local (file://) paths need no cloud credentials, so short-circuit before vending: the
@@ -121,10 +133,7 @@ public class FileOperations {
       return Map.of();
     }
 
-    // FIXME!! privileges are defaulted to READ only here for now as Iceberg REST impl doesn't
-    //  support write
-    TemporaryCredentials cred =
-        storageCredentialVendor.vendCredential(path, Set.of(CredentialContext.Privilege.SELECT));
+    TemporaryCredentials cred = storageCredentialVendor.vendCredential(path, privileges);
     if (cred.getAzureUserDelegationSas() != null) {
       return getADLSConfig(path, cred.getAzureUserDelegationSas());
     } else if (cred.getGcpOauthToken() != null) {

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
@@ -15,17 +15,39 @@ import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.utils.Constants;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.HashMap;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
 public class RepositoryUtils {
 
   private static final Map<String, Class<?>> PROPERTY_TYPE_MAP = new HashMap<>();
+
+  /**
+   * Acquires the table row lock shared by Delta and Iceberg commit paths. Lock waits and deadlock
+   * victims are reported as retryable requirement conflicts instead of leaking ORM exceptions.
+   */
+  public static void lockTableForCommit(
+      Session session, TableInfoDAO dao, UUID tableId, Optional<String> tableFullNameForLogging) {
+    try {
+      session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
+    } catch (RuntimeException e) {
+      if (!(e instanceof org.hibernate.PessimisticLockException)
+          && !(e instanceof jakarta.persistence.PessimisticLockException)) {
+        throw e;
+      }
+      throw new BaseException(
+          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+          "Concurrent commit in progress on table "
+              + tableFullNameForLogging.orElseGet(tableId::toString)
+              + "; retry the request.");
+    }
+  }
 
   static {
     PROPERTY_TYPE_MAP.put(Constants.FUNCTION, String.class);

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/SimpleLocalFileIO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/SimpleLocalFileIO.java
@@ -24,9 +24,8 @@ import org.slf4j.LoggerFactory;
  * java.nio} with reads delegating to iceberg-core's {@link org.apache.iceberg.Files}.
  *
  * <p>Iceberg's {@link org.apache.iceberg.io.ResolvingFileIO} resolves the file:// scheme to
- * HadoopFileIO, which requires hadoop-client-runtime on the classpath. Since the server only needs
- * read + directory operations on local paths (the Iceberg REST path is read-only), this wrapper
- * avoids that heavy runtime dependency by using only {@code java.nio} and iceberg-core.
+ * HadoopFileIO, which requires hadoop-client-runtime on the classpath. This wrapper keeps local
+ * Iceberg REST metadata reads and writes on the lightweight iceberg-core adapter.
  *
  * <p>It implements {@link DelegateFileIO} (rather than plain {@code FileIO}) for the {@link
  * #deletePrefix(String)} operation that backs directory deletion for managed tables/volumes.
@@ -42,9 +41,18 @@ public class SimpleLocalFileIO implements DelegateFileIO {
 
   @Override
   public OutputFile newOutputFile(String path) {
-    // SimpleLocalFileIO is read-only: the Iceberg REST path only reads local metadata, and managed
-    // storage writes go through other code paths. Writes are intentionally unsupported.
-    throw new UnsupportedOperationException("SimpleLocalFileIO is read-only: " + path);
+    // Local Iceberg REST tables write metadata through the same FileIO abstraction as cloud
+    // tables. The core local adapter supplies the required atomic create/overwrite semantics.
+    Path filePath = toPath(path);
+    Path parent = filePath.getParent();
+    if (parent != null) {
+      try {
+        Files.createDirectories(parent);
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to create parent directories for: " + path, e);
+      }
+    }
+    return org.apache.iceberg.Files.localOutput(filePath.toFile());
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -1,42 +1,74 @@
 package io.unitycatalog.server.service;
 
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.service.credential.CredentialContext.READ_ONLY;
+import static io.unitycatalog.server.service.credential.CredentialContext.READ_WRITE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
+import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
+import io.unitycatalog.server.model.CatalogInfo;
+import io.unitycatalog.server.model.CreateSchema;
+import io.unitycatalog.server.model.CreateStagingTable;
+import io.unitycatalog.server.model.CreateTable;
+import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.StagingTableInfo;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.persist.CatalogRepository;
 import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.SchemaRepository;
+import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.model.Privileges;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.iceberg.IcebergSchemaConverter;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
-import io.unitycatalog.server.utils.JsonUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -45,7 +77,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
 @ExceptionHandler(IcebergRestExceptionHandler.class)
-public class IcebergRestCatalogService {
+public class IcebergRestCatalogService extends AuthorizedService {
 
   private static final String PREFIX_BASE = "catalogs/";
 
@@ -57,23 +89,32 @@ public class IcebergRestCatalogService {
           Endpoint.V1_LOAD_TABLE,
           Endpoint.V1_LOAD_VIEW,
           Endpoint.V1_REPORT_METRICS,
-          Endpoint.V1_LIST_TABLES);
+          Endpoint.V1_LIST_TABLES,
+          Endpoint.V1_CREATE_NAMESPACE,
+          Endpoint.V1_CREATE_TABLE,
+          Endpoint.V1_UPDATE_TABLE,
+          Endpoint.V1_DELETE_TABLE);
 
-  private final SchemaService schemaService;
   private final TableConfigService tableConfigService;
   private final MetadataService metadataService;
+  private final CatalogRepository catalogRepository;
+  private final SchemaRepository schemaRepository;
+  private final StagingTableRepository stagingTableRepository;
   private final TableRepository tableRepository;
   private final SessionFactory sessionFactory;
 
   public IcebergRestCatalogService(
-      SchemaService schemaService,
+      UnityCatalogAuthorizer authorizer,
       TableConfigService tableConfigService,
       MetadataService metadataService,
-      Repositories repositories) {
-    // TODO: avoid this service to service dependency
-    this.schemaService = schemaService;
+      Repositories repositories,
+      ServerProperties serverProperties) {
+    super(authorizer, repositories, serverProperties);
     this.tableConfigService = tableConfigService;
     this.metadataService = metadataService;
+    this.catalogRepository = repositories.getCatalogRepository();
+    this.schemaRepository = repositories.getSchemaRepository();
+    this.stagingTableRepository = repositories.getStagingTableRepository();
     this.tableRepository = repositories.getTableRepository();
     this.sessionFactory = repositories.getSessionFactory();
   }
@@ -104,21 +145,14 @@ public class IcebergRestCatalogService {
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public ListNamespacesResponse listNamespaces(
-      @Param("catalog") String catalog, @Param("parent") Optional<String> parent)
-      throws JsonProcessingException {
+      @Param("catalog") String catalog, @Param("parent") Optional<String> parent) {
     List<Namespace> namespaces;
     if (parent.isPresent() && !parent.get().isEmpty()) {
       // nested namespaces is not supported, so child namespaces will be empty
       namespaces = Collections.emptyList();
     } else {
-      String respContent =
-          schemaService
-              .listSchemas(catalog, Optional.of(Integer.MAX_VALUE), Optional.empty())
-              .aggregate()
-              .join()
-              .contentUtf8();
       ListSchemasResponse resp =
-          JsonUtils.getInstance().readValue(respContent, ListSchemasResponse.class);
+          schemaRepository.listSchemas(catalog, Optional.of(Integer.MAX_VALUE), Optional.empty());
       assert resp.getSchemas() != null;
       namespaces =
           resp.getSchemas().stream()
@@ -134,13 +168,36 @@ public class IcebergRestCatalogService {
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public GetNamespaceResponse getNamespace(
-      @Param("catalog") String catalog, @Param("namespace") String namespace)
-      throws JsonProcessingException {
+      @Param("catalog") String catalog, @Param("namespace") String namespace) {
     String schemaFullName = String.join(".", catalog, namespace);
-    String resp = schemaService.getSchema(schemaFullName).aggregate().join().contentUtf8();
+    SchemaInfo schemaInfo = schemaRepository.getSchema(schemaFullName);
     return GetNamespaceResponse.builder()
         .withNamespace(Namespace.of(namespace))
-        .setProperties(JsonUtils.getInstance().readValue(resp, SchemaInfo.class).getProperties())
+        .setProperties(schemaInfo.getProperties())
+        .build();
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public CreateNamespaceResponse createNamespace(
+      @Param("catalog") String catalog, CreateNamespaceRequest request) {
+    request.validate();
+    if (request.namespace().levels().length != 1) {
+      throw new BadRequestException("Nested namespaces are not supported: %s", request.namespace());
+    }
+    String schemaName = request.namespace().level(0);
+    CreateSchema createSchema =
+        new CreateSchema().name(schemaName).catalogName(catalog).properties(request.properties());
+    SchemaInfo schemaInfo = schemaRepository.createSchema(createSchema);
+    CatalogInfo catalogInfo = catalogRepository.getCatalog(catalog);
+    initializeHierarchicalAuthorization(schemaInfo.getSchemaId(), catalogInfo.getId());
+    Map<String, String> properties =
+        schemaInfo.getProperties() == null ? Map.of() : schemaInfo.getProperties();
+    return CreateNamespaceResponse.builder()
+        .withNamespace(request.namespace())
+        .setProperties(properties)
         .build();
   }
 
@@ -153,16 +210,12 @@ public class IcebergRestCatalogService {
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       @Param("table") String table) {
-    try (Session session = sessionFactory.openSession()) {
-      tableRepository.getTable(catalog + "." + namespace + "." + table);
-      String metadataLocation =
-          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
-      if (metadataLocation == null) {
-        throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
-      } else {
-        return HttpResponse.of(HttpStatus.OK);
-      }
+    TableRepository.IcebergTableState state =
+        tableRepository.getIcebergTableState(catalog, namespace, table);
+    if (state.metadataLocation() == null) {
+      throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
     }
+    return HttpResponse.of(HttpStatus.OK);
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
@@ -173,25 +226,295 @@ public class IcebergRestCatalogService {
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       @Param("table") String table) {
-    String metadataLocation;
-    try (Session session = sessionFactory.openSession()) {
-      tableRepository.getTable(catalog + "." + namespace + "." + table);
-      metadataLocation =
-          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
-    }
-
-    if (metadataLocation == null) {
+    TableRepository.IcebergTableState state =
+        tableRepository.getIcebergTableState(catalog, namespace, table);
+    if (state.metadataLocation() == null) {
       throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
     }
 
     TableMetadata tableMetadata =
-        metadataService.readTableMetadata(NormalizedURL.from(metadataLocation));
-    Map<String, String> config = tableConfigService.getTableConfig(tableMetadata);
+        metadataService.readTableMetadata(NormalizedURL.from(state.metadataLocation()));
+    Map<String, String> config =
+        tableConfigService.getTableConfig(tableMetadata, getLoadCredentialPrivileges(state));
 
     return LoadTableResponse.builder()
         .withTableMetadata(tableMetadata)
         .addAllConfig(config)
         .build();
+  }
+
+  Set<CredentialContext.Privilege> getLoadCredentialPrivileges(
+      TableRepository.IcebergTableState state) {
+    if (state.dataSourceFormat() != DataSourceFormat.ICEBERG) {
+      return READ_ONLY;
+    }
+    UUID principalId = userRepository.findPrincipalId();
+    if (principalId == null) {
+      return READ_ONLY;
+    }
+    boolean canWrite =
+        authorizer.authorize(principalId, state.tableId(), Privileges.OWNER)
+            || authorizer.authorizeAll(
+                principalId, state.tableId(), Privileges.SELECT, Privileges.MODIFY);
+    return canWrite ? READ_WRITE : READ_ONLY;
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse createTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      CreateTableRequest request) {
+    request.validate();
+    NormalizedURL location;
+    TableType tableType;
+    if (request.location() == null || request.location().isEmpty()) {
+      StagingTableInfo stagingTable =
+          stagingTableRepository.createStagingTable(
+              new CreateStagingTable()
+                  .name(request.name())
+                  .catalogName(catalog)
+                  .schemaName(namespace));
+      initializeHierarchicalAuthorization(
+          stagingTable.getId(), schemaRepository.getSchemaIdOrThrow(catalog, namespace).toString());
+      tableType = TableType.MANAGED;
+      location = NormalizedURL.from(stagingTable.getStagingLocation());
+    } else {
+      tableType = TableType.EXTERNAL;
+      location = NormalizedURL.from(request.location());
+    }
+    Map<String, String> properties = request.properties() == null ? Map.of() : request.properties();
+    PartitionSpec spec = request.spec() == null ? PartitionSpec.unpartitioned() : request.spec();
+    SortOrder writeOrder =
+        request.writeOrder() == null ? SortOrder.unsorted() : request.writeOrder();
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            request.schema(), spec, writeOrder, location.toString(), properties);
+
+    if (request.stageCreate()) {
+      // The permanent table is not registered and no metadata file is written. Managed creates
+      // retain their staging row so duplicate validation, temporary credentials, and later
+      // lifecycle management use the same path as other managed tables.
+      if (ucTableExists(catalog, namespace, request.name())) {
+        throw new AlreadyExistsException("Table already exists: %s.%s", namespace, request.name());
+      }
+      metadataService.prepareTableLocation(tableMetadata);
+      return LoadTableResponse.builder()
+          .withTableMetadata(tableMetadata)
+          .addAllConfig(tableConfigService.getTableConfig(tableMetadata, READ_WRITE))
+          .build();
+    }
+
+    return finalizeIcebergTableCreation(
+        catalog, namespace, request.name(), tableType, tableMetadata, false);
+  }
+
+  /**
+   * Writes a new Iceberg table's first metadata file and atomically registers the UC row, columns,
+   * properties, committed staging row, and metadata pointer. Shared by direct creates and commits
+   * of staged creates; {@code fromCommit} only changes the already-exists error shape (409 {@link
+   * CommitFailedException} for commits, 409 {@link AlreadyExistsException} for creates).
+   */
+  private LoadTableResponse finalizeIcebergTableCreation(
+      String catalog,
+      String namespace,
+      String name,
+      TableType tableType,
+      TableMetadata tableMetadata,
+      boolean fromCommit) {
+    NormalizedURL metadataLocation = MetadataService.newMetadataLocation(tableMetadata, 0);
+    TableMetadata committed =
+        TableMetadata.buildFrom(tableMetadata)
+            .discardChanges()
+            .withMetadataLocation(MetadataService.toIcebergMetadataLocation(metadataLocation))
+            .build();
+
+    CreateTable createTable =
+        new CreateTable()
+            .name(name)
+            .catalogName(catalog)
+            .schemaName(namespace)
+            .tableType(tableType)
+            .dataSourceFormat(DataSourceFormat.ICEBERG)
+            .columns(IcebergSchemaConverter.toColumnInfos(committed.schema()))
+            .storageLocation(committed.location())
+            .properties(committed.properties());
+    metadataService.writeTableMetadata(committed, metadataLocation);
+    TableInfo tableInfo;
+    try {
+      tableInfo = tableRepository.createTableForIceberg(createTable, metadataLocation);
+    } catch (RuntimeException e) {
+      metadataService.deleteTableMetadata(metadataLocation);
+      if (fromCommit
+          && e instanceof BaseException baseException
+          && baseException.getErrorCode() == ErrorCode.TABLE_ALREADY_EXISTS) {
+        throw new CommitFailedException(
+            "Requirement failed: table already exists: %s.%s", namespace, name);
+      }
+      throw e;
+    }
+    SchemaInfo schemaInfo =
+        schemaRepository.getSchema(tableInfo.getCatalogName() + "." + tableInfo.getSchemaName());
+    if (tableType == TableType.EXTERNAL) {
+      initializeHierarchicalAuthorization(tableInfo.getTableId(), schemaInfo.getSchemaId());
+    }
+
+    return LoadTableResponse.builder()
+        .withTableMetadata(committed)
+        .addAllConfig(tableConfigService.getTableConfig(committed, READ_WRITE))
+        .build();
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse updateTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table,
+      UpdateTableRequest request) {
+    boolean isCreateCommit =
+        request.requirements().stream()
+            .anyMatch(r -> r instanceof UpdateRequirement.AssertTableDoesNotExist);
+    if (isCreateCommit) {
+      return commitStagedCreate(catalog, namespace, table, request);
+    }
+    TableRepository.IcebergTableState state =
+        tableRepository.getNativeIcebergTableState(catalog, namespace, table);
+    if (state.metadataLocation() == null) {
+      throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
+    }
+
+    NormalizedURL metadataLocation = NormalizedURL.from(state.metadataLocation());
+    TableMetadata base = metadataService.readTableMetadata(metadataLocation);
+    request.requirements().forEach(requirement -> requirement.validate(base));
+
+    TableMetadata.Builder builder = TableMetadata.buildFrom(base);
+    request.updates().forEach(update -> update.applyTo(builder));
+    TableMetadata updatedWithoutLocation = builder.build();
+    if (updatedWithoutLocation.changes().isEmpty()) {
+      return LoadTableResponse.builder()
+          .withTableMetadata(base)
+          .addAllConfig(tableConfigService.getTableConfig(base, READ_WRITE))
+          .build();
+    }
+
+    NormalizedURL newMetadataLocation =
+        MetadataService.newMetadataLocation(
+            updatedWithoutLocation, MetadataService.parseMetadataVersion(metadataLocation) + 1);
+    TableMetadata updated =
+        TableMetadata.buildFrom(updatedWithoutLocation)
+            .discardChanges()
+            .withMetadataLocation(MetadataService.toIcebergMetadataLocation(newMetadataLocation))
+            .build();
+    metadataService.writeTableMetadata(updated, newMetadataLocation);
+    try {
+      tableRepository.commitIcebergTable(
+          catalog,
+          namespace,
+          table,
+          metadataLocation.toString(),
+          newMetadataLocation,
+          IcebergSchemaConverter.toColumnInfos(updated.schema()),
+          updated.properties());
+    } catch (RuntimeException e) {
+      // The metadata file was written before the swap, so any failure (a lost commit race or an
+      // unexpected error) leaves it orphaned unless we clean it up.
+      metadataService.deleteTableMetadata(newMetadataLocation);
+      throw e;
+    }
+
+    return LoadTableResponse.builder()
+        .withTableMetadata(updated)
+        .addAllConfig(tableConfigService.getTableConfig(updated, READ_WRITE))
+        .build();
+  }
+
+  @Delete("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse dropTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table,
+      @Param("purgeRequested") Optional<Boolean> purgeRequested) {
+    String fullName = catalog + "." + namespace + "." + table;
+    TableRepository.IcebergTableState state =
+        tableRepository.getIcebergTableState(catalog, namespace, table);
+    if (state.dataSourceFormat() != DataSourceFormat.ICEBERG) {
+      throw new BadRequestException(
+          "Table %s was not created through the Iceberg REST catalog; drop it through the Unity"
+              + " Catalog API instead.",
+          fullName);
+    }
+    // EXTERNAL tables leave data and metadata files in place (purgeRequested is accepted for
+    // spec compatibility but does not delete files); MANAGED tables have their storage directory
+    // removed by the repository's delete path.
+    TableInfoDAO deleted = tableRepository.deleteTable(catalog, namespace, table);
+    removeHierarchicalAuthorizations(deleted.getId().toString(), deleted.getSchemaId().toString());
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+
+  /**
+   * Materializes a staged create: a commit whose requirements carry {@code assert-create}
+   * (AssertTableDoesNotExist). Mirroring Iceberg's reference CatalogHandlers, the staged metadata
+   * is rebuilt from the commit's updates against an empty base, the first metadata file is written,
+   * and the table is registered in UC. The table is MANAGED when its location matches an
+   * uncommitted staging row, EXTERNAL otherwise.
+   */
+  private LoadTableResponse commitStagedCreate(
+      String catalog, String namespace, String table, UpdateTableRequest request) {
+    String fullName = catalog + "." + namespace + "." + table;
+    for (UpdateRequirement requirement : request.requirements()) {
+      if (!(requirement instanceof UpdateRequirement.AssertTableDoesNotExist)) {
+        throw new BadRequestException(
+            "Invalid requirement for a create commit: %s", requirement.getClass().getSimpleName());
+      }
+    }
+    if (ucTableExists(catalog, namespace, table)) {
+      throw new CommitFailedException("Requirement failed: table already exists: %s", fullName);
+    }
+
+    // Pick the format version out of the updates before building, like CatalogHandlers.create:
+    // buildFromEmpty defaults to v2, and applying an upgrade-format-version update for a lower
+    // version would otherwise fail as a downgrade.
+    Optional<Integer> formatVersion =
+        request.updates().stream()
+            .filter(update -> update instanceof MetadataUpdate.UpgradeFormatVersion)
+            .map(update -> ((MetadataUpdate.UpgradeFormatVersion) update).formatVersion())
+            .findFirst();
+    // buildFromEmpty(int) seeds the requested version; the no-arg overload uses the default.
+    TableMetadata.Builder builder =
+        formatVersion.map(TableMetadata::buildFromEmpty).orElseGet(TableMetadata::buildFromEmpty);
+    request.updates().forEach(update -> update.applyTo(builder));
+    TableMetadata tableMetadata = builder.build();
+    if (tableMetadata.location() == null || tableMetadata.location().isEmpty()) {
+      throw new BadRequestException(
+          "Create commit for %s must include a set-location update", fullName);
+    }
+
+    TableType tableType =
+        stagingTableRepository.isUncommittedStagingLocation(
+                NormalizedURL.from(tableMetadata.location()))
+            ? TableType.MANAGED
+            : TableType.EXTERNAL;
+    return finalizeIcebergTableCreation(
+        catalog, namespace, table, tableType, tableMetadata, true);
+  }
+
+  private boolean ucTableExists(String catalog, String namespace, String table) {
+    try {
+      tableRepository.getTable(catalog + "." + namespace + "." + table);
+      return true;
+    } catch (BaseException e) {
+      if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/views/{view}")
@@ -220,8 +543,7 @@ public class IcebergRestCatalogService {
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public org.apache.iceberg.rest.responses.ListTablesResponse listTables(
-      @Param("catalog") String catalog, @Param("namespace") String namespace)
-      throws JsonProcessingException {
+      @Param("catalog") String catalog, @Param("namespace") String namespace) {
     ListTablesResponse tables =
         tableRepository.listTables(
             catalog, namespace, Optional.of(Integer.MAX_VALUE), Optional.empty(), false, false);

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -41,6 +41,7 @@ import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.iceberg.IcebergSchemaConverter;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
+import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Collections;
@@ -51,6 +52,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
@@ -81,7 +83,7 @@ public class IcebergRestCatalogService extends AuthorizedService {
 
   private static final String PREFIX_BASE = "catalogs/";
 
-  private static final List<Endpoint> ENDPOINTS =
+  private static final List<Endpoint> READ_ENDPOINTS =
       List.of(
           Endpoint.V1_LIST_NAMESPACES,
           Endpoint.V1_LOAD_NAMESPACE,
@@ -89,7 +91,10 @@ public class IcebergRestCatalogService extends AuthorizedService {
           Endpoint.V1_LOAD_TABLE,
           Endpoint.V1_LOAD_VIEW,
           Endpoint.V1_REPORT_METRICS,
-          Endpoint.V1_LIST_TABLES,
+          Endpoint.V1_LIST_TABLES);
+
+  private static final List<Endpoint> WRITE_ENDPOINTS =
+      List.of(
           Endpoint.V1_CREATE_NAMESPACE,
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
@@ -134,7 +139,10 @@ public class IcebergRestCatalogService extends AuthorizedService {
     // set catalog prefix
     return ConfigResponse.builder()
         .withOverride("prefix", PREFIX_BASE + catalog)
-        .withEndpoints(ENDPOINTS)
+        .withEndpoints(
+            serverProperties.isIcebergTableEnabled()
+                ? Stream.concat(READ_ENDPOINTS.stream(), WRITE_ENDPOINTS.stream()).toList()
+                : READ_ENDPOINTS)
         .build();
   }
 
@@ -183,6 +191,7 @@ public class IcebergRestCatalogService extends AuthorizedService {
   @AuthorizeResourceKey(METASTORE)
   public CreateNamespaceResponse createNamespace(
       @Param("catalog") String catalog, CreateNamespaceRequest request) {
+    serverProperties.checkIcebergTableEnabled();
     request.validate();
     if (request.namespace().levels().length != 1) {
       throw new BadRequestException("Nested namespaces are not supported: %s", request.namespace());
@@ -232,10 +241,12 @@ public class IcebergRestCatalogService extends AuthorizedService {
       throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
     }
 
+    NormalizedURL tableLocation = NormalizedURL.from(state.storageLocation());
     TableMetadata tableMetadata =
-        metadataService.readTableMetadata(NormalizedURL.from(state.metadataLocation()));
+        metadataService.readTableMetadata(
+            NormalizedURL.from(state.metadataLocation()), tableLocation);
     Map<String, String> config =
-        tableConfigService.getTableConfig(tableMetadata, getLoadCredentialPrivileges(state));
+        tableConfigService.getTableConfig(tableLocation, getLoadCredentialPrivileges(state));
 
     return LoadTableResponse.builder()
         .withTableMetadata(tableMetadata)
@@ -267,6 +278,7 @@ public class IcebergRestCatalogService extends AuthorizedService {
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       CreateTableRequest request) {
+    serverProperties.checkIcebergTableEnabled();
     request.validate();
     NormalizedURL location;
     TableType tableType;
@@ -297,13 +309,13 @@ public class IcebergRestCatalogService extends AuthorizedService {
       // The permanent table is not registered and no metadata file is written. Managed creates
       // retain their staging row so duplicate validation, temporary credentials, and later
       // lifecycle management use the same path as other managed tables.
-      if (ucTableExists(catalog, namespace, request.name())) {
+      if (tableType == TableType.EXTERNAL && ucTableExists(catalog, namespace, request.name())) {
         throw new AlreadyExistsException("Table already exists: %s.%s", namespace, request.name());
       }
-      metadataService.prepareTableLocation(tableMetadata);
+      metadataService.prepareTableLocation(tableMetadata, location);
       return LoadTableResponse.builder()
           .withTableMetadata(tableMetadata)
-          .addAllConfig(tableConfigService.getTableConfig(tableMetadata, READ_WRITE))
+          .addAllConfig(tableConfigService.getTableConfig(location, READ_WRITE))
           .build();
     }
 
@@ -324,9 +336,12 @@ public class IcebergRestCatalogService extends AuthorizedService {
       TableType tableType,
       TableMetadata tableMetadata,
       boolean fromCommit) {
-    NormalizedURL metadataLocation = MetadataService.newMetadataLocation(tableMetadata, 0);
+    NormalizedURL tableLocation = NormalizedURL.from(tableMetadata.location());
+    NormalizedURL metadataLocation =
+        MetadataService.newMetadataLocation(tableMetadata, 0, tableLocation);
     TableMetadata committed =
         TableMetadata.buildFrom(tableMetadata)
+            // Discard builder-only changes before assigning the authoritative metadata pointer.
             .discardChanges()
             .withMetadataLocation(MetadataService.toIcebergMetadataLocation(metadataLocation))
             .build();
@@ -341,12 +356,12 @@ public class IcebergRestCatalogService extends AuthorizedService {
             .columns(IcebergSchemaConverter.toColumnInfos(committed.schema()))
             .storageLocation(committed.location())
             .properties(committed.properties());
-    metadataService.writeTableMetadata(committed, metadataLocation);
+    metadataService.writeTableMetadata(committed, metadataLocation, tableLocation);
     TableInfo tableInfo;
     try {
       tableInfo = tableRepository.createTableForIceberg(createTable, metadataLocation);
     } catch (RuntimeException e) {
-      metadataService.deleteTableMetadata(metadataLocation);
+      metadataService.deleteTableMetadata(metadataLocation, tableLocation);
       if (fromCommit
           && e instanceof BaseException baseException
           && baseException.getErrorCode() == ErrorCode.TABLE_ALREADY_EXISTS) {
@@ -361,9 +376,12 @@ public class IcebergRestCatalogService extends AuthorizedService {
       initializeHierarchicalAuthorization(tableInfo.getTableId(), schemaInfo.getSchemaId());
     }
 
+    // Use the location returned from the persisted UC row for credential vending, not the
+    // client-supplied metadata object used to create the row.
+    NormalizedURL persistedTableLocation = NormalizedURL.from(tableInfo.getStorageLocation());
     return LoadTableResponse.builder()
         .withTableMetadata(committed)
-        .addAllConfig(tableConfigService.getTableConfig(committed, READ_WRITE))
+        .addAllConfig(tableConfigService.getTableConfig(persistedTableLocation, READ_WRITE))
         .build();
   }
 
@@ -376,6 +394,7 @@ public class IcebergRestCatalogService extends AuthorizedService {
       @Param("namespace") String namespace,
       @Param("table") String table,
       UpdateTableRequest request) {
+    serverProperties.checkIcebergTableEnabled();
     boolean isCreateCommit =
         request.requirements().stream()
             .anyMatch(r -> r instanceof UpdateRequirement.AssertTableDoesNotExist);
@@ -388,29 +407,35 @@ public class IcebergRestCatalogService extends AuthorizedService {
       throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
     }
 
+    NormalizedURL tableLocation = NormalizedURL.from(state.storageLocation());
     NormalizedURL metadataLocation = NormalizedURL.from(state.metadataLocation());
-    TableMetadata base = metadataService.readTableMetadata(metadataLocation);
+    TableMetadata base = metadataService.readTableMetadata(metadataLocation, tableLocation);
     request.requirements().forEach(requirement -> requirement.validate(base));
 
     TableMetadata.Builder builder = TableMetadata.buildFrom(base);
     request.updates().forEach(update -> update.applyTo(builder));
     TableMetadata updatedWithoutLocation = builder.build();
     if (updatedWithoutLocation.changes().isEmpty()) {
+      // No-op update: requirements were validated, but there is no new metadata file or DAO write.
       return LoadTableResponse.builder()
           .withTableMetadata(base)
-          .addAllConfig(tableConfigService.getTableConfig(base, READ_WRITE))
+          .addAllConfig(tableConfigService.getTableConfig(tableLocation, READ_WRITE))
           .build();
     }
 
     NormalizedURL newMetadataLocation =
         MetadataService.newMetadataLocation(
-            updatedWithoutLocation, MetadataService.parseMetadataVersion(metadataLocation) + 1);
+            updatedWithoutLocation,
+            MetadataService.parseMetadataVersion(metadataLocation) + 1,
+            tableLocation);
     TableMetadata updated =
         TableMetadata.buildFrom(updatedWithoutLocation)
+            // Iceberg update builders retain pending changes; persist a clean snapshot with the
+            // newly assigned metadata location.
             .discardChanges()
             .withMetadataLocation(MetadataService.toIcebergMetadataLocation(newMetadataLocation))
             .build();
-    metadataService.writeTableMetadata(updated, newMetadataLocation);
+    metadataService.writeTableMetadata(updated, newMetadataLocation, tableLocation);
     try {
       tableRepository.commitIcebergTable(
           catalog,
@@ -423,13 +448,13 @@ public class IcebergRestCatalogService extends AuthorizedService {
     } catch (RuntimeException e) {
       // The metadata file was written before the swap, so any failure (a lost commit race or an
       // unexpected error) leaves it orphaned unless we clean it up.
-      metadataService.deleteTableMetadata(newMetadataLocation);
+      metadataService.deleteTableMetadata(newMetadataLocation, tableLocation);
       throw e;
     }
 
     return LoadTableResponse.builder()
         .withTableMetadata(updated)
-        .addAllConfig(tableConfigService.getTableConfig(updated, READ_WRITE))
+        .addAllConfig(tableConfigService.getTableConfig(tableLocation, READ_WRITE))
         .build();
   }
 
@@ -441,6 +466,7 @@ public class IcebergRestCatalogService extends AuthorizedService {
       @Param("namespace") String namespace,
       @Param("table") String table,
       @Param("purgeRequested") Optional<Boolean> purgeRequested) {
+    serverProperties.checkIcebergTableEnabled();
     String fullName = catalog + "." + namespace + "." + table;
     TableRepository.IcebergTableState state =
         tableRepository.getIcebergTableState(catalog, namespace, table);
@@ -474,10 +500,6 @@ public class IcebergRestCatalogService extends AuthorizedService {
             "Invalid requirement for a create commit: %s", requirement.getClass().getSimpleName());
       }
     }
-    if (ucTableExists(catalog, namespace, table)) {
-      throw new CommitFailedException("Requirement failed: table already exists: %s", fullName);
-    }
-
     // Pick the format version out of the updates before building, like CatalogHandlers.create:
     // buildFromEmpty defaults to v2, and applying an upgrade-format-version update for a lower
     // version would otherwise fail as a downgrade.
@@ -496,9 +518,10 @@ public class IcebergRestCatalogService extends AuthorizedService {
           "Create commit for %s must include a set-location update", fullName);
     }
 
+    // Managed locations carry UC's reserved marker. The final repository transaction performs the
+    // authoritative staging-row ownership and committed-state validation.
     TableType tableType =
-        stagingTableRepository.isUncommittedStagingLocation(
-                NormalizedURL.from(tableMetadata.location()))
+        tableMetadata.location().contains(Constants.MANAGED_STORAGE_PREFIX)
             ? TableType.MANAGED
             : TableType.EXTERNAL;
     return finalizeIcebergTableCreation(

--- a/server/src/main/java/io/unitycatalog/server/service/credential/CredentialContext.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/CredentialContext.java
@@ -23,6 +23,11 @@ public class CredentialContext {
     UPDATE
   }
 
+  // Common privilege sets: SELECT alone vends read-only storage credentials, SELECT + UPDATE vends
+  // read/write credentials.
+  public static final Set<Privilege> READ_ONLY = Set.of(Privilege.SELECT);
+  public static final Set<Privilege> READ_WRITE = Set.of(Privilege.SELECT, Privilege.UPDATE);
+
   // The storage scheme (S3, GCS, ABFS) to determine which cloud vendor to use
   private final UriScheme storageScheme;
   // The storage base (e.g., s3://bucket) for looking up per-bucket configurations

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
@@ -1,0 +1,161 @@
+package io.unitycatalog.server.service.iceberg;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.ColumnTypeName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Converts an Iceberg schema into Unity Catalog {@link ColumnInfo}s so tables created through the
+ * Iceberg REST catalog are browsable through the UC API and UI. The Iceberg metadata file remains
+ * the source of truth for Iceberg clients; this conversion only feeds UC's own column listing.
+ *
+ * <p>{@code type_json} is rendered in the Spark StructField JSON shape that UC stores for all
+ * other formats (see {@code ColumnUtils.validateTypeJson}).
+ */
+public final class IcebergSchemaConverter {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private IcebergSchemaConverter() {}
+
+  public static List<ColumnInfo> toColumnInfos(Schema schema) {
+    List<ColumnInfo> columns = new ArrayList<>();
+    List<Types.NestedField> fields = schema.columns();
+    for (int i = 0; i < fields.size(); i++) {
+      Types.NestedField field = fields.get(i);
+      ColumnInfo column =
+          new ColumnInfo()
+              .name(field.name())
+              .typeText(typeText(field.type()))
+              .typeJson(structFieldJson(field).toString())
+              .typeName(typeName(field.type()))
+              .position(i)
+              .nullable(field.isOptional())
+              .comment(field.doc());
+      if (field.type().typeId() == Type.TypeID.DECIMAL) {
+        Types.DecimalType decimal = (Types.DecimalType) field.type();
+        column.typePrecision(decimal.precision()).typeScale(decimal.scale());
+      }
+      columns.add(column);
+    }
+    return columns;
+  }
+
+  private static ObjectNode structFieldJson(Types.NestedField field) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("name", field.name());
+    node.set("type", typeJson(field.type()));
+    node.put("nullable", field.isOptional());
+    node.set("metadata", MAPPER.createObjectNode());
+    return node;
+  }
+
+  private static JsonNode typeJson(Type type) {
+    return switch (type.typeId()) {
+      case STRUCT -> {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "struct");
+        ArrayNode fields = node.putArray("fields");
+        ((Types.StructType) type).fields().forEach(f -> fields.add(structFieldJson(f)));
+        yield node;
+      }
+      case LIST -> {
+        Types.ListType list = (Types.ListType) type;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "array");
+        node.set("elementType", typeJson(list.elementType()));
+        node.put("containsNull", list.isElementOptional());
+        yield node;
+      }
+      case MAP -> {
+        Types.MapType map = (Types.MapType) type;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "map");
+        node.set("keyType", typeJson(map.keyType()));
+        node.set("valueType", typeJson(map.valueType()));
+        node.put("valueContainsNull", map.isValueOptional());
+        yield node;
+      }
+      default -> MAPPER.getNodeFactory().textNode(primitiveTypeName(type));
+    };
+  }
+
+  private static String typeText(Type type) {
+    return switch (type.typeId()) {
+      case STRUCT ->
+          ((Types.StructType) type)
+              .fields().stream()
+                  .map(f -> f.name() + ":" + typeText(f.type()))
+                  .collect(Collectors.joining(",", "struct<", ">"));
+      case LIST -> "array<" + typeText(((Types.ListType) type).elementType()) + ">";
+      case MAP -> {
+        Types.MapType map = (Types.MapType) type;
+        yield "map<" + typeText(map.keyType()) + "," + typeText(map.valueType()) + ">";
+      }
+      case INTEGER -> "int";
+      case LONG -> "bigint";
+      default -> primitiveTypeName(type);
+    };
+  }
+
+  private static String primitiveTypeName(Type type) {
+    return switch (type.typeId()) {
+      case BOOLEAN -> "boolean";
+      case INTEGER -> "integer";
+      case LONG -> "long";
+      case FLOAT -> "float";
+      case DOUBLE -> "double";
+      case DATE -> "date";
+      case TIMESTAMP ->
+          ((Types.TimestampType) type).shouldAdjustToUTC() ? "timestamp" : "timestamp_ntz";
+      case STRING, UUID -> "string";
+      case FIXED, BINARY -> "binary";
+      case DECIMAL -> {
+        Types.DecimalType decimal = (Types.DecimalType) type;
+        yield String.format("decimal(%d,%d)", decimal.precision(), decimal.scale());
+      }
+      case VARIANT -> "variant";
+      default ->
+          throw new BadRequestException(
+              "Iceberg type %s is not supported by Unity Catalog",
+              type.toString().toUpperCase(Locale.ROOT));
+    };
+  }
+
+  private static ColumnTypeName typeName(Type type) {
+    return switch (type.typeId()) {
+      case BOOLEAN -> ColumnTypeName.BOOLEAN;
+      case INTEGER -> ColumnTypeName.INT;
+      case LONG -> ColumnTypeName.LONG;
+      case FLOAT -> ColumnTypeName.FLOAT;
+      case DOUBLE -> ColumnTypeName.DOUBLE;
+      case DATE -> ColumnTypeName.DATE;
+      case TIMESTAMP ->
+          ((Types.TimestampType) type).shouldAdjustToUTC()
+              ? ColumnTypeName.TIMESTAMP
+              : ColumnTypeName.TIMESTAMP_NTZ;
+      case STRING, UUID -> ColumnTypeName.STRING;
+      case FIXED, BINARY -> ColumnTypeName.BINARY;
+      case DECIMAL -> ColumnTypeName.DECIMAL;
+      case VARIANT -> ColumnTypeName.VARIANT;
+      case STRUCT -> ColumnTypeName.STRUCT;
+      case LIST -> ColumnTypeName.ARRAY;
+      case MAP -> ColumnTypeName.MAP;
+      default ->
+          throw new BadRequestException(
+              "Iceberg type %s is not supported by Unity Catalog",
+              type.toString().toUpperCase(Locale.ROOT));
+    };
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
@@ -57,7 +57,11 @@ public final class IcebergSchemaConverter {
     node.put("name", field.name());
     node.set("type", typeJson(field.type()));
     node.put("nullable", field.isOptional());
-    node.set("metadata", MAPPER.createObjectNode());
+    ObjectNode metadata = MAPPER.createObjectNode();
+    if (field.doc() != null) {
+      metadata.put("comment", field.doc());
+    }
+    node.set("metadata", metadata);
     return node;
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
@@ -126,6 +126,8 @@ public final class IcebergSchemaConverter {
         yield String.format("decimal(%d,%d)", decimal.precision(), decimal.scale());
       }
       case VARIANT -> "variant";
+      // Iceberg has no standard GEOMETRY or GEOGRAPHY primitive type today. Add explicit mappings
+      // here if those types are standardized instead of silently coercing extension types.
       default ->
           throw new BadRequestException(
               "Iceberg type %s is not supported by Unity Catalog",
@@ -152,6 +154,8 @@ public final class IcebergSchemaConverter {
       case STRUCT -> ColumnTypeName.STRUCT;
       case LIST -> ColumnTypeName.ARRAY;
       case MAP -> ColumnTypeName.MAP;
+      // Iceberg has no standard GEOMETRY or GEOGRAPHY primitive type today. Keep this rejection in
+      // sync with primitiveTypeName until Iceberg defines interoperable type IDs for them.
       default ->
           throw new BadRequestException(
               "Iceberg type %s is not supported by Unity Catalog",

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -28,13 +28,6 @@ public class MetadataService {
     this.fileOperations = fileOperations;
   }
 
-  public TableMetadata readTableMetadata(NormalizedURL metadataLocation) {
-    // TODO: cache fileIO
-    try (FileIO fileIO = fileOperations.getFileIO(metadataLocation)) {
-      return TableMetadataParser.read(fileIO, metadataLocation.toString());
-    }
-  }
-
   /**
    * Reads metadata only after confirming both the requested file and the table root recorded in the
    * metadata are inside the persisted table location.
@@ -42,14 +35,13 @@ public class MetadataService {
   public TableMetadata readTableMetadata(
       NormalizedURL metadataLocation, NormalizedURL persistedTableLocation) {
     validateMetadataLocation(metadataLocation, persistedTableLocation);
-    TableMetadata tableMetadata = readTableMetadata(metadataLocation);
+    // TODO: cache fileIO
+    TableMetadata tableMetadata;
+    try (FileIO fileIO = fileOperations.getFileIO(metadataLocation)) {
+      tableMetadata = TableMetadataParser.read(fileIO, metadataLocation.toString());
+    }
     validateTableMetadataLocation(tableMetadata, persistedTableLocation);
     return tableMetadata;
-  }
-
-  public void writeTableMetadata(TableMetadata tableMetadata, NormalizedURL metadataLocation) {
-    writeTableMetadata(
-        tableMetadata, metadataLocation, NormalizedURL.from(tableMetadata.location()));
   }
 
   /** Writes metadata only within the table location persisted by UC. */
@@ -67,12 +59,8 @@ public class MetadataService {
   /**
    * For local file locations, pre-creates the table's directory layout so staged creates can write
    * data and manifest files before the first metadata commit. Object stores have no directories.
+   * Prepares the directories only after validating the table's client-supplied locations.
    */
-  public void prepareTableLocation(TableMetadata tableMetadata) {
-    prepareTableLocation(tableMetadata, NormalizedURL.from(tableMetadata.location()));
-  }
-
-  /** Prepares local table directories after validating the table's client-supplied locations. */
   public void prepareTableLocation(
       TableMetadata tableMetadata, NormalizedURL persistedTableLocation) {
     validateTableMetadataLocation(tableMetadata, persistedTableLocation);
@@ -83,7 +71,7 @@ public class MetadataService {
   }
 
   /** Best-effort cleanup of a metadata file that lost a commit race or whose commit failed. */
-  public void deleteTableMetadata(NormalizedURL metadataLocation) {
+  private void deleteTableMetadata(NormalizedURL metadataLocation) {
     try (FileIO fileIO = fileOperations.getFileIO(metadataLocation, CredentialContext.READ_WRITE)) {
       fileIO.deleteFile(metadataLocation.toString());
     } catch (Exception e) {
@@ -99,7 +87,7 @@ public class MetadataService {
   }
 
   /** Builds the location of the next metadata file, following Iceberg's naming scheme. */
-  public static NormalizedURL newMetadataLocation(TableMetadata tableMetadata, int version) {
+  private static NormalizedURL newMetadataLocation(TableMetadata tableMetadata, int version) {
     String metadataDirectory =
         tableMetadata
             .properties()

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -1,13 +1,25 @@
 package io.unitycatalog.server.service.iceberg;
 
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.UriScheme;
+import java.nio.file.Paths;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.FileIO;
 
-/** Reads Iceberg table metadata for the Iceberg REST catalog's loadTable responses. */
+/** Reads and writes Iceberg table metadata for the Iceberg REST catalog. */
 public class MetadataService {
+
+  private static final Pattern METADATA_FILE_VERSION =
+      Pattern.compile("^(?:v)?(\\d+)-?.*\\.metadata\\.json(?:\\.gz)?$");
 
   private final FileOperations fileOperations;
 
@@ -15,16 +27,77 @@ public class MetadataService {
     this.fileOperations = fileOperations;
   }
 
-  /**
-   * Reads and parses the Iceberg {@link TableMetadata} at the given metadata-file location, using a
-   * credential-vended {@link org.apache.iceberg.io.FileIO} obtained from {@link FileOperations}.
-   *
-   * @param metadataLocation the normalized location of the {@code *.metadata.json} file
-   */
   public TableMetadata readTableMetadata(NormalizedURL metadataLocation) {
     // TODO: cache fileIO
     try (FileIO fileIO = fileOperations.getFileIO(metadataLocation)) {
       return TableMetadataParser.read(fileIO, metadataLocation.toString());
+    }
+  }
+
+  public void writeTableMetadata(TableMetadata tableMetadata, NormalizedURL metadataLocation) {
+    try (FileIO fileIO = fileOperations.getFileIO(metadataLocation, CredentialContext.READ_WRITE)) {
+      TableMetadataParser.write(tableMetadata, fileIO.newOutputFile(metadataLocation.toString()));
+    }
+  }
+
+  /**
+   * For local file locations, pre-creates the table's directory layout so staged creates can write
+   * data and manifest files before the first metadata commit. Object stores have no directories.
+   */
+  public void prepareTableLocation(TableMetadata tableMetadata) {
+    NormalizedURL location = NormalizedURL.from(tableMetadata.location());
+    createStorageLocationDirIfAbsent(location);
+    createStorageLocationDirIfAbsent(NormalizedURL.from(location + "/metadata"));
+    createStorageLocationDirIfAbsent(NormalizedURL.from(location + "/data"));
+  }
+
+  /** Best-effort cleanup of a metadata file that lost a commit race or whose commit failed. */
+  public void deleteTableMetadata(NormalizedURL metadataLocation) {
+    try (FileIO fileIO = fileOperations.getFileIO(metadataLocation, CredentialContext.READ_WRITE)) {
+      fileIO.deleteFile(metadataLocation.toString());
+    } catch (Exception e) {
+      // Orphaned metadata files are harmless; the commit outcome is decided by the catalog.
+    }
+  }
+
+  /** Builds the location of the next metadata file, following Iceberg's naming scheme. */
+  public static NormalizedURL newMetadataLocation(TableMetadata tableMetadata, int version) {
+    String metadataDirectory =
+        tableMetadata
+            .properties()
+            .getOrDefault(
+                TableProperties.WRITE_METADATA_LOCATION, tableMetadata.location() + "/metadata");
+    return NormalizedURL.from(
+        String.format("%s/%05d-%s.metadata.json", metadataDirectory, version, UUID.randomUUID()));
+  }
+
+  public static int parseMetadataVersion(NormalizedURL metadataLocation) {
+    String location = metadataLocation.toString();
+    String fileName = location.substring(location.lastIndexOf('/') + 1);
+    Matcher matcher = METADATA_FILE_VERSION.matcher(fileName);
+    if (matcher.matches()) {
+      try {
+        return Integer.parseInt(matcher.group(1));
+      } catch (NumberFormatException e) {
+        return -1;
+      }
+    }
+    return -1;
+  }
+
+  public static String toIcebergMetadataLocation(NormalizedURL metadataLocation) {
+    return UriScheme.fromURI(metadataLocation.toUri()) == UriScheme.FILE
+        ? Paths.get(metadataLocation.toUri()).toString()
+        : metadataLocation.toString();
+  }
+
+  private static void createStorageLocationDirIfAbsent(NormalizedURL location) {
+    try {
+      FileOperations.createStorageLocationDir(location);
+    } catch (BaseException e) {
+      if (e.getErrorCode() != ErrorCode.ALREADY_EXISTS) {
+        throw e;
+      }
     }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -6,6 +6,7 @@ import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.UriScheme;
+import io.unitycatalog.server.utils.ValidationUtils;
 import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -34,7 +35,30 @@ public class MetadataService {
     }
   }
 
+  /**
+   * Reads metadata only after confirming both the requested file and the table root recorded in the
+   * metadata are inside the persisted table location.
+   */
+  public TableMetadata readTableMetadata(
+      NormalizedURL metadataLocation, NormalizedURL persistedTableLocation) {
+    validateMetadataLocation(metadataLocation, persistedTableLocation);
+    TableMetadata tableMetadata = readTableMetadata(metadataLocation);
+    validateTableMetadataLocation(tableMetadata, persistedTableLocation);
+    return tableMetadata;
+  }
+
   public void writeTableMetadata(TableMetadata tableMetadata, NormalizedURL metadataLocation) {
+    writeTableMetadata(
+        tableMetadata, metadataLocation, NormalizedURL.from(tableMetadata.location()));
+  }
+
+  /** Writes metadata only within the table location persisted by UC. */
+  public void writeTableMetadata(
+      TableMetadata tableMetadata,
+      NormalizedURL metadataLocation,
+      NormalizedURL persistedTableLocation) {
+    validateTableMetadataLocation(tableMetadata, persistedTableLocation);
+    validateMetadataLocation(metadataLocation, persistedTableLocation);
     try (FileIO fileIO = fileOperations.getFileIO(metadataLocation, CredentialContext.READ_WRITE)) {
       TableMetadataParser.write(tableMetadata, fileIO.newOutputFile(metadataLocation.toString()));
     }
@@ -45,7 +69,14 @@ public class MetadataService {
    * data and manifest files before the first metadata commit. Object stores have no directories.
    */
   public void prepareTableLocation(TableMetadata tableMetadata) {
-    NormalizedURL location = NormalizedURL.from(tableMetadata.location());
+    prepareTableLocation(tableMetadata, NormalizedURL.from(tableMetadata.location()));
+  }
+
+  /** Prepares local table directories after validating the table's client-supplied locations. */
+  public void prepareTableLocation(
+      TableMetadata tableMetadata, NormalizedURL persistedTableLocation) {
+    validateTableMetadataLocation(tableMetadata, persistedTableLocation);
+    NormalizedURL location = persistedTableLocation;
     createStorageLocationDirIfAbsent(location);
     createStorageLocationDirIfAbsent(NormalizedURL.from(location + "/metadata"));
     createStorageLocationDirIfAbsent(NormalizedURL.from(location + "/data"));
@@ -60,6 +91,13 @@ public class MetadataService {
     }
   }
 
+  /** Best-effort cleanup constrained to the persisted table location. */
+  public void deleteTableMetadata(
+      NormalizedURL metadataLocation, NormalizedURL persistedTableLocation) {
+    validateMetadataLocation(metadataLocation, persistedTableLocation);
+    deleteTableMetadata(metadataLocation);
+  }
+
   /** Builds the location of the next metadata file, following Iceberg's naming scheme. */
   public static NormalizedURL newMetadataLocation(TableMetadata tableMetadata, int version) {
     String metadataDirectory =
@@ -69,6 +107,46 @@ public class MetadataService {
                 TableProperties.WRITE_METADATA_LOCATION, tableMetadata.location() + "/metadata");
     return NormalizedURL.from(
         String.format("%s/%05d-%s.metadata.json", metadataDirectory, version, UUID.randomUUID()));
+  }
+
+  /** Builds and validates the next metadata location against the persisted table root. */
+  public static NormalizedURL newMetadataLocation(
+      TableMetadata tableMetadata, int version, NormalizedURL persistedTableLocation) {
+    validateTableMetadataLocation(tableMetadata, persistedTableLocation);
+    NormalizedURL metadataLocation = newMetadataLocation(tableMetadata, version);
+    validateMetadataLocation(metadataLocation, persistedTableLocation);
+    return metadataLocation;
+  }
+
+  /**
+   * Validates the table root and optional write-metadata directory from an Iceberg metadata
+   * document against the location stored in UC's table DAO.
+   */
+  public static void validateTableMetadataLocation(
+      TableMetadata tableMetadata, NormalizedURL persistedTableLocation) {
+    NormalizedURL metadataTableLocation = NormalizedURL.from(tableMetadata.location());
+    ValidationUtils.checkArgument(
+        metadataTableLocation.equals(persistedTableLocation),
+        "Iceberg table location ('%s') must match the persisted table location ('%s').",
+        metadataTableLocation,
+        persistedTableLocation);
+
+    String configuredMetadataLocation =
+        tableMetadata.properties().get(TableProperties.WRITE_METADATA_LOCATION);
+    if (configuredMetadataLocation != null) {
+      validateMetadataLocation(
+          NormalizedURL.from(configuredMetadataLocation), persistedTableLocation);
+    }
+  }
+
+  /** Validates that a metadata file or metadata directory is strictly under the table root. */
+  public static void validateMetadataLocation(
+      NormalizedURL metadataLocation, NormalizedURL persistedTableLocation) {
+    ValidationUtils.checkArgument(
+        metadataLocation.toString().startsWith(persistedTableLocation.toString() + "/"),
+        "Iceberg metadata location ('%s') must be a subpath of the persisted table location ('%s').",
+        metadataLocation,
+        persistedTableLocation);
   }
 
   public static int parseMetadataVersion(NormalizedURL metadataLocation) {

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -1,8 +1,10 @@
 package io.unitycatalog.server.service.iceberg;
 
 import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.TableMetadata;
 
 /**
@@ -16,16 +18,9 @@ public class TableConfigService {
     this.fileOperations = fileOperations;
   }
 
-  /**
-   * Returns the FileIO config for the given table. Note this vends temporary storage credentials
-   * for the table's location as a side effect.
-   *
-   * @param tableMetadata the Iceberg table metadata whose location is used to scope credentials
-   */
-  public Map<String, String> getTableConfig(TableMetadata tableMetadata) {
-    // TODO: metadataService.readTableMetadata called fileOperations.getFileIO already. It already
-    //  generated this config but not passed back. For best efficiency the result from
-    //  readTableMetadata should be reused.
-    return fileOperations.getFileIOConfig(NormalizedURL.from(tableMetadata.location()));
+  public Map<String, String> getTableConfig(
+      TableMetadata tableMetadata, Set<CredentialContext.Privilege> privileges) {
+    return fileOperations.getFileIOConfig(
+        NormalizedURL.from(tableMetadata.location()), privileges);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -5,7 +5,6 @@ import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Map;
 import java.util.Set;
-import org.apache.iceberg.TableMetadata;
 
 /**
  * Builds the per-table FileIO configuration (credentials, region, etc.) returned to clients in the
@@ -18,9 +17,12 @@ public class TableConfigService {
     this.fileOperations = fileOperations;
   }
 
+  /**
+   * Builds credentials from the location persisted in the UC table DAO. Do not accept a location
+   * extracted from client-supplied Iceberg metadata here: that metadata is untrusted input.
+   */
   public Map<String, String> getTableConfig(
-      TableMetadata tableMetadata, Set<CredentialContext.Privilege> privileges) {
-    return fileOperations.getFileIOConfig(
-        NormalizedURL.from(tableMetadata.location()), privileges);
+      NormalizedURL tableLocation, Set<CredentialContext.Privilege> privileges) {
+    return fileOperations.getFileIOConfig(tableLocation, privileges);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -201,6 +201,8 @@ public class ServerProperties {
     COOKIE_TIMEOUT("server.cookie-timeout", "P5D", DURATION_VALIDATOR),
     ACCESS_TOKEN_TIMEOUT("server.access-token-timeout", "PT24H", DURATION_VALIDATOR),
     MANAGED_TABLE_ENABLED("server.managed-table.enabled", "true", BOOLEAN_VALIDATOR),
+    // Native Iceberg REST writes are experimental and opt-in until the API is stable.
+    ICEBERG_TABLE_ENABLED("server.iceberg-table.enabled", "false", BOOLEAN_VALIDATOR),
     MANAGED_TABLE_USE_DELTA_API_ONLY(
         "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
     UNIFORM_ICEBERG_V2_ALLOW_MISSING_DV(
@@ -493,6 +495,23 @@ public class ServerProperties {
           "MANAGED table is an is currently disabled. To enable it, set "
               + "'server.managed-table.enabled=true' in server.properties");
     }
+  }
+
+  /**
+   * Check if experimental native Iceberg REST table writes are enabled. Reads remain available when
+   * this flag is disabled; only namespace/table mutations are gated by this check.
+   */
+  public void checkIcebergTableEnabled() {
+    if (!isIcebergTableEnabled()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Iceberg table writes are currently disabled. To enable them, set "
+              + "'server.iceberg-table.enabled=true' in server.properties");
+    }
+  }
+
+  public boolean isIcebergTableEnabled() {
+    return isTrueOrEnable(get(Property.ICEBERG_TABLE_ENABLED));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/SimpleLocalFileIOTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/SimpleLocalFileIOTest.java
@@ -1,0 +1,150 @@
+package io.unitycatalog.server.persist.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SimpleLocalFileIOTest {
+
+  private final SimpleLocalFileIO fileIO = new SimpleLocalFileIO();
+
+  private static String uri(Path path) {
+    return path.toUri().toString();
+  }
+
+  @SneakyThrows
+  private void write(String location, String content) {
+    OutputFile outputFile = fileIO.newOutputFile(location);
+    try (OutputStream out = outputFile.createOrOverwrite()) {
+      out.write(content.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @SneakyThrows
+  private String read(String location) {
+    InputFile inputFile = fileIO.newInputFile(location);
+    try (InputStream in = inputFile.newStream()) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void writesAndReadsBackThroughFileUris(@TempDir Path tempDir) {
+    String location = uri(tempDir.resolve("data.txt"));
+    write(location, "hello");
+    assertThat(read(location)).isEqualTo("hello");
+  }
+
+  @Test
+  public void newOutputFileCreatesMissingParentDirectories(@TempDir Path tempDir) {
+    String location = uri(tempDir.resolve("nested/deeper/data.txt"));
+    write(location, "content");
+    assertThat(Files.exists(tempDir.resolve("nested/deeper/data.txt"))).isTrue();
+    assertThat(read(location)).isEqualTo("content");
+  }
+
+  @Test
+  public void deleteFileRemovesTheFile(@TempDir Path tempDir) {
+    Path file = tempDir.resolve("data.txt");
+    String location = uri(file);
+    write(location, "x");
+
+    fileIO.deleteFile(location);
+    assertThat(Files.exists(file)).isFalse();
+  }
+
+  @Test
+  public void deleteFileThrowsWhenTheFileIsMissing(@TempDir Path tempDir) {
+    assertThatThrownBy(() -> fileIO.deleteFile(uri(tempDir.resolve("missing.txt"))))
+        .isInstanceOf(UncheckedIOException.class);
+  }
+
+  @Test
+  public void deleteFilesDeletesEveryPathThatExists(@TempDir Path tempDir) {
+    String a = uri(tempDir.resolve("a.txt"));
+    String b = uri(tempDir.resolve("b.txt"));
+    write(a, "a");
+    write(b, "b");
+
+    fileIO.deleteFiles(List.of(a, b));
+    assertThat(Files.exists(tempDir.resolve("a.txt"))).isFalse();
+    assertThat(Files.exists(tempDir.resolve("b.txt"))).isFalse();
+  }
+
+  @Test
+  public void deleteFilesReportsFailuresAsBulkDeletionFailure(@TempDir Path tempDir) {
+    String existing = uri(tempDir.resolve("a.txt"));
+    String missing = uri(tempDir.resolve("missing.txt"));
+    write(existing, "a");
+
+    assertThatThrownBy(() -> fileIO.deleteFiles(List.of(existing, missing)))
+        .isInstanceOf(BulkDeletionFailureException.class);
+    // The deletable file is still removed before the missing one fails.
+    assertThat(Files.exists(tempDir.resolve("a.txt"))).isFalse();
+  }
+
+  @SneakyThrows
+  @Test
+  public void listPrefixReturnsRegularFilesRecursivelyAndExcludesDirectories(
+      @TempDir Path tempDir) {
+    write(uri(tempDir.resolve("top.txt")), "1234");
+    write(uri(tempDir.resolve("sub/child.txt")), "56");
+
+    try (CloseableIterable<FileInfo> listed = fileIO.listPrefix(uri(tempDir))) {
+      List<FileInfo> files =
+          java.util.stream.StreamSupport.stream(listed.spliterator(), false)
+              .collect(Collectors.toList());
+      assertThat(files).hasSize(2);
+      assertThat(files.stream().map(FileInfo::location))
+          .containsExactlyInAnyOrder(
+              uri(tempDir.resolve("top.txt")), uri(tempDir.resolve("sub/child.txt")));
+      assertThat(files.stream().map(FileInfo::size)).containsExactlyInAnyOrder(4L, 2L);
+    }
+  }
+
+  @Test
+  public void deletePrefixRemovesTheEntireTree(@TempDir Path tempDir) {
+    Path root = tempDir.resolve("table");
+    write(uri(root.resolve("metadata/v1.json")), "m");
+    write(uri(root.resolve("data/part-0")), "d");
+
+    fileIO.deletePrefix(uri(root));
+    assertThat(Files.exists(root)).isFalse();
+  }
+
+  @Test
+  public void deleteDirectoryThrowsFileNotFoundWhenPrefixIsMissing(@TempDir Path tempDir) {
+    assertThatThrownBy(() -> SimpleLocalFileIO.deleteDirectory(uri(tempDir.resolve("absent"))))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasCauseInstanceOf(java.io.FileNotFoundException.class);
+  }
+
+  @Test
+  public void listPrefixOnMissingDirectoryIsEmpty(@TempDir Path tempDir) {
+    assertThatCode(
+            () -> {
+              try (CloseableIterable<FileInfo> listed =
+                  fileIO.listPrefix(uri(tempDir.resolve("absent")))) {
+                assertThat(listed.iterator().hasNext()).isFalse();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -223,7 +223,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             ex ->
                 assertThat(ex.getCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
-        .withMessageContaining("Managed table creation is only supported for Delta format");
+        .withMessageContaining(
+            "Managed table creation is only supported for Delta and Iceberg formats");
 
     // Step 3: Create a managed table using the staging location
     CreateTable createTableRequest =

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogServiceTest.java
@@ -1,0 +1,88 @@
+package io.unitycatalog.server.service;
+
+import static io.unitycatalog.server.service.credential.CredentialContext.READ_ONLY;
+import static io.unitycatalog.server.service.credential.CredentialContext.READ_WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.model.DataSourceFormat;
+import io.unitycatalog.server.persist.CatalogRepository;
+import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.SchemaRepository;
+import io.unitycatalog.server.persist.StagingTableRepository;
+import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.UserRepository;
+import io.unitycatalog.server.persist.model.Privileges;
+import io.unitycatalog.server.service.iceberg.MetadataService;
+import io.unitycatalog.server.service.iceberg.TableConfigService;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.UUID;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IcebergRestCatalogServiceTest {
+
+  private final UnityCatalogAuthorizer authorizer = mock();
+  private final Repositories repositories = mock();
+  private final UserRepository userRepository = mock();
+  private IcebergRestCatalogService service;
+
+  @BeforeEach
+  public void setUp() {
+    when(repositories.getUserRepository()).thenReturn(userRepository);
+    when(repositories.getCatalogRepository()).thenReturn(mock(CatalogRepository.class));
+    when(repositories.getSchemaRepository()).thenReturn(mock(SchemaRepository.class));
+    when(repositories.getStagingTableRepository()).thenReturn(mock(StagingTableRepository.class));
+    when(repositories.getTableRepository()).thenReturn(mock(TableRepository.class));
+    when(repositories.getSessionFactory()).thenReturn(mock(SessionFactory.class));
+    service =
+        new IcebergRestCatalogService(
+            authorizer,
+            mock(TableConfigService.class),
+            mock(MetadataService.class),
+            repositories,
+            mock(ServerProperties.class));
+  }
+
+  @Test
+  public void nativeIcebergLoadFallsBackToReadOnlyWithoutWriteAccess() {
+    UUID principalId = UUID.randomUUID();
+    UUID tableId = UUID.randomUUID();
+    when(userRepository.findPrincipalId()).thenReturn(principalId);
+    when(authorizer.authorize(principalId, tableId, Privileges.OWNER)).thenReturn(false);
+    when(authorizer.authorizeAll(principalId, tableId, Privileges.SELECT, Privileges.MODIFY))
+        .thenReturn(false);
+
+    assertThat(
+            service.getLoadCredentialPrivileges(
+                new TableRepository.IcebergTableState(
+                    tableId, DataSourceFormat.ICEBERG, "s3://bucket/table/metadata.json")))
+        .isEqualTo(READ_ONLY);
+  }
+
+  @Test
+  public void nativeIcebergLoadUsesReadWriteWithOwnerAccess() {
+    UUID principalId = UUID.randomUUID();
+    UUID tableId = UUID.randomUUID();
+    when(userRepository.findPrincipalId()).thenReturn(principalId);
+    when(authorizer.authorize(principalId, tableId, Privileges.OWNER)).thenReturn(true);
+
+    assertThat(
+            service.getLoadCredentialPrivileges(
+                new TableRepository.IcebergTableState(
+                    tableId, DataSourceFormat.ICEBERG, "s3://bucket/table/metadata.json")))
+        .isEqualTo(READ_WRITE);
+  }
+
+  @Test
+  public void uniformLoadAlwaysUsesReadOnlyCredentials() {
+    assertThat(
+            service.getLoadCredentialPrivileges(
+                new TableRepository.IcebergTableState(
+                    UUID.randomUUID(), DataSourceFormat.DELTA, "s3://bucket/table/metadata.json")))
+        .isEqualTo(READ_ONLY);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogServiceTest.java
@@ -19,6 +19,8 @@ import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.UUID;
+import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ public class IcebergRestCatalogServiceTest {
   private final UnityCatalogAuthorizer authorizer = mock();
   private final Repositories repositories = mock();
   private final UserRepository userRepository = mock();
+  private final ServerProperties serverProperties = mock();
   private IcebergRestCatalogService service;
 
   @BeforeEach
@@ -44,7 +47,7 @@ public class IcebergRestCatalogServiceTest {
             mock(TableConfigService.class),
             mock(MetadataService.class),
             repositories,
-            mock(ServerProperties.class));
+            serverProperties);
   }
 
   @Test
@@ -59,7 +62,10 @@ public class IcebergRestCatalogServiceTest {
     assertThat(
             service.getLoadCredentialPrivileges(
                 new TableRepository.IcebergTableState(
-                    tableId, DataSourceFormat.ICEBERG, "s3://bucket/table/metadata.json")))
+                    tableId,
+                    DataSourceFormat.ICEBERG,
+                    "s3://bucket/table/metadata.json",
+                    "s3://bucket/table")))
         .isEqualTo(READ_ONLY);
   }
 
@@ -73,7 +79,10 @@ public class IcebergRestCatalogServiceTest {
     assertThat(
             service.getLoadCredentialPrivileges(
                 new TableRepository.IcebergTableState(
-                    tableId, DataSourceFormat.ICEBERG, "s3://bucket/table/metadata.json")))
+                    tableId,
+                    DataSourceFormat.ICEBERG,
+                    "s3://bucket/table/metadata.json",
+                    "s3://bucket/table")))
         .isEqualTo(READ_WRITE);
   }
 
@@ -82,7 +91,22 @@ public class IcebergRestCatalogServiceTest {
     assertThat(
             service.getLoadCredentialPrivileges(
                 new TableRepository.IcebergTableState(
-                    UUID.randomUUID(), DataSourceFormat.DELTA, "s3://bucket/table/metadata.json")))
+                    UUID.randomUUID(),
+                    DataSourceFormat.DELTA,
+                    "s3://bucket/table/metadata.json",
+                    "s3://bucket/table")))
         .isEqualTo(READ_ONLY);
+  }
+
+  @Test
+  public void configAdvertisesWritesOnlyWhenIcebergTableWritesAreEnabled() {
+    when(serverProperties.isIcebergTableEnabled()).thenReturn(false);
+    ConfigResponse readOnly = service.config(java.util.Optional.of("catalog"));
+    assertThat(readOnly.endpoints()).doesNotContain(Endpoint.V1_CREATE_TABLE);
+    assertThat(readOnly.endpoints()).doesNotContain(Endpoint.V1_UPDATE_TABLE);
+
+    when(serverProperties.isIcebergTableEnabled()).thenReturn(true);
+    ConfigResponse writable = service.config(java.util.Optional.of("catalog"));
+    assertThat(writable.endpoints()).contains(Endpoint.V1_CREATE_TABLE, Endpoint.V1_UPDATE_TABLE);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.auth.AuthToken;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.CatalogInfo;
@@ -28,20 +31,32 @@ import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +111,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/views/{view}\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\""
+                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\","
+                + "\"POST /v1/{prefix}/namespaces\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
+                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
                 + "]}");
 
     // not setting warehouse param should result in 400 BadRequestException
@@ -329,5 +348,197 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
+
+    // UniForm-derived Iceberg metadata is read-only: commits and drops through the Iceberg REST
+    // catalog must be rejected.
+    {
+      String tablePath =
+          TEST_BASE_PREFIX
+              + "/namespaces/"
+              + TestUtils.SCHEMA_NAME
+              + "/tables/"
+              + TestUtils.TABLE_NAME;
+      UpdateTableRequest commitRequest =
+          new UpdateTableRequest(
+              List.of(), List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(commitRequest));
+      assertThat(resp.status().code()).isEqualTo(400);
+
+      resp = client.delete(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(400);
+    }
+  }
+
+  @Test
+  public void testIcebergTableWriteLifecycle() throws ApiException, IOException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+
+    String namespacesPath = TEST_BASE_PREFIX + "/namespaces";
+    String tablesPath = namespacesPath + "/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+
+    // Create the namespace through the Iceberg REST catalog
+    {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.builder()
+              .withNamespace(Namespace.of(TestUtils.SCHEMA_NAME))
+              .setProperties(TestUtils.PROPERTIES)
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      CreateNamespaceResponse createNamespaceResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), CreateNamespaceResponse.class);
+      assertThat(createNamespaceResponse.namespace())
+          .isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME));
+
+      // creating it again is a conflict
+      resp = postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+    }
+
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    String location = Files.createTempDirectory("iceberg-rest-table").toUri().toString();
+
+    // Staged creation is rejected with a clear error
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .withLocation(location)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(400);
+    }
+
+    // Create the table
+    String initialMetadataLocation;
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .withLocation(location)
+              .setProperty("created-by", "iceberg-rest-test")
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      initialMetadataLocation = loadTableResponse.tableMetadata().metadataFileLocation();
+      assertThat(initialMetadataLocation).contains("/metadata/00000-");
+      assertThat(loadTableResponse.tableMetadata().schema().columns()).hasSize(2);
+      assertThat(loadTableResponse.tableMetadata().properties())
+          .containsEntry("created-by", "iceberg-rest-test");
+
+      // creating it again is a conflict
+      resp = postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+    }
+
+    // The table is registered in UC as a native Iceberg table with converted columns
+    {
+      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.EXTERNAL);
+      assertThat(tableInfo.getColumns())
+          .extracting(ColumnInfo::getName)
+          .containsExactly("id", "data");
+    }
+
+    // The table is loadable and listable through the Iceberg REST catalog
+    String tableUuid;
+    {
+      AggregatedHttpResponse resp = client.head(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .isEqualTo(initialMetadataLocation);
+      tableUuid = loadTableResponse.tableMetadata().uuid();
+
+      resp = client.get(tablesPath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      ListTablesResponse listTablesResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+      assertThat(listTablesResponse.identifiers())
+          .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
+    }
+
+    // Commit an update against the table
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableUUID(tableUuid)),
+              List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00001-");
+      assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("foo", "bar");
+
+      // the new metadata location is what loadTable now returns
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse reloaded =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(reloaded.tableMetadata().metadataFileLocation())
+          .isEqualTo(loadTableResponse.tableMetadata().metadataFileLocation());
+      assertThat(reloaded.tableMetadata().properties()).containsEntry("foo", "bar");
+    }
+
+    // A commit whose requirements no longer hold fails with CommitFailedException
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableUUID(UUID.randomUUID().toString())),
+              List.of(new MetadataUpdate.SetProperties(Map.of("should", "fail"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(CommitFailedException.class.getSimpleName());
+    }
+
+    // Drop the table
+    {
+      AggregatedHttpResponse resp = client.delete(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(204);
+
+      resp = client.head(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(404);
+
+      resp = client.get(tablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(404);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(NoSuchTableException.class.getSimpleName());
+    }
+  }
+
+  private AggregatedHttpResponse postJson(String path, String body) {
+    return client
+        .execute(
+            RequestHeaders.builder(HttpMethod.POST, path).contentType(MediaType.JSON).build(), body)
+        .aggregate()
+        .join();
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -30,6 +30,7 @@ import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties.Property;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -82,6 +83,13 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   protected SchemaOperations schemaOperations;
   protected TableOperations tableOperations;
   private WebClient client;
+
+  @Override
+  protected void setUpProperties() {
+    super.setUpProperties();
+    // Native Iceberg REST writes are opt-in in production; this integration suite exercises them.
+    serverProperties.setProperty(Property.ICEBERG_TABLE_ENABLED.getKey(), "true");
+  }
 
   @BeforeEach
   public void setUp() {
@@ -285,6 +293,10 @@ public class IcebergRestCatalogTest extends BaseServerTest {
           Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
               .toURI()
               .toString();
+      // The fixture's metadata document declares file:/tmp/uniform_iceberg_table as its table
+      // root; keep the persisted DAO location aligned so the REST service's location check models
+      // a valid UniForm table rather than an out-of-root metadata pointer.
+      tableInfoDAO.setUrl("file:/tmp/uniform_iceberg_table");
       tableInfoDAO.setUniformIcebergMetadataLocation(metadataLocation);
       session.merge(tableInfoDAO);
       tx.commit();

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -23,11 +23,13 @@ import io.unitycatalog.server.base.BaseServerTest;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.persist.dao.StagingTableDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -47,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -415,7 +418,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             Types.NestedField.optional(2, "data", Types.StringType.get()));
     String location = Files.createTempDirectory("iceberg-rest-table").toUri().toString();
 
-    // Staged creation is rejected with a clear error
+    // Staged creation is stateless: it returns metadata without a metadata-location and
+    // registers nothing, so the direct create below still succeeds.
     {
       CreateTableRequest request =
           CreateTableRequest.builder()
@@ -426,7 +430,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .build();
       AggregatedHttpResponse resp =
           postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertThat(resp.status().code()).as(resp.contentUtf8()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation()).isNull();
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
     }
 
     // Create the table
@@ -441,7 +449,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .build();
       AggregatedHttpResponse resp =
           postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
+      assertThat(resp.status().code()).as(resp.contentUtf8()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
           IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
       initialMetadataLocation = loadTableResponse.tableMetadata().metadataFileLocation();
@@ -449,6 +457,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(loadTableResponse.tableMetadata().schema().columns()).hasSize(2);
       assertThat(loadTableResponse.tableMetadata().properties())
           .containsEntry("created-by", "iceberg-rest-test");
+      try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+        TableInfoDAO tableInfoDAO = getTableByName(session, TestUtils.TABLE_NAME);
+        assertThat(tableInfoDAO.getUniformIcebergMetadataLocation())
+            .isEqualTo(NormalizedURL.from(initialMetadataLocation).toString());
+      }
 
       // creating it again is a conflict
       resp = postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
@@ -465,6 +478,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(tableInfo.getColumns())
           .extracting(ColumnInfo::getName)
           .containsExactly("id", "data");
+      assertThat(tableInfo.getProperties()).containsEntry("created-by", "iceberg-rest-test");
     }
 
     // The table is loadable and listable through the Iceberg REST catalog
@@ -491,10 +505,18 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
     // Commit an update against the table
     {
+      Schema updatedSchema =
+          new Schema(
+              Types.NestedField.required(1, "id", Types.LongType.get()),
+              Types.NestedField.optional(2, "data", Types.StringType.get()),
+              Types.NestedField.optional(3, "category", Types.StringType.get()));
       UpdateTableRequest request =
           new UpdateTableRequest(
               List.of(new UpdateRequirement.AssertTableUUID(tableUuid)),
-              List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
+              List.of(
+                  new MetadataUpdate.AddSchema(updatedSchema),
+                  new MetadataUpdate.SetCurrentSchema(-1),
+                  new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
       AggregatedHttpResponse resp =
           postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
       assertThat(resp.status().code()).isEqualTo(200);
@@ -503,6 +525,15 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .contains("/metadata/00001-");
       assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("foo", "bar");
+      assertThat(loadTableResponse.tableMetadata().schema().columns())
+          .extracting(Types.NestedField::name)
+          .containsExactly("id", "data", "category");
+
+      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      assertThat(tableInfo.getColumns())
+          .extracting(ColumnInfo::getName)
+          .containsExactly("id", "data", "category");
+      assertThat(tableInfo.getProperties()).containsEntry("foo", "bar");
 
       // the new metadata location is what loadTable now returns
       resp = client.get(tablePath).aggregate().join();
@@ -540,6 +571,134 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(NoSuchTableException.class.getSimpleName());
     }
+
+    // A create request without a location gets a server-assigned managed location
+    {
+      String managedTablePath = tablesPath + "/managed_iceberg_table";
+      CreateTableRequest request =
+          CreateTableRequest.builder().withName("managed_iceberg_table").withSchema(schema).build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().location()).contains("/tables/");
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00000-");
+
+      TableInfo tableInfo =
+          tableOperations.getTable(
+              TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".managed_iceberg_table");
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.MANAGED);
+      assertThat(tableInfo.getStorageLocation())
+          .isEqualTo(loadTableResponse.tableMetadata().location());
+
+      resp = client.delete(managedTablePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(204);
+    }
+  }
+
+  @Test
+  public void testStagedCreateAndCommit() throws ApiException, IOException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+    // Stage the create (no location -> server-assigned managed location). No permanent table is
+    // registered.
+    TableMetadata staged;
+    UUID stagingTableId;
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      staged = loadTableResponse.tableMetadata();
+      assertThat(staged.metadataFileLocation()).isNull();
+      assertThat(staged.location()).contains("/tables/");
+
+      StagingTableDAO stagingTable = getStagingTableByLocation(staged.location());
+      assertThat(stagingTable).isNotNull();
+      assertThat(stagingTable.isStageCommitted()).isFalse();
+      stagingTableId = stagingTable.getId();
+
+      // the staged table is not yet a permanent UC table, so it is not loadable or listable
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
+    }
+
+    // Commit the staged create: assert-create requirement + updates rebuilding the metadata
+    {
+      UpdateTableRequest request =
+          new UpdateTableRequest(
+              List.of(new UpdateRequirement.AssertTableDoesNotExist()),
+              List.of(
+                  new MetadataUpdate.AssignUUID(staged.uuid()),
+                  new MetadataUpdate.UpgradeFormatVersion(staged.formatVersion()),
+                  new MetadataUpdate.AddSchema(staged.schema()),
+                  new MetadataUpdate.SetCurrentSchema(-1),
+                  new MetadataUpdate.AddPartitionSpec(staged.spec()),
+                  new MetadataUpdate.SetDefaultPartitionSpec(-1),
+                  new MetadataUpdate.AddSortOrder(staged.sortOrder()),
+                  new MetadataUpdate.SetDefaultSortOrder(-1),
+                  new MetadataUpdate.SetLocation(staged.location()),
+                  new MetadataUpdate.SetProperties(Map.of("staged", "true"))));
+      AggregatedHttpResponse resp =
+          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(200);
+      LoadTableResponse loadTableResponse =
+          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
+          .contains("/metadata/00000-");
+      assertThat(loadTableResponse.tableMetadata().uuid()).isEqualTo(staged.uuid());
+      assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("staged", "true");
+
+      // the table is now registered in UC as a managed Iceberg table and loadable
+      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+      assertThat(tableInfo.getTableType()).isEqualTo(TableType.MANAGED);
+      assertThat(tableInfo.getTableId()).isEqualTo(stagingTableId.toString());
+      try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+        assertThat(session.get(StagingTableDAO.class, stagingTableId).isStageCommitted()).isTrue();
+      }
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(200);
+
+      // replaying the create commit loses the race: 409 CommitFailedException
+      resp = postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(CommitFailedException.class.getSimpleName());
+    }
+
+    // staging a create for an existing table is a conflict
+    {
+      CreateTableRequest request =
+          CreateTableRequest.builder()
+              .withName(TestUtils.TABLE_NAME)
+              .withSchema(schema)
+              .stageCreate()
+              .build();
+      AggregatedHttpResponse resp =
+          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+    }
   }
 
   @Test
@@ -572,7 +731,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     // Fire N commits at once. Each asserts the original current-schema-id (0) and bumps the schema
     // to a new id, so the commits are mutually exclusive: only the first to land can both satisfy
     // its requirement and win the metadata-location compare-and-swap in
-    // TableRepository#setIcebergMetadataLocation. A loser fails either because it raced and lost
+    // TableRepository#commitIcebergTable. A loser fails either because it raced and lost
     // the CAS, or because it read post-winner state where assert-current-schema-id no longer holds;
     // both surface as 409 CommitFailedException. The CyclicBarrier releases the threads together to
     // exercise the CAS path when timing allows, but the outcome is deterministic either way.
@@ -636,5 +795,22 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             RequestHeaders.builder(HttpMethod.POST, path).contentType(MediaType.JSON).build(), body)
         .aggregate()
         .join();
+  }
+
+  private StagingTableDAO getStagingTableByLocation(String location) {
+    try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+      return session
+          .createQuery(
+              "FROM StagingTableDAO WHERE stagingLocation = :location", StagingTableDAO.class)
+          .setParameter("location", location)
+          .uniqueResult();
+    }
+  }
+
+  private TableInfoDAO getTableByName(Session session, String name) {
+    return session
+        .createQuery("FROM TableInfoDAO WHERE name = :name", TableInfoDAO.class)
+        .setParameter("name", name)
+        .getSingleResult();
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -33,8 +33,10 @@ import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties.Property;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -212,7 +214,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   }
 
   @Test
-  public void testTable() throws ApiException, IOException, URISyntaxException {
+  public void testTable() throws ApiException, IOException {
     CreateCatalog createCatalog =
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
     catalogOperations.createCatalog(createCatalog);
@@ -283,20 +285,28 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(errorResponse.type()).isEqualTo(NoSuchTableException.class.getSimpleName());
     }
 
-    // Add the uniform metadata
+    // Register UniForm-derived Iceberg metadata for the table. The fixture's baked table root is
+    // rewritten onto a hermetic temp directory and the metadata file is written under it, modeling
+    // a real UniForm table whose persisted metadata pointer lives inside the table location that
+    // the REST load path validates.
+    Path tableRoot = testDirectoryRoot.resolve("uniform_iceberg_table");
+    NormalizedURL tableLocation = NormalizedURL.from(tableRoot.toUri());
+    Path metadataFile = tableRoot.resolve("metadata/v1.metadata.json");
+    Files.createDirectories(metadataFile.getParent());
+    try (InputStream fixture =
+        Objects.requireNonNull(this.getClass().getResourceAsStream("/iceberg.metadata.json"))) {
+      String fixtureJson =
+          new String(fixture.readAllBytes(), StandardCharsets.UTF_8)
+              .replace("file:/tmp/uniform_iceberg_table", tableLocation.toString());
+      Files.writeString(metadataFile, fixtureJson);
+    }
+    String metadataLocation = metadataFile.toUri().toString();
     try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
       Transaction tx = session.beginTransaction();
       TableInfoDAO tableInfoDAO = TableInfoDAO.builder().build();
       assertThat(tableInfo.getTableId()).isNotNull();
       session.load(tableInfoDAO, UUID.fromString(tableInfo.getTableId()));
-      String metadataLocation =
-          Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
-              .toURI()
-              .toString();
-      // The fixture's metadata document declares file:/tmp/uniform_iceberg_table as its table
-      // root; keep the persisted DAO location aligned so the REST service's location check models
-      // a valid UniForm table rather than an out-of-root metadata pointer.
-      tableInfoDAO.setUrl("file:/tmp/uniform_iceberg_table");
+      tableInfoDAO.setUrl(tableLocation.toString());
       tableInfoDAO.setUniformIcebergMetadataLocation(metadataLocation);
       session.merge(tableInfoDAO);
       tx.commit();
@@ -332,9 +342,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       LoadTableResponse loadTableResponse =
           IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
-          .isEqualTo(
-              Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
-                  .getPath());
+          .isEqualTo(metadataFile.toString());
 
       // non-prefixed URL should result in 404
       resp =

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -32,11 +32,19 @@ import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.UpdateRequirement;
@@ -532,6 +540,94 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(NoSuchTableException.class.getSimpleName());
     }
+  }
+
+  @Test
+  public void testConcurrentCommitsSerializeWithCompareAndSwap()
+      throws ApiException, IOException, InterruptedException, ExecutionException, TimeoutException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    String location = Files.createTempDirectory("iceberg-rest-concurrent").toUri().toString();
+
+    // Create the table; its current-schema-id is 0.
+    CreateTableRequest createRequest =
+        CreateTableRequest.builder()
+            .withName(TestUtils.TABLE_NAME)
+            .withSchema(schema)
+            .withLocation(location)
+            .build();
+    AggregatedHttpResponse createResp =
+        postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(createRequest));
+    assertThat(createResp.status().code()).isEqualTo(200);
+    LoadTableResponse created =
+        IcebergObjectMapper.mapper().readValue(createResp.contentUtf8(), LoadTableResponse.class);
+    assertThat(created.tableMetadata().metadataFileLocation()).contains("/metadata/00000-");
+
+    // Fire N commits at once. Each asserts the original current-schema-id (0) and bumps the schema
+    // to a new id, so the commits are mutually exclusive: only the first to land can both satisfy
+    // its requirement and win the metadata-location compare-and-swap in
+    // TableRepository#setIcebergMetadataLocation. A loser fails either because it raced and lost
+    // the CAS, or because it read post-winner state where assert-current-schema-id no longer holds;
+    // both surface as 409 CommitFailedException. The CyclicBarrier releases the threads together to
+    // exercise the CAS path when timing allows, but the outcome is deterministic either way.
+    int concurrency = 8;
+    Schema bumpedSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "added", Types.StringType.get()));
+    CyclicBarrier barrier = new CyclicBarrier(concurrency);
+    ExecutorService pool = Executors.newFixedThreadPool(concurrency);
+    List<Future<Integer>> futures = new ArrayList<>();
+    for (int i = 0; i < concurrency; i++) {
+      futures.add(
+          pool.submit(
+              () -> {
+                UpdateTableRequest request =
+                    new UpdateTableRequest(
+                        List.of(new UpdateRequirement.AssertCurrentSchemaID(0)),
+                        List.of(
+                            new MetadataUpdate.AddSchema(bumpedSchema),
+                            new MetadataUpdate.SetCurrentSchema(-1)));
+                String body = IcebergObjectMapper.mapper().writeValueAsString(request);
+                barrier.await();
+                return postJson(tablePath, body).status().code();
+              }));
+    }
+
+    int successes = 0;
+    int conflicts = 0;
+    for (Future<Integer> future : futures) {
+      int code = future.get(30, TimeUnit.SECONDS);
+      // A commit either wins (200) or loses cleanly (409 CommitFailedException); any other status
+      // would mean the contention surfaced as a server error.
+      assertThat(code).isIn(200, 409);
+      if (code == 200) {
+        successes++;
+      } else {
+        conflicts++;
+      }
+    }
+    pool.shutdown();
+    assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+    // Exactly one commit wins and the rest lose cleanly: no lost updates, no double-applies.
+    assertThat(successes).isEqualTo(1);
+    assertThat(conflicts).isEqualTo(concurrency - 1);
+
+    // The single winner advanced the table to version 1 with the bumped schema; losers left no
+    // trace (their metadata files were rolled back), so the table is loadable and consistent.
+    AggregatedHttpResponse loadResp = client.get(tablePath).aggregate().join();
+    assertThat(loadResp.status().code()).isEqualTo(200);
+    LoadTableResponse loaded =
+        IcebergObjectMapper.mapper().readValue(loadResp.contentUtf8(), LoadTableResponse.class);
+    assertThat(loaded.tableMetadata().metadataFileLocation()).contains("/metadata/00001-");
+    assertThat(loaded.tableMetadata().schema().columns()).hasSize(2);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
@@ -1,0 +1,131 @@
+package io.unitycatalog.server.service.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.model.ColumnInfo;
+import io.unitycatalog.server.model.ColumnTypeName;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class IcebergSchemaConverterTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  public void convertsPrimitivesWithPositionAndNullability() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get(), "the name"));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+
+    assertThat(columns).hasSize(2);
+
+    ColumnInfo id = columns.get(0);
+    assertThat(id.getName()).isEqualTo("id");
+    assertThat(id.getPosition()).isEqualTo(0);
+    assertThat(id.getNullable()).isFalse();
+    assertThat(id.getTypeName()).isEqualTo(ColumnTypeName.LONG);
+    // Spark DDL text renders LONG as "bigint" while the type JSON uses "long".
+    assertThat(id.getTypeText()).isEqualTo("bigint");
+
+    ColumnInfo name = columns.get(1);
+    assertThat(name.getName()).isEqualTo("name");
+    assertThat(name.getPosition()).isEqualTo(1);
+    assertThat(name.getNullable()).isTrue();
+    assertThat(name.getComment()).isEqualTo("the name");
+    assertThat(name.getTypeName()).isEqualTo(ColumnTypeName.STRING);
+  }
+
+  @Test
+  public void rendersStructFieldTypeJsonInSparkShape() throws Exception {
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+
+    ColumnInfo id = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    JsonNode json = MAPPER.readTree(id.getTypeJson());
+
+    assertThat(json.get("name").asText()).isEqualTo("id");
+    assertThat(json.get("type").asText()).isEqualTo("long");
+    assertThat(json.get("nullable").asBoolean()).isFalse();
+    assertThat(json.get("metadata")).isNotNull();
+  }
+
+  @Test
+  public void carriesDecimalPrecisionAndScale() {
+    Schema schema =
+        new Schema(Types.NestedField.required(1, "amount", Types.DecimalType.of(18, 4)));
+
+    ColumnInfo amount = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    assertThat(amount.getTypeName()).isEqualTo(ColumnTypeName.DECIMAL);
+    assertThat(amount.getTypePrecision()).isEqualTo(18);
+    assertThat(amount.getTypeScale()).isEqualTo(4);
+    assertThat(amount.getTypeText()).isEqualTo("decimal(18,4)");
+  }
+
+  @Test
+  public void distinguishesTimestampWithAndWithoutZone() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+            Types.NestedField.required(2, "ts_ntz", Types.TimestampType.withoutZone()));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+    assertThat(columns.get(0).getTypeName()).isEqualTo(ColumnTypeName.TIMESTAMP);
+    assertThat(columns.get(1).getTypeName()).isEqualTo(ColumnTypeName.TIMESTAMP_NTZ);
+  }
+
+  @Test
+  public void mapsUuidToStringLossily() {
+    Schema schema = new Schema(Types.NestedField.required(1, "key", Types.UUIDType.get()));
+
+    ColumnInfo key = IcebergSchemaConverter.toColumnInfos(schema).get(0);
+    assertThat(key.getTypeName()).isEqualTo(ColumnTypeName.STRING);
+    assertThat(key.getTypeText()).isEqualTo("string");
+  }
+
+  @Test
+  public void convertsNestedStructListAndMap() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "props",
+                Types.StructType.of(
+                    Types.NestedField.optional(2, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(3, "b", Types.StringType.get()))),
+            Types.NestedField.required(
+                4, "tags", Types.ListType.ofOptional(5, Types.StringType.get())),
+            Types.NestedField.required(
+                6,
+                "scores",
+                Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.DoubleType.get())));
+
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(schema);
+
+    ColumnInfo props = columns.get(0);
+    assertThat(props.getTypeName()).isEqualTo(ColumnTypeName.STRUCT);
+    assertThat(props.getTypeText()).isEqualTo("struct<a:int,b:string>");
+
+    ColumnInfo tags = columns.get(1);
+    assertThat(tags.getTypeName()).isEqualTo(ColumnTypeName.ARRAY);
+    assertThat(tags.getTypeText()).isEqualTo("array<string>");
+    JsonNode tagsJson = MAPPER.readTree(tags.getTypeJson()).get("type");
+    assertThat(tagsJson.get("type").asText()).isEqualTo("array");
+    assertThat(tagsJson.get("elementType").asText()).isEqualTo("string");
+    assertThat(tagsJson.get("containsNull").asBoolean()).isTrue();
+
+    ColumnInfo scores = columns.get(2);
+    assertThat(scores.getTypeName()).isEqualTo(ColumnTypeName.MAP);
+    assertThat(scores.getTypeText()).isEqualTo("map<string,double>");
+    JsonNode scoresJson = MAPPER.readTree(scores.getTypeJson()).get("type");
+    assertThat(scoresJson.get("type").asText()).isEqualTo("map");
+    assertThat(scoresJson.get("keyType").asText()).isEqualTo("string");
+    assertThat(scoresJson.get("valueType").asText()).isEqualTo("double");
+    assertThat(scoresJson.get("valueContainsNull").asBoolean()).isFalse();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverterTest.java
@@ -53,6 +53,14 @@ public class IcebergSchemaConverterTest {
     assertThat(json.get("type").asText()).isEqualTo("long");
     assertThat(json.get("nullable").asBoolean()).isFalse();
     assertThat(json.get("metadata")).isNotNull();
+
+    ColumnInfo named =
+        IcebergSchemaConverter.toColumnInfos(
+                new Schema(
+                    Types.NestedField.optional(2, "name", Types.StringType.get(), "the name")))
+            .get(0);
+    assertThat(MAPPER.readTree(named.getTypeJson()).path("metadata").path("comment").asText())
+        .isEqualTo("the name");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.service.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -8,6 +9,8 @@ import static org.mockito.Mockito.when;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.amazonaws.util.IOUtils;
+import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Map;
 import java.util.Objects;
@@ -16,6 +19,7 @@ import lombok.SneakyThrows;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +39,7 @@ public class MetadataServiceTest {
   public static final String TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME =
       "simple-v1-iceberg.metadata.json";
 
-  private final FileIOFactory mockFileIOFactory = mock();
+  private final FileOperations mockFileOperations = mock();
   private final S3Client mockS3Client = S3_MOCK.createS3ClientV2();
 
   private MetadataService metadataService;
@@ -43,13 +47,13 @@ public class MetadataServiceTest {
   @SneakyThrows
   @BeforeEach
   public void setUp() {
-    metadataService = new MetadataService(mockFileIOFactory);
+    metadataService = new MetadataService(mockFileOperations);
   }
 
   @SneakyThrows
   @Test
   public void testGetTableMetadataFromS3() {
-    when(mockFileIOFactory.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileOperations.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
     mockS3Client.createBucket(builder -> builder.bucket(TEST_BUCKET).build());
     String simpleMetadataJson =
         IOUtils.toString(
@@ -79,7 +83,7 @@ public class MetadataServiceTest {
   @SneakyThrows
   @Test
   public void testGetTableMetadataFromLocalFS() {
-    when(mockFileIOFactory.getFileIO(any())).thenReturn(new SimpleLocalFileIO());
+    when(mockFileOperations.getFileIO(any())).thenReturn(new SimpleLocalFileIO());
     NormalizedURL metadataLocation =
         NormalizedURL.from(
             Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json")).toURI());
@@ -90,8 +94,8 @@ public class MetadataServiceTest {
   @SneakyThrows
   @Test
   public void testWriteAndDeleteTableMetadataOnS3() {
-    when(mockFileIOFactory.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
-    when(mockFileIOFactory.getFileIO(any(), any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileOperations.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileOperations.getFileIO(any(), any())).thenReturn(new S3FileIO(() -> mockS3Client));
     // Dedicated bucket: the S3Mock extension is static and shared across this class's tests.
     String bucket = "metadata-write-test";
     mockS3Client.createBucket(builder -> builder.bucket(bucket).build());
@@ -114,5 +118,59 @@ public class MetadataServiceTest {
     metadataService.deleteTableMetadata(metadataLocation);
     assertThatThrownBy(() -> metadataService.readTableMetadata(metadataLocation))
         .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void acceptsMetadataLocationsUnderPersistedTableLocation() {
+    NormalizedURL tableLocation = NormalizedURL.from("s3://bucket/table");
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
+            PartitionSpec.unpartitioned(),
+            tableLocation.toString(),
+            Map.of(TableProperties.WRITE_METADATA_LOCATION, tableLocation + "/metadata"));
+
+    assertThatCode(() -> MetadataService.validateTableMetadataLocation(metadata, tableLocation))
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              MetadataService.validateMetadataLocation(
+                  NormalizedURL.from(tableLocation + "/metadata/v1.metadata.json"), tableLocation);
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void rejectsClientSuppliedMetadataLocationsOutsidePersistedTableLocation() {
+    NormalizedURL tableLocation = NormalizedURL.from("s3://bucket/table");
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
+            PartitionSpec.unpartitioned(),
+            tableLocation.toString(),
+            Map.of(TableProperties.WRITE_METADATA_LOCATION, "s3://bucket/other-table/metadata"));
+
+    assertThatThrownBy(() -> MetadataService.validateTableMetadataLocation(metadata, tableLocation))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("must be a subpath");
+    assertThatThrownBy(
+            () ->
+                MetadataService.validateMetadataLocation(
+                    NormalizedURL.from("s3://bucket/other-table/v1.metadata.json"), tableLocation))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("must be a subpath");
+
+    TableMetadata metadataWithWrongTableRoot =
+        TableMetadata.newTableMetadata(
+            new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
+            PartitionSpec.unpartitioned(),
+            "s3://bucket/other-table",
+            Map.of());
+    assertThatThrownBy(
+            () ->
+                MetadataService.validateTableMetadataLocation(
+                    metadataWithWrongTableRoot, tableLocation))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("must match the persisted table location");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
@@ -12,6 +12,10 @@ import com.amazonaws.util.IOUtils;
 import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
 import io.unitycatalog.server.utils.NormalizedURL;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -35,7 +40,9 @@ public class MetadataServiceTest {
   public static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
   public static final String TEST_BUCKET = "test-bucket";
-  public static final String TEST_LOCATION = "test-bucket";
+  // Matches the table root declared inside the simple-v1-iceberg fixture ("s3://test-bucket/
+  // testLocation"), so the metadata file resolves under the persisted table location.
+  public static final String TEST_LOCATION = "testLocation";
   public static final String TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME =
       "simple-v1-iceberg.metadata.json";
 
@@ -68,6 +75,7 @@ public class MetadataServiceTest {
                 .build(),
         RequestBody.fromString(simpleMetadataJson));
 
+    NormalizedURL tableLocation = NormalizedURL.from("s3://" + TEST_BUCKET + "/" + TEST_LOCATION);
     NormalizedURL metadataLocation =
         NormalizedURL.from(
             "s3://"
@@ -76,19 +84,39 @@ public class MetadataServiceTest {
                 + TEST_LOCATION
                 + "/"
                 + TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME);
-    TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
+    TableMetadata tableMetadata =
+        metadataService.readTableMetadata(metadataLocation, tableLocation);
     assertThat(tableMetadata.uuid()).isEqualTo("11111111-2222-3333-4444-555555555555");
   }
 
   @SneakyThrows
   @Test
-  public void testGetTableMetadataFromLocalFS() {
+  public void testGetTableMetadataFromLocalFS(@TempDir Path tableRoot) {
     when(mockFileOperations.getFileIO(any())).thenReturn(new SimpleLocalFileIO());
-    NormalizedURL metadataLocation =
-        NormalizedURL.from(
-            Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json")).toURI());
-    TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
+    // Read a real Iceberg metadata fixture from local disk. The fixture's baked table root is
+    // rewritten onto a hermetic temp directory, then written under it, so the metadata file
+    // resolves inside the persisted table location the two-arg read validates against.
+    NormalizedURL tableLocation = NormalizedURL.from(tableRoot.toUri());
+    Path metadataFile = tableRoot.resolve("metadata/v1.metadata.json");
+    Files.createDirectories(metadataFile.getParent());
+    Files.writeString(metadataFile, fixtureWithTableRoot(tableLocation));
+    NormalizedURL metadataLocation = NormalizedURL.from(metadataFile.toUri());
+
+    TableMetadata tableMetadata =
+        metadataService.readTableMetadata(metadataLocation, tableLocation);
     assertThat(tableMetadata.uuid()).isEqualTo("55d4dc69-5b14-4483-bfc8-f33b80f99f99");
+  }
+
+  /**
+   * Loads the local Iceberg metadata fixture with its baked table root rewritten to {@code root}.
+   */
+  @SneakyThrows
+  private String fixtureWithTableRoot(NormalizedURL root) {
+    try (InputStream fixture =
+        Objects.requireNonNull(this.getClass().getResourceAsStream("/iceberg.metadata.json"))) {
+      return new String(fixture.readAllBytes(), StandardCharsets.UTF_8)
+          .replace("file:/tmp/uniform_iceberg_table", root.toString());
+    }
   }
 
   @SneakyThrows
@@ -105,18 +133,20 @@ public class MetadataServiceTest {
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(
             schema, PartitionSpec.unpartitioned(), tableLocation, Map.of());
+    NormalizedURL persistedTableLocation = NormalizedURL.from(tableLocation);
     NormalizedURL metadataLocation =
         NormalizedURL.from(
             tableLocation + "/metadata/00000-" + UUID.randomUUID() + ".metadata.json");
 
     // The metadata is written to S3 through the FileIO and reads back identically.
-    metadataService.writeTableMetadata(tableMetadata, metadataLocation);
-    assertThat(metadataService.readTableMetadata(metadataLocation).uuid())
+    metadataService.writeTableMetadata(tableMetadata, metadataLocation, persistedTableLocation);
+    assertThat(metadataService.readTableMetadata(metadataLocation, persistedTableLocation).uuid())
         .isEqualTo(tableMetadata.uuid());
 
     // Delete removes the object, so a subsequent read of that location fails.
-    metadataService.deleteTableMetadata(metadataLocation);
-    assertThatThrownBy(() -> metadataService.readTableMetadata(metadataLocation))
+    metadataService.deleteTableMetadata(metadataLocation, persistedTableLocation);
+    assertThatThrownBy(
+            () -> metadataService.readTableMetadata(metadataLocation, persistedTableLocation))
         .isInstanceOf(RuntimeException.class);
   }
 
@@ -172,5 +202,20 @@ public class MetadataServiceTest {
                     metadataWithWrongTableRoot, tableLocation))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("must match the persisted table location");
+  }
+
+  @Test
+  public void toIcebergMetadataLocationStripsFileSchemeButKeepsObjectStoreUris() {
+    // Local files are handed to Iceberg as filesystem paths (no scheme), so SimpleLocalFileIO's
+    // java.nio-based reads/writes resolve them.
+    assertThat(
+            MetadataService.toIcebergMetadataLocation(
+                NormalizedURL.from("file:///tmp/table/metadata/v1.metadata.json")))
+        .isEqualTo("/tmp/table/metadata/v1.metadata.json");
+
+    // Object-store locations are passed through verbatim, scheme included.
+    String s3Location = "s3://bucket/table/metadata/v1.metadata.json";
+    assertThat(MetadataService.toIcebergMetadataLocation(NormalizedURL.from(s3Location)))
+        .isEqualTo(s3Location);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/MetadataServiceTest.java
@@ -1,19 +1,23 @@
 package io.unitycatalog.server.service.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import com.amazonaws.util.IOUtils;
-import io.unitycatalog.server.persist.utils.FileOperations;
-import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
 import io.unitycatalog.server.utils.NormalizedURL;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.SneakyThrows;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +35,7 @@ public class MetadataServiceTest {
   public static final String TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME =
       "simple-v1-iceberg.metadata.json";
 
-  private final FileOperations mockFileOperations = mock();
+  private final FileIOFactory mockFileIOFactory = mock();
   private final S3Client mockS3Client = S3_MOCK.createS3ClientV2();
 
   private MetadataService metadataService;
@@ -39,13 +43,13 @@ public class MetadataServiceTest {
   @SneakyThrows
   @BeforeEach
   public void setUp() {
-    metadataService = new MetadataService(mockFileOperations);
+    metadataService = new MetadataService(mockFileIOFactory);
   }
 
   @SneakyThrows
   @Test
   public void testGetTableMetadataFromS3() {
-    when(mockFileOperations.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileIOFactory.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
     mockS3Client.createBucket(builder -> builder.bucket(TEST_BUCKET).build());
     String simpleMetadataJson =
         IOUtils.toString(
@@ -60,28 +64,55 @@ public class MetadataServiceTest {
                 .build(),
         RequestBody.fromString(simpleMetadataJson));
 
-    String metadataLocation =
-        "s3://"
-            + TEST_BUCKET
-            + "/"
-            + TEST_LOCATION
-            + "/"
-            + TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME;
-    TableMetadata tableMetadata =
-        metadataService.readTableMetadata(NormalizedURL.from(metadataLocation));
+    NormalizedURL metadataLocation =
+        NormalizedURL.from(
+            "s3://"
+                + TEST_BUCKET
+                + "/"
+                + TEST_LOCATION
+                + "/"
+                + TEST_SIMPLE_ICEBERG_V1_METADATA_FILE_NAME);
+    TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
     assertThat(tableMetadata.uuid()).isEqualTo("11111111-2222-3333-4444-555555555555");
   }
 
   @SneakyThrows
   @Test
   public void testGetTableMetadataFromLocalFS() {
-    when(mockFileOperations.getFileIO(any())).thenReturn(new SimpleLocalFileIO());
-    String metadataLocation =
-        Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
-            .toURI()
-            .toString();
-    TableMetadata tableMetadata =
-        metadataService.readTableMetadata(NormalizedURL.from(metadataLocation));
+    when(mockFileIOFactory.getFileIO(any())).thenReturn(new SimpleLocalFileIO());
+    NormalizedURL metadataLocation =
+        NormalizedURL.from(
+            Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json")).toURI());
+    TableMetadata tableMetadata = metadataService.readTableMetadata(metadataLocation);
     assertThat(tableMetadata.uuid()).isEqualTo("55d4dc69-5b14-4483-bfc8-f33b80f99f99");
+  }
+
+  @SneakyThrows
+  @Test
+  public void testWriteAndDeleteTableMetadataOnS3() {
+    when(mockFileIOFactory.getFileIO(any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    when(mockFileIOFactory.getFileIO(any(), any())).thenReturn(new S3FileIO(() -> mockS3Client));
+    // Dedicated bucket: the S3Mock extension is static and shared across this class's tests.
+    String bucket = "metadata-write-test";
+    mockS3Client.createBucket(builder -> builder.bucket(bucket).build());
+
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    String tableLocation = "s3://" + bucket + "/write-roundtrip";
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), tableLocation, Map.of());
+    NormalizedURL metadataLocation =
+        NormalizedURL.from(
+            tableLocation + "/metadata/00000-" + UUID.randomUUID() + ".metadata.json");
+
+    // The metadata is written to S3 through the FileIO and reads back identically.
+    metadataService.writeTableMetadata(tableMetadata, metadataLocation);
+    assertThat(metadataService.readTableMetadata(metadataLocation).uuid())
+        .isEqualTo(tableMetadata.uuid());
+
+    // Delete removes the object, so a subsequent read of that location fails.
+    metadataService.deleteTableMetadata(metadataLocation);
+    assertThatThrownBy(() -> metadataService.readTableMetadata(metadataLocation))
+        .isInstanceOf(RuntimeException.class);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
@@ -1,0 +1,48 @@
+package io.unitycatalog.server.service.iceberg;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.model.GcpOauthToken;
+import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link TableConfigService} vends storage credentials with the privileges the caller
+ * asks for. A GCS location is used because that path returns a plain config map without
+ * constructing any cloud client.
+ */
+public class TableConfigServiceTest {
+
+  private final StorageCredentialVendor mockVendor = mock();
+  private final TableMetadata mockMetadata = mock();
+  private TableConfigService tableConfigService;
+
+  @BeforeEach
+  public void setUp() {
+    ServerProperties serverProperties = mock();
+    when(serverProperties.getS3Configurations()).thenReturn(Map.of());
+    when(mockMetadata.location()).thenReturn("gs://test-bucket/table");
+    when(mockVendor.vendCredential(any(), any()))
+        .thenReturn(
+            new TemporaryCredentials()
+                .gcpOauthToken(new GcpOauthToken().oauthToken("token"))
+                .expirationTime(0L));
+    tableConfigService = new TableConfigService(mockVendor, serverProperties);
+  }
+
+  @Test
+  public void passesThroughRequestedPrivileges() {
+    tableConfigService.getTableConfig(mockMetadata, CredentialContext.READ_WRITE);
+    verify(mockVendor).vendCredential(any(), eq(CredentialContext.READ_WRITE));
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/iceberg/TableConfigServiceTest.java
@@ -4,15 +4,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.unitycatalog.server.model.GcpOauthToken;
-import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.service.credential.CredentialContext;
-import io.unitycatalog.server.service.credential.StorageCredentialVendor;
-import io.unitycatalog.server.utils.ServerProperties;
-import java.util.Map;
-import org.apache.iceberg.TableMetadata;
+import io.unitycatalog.server.utils.NormalizedURL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,26 +18,19 @@ import org.junit.jupiter.api.Test;
  */
 public class TableConfigServiceTest {
 
-  private final StorageCredentialVendor mockVendor = mock();
-  private final TableMetadata mockMetadata = mock();
+  private final FileOperations mockFileOperations = mock();
   private TableConfigService tableConfigService;
 
   @BeforeEach
   public void setUp() {
-    ServerProperties serverProperties = mock();
-    when(serverProperties.getS3Configurations()).thenReturn(Map.of());
-    when(mockMetadata.location()).thenReturn("gs://test-bucket/table");
-    when(mockVendor.vendCredential(any(), any()))
-        .thenReturn(
-            new TemporaryCredentials()
-                .gcpOauthToken(new GcpOauthToken().oauthToken("token"))
-                .expirationTime(0L));
-    tableConfigService = new TableConfigService(mockVendor, serverProperties);
+    tableConfigService = new TableConfigService(mockFileOperations);
   }
 
   @Test
   public void passesThroughRequestedPrivileges() {
-    tableConfigService.getTableConfig(mockMetadata, CredentialContext.READ_WRITE);
-    verify(mockVendor).vendCredential(any(), eq(CredentialContext.READ_WRITE));
+    tableConfigService.getTableConfig(
+        NormalizedURL.from("gs://test-bucket/table"), CredentialContext.READ_WRITE);
+    verify(mockFileOperations)
+        .getFileIOConfig(any(NormalizedURL.class), eq(CredentialContext.READ_WRITE));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/FileOperationsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/FileOperationsTest.java
@@ -37,6 +37,8 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -320,6 +322,22 @@ public class FileOperationsTest {
       InputFile input = fileIO.newInputFile(file.toUri().toString());
       assertThat(input.getLength()).isEqualTo("hello world".length());
     }
+  }
+
+  @SneakyThrows
+  @Test
+  public void testGetFileIOForLocalPathWritesThroughReturnedFileIO() {
+    Path file = rootBase.resolve("metadata-" + UUID.randomUUID() + ".json");
+    StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
+    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+
+    try (FileIO fileIO = fileOps.getFileIO(NormalizedURL.from(file.toUri().toString()))) {
+      OutputFile output = fileIO.newOutputFile(file.toUri().toString());
+      try (PositionOutputStream stream = output.createOrOverwrite()) {
+        stream.write("{\"table\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      }
+    }
+    assertThat(Files.readString(file)).isEqualTo("{\"table\":true}");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -100,6 +100,9 @@ public class ServerPropertiesTest {
     testValidProperty(Property.MANAGED_TABLE_ENABLED, "true");
     testValidProperty(Property.MANAGED_TABLE_ENABLED, "false");
     testValidProperty(Property.MANAGED_TABLE_ENABLED, "TRUE");
+    testValidProperty(Property.ICEBERG_TABLE_ENABLED, "true");
+    testValidProperty(Property.ICEBERG_TABLE_ENABLED, "false");
+    testValidProperty(Property.ICEBERG_TABLE_ENABLED, "TRUE");
 
     // Invalid values
     testInvalidProperty(
@@ -108,6 +111,25 @@ public class ServerPropertiesTest {
         "Invalid value 'yes'",
         "server.managed-table.enabled",
         "Allowed values: [true, false]");
+    testInvalidProperty(
+        Property.ICEBERG_TABLE_ENABLED,
+        "yes",
+        "Invalid value 'yes'",
+        "server.iceberg-table.enabled",
+        "Allowed values: [true, false]");
+  }
+
+  @Test
+  public void testIcebergTableEnabledCheck() {
+    ServerProperties serverProperties = new ServerProperties();
+    assertThat(serverProperties.isIcebergTableEnabled()).isFalse();
+    assertThatThrownBy(serverProperties::checkIcebergTableEnabled)
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("server.iceberg-table.enabled=true");
+
+    serverProperties.set(Property.ICEBERG_TABLE_ENABLED, "true");
+    assertThat(serverProperties.isIcebergTableEnabled()).isTrue();
+    serverProperties.checkIcebergTableEnabled();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Unity Catalog's Iceberg REST catalog can now create and commit native Iceberg tables instead of limiting Iceberg clients to read-only Delta UniForm metadata. Spec-aware clients can discover the write endpoints, create managed or external tables, perform staged creates, commit new snapshots with conflict protection, and drop catalog-created tables.

This draft is a current-`main`, DCO-clean continuation of the implementation developed by @dataders in #1618. The implementation credit and history are called out here explicitly; the commits were replayed onto current upstream because the original branch is behind `main` and its DCO check cannot be repaired by a third-party sign-off.

## Design decisions

- Native `ICEBERG` tables are writable, while Delta UniForm tables remain read-only so Iceberg metadata cannot diverge from the Delta log.
- Commits write a new metadata file and then compare-and-swap the catalog's metadata pointer under a row lock. Concurrent losers receive a conflict instead of silently overwriting another snapshot.
- Location-less creates receive a managed location under Unity Catalog's configured managed root. Explicit locations remain external.
- Staged creates remain unregistered until the client's `assert-create` commit materializes the table.
- Storage credentials are vended according to the requested read or write privileges, and the write routes retain metastore-owner authorization.

The remaining endpoint families in the broader Iceberg REST specification—such as multi-table transactions, rename/register, namespace property updates, and view writes—remain outside this change.

## Validation

- Focused Iceberg, schema conversion, metadata, credential, and cloud-vendor suites: **24 passed, 0 failed**.
- Full server suite: **313 total, 311 passed, 2 skipped, 0 failed, 0 errors**.
- The two skipped classes are the MySQL and PostgreSQL Delta Commits Testcontainers suites. The local OrbStack endpoint requires Docker API 1.40+, while this repository's older Testcontainers client advertises API 1.32. Upstream CI should exercise these suites in its supported Docker environment.
- `serverShaded/assembly`: **passed**.
- Checkstyle and `git diff --check`: **passed**.
- The DCO rewrite changed commit metadata only; the source tree hash remained identical before and after the rewrite.

## Known interoperability checks

- Recheck the table `HEAD` endpoint with a real HTTP/1.1 Iceberg client; the Java integration suite passes, but an earlier local client probe could stall.
- Lowercase REST boolean values work for `purgeRequested`; mixed-case values such as `False` remain an optional compatibility improvement.

## Related

Related: #3

Continuation of and implementation credit: #1618 by @dataders.

## Post-deploy monitoring & validation

- **Window/owner:** PR author and maintainers during CI, release qualification, and the first 24 hours of any deployment enabling the new endpoints.
- **Exercise:** create a namespace and native Iceberg table, append two snapshots, force one concurrent stale commit, reload the table, and drop it through a released Iceberg client.
- **Healthy signals:** create/commit/load/drop return expected 2xx responses; stale commits return 409; the stored metadata location advances once per successful commit; data remains readable after server restart.
- **Watch logs for:** `CommitFailedException`, `UPDATE_REQUIREMENT_CONFLICT`, `Failed to update Iceberg metadata location`, credential-vending failures, and metadata read/write exceptions.
- **Failure/rollback trigger:** unexpected 5xx responses, catalog pointers referencing missing metadata, unauthorized write credentials, or lost concurrent updates. Stop advertising the write endpoints and revert this change while preserving the catalog database and Iceberg metadata for diagnosis.

## PR checklist

- [x] Description explains the behavior and design boundaries.
- [x] Unit and integration coverage is included.
- [x] Focused and full local server validation completed.
- [ ] Upstream CI validates the Docker-backed database suites.
- [ ] Maintainers confirm whether separate user documentation is required.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
