### PR TITLE
[Spark] Fix ClassCastException on namespace ops when DeltaCatalog is absent

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -118,6 +118,16 @@ class UCSingleCatalog
     }
   }
 
+  /**
+   * The catalog to route `SupportsNamespaces` operations to.
+   *
+   * Both possible values of `delegate` are a `SupportsNamespaces`: when DeltaCatalog is on the
+   * classpath `delegate` is a `DelegatingCatalogExtension` (a `SupportsNamespaces` via
+   * `CatalogExtension`), and when it is absent `delegate` is `ucProxy` itself (a plain
+   * `TableCatalog with SupportsNamespaces`). So we can cast unconditionally.
+   */
+  private def namespaceCatalog: SupportsNamespaces = delegate.asInstanceOf[SupportsNamespaces]
+
   /** See [[DeltaVersionUtils.isDeltaRestApiReady]] for the predicate. */
   private def shouldUseDeltaAPI: Boolean =
     DeltaVersionUtils.isDeltaRestApiReady(deltaCatalogLoaded, deltaRestApiEnabled)
@@ -395,27 +405,27 @@ class UCSingleCatalog
   }
 
   override def listNamespaces(): Array[Array[String]] = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].listNamespaces()
+    namespaceCatalog.listNamespaces()
   }
 
   override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].listNamespaces(namespace)
+    namespaceCatalog.listNamespaces(namespace)
   }
 
   override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].loadNamespaceMetadata(namespace)
+    namespaceCatalog.loadNamespaceMetadata(namespace)
   }
 
   override def createNamespace(namespace: Array[String], metadata: util.Map[String, String]): Unit = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].createNamespace(namespace, metadata)
+    namespaceCatalog.createNamespace(namespace, metadata)
   }
 
   override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].alterNamespace(namespace, changes: _*)
+    namespaceCatalog.alterNamespace(namespace, changes: _*)
   }
 
   override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {
-    delegate.asInstanceOf[DelegatingCatalogExtension].dropNamespace(namespace, cascade)
+    namespaceCatalog.dropNamespace(namespace, cascade)
   }
 
   /** Only called for REPLACE TABLE and RTAS */

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
@@ -14,22 +14,57 @@ import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SchemaOperationsTest extends BaseSparkIntegrationTest {
-  @Test
-  public void testCreateSchema() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
-    session.catalog().setCurrentCatalog(CATALOG_NAME);
-    sql("CREATE DATABASE my_test_database;");
-    assertThat(session.catalog().databaseExists("my_test_database")).isTrue();
-    sql("DROP DATABASE %s.my_test_database;", CATALOG_NAME);
-    assertThat(session.catalog().databaseExists("my_test_database")).isFalse();
+  @AfterEach
+  public void restoreLoadDeltaCatalog() {
+    // Restore the default in case testNamespaceOps flipped it (and even if it failed mid-way), so
+    // other tests still load the Delta catalog.
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
+  }
 
-    session.catalog().setCurrentCatalog(SPARK_CATALOG);
-    sql("CREATE DATABASE my_test_database;");
-    assertThat(session.catalog().databaseExists("my_test_database")).isTrue();
-    sql("DROP DATABASE %s.my_test_database;", SPARK_CATALOG);
-    assertThat(session.catalog().databaseExists("my_test_database")).isFalse();
+  // Exercises the full namespace lifecycle (create/list/desc/drop) for both delegate paths:
+  // Delta catalog loaded (DelegatingCatalogExtension) vs not (UCProxy). Within each round we run
+  // the lifecycle against both the UC catalog (CATALOG_NAME) and the session catalog
+  // (spark_catalog) in the same session.
+  //
+  // The Delta flags must be set before the session is created because the delegate is chosen at
+  // catalog-init time. DELTA_CATALOG_LOADED is expected to end up equal to loadDeltaCatalog: it is
+  // flipped to true only when the flag is on and DeltaCatalog is on the classpath, so asserting it
+  // also confirms the delegate really was UCProxy in the Delta-disabled case.
+  @ParameterizedTest(name = "loadDeltaCatalog={0}")
+  @ValueSource(booleans = {true, false})
+  public void testNamespaceOps(boolean loadDeltaCatalog) {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(loadDeltaCatalog);
+    UCSingleCatalog.DELTA_CATALOG_LOADED().set(false);
+    session = createSparkSessionWithCatalogs(CATALOG_NAME, SPARK_CATALOG);
+
+    for (String catalog : List.of(CATALOG_NAME, SPARK_CATALOG)) {
+      session.catalog().setCurrentCatalog(catalog);
+
+      // createNamespace
+      sql("CREATE DATABASE my_test_database");
+      assertThat(session.catalog().databaseExists("my_test_database")).isTrue();
+
+      // listNamespaces (SHOW SCHEMAS) -- includes the default schema plus the one we created.
+      List<String> schemaNames =
+          sql("SHOW SCHEMAS").stream().map(row -> row.getString(0)).collect(Collectors.toList());
+      assertThat(schemaNames).contains("my_test_database", SCHEMA_NAME);
+
+      // loadNamespaceMetadata (DESC SCHEMA)
+      List<Row> desc = sql("DESC SCHEMA my_test_database");
+      assertThat(desc.get(0).getString(0)).isEqualTo("Catalog Name");
+      assertThat(desc.get(0).getString(1)).isEqualTo(catalog);
+
+      // dropNamespace
+      sql("DROP DATABASE %s.my_test_database", catalog);
+      assertThat(session.catalog().databaseExists("my_test_database")).isFalse();
+    }
+
+    // See method comment: when Delta is disabled the delegate must be UCProxy (flag stays false).
+    assertThat(UCSingleCatalog.DELTA_CATALOG_LOADED().get()).isEqualTo(loadDeltaCatalog);
   }
 
   // On Spark 4.2+ (SPARK-55250), this exercises the UCProxy.createNamespace catch
@@ -94,42 +129,6 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
 
     assertThatThrownBy(() -> sql("DESC NAMESPACE NonExist"))
         .isInstanceOf(NoSuchNamespaceException.class);
-  }
-
-  @Test
-  public void testNamespaceOpsWithoutDeltaCatalog() {
-    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
-    UCSingleCatalog.DELTA_CATALOG_LOADED().set(false);
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
-    session.catalog().setCurrentCatalog(CATALOG_NAME);
-
-    // createNamespace
-    sql("CREATE DATABASE no_delta_ns");
-    assertThat(session.catalog().databaseExists("no_delta_ns")).isTrue();
-
-    // listNamespaces (SHOW SCHEMAS) -- includes the default schema plus the one we created.
-    List<String> schemaNames =
-        sql("SHOW SCHEMAS").stream().map(row -> row.getString(0)).collect(Collectors.toList());
-    assertThat(schemaNames).contains("no_delta_ns", SCHEMA_NAME);
-
-    // loadNamespaceMetadata (DESC SCHEMA)
-    List<Row> desc = sql("DESC SCHEMA no_delta_ns");
-    assertThat(desc.get(0).getString(0)).isEqualTo("Catalog Name");
-    assertThat(desc.get(0).getString(1)).isEqualTo(CATALOG_NAME);
-
-    // dropNamespace
-    sql("DROP DATABASE %s.no_delta_ns", CATALOG_NAME);
-    assertThat(session.catalog().databaseExists("no_delta_ns")).isFalse();
-
-    // Sanity check: the delegate really was UCProxy, not a DelegatingCatalogExtension.
-    assertThat(UCSingleCatalog.DELTA_CATALOG_LOADED().get()).isEqualTo(false);
-  }
-
-  @AfterEach
-  public void restoreLoadDeltaCatalog() {
-    // Restore the default in case testNamespaceOpsWithoutDeltaCatalog flipped it (and even if it
-    // failed mid-way), so other tests still load the Delta catalog.
-    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
   }
 
   @Test

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/SchemaOperationsTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class SchemaOperationsTest extends BaseSparkIntegrationTest {
@@ -93,6 +94,42 @@ public class SchemaOperationsTest extends BaseSparkIntegrationTest {
 
     assertThatThrownBy(() -> sql("DESC NAMESPACE NonExist"))
         .isInstanceOf(NoSuchNamespaceException.class);
+  }
+
+  @Test
+  public void testNamespaceOpsWithoutDeltaCatalog() {
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(false);
+    UCSingleCatalog.DELTA_CATALOG_LOADED().set(false);
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    session.catalog().setCurrentCatalog(CATALOG_NAME);
+
+    // createNamespace
+    sql("CREATE DATABASE no_delta_ns");
+    assertThat(session.catalog().databaseExists("no_delta_ns")).isTrue();
+
+    // listNamespaces (SHOW SCHEMAS) -- includes the default schema plus the one we created.
+    List<String> schemaNames =
+        sql("SHOW SCHEMAS").stream().map(row -> row.getString(0)).collect(Collectors.toList());
+    assertThat(schemaNames).contains("no_delta_ns", SCHEMA_NAME);
+
+    // loadNamespaceMetadata (DESC SCHEMA)
+    List<Row> desc = sql("DESC SCHEMA no_delta_ns");
+    assertThat(desc.get(0).getString(0)).isEqualTo("Catalog Name");
+    assertThat(desc.get(0).getString(1)).isEqualTo(CATALOG_NAME);
+
+    // dropNamespace
+    sql("DROP DATABASE %s.no_delta_ns", CATALOG_NAME);
+    assertThat(session.catalog().databaseExists("no_delta_ns")).isFalse();
+
+    // Sanity check: the delegate really was UCProxy, not a DelegatingCatalogExtension.
+    assertThat(UCSingleCatalog.DELTA_CATALOG_LOADED().get()).isEqualTo(false);
+  }
+
+  @AfterEach
+  public void restoreLoadDeltaCatalog() {
+    // Restore the default in case testNamespaceOpsWithoutDeltaCatalog flipped it (and even if it
+    // failed mid-way), so other tests still load the Delta catalog.
+    UCSingleCatalog.LOAD_DELTA_CATALOG().set(true);
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
When `DeltaCatalog` is not on the classpath (e.g. Spark 4.2, which has no matching Delta release yet), namespace commands like `SHOW`/`CREATE`/`DESC`/`DROP SCHEMA` failed with:
```
  java.lang.ClassCastException: class io.unitycatalog.spark.UCProxy cannot be cast to class org.apache.spark.sql.connector.catalog.DelegatingCatalogExtension
```
The namespace methods cast `delegate` to `DelegatingCatalogExtension`, which only holds when DeltaCatalog is loaded. Without it, `delegate` is `ucProxy`, a plain `TableCatalog with SupportsNamespaces`, so the cast throws.

Route namespace ops through a `namespaceCatalog` accessor that casts to `SupportsNamespaces` instead. Both possible delegates satisfy it: DeltaCatalog via CatalogExtension, and ucProxy directly.

Add a regression test that forces the no-Delta path and reproduces the failure without the fix.