### PR TITLE
refactor(client): promote ApiClientFactory to the client module (#1181, phase 1)

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/ApiClientFactory.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/ApiClientFactory.java
@@ -1,17 +1,23 @@
-package io.unitycatalog.client.internal;
+package io.unitycatalog.client;
 
-import io.unitycatalog.client.ApiClient;
-import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.client.retry.RetryPolicy;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
 
-public final class ApiClientUtils {
+/** The canonical entry point for constructing an {@link ApiClient}. */
+public final class ApiClientFactory {
 
-  private ApiClientUtils() {}
+  private ApiClientFactory() {}
 
-  public static ApiClient create(
+  public static ApiClient createApiClient(
+      URI uri, TokenProvider tokenProvider, RetryPolicy retryPolicy) {
+    return createApiClient(uri, tokenProvider, retryPolicy, Collections.emptyMap());
+  }
+
+  public static ApiClient createApiClient(
       URI uri,
       TokenProvider tokenProvider,
       RetryPolicy retryPolicy,

--- a/clients/java/src/test/java/io/unitycatalog/client/UserAgentTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/UserAgentTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.auth.TokenProviderUtils;
-import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -94,9 +93,9 @@ public class UserAgentTest {
   }
 
   @Test
-  public void testApiClientUtilsCreateAddsAppVersions() {
+  public void testCreateApiClientAddsAppVersions() {
     ApiClient client =
-        ApiClientUtils.create(
+        ApiClientFactory.createApiClient(
             URI.create(TEST_URI),
             TOKEN_PROVIDER,
             JitterDelayRetryPolicy.builder().build(),

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -1,9 +1,9 @@
 package io.unitycatalog.hadoop.internal;
 
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientFactory;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.model.AwsCredentials;
 import io.unitycatalog.client.model.AzureUserDelegationSAS;
 import io.unitycatalog.client.model.GcpOauthToken;
@@ -574,7 +574,7 @@ public class CredPropsUtil {
 
   private static ApiClient createApiClient(
       String catalogUri, TokenProvider tokenProvider, Map<String, String> appVersions) {
-    return ApiClientUtils.create(
+    return ApiClientFactory.createApiClient(
         URI.create(catalogUri),
         tokenProvider,
         UCHadoopConfConstants.createRequestRetryPolicy(null),

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -1,11 +1,11 @@
 package io.unitycatalog.hadoop.internal.auth;
 
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientFactory;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.TemporaryCredentialsApi;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.api.DeltaTemporaryCredentialsApi;
-import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.CredId;
@@ -76,7 +76,7 @@ public interface GenericCredentialFetcher {
         "Failed to create GenericCredentialFetcher, the '%s' is not set in hadoop configuration",
         UCHadoopConfConstants.UC_URI_KEY);
     ApiClient apiClient =
-        ApiClientUtils.create(
+        ApiClientFactory.createApiClient(
             URI.create(ucUriStr),
             TokenProvider.create(conf.getPropsWithPrefix(UCHadoopConfConstants.UC_AUTH_PREFIX)),
             UCHadoopConfConstants.createRequestRetryPolicy(conf),

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/EngineVersions.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/EngineVersions.java
@@ -1,24 +1,19 @@
 package io.unitycatalog.spark;
 
-import io.unitycatalog.client.ApiClient;
-import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.internal.ApiClientUtils;
-import io.unitycatalog.client.retry.RetryPolicy;
-import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class ApiClientFactory {
+/**
+ * Detects the engine's Spark / Delta / Java / Scala versions, reported in the User-Agent header via
+ * {@code ApiClientFactory}. Lives in the connector because it references Spark and Delta classes
+ * the client module does not depend on.
+ */
+public final class EngineVersions {
 
-  private ApiClientFactory() {}
+  private EngineVersions() {}
 
-  public static ApiClient createApiClient(
-      RetryPolicy retryPolicy, URI uri, TokenProvider tokenProvider) {
-    return ApiClientUtils.create(uri, tokenProvider, retryPolicy, appEngineVersions());
-  }
-
-  static Map<String, String> appEngineVersions() {
+  public static Map<String, String> appEngineVersions() {
     Map<String, String> versions = new LinkedHashMap<>();
     putIfNotNull(versions, "Spark", getSparkVersion());
     putIfNotNull(versions, "Delta", DeltaVersionUtils.getDeltaVersion());

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -16,7 +16,7 @@ import io.unitycatalog.client.model.{
   _
 }
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy
-import io.unitycatalog.client.{ApiClient, ApiException}
+import io.unitycatalog.client.{ApiClient, ApiClientFactory, ApiException}
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs.{PathOperation, TableOperation}
 import io.unitycatalog.spark.auth.AuthConfigUtils
@@ -95,7 +95,8 @@ class UCSingleCatalog
       OptionsUtil.DELTA_API_ENABLED, OptionsUtil.DEFAULT_DELTA_API_ENABLED)
 
     apiClient = ApiClientFactory.createApiClient(
-      JitterDelayRetryPolicy.builder().build(),uri, tokenProvider)
+      uri, tokenProvider, JitterDelayRetryPolicy.builder().build(),
+      EngineVersions.appEngineVersions())
     tablesApi = new TablesApi(apiClient)
     ucProxy = new UCProxy(uri, tokenProvider, renewCredEnabled, credScopedFsEnabled,
       serverSidePlanningEnabled, apiClient, tablesApi)
@@ -223,7 +224,7 @@ class UCSingleCatalog
 
     val credentialProps = UCCredentialHadoopConfs
       .builder(uri.toString, CatalogUtils.stringToURI(stagingLocation).getScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
+      .addAppVersions(EngineVersions.appEngineVersions())
       .tokenProvider(tokenProvider)
       .apiClient(apiClient)
       .enableCredentialRenewal(renewCredEnabled)
@@ -327,7 +328,7 @@ class UCSingleCatalog
     val tableUriScheme = new Path(tableLocation).toUri.getScheme
     val credentialProps = UCCredentialHadoopConfs
       .builder(uri.toString, tableUriScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
+      .addAppVersions(EngineVersions.appEngineVersions())
       .tokenProvider(tokenProvider)
       .apiClient(apiClient)
       .enableCredentialRenewal(renewCredEnabled)
@@ -363,7 +364,7 @@ class UCSingleCatalog
 
     val credentialProps = UCCredentialHadoopConfs
       .builder(uri.toString, CatalogUtils.stringToURI(location).getScheme)
-      .addAppVersions(ApiClientFactory.appEngineVersions())
+      .addAppVersions(EngineVersions.appEngineVersions())
       .tokenProvider(tokenProvider)
       .apiClient(apiClient)
       .enableCredentialRenewal(renewCredEnabled)
@@ -712,7 +713,7 @@ private[spark] class UCProxy(
     val credBuilder =
       UCCredentialHadoopConfs
         .builder(uri.toString, locationUri.getScheme)
-        .addAppVersions(ApiClientFactory.appEngineVersions())
+        .addAppVersions(EngineVersions.appEngineVersions())
         .tokenProvider(tokenProvider)
         .apiClient(apiClient)
         .enableCredentialRenewal(renewCredEnabled)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/EngineVersionsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/EngineVersionsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientFactory;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.client.retry.RetryPolicy;
@@ -16,13 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
- * Test class for ApiClientFactory to verify Spark-specific functionality.
- *
- * <p>This test class focuses on Spark/Delta/Java/Scala version metadata injection into the
- * User-Agent. For general ApiClient configuration tests, see {@link
+ * Verifies Spark/Delta/Java/Scala version metadata injection into the User-Agent via {@link
+ * EngineVersions}. For general ApiClient configuration tests, see {@link
  * io.unitycatalog.client.ApiClientBuilderTest}.
  */
-public class ApiClientFactoryTest {
+public class EngineVersionsTest {
   private static final TokenProvider UC_TOKEN_PROVIDER = createStaticTokenProvider("token");
   private static final RetryPolicy RETRY_POLICY = JitterDelayRetryPolicy.builder().build();
   private static final URI TEST_URI = URI.create("http://localhost:8080");
@@ -49,7 +48,9 @@ public class ApiClientFactoryTest {
 
   @Test
   public void testAllVersionsInUserAgent() {
-    ApiClient client = ApiClientFactory.createApiClient(RETRY_POLICY, TEST_URI, UC_TOKEN_PROVIDER);
+    ApiClient client =
+        ApiClientFactory.createApiClient(
+            TEST_URI, UC_TOKEN_PROVIDER, RETRY_POLICY, EngineVersions.appEngineVersions());
     String userAgent = extractUserAgent(client);
 
     // Verify the base Unity Catalog client is present
@@ -79,7 +80,9 @@ public class ApiClientFactoryTest {
   public void testTokenNotLeakedInUserAgent() {
     String sensitiveToken = "test-token-12345";
     TokenProvider tokenProvider = createStaticTokenProvider(sensitiveToken);
-    ApiClient client = ApiClientFactory.createApiClient(RETRY_POLICY, TEST_URI, tokenProvider);
+    ApiClient client =
+        ApiClientFactory.createApiClient(
+            TEST_URI, tokenProvider, RETRY_POLICY, EngineVersions.appEngineVersions());
 
     String userAgent = extractUserAgent(client);
 
@@ -96,7 +99,9 @@ public class ApiClientFactoryTest {
 
   @Test
   public void testUserAgentFormat() {
-    ApiClient client = ApiClientFactory.createApiClient(RETRY_POLICY, TEST_URI, UC_TOKEN_PROVIDER);
+    ApiClient client =
+        ApiClientFactory.createApiClient(
+            TEST_URI, UC_TOKEN_PROVIDER, RETRY_POLICY, EngineVersions.appEngineVersions());
     String userAgent = extractUserAgent(client);
 
     // Verify format: project/version,[project/version,...]
@@ -133,7 +138,7 @@ public class ApiClientFactoryTest {
 
   @Test
   public void testAppEngineVersionsContainsExpectedKeys() {
-    Map<String, String> versions = ApiClientFactory.appEngineVersions();
+    Map<String, String> versions = EngineVersions.appEngineVersions();
     assertThat(versions).containsKeys("Spark", "Delta", "Java", "Scala");
   }
 

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -4,21 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.unitycatalog.client.ApiClient;
-import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.DeltaApiException;
 import io.unitycatalog.client.delta.model.DeltaErrorType;
+import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.function.Executable;
 
-public class TestUtils {
+public final class TestUtils {
+
+  private TestUtils() {}
+
   public static final String CATALOG_NAME = "uc_testcatalog";
   public static final String SCHEMA_NAME = "uc_testschema";
   public static final String CATALOG_NAME2 = "uc_testcatalog2";
@@ -59,20 +62,19 @@ public class TestUtils {
   public static final String TEST_AWS_MASTER_ROLE_SECRET_KEY = "masterRoleSecretKey";
   public static final String TEST_AWS_REGION = "us-west-2";
 
-  public static final Map<String, String> PROPERTIES =
-      new HashMap<>(Map.of("prop1", "value1", "prop2", "value2"));
+  public static final Map<String, String> PROPERTIES = Map.of("prop1", "value1", "prop2", "value2");
   public static final Map<String, String> NEW_PROPERTIES =
-      new HashMap<>(Map.of("prop2", "value22", "prop3", "value33"));
+      Map.of("prop2", "value22", "prop3", "value33");
   public static final String COMMON_ENTITY_NAME = "zz_uc_common_entity_name";
 
   public static ApiClient createApiClient(ServerConfig serverConfig) {
     URI uri = URI.create(serverConfig.getServerUrl());
     String token = serverConfig.getAuthToken() != null ? serverConfig.getAuthToken() : "";
-    return ApiClientBuilder.create()
-        .uri(uri)
-        .tokenProvider(TokenProvider.create(Map.of("type", "static", "token", token)))
-        .retryPolicy(JitterDelayRetryPolicy.builder().maxAttempts(1).build())
-        .build();
+    return ApiClientUtils.create(
+        uri,
+        TokenProvider.create(Map.of("type", "static", "token", token)),
+        JitterDelayRetryPolicy.builder().maxAttempts(1).build(),
+        Collections.emptyMap());
   }
 
   public static void assertApiException(

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -4,24 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.DeltaApiException;
 import io.unitycatalog.client.delta.model.DeltaErrorType;
-import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.net.URI;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.function.Executable;
 
-public final class TestUtils {
-
-  private TestUtils() {}
-
+public class TestUtils {
   public static final String CATALOG_NAME = "uc_testcatalog";
   public static final String SCHEMA_NAME = "uc_testschema";
   public static final String CATALOG_NAME2 = "uc_testcatalog2";
@@ -62,19 +59,20 @@ public final class TestUtils {
   public static final String TEST_AWS_MASTER_ROLE_SECRET_KEY = "masterRoleSecretKey";
   public static final String TEST_AWS_REGION = "us-west-2";
 
-  public static final Map<String, String> PROPERTIES = Map.of("prop1", "value1", "prop2", "value2");
+  public static final Map<String, String> PROPERTIES =
+      new HashMap<>(Map.of("prop1", "value1", "prop2", "value2"));
   public static final Map<String, String> NEW_PROPERTIES =
-      Map.of("prop2", "value22", "prop3", "value33");
+      new HashMap<>(Map.of("prop2", "value22", "prop3", "value33"));
   public static final String COMMON_ENTITY_NAME = "zz_uc_common_entity_name";
 
   public static ApiClient createApiClient(ServerConfig serverConfig) {
     URI uri = URI.create(serverConfig.getServerUrl());
     String token = serverConfig.getAuthToken() != null ? serverConfig.getAuthToken() : "";
-    return ApiClientUtils.create(
-        uri,
-        TokenProvider.create(Map.of("type", "static", "token", token)),
-        JitterDelayRetryPolicy.builder().maxAttempts(1).build(),
-        Collections.emptyMap());
+    return ApiClientBuilder.create()
+        .uri(uri)
+        .tokenProvider(TokenProvider.create(Map.of("type", "static", "token", token)))
+        .retryPolicy(JitterDelayRetryPolicy.builder().maxAttempts(1).build())
+        .build();
   }
 
   public static void assertApiException(


### PR DESCRIPTION
## Summary

Implements #1181 in two phases so each is independently reviewable. **This PR currently contains Phase 1.**

**Phase 1 (this change): promote the internal `ApiClientUtils` to the public `io.unitycatalog.client.ApiClientFactory`.**
- One class, no wrapper or delegation layer: the internal `ApiClientUtils` is renamed/moved to `io.unitycatalog.client.ApiClientFactory` (`createApiClient(uri, tokenProvider, retryPolicy[, appVersions])`), and all its former callers — hadoop's `CredPropsUtil` and `GenericCredentialFetcher`, plus `UserAgentTest` — now call the factory directly.
- The engine-version detection (Spark/Delta/Java/Scala) cannot move down — it compile-references Spark and Delta classes the client module does not depend on — so the old spark `ApiClientFactory` becomes `EngineVersions`, and `UCSingleCatalog`'s three call sites pass `EngineVersions.appEngineVersions()` to the promoted factory. `ApiClientFactoryTest` is renamed `EngineVersionsTest` accordingly.

**Phase 2 (follow-up commit, after Phase 1 review): route `TestUtils.createApiClient` through the promoted factory.** `TestUtils.createApiClient` cannot be removed outright — its ~157 call sites across 51 server-test files all pass a `ServerConfig` (a server-test class the client module cannot see), and the test-specific no-retry policy should stay decided in one place — but its construction plumbing will delegate to the promoted factory.

Why the factory could not simply be referenced from server tests as-is: `connectors/spark` builds against the server module's compiled test output, so `server -> connectors/spark` would be a dependency cycle. Promoting the factory to `clients/java` (which both depend on) resolves it.

## How we tested

```
build/sbt ";client/testOnly io.unitycatalog.client.UserAgentTest;spark/testOnly io.unitycatalog.spark.EngineVersionsTest;server/Test/compile"
[info] Passed: Total 8, Failed 0, Errors 0, Passed 8   (UserAgentTest)
[info] Passed: Total 4, Failed 0, Errors 0, Passed 4   (EngineVersionsTest)
```

`EngineVersionsTest` pins that the engine versions still land in the User-Agent through the promoted factory; `UserAgentTest` pins the client-side header construction.
