### PR TITLE
Fix JCasbinAuthorizer reading the wrong Hibernate username property

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -149,7 +149,7 @@ public class UnityCatalogServer {
         new UnityAccessUtil(repositories).initializeAdmin(authorizer);
         return authorizer;
       } catch (Exception e) {
-        throw new BaseException(ErrorCode.INTERNAL, "Problem initializing authorizer.");
+        throw new BaseException(ErrorCode.INTERNAL, "Problem initializing authorizer.", e);
       }
     } else {
       LOGGER.info("Authorization disabled. Using AllowingAuthorizer.");

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -38,7 +38,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
     Properties properties = hibernateConfigurator.getHibernateProperties();
     String driver = properties.getProperty("hibernate.connection.driver_class");
     String url = properties.getProperty("hibernate.connection.url");
-    String user = properties.getProperty("hibernate.connection.user");
+    String user = resolveConnectionUsername(properties);
     String password = properties.getProperty("hibernate.connection.password");
     JDBCAdapter adapter = new JDBCAdapter(driver, url, user, password);
 
@@ -49,6 +49,24 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
 
     enforcer = new Enforcer(model, adapter);
     enforcer.enableAutoSave(true);
+  }
+
+  /**
+   * Resolves the database connection username from the Hibernate properties.
+   *
+   * <p>Prefers the standard Hibernate key {@code hibernate.connection.username} (used by the main
+   * session factory configuration and by the project's own tests) and falls back to the
+   * non-standard {@code hibernate.connection.user} that the deployment docs and Helm chart
+   * document. Reading only {@code hibernate.connection.user} left the casbin JDBC adapter with a
+   * null username for any standard configuration, which the JDBC driver then silently replaced with
+   * a process default.
+   */
+  static String resolveConnectionUsername(Properties properties) {
+    String username = properties.getProperty("hibernate.connection.username");
+    if (username == null) {
+      username = properties.getProperty("hibernate.connection.user");
+    }
+    return username;
   }
 
   @Override

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -27,6 +27,28 @@ public class JCasbinAuthorizerTest {
   }
 
   @Test
+  void resolvesUsernameFromStandardHibernateProperty() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.username", "alice");
+    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("alice");
+  }
+
+  @Test
+  void fallsBackToLegacyUserProperty() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.user", "bob");
+    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("bob");
+  }
+
+  @Test
+  void prefersStandardUsernameWhenBothPresent() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.username", "alice");
+    properties.setProperty("hibernate.connection.user", "bob");
+    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("alice");
+  }
+
+  @Test
   void testGrantAuthorization() {
     UUID principal = UUID.randomUUID();
     UUID resource = UUID.randomUUID();


### PR DESCRIPTION
## What this fixes

`JCasbinAuthorizer` reads the database username from `hibernate.connection.user`, but the standard Hibernate property (used by the main session factory configuration and by the project's own tests) is `hibernate.connection.username`. With a standard configuration the casbin JDBC adapter received a `null` username, and the JDBC driver then silently fell back to a process default, crashing authorizer startup against an external database that authenticates on the username. Reported in #1697.

## Root cause

Two independent property spellings are in play in the codebase:

- `hibernate.connection.username` — the standard Hibernate key, set by the main session-factory config and by the existing tests.
- `hibernate.connection.user` — a non-standard key the deployment docs and Helm chart document.

`JCasbinAuthorizer` only read the second one, so any deployment using the standard spelling handed the JDBC adapter a `null` username. Separately, `UnityCatalogServer.initializeAuthorizer` swallowed the caught exception when rethrowing, so the original bug report had no `Caused by:` to point at the real failure.

## The fix

- Resolve the username from `hibernate.connection.username` first and fall back to `hibernate.connection.user`, so both spellings work.
- Preserve the caught exception as the cause when rethrowing from `initializeAuthorizer`, so the underlying failure is no longer hidden.
- Add unit tests covering username resolution: standard key, legacy fallback, and standard-wins-when-both-present.

All 13 tests in `JCasbinAuthorizerTest` pass locally via `build/sbt "server / testOnly io.unitycatalog.server.auth.JCasbinAuthorizerTest"`.

Fixes #1697

---
AI was used for assistance.
