### PR TITLE
[Hadoop] Select namespaced credentials by location

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -11,44 +11,30 @@ import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /** Internal utilities for building and selecting {@link GenericCredential}s. */
 public final class CredentialUtil {
   private static final Charset UTF_8 = StandardCharsets.UTF_8;
+  private static final Base64.Encoder ENCODER = Base64.getEncoder();
+  private static final Base64.Decoder DECODER = Base64.getDecoder();
 
   private CredentialUtil() {}
 
   public static String[] encodeMultiCredPrefixes(List<String> prefixes) {
-    Preconditions.checkArgument(
-        prefixes != null && !prefixes.isEmpty(),
-        "List of credential prefixes cannot be null or empty");
-    List<String> encodedPrefixes = new ArrayList<>(prefixes.size());
-    Base64.Encoder encoder = Base64.getEncoder();
-    for (String prefix : prefixes) {
-      Preconditions.checkArgument(
-          prefix != null && !prefix.isEmpty(), "Credential prefixes cannot be null or empty");
-      encodedPrefixes.add(encoder.encodeToString(prefix.getBytes(UTF_8)));
-    }
-    return encodedPrefixes.toArray(String[]::new);
+    return prefixes.stream()
+        .map(prefix -> ENCODER.encodeToString(prefix.getBytes(UTF_8)))
+        .toArray(String[]::new);
   }
 
   public static List<String> decodeMultiCredPrefixes(String[] prefixes) {
-    Preconditions.checkArgument(
-        prefixes != null && prefixes.length > 0,
-        "Encoded credential prefixes cannot be null or empty");
-    Base64.Decoder decoder = Base64.getDecoder();
-    List<String> decodedPrefixes = new ArrayList<>(prefixes.length);
-    for (String prefix : prefixes) {
-      Preconditions.checkArgument(prefix != null, "Encoded credential prefixes cannot be null");
-      String decodedPrefix = new String(decoder.decode(prefix), UTF_8);
-      Preconditions.checkArgument(!decodedPrefix.isEmpty(), "Credential prefixes cannot be empty");
-      decodedPrefixes.add(decodedPrefix);
-    }
-    return decodedPrefixes;
+    return Arrays.stream(prefixes)
+        .map(prefix -> new String(DECODER.decode(prefix), UTF_8))
+        .collect(Collectors.toList());
   }
 
   /** Converts a UC SDK {@link TemporaryCredentials} into an internal {@link GenericCredential}. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -15,6 +15,10 @@ import java.util.List;
 public final class CredentialUtil {
   private CredentialUtil() {}
 
+  public static String hadoopConfNamespaceForIndex(int index) {
+    return UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + index + ".";
+  }
+
   /** Converts a UC SDK {@link TemporaryCredentials} into an internal {@link GenericCredential}. */
   public static GenericCredential toGenericCredential(TemporaryCredentials tempCred) {
     long expiry =

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -9,15 +9,46 @@ import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AzureCredential;
 import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
 
 /** Internal utilities for building and selecting {@link GenericCredential}s. */
 public final class CredentialUtil {
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
+
   private CredentialUtil() {}
 
-  public static String multiCredPrefixKeyForIndex(int index) {
-    return UCHadoopConfConstants.UC_MULTI_CRED_PREFIX_KEY + index;
+  public static String[] encodeMultiCredPrefixes(List<String> prefixes) {
+    Preconditions.checkArgument(
+        prefixes != null && !prefixes.isEmpty(),
+        "List of credential prefixes cannot be null or empty");
+    List<String> encodedPrefixes = new ArrayList<>(prefixes.size());
+    Base64.Encoder encoder = Base64.getEncoder();
+    for (String prefix : prefixes) {
+      Preconditions.checkArgument(
+          prefix != null && !prefix.isEmpty(), "Credential prefixes cannot be null or empty");
+      encodedPrefixes.add(encoder.encodeToString(prefix.getBytes(UTF_8)));
+    }
+    return encodedPrefixes.toArray(String[]::new);
+  }
+
+  public static List<String> decodeMultiCredPrefixes(String[] prefixes) {
+    Preconditions.checkArgument(
+        prefixes != null && prefixes.length > 0,
+        "Encoded credential prefixes cannot be null or empty");
+    Base64.Decoder decoder = Base64.getDecoder();
+    List<String> decodedPrefixes = new ArrayList<>(prefixes.length);
+    for (String prefix : prefixes) {
+      Preconditions.checkArgument(prefix != null, "Encoded credential prefixes cannot be null");
+      String decodedPrefix = new String(decoder.decode(prefix), UTF_8);
+      Preconditions.checkArgument(!decodedPrefix.isEmpty(), "Credential prefixes cannot be empty");
+      decodedPrefixes.add(decodedPrefix);
+    }
+    return decodedPrefixes;
   }
 
   /** Converts a UC SDK {@link TemporaryCredentials} into an internal {@link GenericCredential}. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -96,10 +96,8 @@ public final class CredentialUtil {
   public static GenericCredential selectForLocation(
       String location, List<GenericCredential> creds) {
     Preconditions.checkArgument(
-        creds != null && !creds.isEmpty(), "Credential response has no storage credentials.");
-    if (creds.size() == 1) {
-      Preconditions.checkNotNull(creds.get(0), "Credential response contains null.");
-    }
+        creds != null && creds.size() > 1,
+        "Credential selection requires multiple storage credentials.");
     int selected = longestCoveringIndex(location, creds, GenericCredential::prefix);
     Preconditions.checkArgument(
         selected >= 0, "No vended credential covers location '%s'.", location);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -16,8 +16,8 @@ import java.util.function.Function;
 public final class CredentialUtil {
   private CredentialUtil() {}
 
-  public static String hadoopConfNamespaceForIndex(int index) {
-    return UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + index + ".";
+  public static String multiCredPrefixKeyForIndex(int index) {
+    return UCHadoopConfConstants.UC_MULTI_CRED_PREFIX_KEY + index;
   }
 
   /** Converts a UC SDK {@link TemporaryCredentials} into an internal {@link GenericCredential}. */

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -85,6 +85,27 @@ public final class CredentialUtil {
     return best;
   }
 
+  /**
+   * Returns the index of the prefix that covers {@code location} by the longest match, or {@code
+   * -1} if none does. Null prefixes are skipped.
+   */
+  public static int longestCoveringIndex(String location, List<String> prefixes) {
+    int best = -1;
+    int bestLen = -1;
+    for (int i = 0; i < prefixes.size(); i++) {
+      String prefix = prefixes.get(i);
+      if (prefix == null || !prefixCovers(location, prefix)) {
+        continue;
+      }
+      int len = stripTrailingSlashes(prefix).length();
+      if (len > bestLen) {
+        best = i;
+        bestLen = len;
+      }
+    }
+    return best;
+  }
+
   static boolean prefixCovers(String location, String prefix) {
     String l = stripTrailingSlashes(location);
     String p = stripTrailingSlashes(prefix);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -10,6 +10,7 @@ import io.unitycatalog.hadoop.internal.auth.AzureCredential;
 import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import java.util.List;
+import java.util.function.Function;
 
 /** Internal utilities for building and selecting {@link GenericCredential}s. */
 public final class CredentialUtil {
@@ -68,25 +69,10 @@ public final class CredentialUtil {
     if (creds.size() == 1) {
       Preconditions.checkNotNull(creds.get(0), "Credential response contains null.");
     }
-    GenericCredential best = null;
-    int bestLen = -1;
-    for (GenericCredential cred : creds) {
-      if (cred == null) {
-        continue;
-      }
-      String prefix = cred.prefix();
-      if (prefix == null || !prefixCovers(location, prefix)) {
-        continue;
-      }
-      int len = stripTrailingSlashes(prefix).length();
-      if (len > bestLen) {
-        best = cred;
-        bestLen = len;
-      }
-    }
+    int selected = longestCoveringIndex(location, creds, GenericCredential::prefix);
     Preconditions.checkArgument(
-        best != null, "No vended credential covers location '%s'.", location);
-    return best;
+        selected >= 0, "No vended credential covers location '%s'.", location);
+    return creds.get(selected);
   }
 
   /**
@@ -94,10 +80,20 @@ public final class CredentialUtil {
    * -1} if none does. Null prefixes are skipped.
    */
   public static int longestCoveringIndex(String location, List<String> prefixes) {
+    Preconditions.checkNotNull(prefixes, "List of prefixes cannot be null.");
+    return longestCoveringIndex(location, prefixes, Function.identity());
+  }
+
+  private static <T> int longestCoveringIndex(
+      String location, List<T> values, Function<T, String> prefixExtractor) {
     int best = -1;
     int bestLen = -1;
-    for (int i = 0; i < prefixes.size(); i++) {
-      String prefix = prefixes.get(i);
+    for (int i = 0; i < values.size(); i++) {
+      T value = values.get(i);
+      if (value == null) {
+        continue;
+      }
+      String prefix = prefixExtractor.apply(value);
       if (prefix == null || !prefixCovers(location, prefix)) {
         continue;
       }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredentialUtil.java
@@ -25,13 +25,13 @@ public final class CredentialUtil {
 
   private CredentialUtil() {}
 
-  public static String[] encodeMultiCredPrefixes(List<String> prefixes) {
+  public static String[] encodeCredPrefixes(List<String> prefixes) {
     return prefixes.stream()
         .map(prefix -> ENCODER.encodeToString(prefix.getBytes(UTF_8)))
         .toArray(String[]::new);
   }
 
-  public static List<String> decodeMultiCredPrefixes(String[] prefixes) {
+  public static List<String> decodeCredPrefixes(String[] prefixes) {
     return Arrays.stream(prefixes)
         .map(prefix -> new String(DECODER.decode(prefix), UTF_8))
         .collect(Collectors.toList());

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -62,16 +62,10 @@ public class UCHadoopConfConstants {
   public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
   /**
-   * Denotes the number of credentials that are vended. When multiple credentials are vended, this
-   * key should be set; otherwise, it should be absent.
+   * The list of credential prefixes for multi-credential responses. This should not be set when
+   * only one credential is vended. It must be set when there are multiple credentials.
    */
-  public static final String UC_MULTI_CRED_COUNT_KEY = "fs.unitycatalog.multi.cred.count";
-
-  /**
-   * The Hadoop configuration prefix used to separate the different prefixes that the vended
-   * credentials cover.
-   */
-  public static final String UC_MULTI_CRED_PREFIX_KEY = "fs.unitycatalog.multi.cred.prefix.";
+  public static final String UC_MULTI_CRED_PREFIXES_KEY = "fs.unitycatalog.multi.cred.prefixes";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -47,10 +47,7 @@ public class UCHadoopConfConstants {
   public static final String UC_AUTH_TYPE = "fs.unitycatalog.auth.type";
   public static final String UC_AUTH_TOKEN_KEY = "fs.unitycatalog.auth.token";
 
-  /**
-   * The storage prefix that a UC credential covers. When there are multiple credentials, each
-   * credential must set this key so the correct credential can be selected.
-   */
+  /** The storage prefix covered by a file system or a UC credential. */
   public static final String UC_CREDENTIAL_PREFIX_KEY = "fs.unitycatalog.credential.prefix";
   /**
    * Stable id derived from the credential context ({@code catalogUri}, storage {@code scheme}, and
@@ -61,11 +58,8 @@ public class UCHadoopConfConstants {
    */
   public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
-  /**
-   * The list of credential prefixes for multi-credential responses. This should not be set when
-   * only one credential is vended. It must be set when there are multiple credentials.
-   */
-  public static final String UC_MULTI_CRED_PREFIXES_KEY = "fs.unitycatalog.multi.cred.prefixes";
+  /** The list of storage prefixes that are served by the vended credentials. */
+  public static final String UC_CREDENTIAL_PREFIXES_KEY = "fs.unitycatalog.cred.prefixes";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -62,18 +62,16 @@ public class UCHadoopConfConstants {
   public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
   /**
-   * Number of credential namespaces encoded in the Hadoop configuration. When there is only one
-   * credential vended, it should never be encoded under a namespace. This key is only used when
-   * there are multiple credentials.
+   * Denotes the number of credentials that are vended. When multiple credentials are vended, this
+   * key should be set; otherwise, it should be absent.
    */
   public static final String UC_MULTI_CRED_COUNT_KEY = "fs.unitycatalog.multi.cred.count";
 
   /**
-   * Hadoop configuration prefix used for encoding multiple credentials. Credential-specific keys
-   * are encoded as {@code fs.unitycatalog.multi.cred.<index>.<key>}; stripping the namespace yields
-   * the existing top-level (single credential) keys consumed by downstream providers.
+   * The Hadoop configuration prefix used to separate the different prefixes that the vended
+   * credentials cover.
    */
-  public static final String UC_MULTI_CRED_NAMESPACE_PREFIX = "fs.unitycatalog.multi.cred.";
+  public static final String UC_MULTI_CRED_PREFIX_KEY = "fs.unitycatalog.multi.cred.prefix.";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -61,6 +61,19 @@ public class UCHadoopConfConstants {
    */
   public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
+  /**
+   * Number of credential namespaces encoded in the Hadoop configuration. A missing or zero value
+   * indicates the legacy top-level credential layout.
+   */
+  public static final String UC_SCOPED_CRED_COUNT_KEY = "fs.unitycatalog.scoped.cred.count";
+
+  /**
+   * Prefix for indexed credential namespaces. Credential-specific keys are encoded as {@code
+   * fs.unitycatalog.scoped.cred.<index>.<key>}; stripping the namespace yields the existing
+   * top-level key consumed by downstream providers.
+   */
+  public static final String UC_SCOPED_CRED_PREFIX = "fs.unitycatalog.scoped.cred.";
+
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the
   // server can trace which engine versions are calling.

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -62,17 +62,18 @@ public class UCHadoopConfConstants {
   public static final String UC_CRED_CONTEXT_ID_KEY = "fs.unitycatalog.cred.context.id";
 
   /**
-   * Number of credential namespaces encoded in the Hadoop configuration. A missing or zero value
-   * indicates the legacy top-level credential layout.
+   * Number of credential namespaces encoded in the Hadoop configuration. When there is only one
+   * credential vended, it should never be encoded under a namespace. This key is only used when
+   * there are multiple credentials.
    */
-  public static final String UC_SCOPED_CRED_COUNT_KEY = "fs.unitycatalog.scoped.cred.count";
+  public static final String UC_MULTI_CRED_COUNT_KEY = "fs.unitycatalog.multi.cred.count";
 
   /**
-   * Prefix for indexed credential namespaces. Credential-specific keys are encoded as {@code
-   * fs.unitycatalog.scoped.cred.<index>.<key>}; stripping the namespace yields the existing
-   * top-level key consumed by downstream providers.
+   * Hadoop configuration prefix used for encoding multiple credentials. Credential-specific keys
+   * are encoded as {@code fs.unitycatalog.multi.cred.<index>.<key>}; stripping the namespace yields
+   * the existing top-level (single credential) keys consumed by downstream providers.
    */
-  public static final String UC_SCOPED_CRED_PREFIX = "fs.unitycatalog.scoped.cred.";
+  public static final String UC_MULTI_CRED_NAMESPACE_PREFIX = "fs.unitycatalog.multi.cred.";
 
   // Prefix for engine version metadata (e.g. fs.unitycatalog.engine.version.Spark=4.0.0). Values
   // stored under this prefix are propagated to the User-Agent header on UC API calls so the

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -59,11 +59,11 @@ public class CredScopedFileSystem extends FilterFileSystem {
       "unitycatalog.credScopedFs.cache.maxSize";
   private static final int CRED_SCOPED_FS_CACHE_MAX_SIZE_DEFAULT = 100;
 
-  // Hard ceiling to the number of scoped credentials to read from the configuration to prevent OOM.
-  private static final String MAX_SCOPED_CRED_COUNT_PROPERTY = "unitycatalog.scoped.cred.maxCount";
-  private static final int MAX_SCOPED_CRED_COUNT_DEFAULT = 10;
-  private static final int MAX_SCOPED_CRED_COUNT =
-      Integer.getInteger(MAX_SCOPED_CRED_COUNT_PROPERTY, MAX_SCOPED_CRED_COUNT_DEFAULT);
+  // Maximum number of namespaced credentials read from the configuration to prevent OOM.
+  private static final String MAX_MULTI_CRED_COUNT_PROPERTY = "unitycatalog.multi.cred.maxCount";
+  private static final int MAX_MULTI_CRED_COUNT_DEFAULT = 10;
+  private static final int MAX_MULTI_CRED_COUNT =
+      Integer.getInteger(MAX_MULTI_CRED_COUNT_PROPERTY, MAX_MULTI_CRED_COUNT_DEFAULT);
 
   /**
    * LRU cache of real {@link FileSystem} instances keyed by {@link FileSystemCredId}. Evicted
@@ -102,44 +102,41 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   /**
    * Returns the namespace key for the credential that covers the given URI, or null if no namespace
-   * is needed. When there are multiple credentials, each credential's details are prefixed with the
-   * namespace key to avoid key collisions. These namespaced keys cannot be picked up downstream;
-   * they must be extracted and restored to top-level keys prior to delegate file system
-   * initialization.
+   * is needed (when there is only one credential). When there are multiple credentials, each
+   * credential's details in the Hadoop configuration are prefixed with the namespace key to avoid
+   * key collisions. These namespaced keys cannot be picked up downstream; they must be extracted
+   * and restored to top-level keys prior to file system initialization.
    */
   private static String selectNamespace(URI uri, Configuration conf) {
-    int count = conf.getInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 0);
+    int count = conf.getInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 0);
     if (count == 0) {
-      return null; // legacy top-level credential layout, no namespace keys
+      return null; // Single credentials should not use a namespace. Key remains at top-level.
     }
-    // A single credential uses the legacy layout, so a namespaced layout always encodes more than
-    // one credential to select among.
+    // Multiple credentials require a namespace and should always contain more than one credential.
+    // Otherwise, this is a single credential and should not set UC_MULTI_CRED_COUNT_KEY.
     Preconditions.checkArgument(
-        count > 1 && count <= MAX_SCOPED_CRED_COUNT,
-        "%s must be greater than 1 and at most %s: %s",
-        UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY,
-        MAX_SCOPED_CRED_COUNT,
+        count > 1 && count <= MAX_MULTI_CRED_COUNT,
+        "Number of credentials must be greater than 1 and at most %s: %s",
+        MAX_MULTI_CRED_COUNT,
         count);
 
     List<String> prefixes = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
-      String prefix =
-          conf.get(namespaceAtIndex(i) + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
-      // With multiple credentials each one must carry a prefix to be selectable.
+      String credNamespace = CredentialUtil.hadoopConfNamespaceForIndex(i);
+      String credPrefixKey = credNamespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
+      String prefix = conf.get(credPrefixKey);
+      // Each credential must include the prefix it covers to be selectable.
       Preconditions.checkArgument(
           prefix != null,
-          "Scoped credential %s is missing its prefix for storage location %s",
+          "Namespaced credential %s is missing its prefix for storage location %s",
           i,
           uri);
       prefixes.add(prefix);
     }
-    int selected = CredentialUtil.longestCoveringIndex(uri.toString(), prefixes);
-    Preconditions.checkArgument(selected >= 0, "No credential covers storage location %s", uri);
-    return namespaceAtIndex(selected);
-  }
-
-  private static String namespaceAtIndex(int index) {
-    return UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
+    int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), prefixes);
+    Preconditions.checkArgument(
+        selectedIndex >= 0, "No credential covers storage location %s", uri);
+    return CredentialUtil.hadoopConfNamespaceForIndex(selectedIndex);
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -89,30 +89,32 @@ public class CredScopedFileSystem extends FilterFileSystem {
   public void initialize(URI uri, Configuration conf) throws IOException {
     List<String> credPrefixes = getCredPrefixes(conf);
     if (credPrefixes.size() <= 1) {
-      String prefix = credPrefixes.isEmpty() ? "" : credPrefixes.get(0);
+      // No selection is necessary when there is only one credential (there is only one choice).
+      String prefix = credPrefixes.isEmpty() ? null : credPrefixes.get(0);
       FileSystemCredId key = FileSystemCredId.create(conf, uri, prefix);
       this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf, prefix));
     } else {
-      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, credPrefixes);
+      // When there are multiple credentials (credPrefixes > 1), select the (longest) prefix that
+      // covers the requested URI.
+      FileSystemCredId key = getFileSystemCredId(uri, conf, credPrefixes);
       this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf, key.prefix()));
     }
   }
 
   private static List<String> getCredPrefixes(Configuration conf) {
-    String[] encodedCredPrefixes =
-        conf.getStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
-    if (encodedCredPrefixes == null) {
+    String encodedCredPrefixes = conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
+    if (encodedCredPrefixes == null || encodedCredPrefixes.isEmpty()) {
       return Collections.emptyList();
     }
-    return CredentialUtil.decodeMultiCredPrefixes(encodedCredPrefixes);
+    return CredentialUtil.decodeCredPrefixes(encodedCredPrefixes.split(",", -1));
   }
 
-  private static FileSystemCredId getMultiCredFileSystemKey(
-      URI uri, Configuration conf, List<String> multiCredPrefixes) {
-    int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), multiCredPrefixes);
+  private static FileSystemCredId getFileSystemCredId(
+      URI uri, Configuration conf, List<String> credPrefixes) {
+    int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), credPrefixes);
     Preconditions.checkArgument(
         selectedIndex >= 0, "No credential covers storage location %s", uri);
-    String selectedPrefix = multiCredPrefixes.get(selectedIndex);
+    String selectedPrefix = credPrefixes.get(selectedIndex);
     return FileSystemCredId.create(conf, uri, selectedPrefix);
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -8,7 +8,7 @@ import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import io.unitycatalog.hadoop.internal.util.CloseableUtils;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -59,7 +59,7 @@ public class CredScopedFileSystem extends FilterFileSystem {
       "unitycatalog.credScopedFs.cache.maxSize";
   private static final int CRED_SCOPED_FS_CACHE_MAX_SIZE_DEFAULT = 100;
 
-  // Maximum number of namespaced credentials read from the configuration to prevent OOM.
+  // Maximum number of credential prefixes read from the configuration to prevent OOM.
   private static final String MAX_MULTI_CRED_COUNT_PROPERTY = "unitycatalog.multi.cred.maxCount";
   private static final int MAX_MULTI_CRED_COUNT_DEFAULT = 10;
   private static final int MAX_MULTI_CRED_COUNT =
@@ -93,39 +93,46 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    int multiCredCount = conf.getInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 0);
-    if (multiCredCount > 1) {
-      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredCount);
-      this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, key.prefix()));
-      return;
+    List<String> multiCredPrefixes = getMultiCredPrefixes(conf);
+    if (multiCredPrefixes.isEmpty()) {
+      initializeSingleCredentialFileSystem(uri, conf);
+    } else {
+      initializeMultiCredentialFileSystem(uri, conf, multiCredPrefixes);
     }
+  }
 
+  private static List<String> getMultiCredPrefixes(Configuration conf) {
+    String[] encodedMultiCredPrefixes =
+        conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
+    if (encodedMultiCredPrefixes == null) {
+      return Collections.emptyList();
+    }
+    Preconditions.checkArgument(
+        encodedMultiCredPrefixes.length > 1
+            && encodedMultiCredPrefixes.length <= MAX_MULTI_CRED_COUNT,
+        "Number of credentials must be between 2 and %s: got %s",
+        MAX_MULTI_CRED_COUNT,
+        encodedMultiCredPrefixes.length);
+    return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);
+  }
+
+  private void initializeSingleCredentialFileSystem(URI uri, Configuration conf) {
     FileSystemCredId key = FileSystemCredId.create(conf, uri);
     this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
   }
 
-  private static FileSystemCredId getMultiCredFileSystemKey(
-      URI uri, Configuration conf, int multiCredCount) {
-    Preconditions.checkArgument(
-        multiCredCount <= MAX_MULTI_CRED_COUNT,
-        "Number of credentials must be at most %s: got %s",
-        MAX_MULTI_CRED_COUNT,
-        multiCredCount);
+  private void initializeMultiCredentialFileSystem(
+      URI uri, Configuration conf, List<String> multiCredPrefixes) {
+    FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredPrefixes);
+    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, key.prefix()));
+  }
 
-    List<String> prefixes = new ArrayList<>(multiCredCount);
-    for (int i = 0; i < multiCredCount; i++) {
-      String prefix = conf.get(CredentialUtil.multiCredPrefixKeyForIndex(i));
-      Preconditions.checkArgument(
-          prefix != null && !prefix.isEmpty(),
-          "Credential prefixes cannot be null or empty: index %s for storage location %s",
-          i,
-          uri);
-      prefixes.add(prefix);
-    }
-    int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), prefixes);
+  private static FileSystemCredId getMultiCredFileSystemKey(
+      URI uri, Configuration conf, List<String> multiCredPrefixes) {
+    int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), multiCredPrefixes);
     Preconditions.checkArgument(
         selectedIndex >= 0, "No credential covers storage location %s", uri);
-    String selectedPrefix = prefixes.get(selectedIndex);
+    String selectedPrefix = multiCredPrefixes.get(selectedIndex);
     return FileSystemCredId.create(conf, uri, selectedPrefix);
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -95,9 +95,9 @@ public class CredScopedFileSystem extends FilterFileSystem {
   public void initialize(URI uri, Configuration conf) throws IOException {
     List<String> multiCredPrefixes = getMultiCredPrefixes(conf);
     if (multiCredPrefixes.isEmpty()) {
-      initializeSingleCredentialFileSystem(uri, conf);
+      initializeFileSystem(uri, conf);
     } else {
-      initializeMultiCredentialFileSystem(uri, conf, multiCredPrefixes);
+      selectPrefixAndInitializeFileSystem(uri, conf, multiCredPrefixes);
     }
   }
 
@@ -116,12 +116,12 @@ public class CredScopedFileSystem extends FilterFileSystem {
     return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);
   }
 
-  private void initializeSingleCredentialFileSystem(URI uri, Configuration conf) {
+  private void initializeFileSystem(URI uri, Configuration conf) {
     FileSystemCredId key = FileSystemCredId.create(conf, uri);
     this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
   }
 
-  private void initializeMultiCredentialFileSystem(
+  private void selectPrefixAndInitializeFileSystem(
       URI uri, Configuration conf, List<String> multiCredPrefixes) {
     FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredPrefixes);
     this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, key.prefix()));

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -1,10 +1,15 @@
 package io.unitycatalog.hadoop.internal.fs;
 
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.CredentialUtil;
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.FileSystemCredId;
 import io.unitycatalog.hadoop.internal.util.BoundedKeyedCache;
 import io.unitycatalog.hadoop.internal.util.CloseableUtils;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FilterFileSystem;
@@ -54,6 +59,12 @@ public class CredScopedFileSystem extends FilterFileSystem {
       "unitycatalog.credScopedFs.cache.maxSize";
   private static final int CRED_SCOPED_FS_CACHE_MAX_SIZE_DEFAULT = 100;
 
+  // Hard ceiling to the number of scoped credentials to read from the configuration to prevent OOM.
+  private static final String MAX_SCOPED_CRED_COUNT_PROPERTY = "unitycatalog.scoped.cred.maxCount";
+  private static final int MAX_SCOPED_CRED_COUNT_DEFAULT = 10;
+  private static final int MAX_SCOPED_CRED_COUNT =
+      Integer.getInteger(MAX_SCOPED_CRED_COUNT_PROPERTY, MAX_SCOPED_CRED_COUNT_DEFAULT);
+
   /**
    * LRU cache of real {@link FileSystem} instances keyed by {@link FileSystemCredId}. Evicted
    * entries are closed to release connection pools and SDK thread pools (e.g. AWS
@@ -82,8 +93,53 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    FileSystemCredId key = FileSystemCredId.create(conf, uri);
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
+    String namespace = selectNamespace(uri, conf);
+    FileSystemCredId key = FileSystemCredId.create(conf, uri, namespace);
+    // Deriving the namespace and key does not copy the conf, delaying expensive copy
+    // operation until it is needed in newFileSystem.
+    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, namespace));
+  }
+
+  /**
+   * Returns the namespace key for the credential that covers the given URI, or null if no namespace
+   * is needed. When there are multiple credentials, each credential's details are prefixed with the
+   * namespace key to avoid key collisions. These namespaced keys cannot be picked up downstream;
+   * they must be extracted and restored to top-level keys prior to delegate file system
+   * initialization.
+   */
+  private static String selectNamespace(URI uri, Configuration conf) {
+    int count = conf.getInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 0);
+    if (count == 0) {
+      return null; // legacy top-level credential layout, no namespace keys
+    }
+    // A single credential uses the legacy layout, so a namespaced layout always encodes more than
+    // one credential to select among.
+    Preconditions.checkArgument(
+        count > 1 && count <= MAX_SCOPED_CRED_COUNT,
+        "%s must be greater than 1 and at most %s: %s",
+        UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY,
+        MAX_SCOPED_CRED_COUNT,
+        count);
+
+    List<String> prefixes = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      String prefix =
+          conf.get(namespaceAtIndex(i) + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
+      // With multiple credentials each one must carry a prefix to be selectable.
+      Preconditions.checkArgument(
+          prefix != null,
+          "Scoped credential %s is missing its prefix for storage location %s",
+          i,
+          uri);
+      prefixes.add(prefix);
+    }
+    int selected = CredentialUtil.longestCoveringIndex(uri.toString(), prefixes);
+    Preconditions.checkArgument(selected >= 0, "No credential covers storage location %s", uri);
+    return namespaceAtIndex(selected);
+  }
+
+  private static String namespaceAtIndex(int index) {
+    return UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
   }
 
   /**
@@ -95,9 +151,13 @@ public class CredScopedFileSystem extends FilterFileSystem {
     fsConf.set(key, fsConf.get(key + ".original", defaultImpl));
   }
 
-  private static FileSystem newFileSystem(URI uri, Configuration conf) {
+  private static FileSystem newFileSystem(URI uri, Configuration conf, String namespace) {
     try {
       Configuration fsConf = new Configuration(conf);
+      if (namespace != null) {
+        // Set the namespaced keys to top-level so downstream readers can pick them up.
+        conf.getPropsWithPrefix(namespace).forEach(fsConf::set);
+      }
 
       // S3: restore impl using the side-channel key saved by CredPropsUtil before it overrode
       // fs.<scheme>.impl with CredScopedFileSystem. Falls back to S3AFileSystem if not set.

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -102,18 +102,17 @@ public class CredScopedFileSystem extends FilterFileSystem {
   }
 
   private static List<String> getMultiCredPrefixes(Configuration conf) {
-    String[] encodedMultiCredPrefixes =
-        conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
-    if (encodedMultiCredPrefixes == null) {
+    String encodedMultiCredPrefixes = conf.get(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
+    if (encodedMultiCredPrefixes == null || encodedMultiCredPrefixes.isEmpty()) {
       return Collections.emptyList();
     }
+    String[] encodedPrefixes = encodedMultiCredPrefixes.split(",", -1);
     Preconditions.checkArgument(
-        encodedMultiCredPrefixes.length > 1
-            && encodedMultiCredPrefixes.length <= MAX_MULTI_CRED_COUNT,
+        encodedPrefixes.length > 1 && encodedPrefixes.length <= MAX_MULTI_CRED_COUNT,
         "Number of credentials must be between 2 and %s: got %s",
         MAX_MULTI_CRED_COUNT,
-        encodedMultiCredPrefixes.length);
-    return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);
+        encodedPrefixes.length);
+    return CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes);
   }
 
   private void initializeFileSystem(URI uri, Configuration conf) {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -94,14 +94,15 @@ public class CredScopedFileSystem extends FilterFileSystem {
       return;
     }
 
-    FileSystemCredId key = FileSystemCredId.create(conf, uri);
+    String prefix = conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
+    FileSystemCredId key = FileSystemCredId.create(conf, uri, prefix);
     this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf));
   }
 
   private static List<String> getMultiCredPrefixes(Configuration conf) {
     String[] encodedMultiCredPrefixes =
         conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
-    if (encodedMultiCredPrefixes == null || encodedMultiCredPrefixes.length == 0) {
+    if (encodedMultiCredPrefixes == null) {
       return Collections.emptyList();
     }
     return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -59,12 +59,6 @@ public class CredScopedFileSystem extends FilterFileSystem {
       "unitycatalog.credScopedFs.cache.maxSize";
   private static final int CRED_SCOPED_FS_CACHE_MAX_SIZE_DEFAULT = 100;
 
-  // Maximum number of credential prefixes read from the configuration to prevent OOM.
-  private static final String MAX_MULTI_CRED_COUNT_PROPERTY = "unitycatalog.multi.cred.maxCount";
-  private static final int MAX_MULTI_CRED_COUNT_DEFAULT = 10;
-  private static final int MAX_MULTI_CRED_COUNT =
-      Integer.getInteger(MAX_MULTI_CRED_COUNT_PROPERTY, MAX_MULTI_CRED_COUNT_DEFAULT);
-
   /**
    * LRU cache of real {@link FileSystem} instances keyed by {@link FileSystemCredId}. Evicted
    * entries are closed to release connection pools and SDK thread pools (e.g. AWS
@@ -94,36 +88,23 @@ public class CredScopedFileSystem extends FilterFileSystem {
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
     List<String> multiCredPrefixes = getMultiCredPrefixes(conf);
-    if (multiCredPrefixes.isEmpty()) {
-      initializeFileSystem(uri, conf);
-    } else {
-      selectPrefixAndInitializeFileSystem(uri, conf, multiCredPrefixes);
+    if (multiCredPrefixes.size() > 1) {
+      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredPrefixes);
+      this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf, key.prefix()));
+      return;
     }
+
+    FileSystemCredId key = FileSystemCredId.create(conf, uri);
+    this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf));
   }
 
   private static List<String> getMultiCredPrefixes(Configuration conf) {
-    String encodedMultiCredPrefixes = conf.get(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
-    if (encodedMultiCredPrefixes == null || encodedMultiCredPrefixes.isEmpty()) {
+    String[] encodedMultiCredPrefixes =
+        conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
+    if (encodedMultiCredPrefixes == null || encodedMultiCredPrefixes.length == 0) {
       return Collections.emptyList();
     }
-    String[] encodedPrefixes = encodedMultiCredPrefixes.split(",", -1);
-    Preconditions.checkArgument(
-        encodedPrefixes.length > 1 && encodedPrefixes.length <= MAX_MULTI_CRED_COUNT,
-        "Number of credentials must be between 2 and %s: got %s",
-        MAX_MULTI_CRED_COUNT,
-        encodedPrefixes.length);
-    return CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes);
-  }
-
-  private void initializeFileSystem(URI uri, Configuration conf) {
-    FileSystemCredId key = FileSystemCredId.create(conf, uri);
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
-  }
-
-  private void selectPrefixAndInitializeFileSystem(
-      URI uri, Configuration conf, List<String> multiCredPrefixes) {
-    FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredPrefixes);
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, key.prefix()));
+    return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);
   }
 
   private static FileSystemCredId getMultiCredFileSystemKey(
@@ -144,50 +125,51 @@ public class CredScopedFileSystem extends FilterFileSystem {
     fsConf.set(key, fsConf.get(key + ".original", defaultImpl));
   }
 
-  private static FileSystem newFileSystem(URI uri, Configuration conf, String prefix) {
+  private static FileSystem copyConfAndCreateNewFileSystem(URI uri, Configuration conf) {
+    Configuration fsConf = new Configuration(conf);
+    return newFileSystem(uri, fsConf);
+  }
+
+  private static FileSystem copyConfAndCreateNewFileSystem(
+      URI uri, Configuration conf, String prefix) {
     Configuration fsConf = new Configuration(conf);
     fsConf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
-    return createFileSystem(uri, fsConf);
+    return newFileSystem(uri, fsConf);
   }
 
-  private static FileSystem newFileSystem(URI uri, Configuration conf) {
-    Configuration fsConf = new Configuration(conf);
-    return createFileSystem(uri, fsConf);
-  }
-
-  private static FileSystem createFileSystem(URI uri, Configuration fsConf) {
+  // Creates a files system from the provided configuration. Note: modifies the conf in-place.
+  private static FileSystem newFileSystem(URI uri, Configuration fsConf) {
     try {
-      restoreFileSystemOverrides(fsConf);
+      // S3: restore impl using the side-channel key saved by CredPropsUtil before it overrode
+      // fs.<scheme>.impl with CredScopedFileSystem. Falls back to S3AFileSystem if not set.
+      restoreImpl(fsConf, "fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+      restoreImpl(fsConf, "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+      restoreImpl(fsConf, "fs.AbstractFileSystem.s3.impl", "org.apache.hadoop.fs.s3a.S3A");
+      restoreImpl(fsConf, "fs.AbstractFileSystem.s3a.impl", "org.apache.hadoop.fs.s3a.S3A");
+      fsConf.set("fs.s3.impl.disable.cache", "true");
+      fsConf.set("fs.s3a.impl.disable.cache", "true");
+
+      // GCS: restore impl using the side-channel key. Falls back to GoogleHadoopFileSystem if not
+      // set (registered via the Java service loader).
+      restoreImpl(fsConf, "fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
+      restoreImpl(
+          fsConf, "fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
+      fsConf.set("fs.gs.impl.disable.cache", "true");
+
+      // Azure: restore impl using the side-channel key. Falls back to AzureBlobFileSystem /
+      // SecureAzureBlobFileSystem if not set (registered via the Java service loader).
+      restoreImpl(fsConf, "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem");
+      restoreImpl(
+          fsConf, "fs.abfss.impl", "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem");
+      restoreImpl(fsConf, "fs.AbstractFileSystem.abfs.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
+      restoreImpl(
+          fsConf, "fs.AbstractFileSystem.abfss.impl", "org.apache.hadoop.fs.azurebfs.Abfss");
+      fsConf.set("fs.abfs.impl.disable.cache", "true");
+      fsConf.set("fs.abfss.impl.disable.cache", "true");
+
       return FileSystem.get(uri, fsConf);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private static void restoreFileSystemOverrides(Configuration fsConf) {
-    // S3: restore impl using the side-channel key saved by CredPropsUtil before it overrode
-    // fs.<scheme>.impl with CredScopedFileSystem. Falls back to S3AFileSystem if not set.
-    restoreImpl(fsConf, "fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-    restoreImpl(fsConf, "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-    restoreImpl(fsConf, "fs.AbstractFileSystem.s3.impl", "org.apache.hadoop.fs.s3a.S3A");
-    restoreImpl(fsConf, "fs.AbstractFileSystem.s3a.impl", "org.apache.hadoop.fs.s3a.S3A");
-    fsConf.set("fs.s3.impl.disable.cache", "true");
-    fsConf.set("fs.s3a.impl.disable.cache", "true");
-
-    // GCS: restore impl using the side-channel key. Falls back to GoogleHadoopFileSystem if not
-    // set (registered via the Java service loader).
-    restoreImpl(fsConf, "fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
-    restoreImpl(
-        fsConf, "fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-    fsConf.set("fs.gs.impl.disable.cache", "true");
-
-    // Azure: restore impl using the side-channel key. Falls back to AzureBlobFileSystem /
-    // SecureAzureBlobFileSystem if not set (registered via the Java service loader).
-    restoreImpl(fsConf, "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem");
-    restoreImpl(fsConf, "fs.abfss.impl", "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem");
-    restoreImpl(fsConf, "fs.AbstractFileSystem.abfs.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
-    restoreImpl(fsConf, "fs.AbstractFileSystem.abfss.impl", "org.apache.hadoop.fs.azurebfs.Abfss");
-    fsConf.set("fs.abfs.impl.disable.cache", "true");
-    fsConf.set("fs.abfss.impl.disable.cache", "true");
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -102,11 +102,12 @@ public class CredScopedFileSystem extends FilterFileSystem {
   }
 
   private static List<String> getCredPrefixes(Configuration conf) {
-    String encodedCredPrefixes = conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
-    if (encodedCredPrefixes == null || encodedCredPrefixes.isEmpty()) {
+    String[] encodedCredPrefixes =
+        conf.getStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
+    if (encodedCredPrefixes == null || encodedCredPrefixes.length == 0) {
       return Collections.emptyList();
     }
-    return CredentialUtil.decodeCredPrefixes(encodedCredPrefixes.split(",", -1));
+    return CredentialUtil.decodeCredPrefixes(encodedCredPrefixes);
   }
 
   private static FileSystemCredId getFileSystemCredId(

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -87,25 +87,24 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    List<String> multiCredPrefixes = getMultiCredPrefixes(conf);
-    if (multiCredPrefixes.size() > 1) {
-      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredPrefixes);
+    List<String> credPrefixes = getCredPrefixes(conf);
+    if (credPrefixes.size() <= 1) {
+      String prefix = credPrefixes.isEmpty() ? "" : credPrefixes.get(0);
+      FileSystemCredId key = FileSystemCredId.create(conf, uri, prefix);
+      this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf, prefix));
+    } else {
+      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, credPrefixes);
       this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf, key.prefix()));
-      return;
     }
-
-    String prefix = conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
-    FileSystemCredId key = FileSystemCredId.create(conf, uri, prefix);
-    this.fs = CACHE.getOrLoad(key, () -> copyConfAndCreateNewFileSystem(uri, conf));
   }
 
-  private static List<String> getMultiCredPrefixes(Configuration conf) {
-    String[] encodedMultiCredPrefixes =
-        conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY);
-    if (encodedMultiCredPrefixes == null) {
+  private static List<String> getCredPrefixes(Configuration conf) {
+    String[] encodedCredPrefixes =
+        conf.getStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
+    if (encodedCredPrefixes == null) {
       return Collections.emptyList();
     }
-    return CredentialUtil.decodeMultiCredPrefixes(encodedMultiCredPrefixes);
+    return CredentialUtil.decodeMultiCredPrefixes(encodedCredPrefixes);
   }
 
   private static FileSystemCredId getMultiCredFileSystemKey(
@@ -126,15 +125,12 @@ public class CredScopedFileSystem extends FilterFileSystem {
     fsConf.set(key, fsConf.get(key + ".original", defaultImpl));
   }
 
-  private static FileSystem copyConfAndCreateNewFileSystem(URI uri, Configuration conf) {
-    Configuration fsConf = new Configuration(conf);
-    return newFileSystem(uri, fsConf);
-  }
-
   private static FileSystem copyConfAndCreateNewFileSystem(
       URI uri, Configuration conf, String prefix) {
     Configuration fsConf = new Configuration(conf);
-    fsConf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
+    if (prefix != null) {
+      fsConf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
+    }
     return newFileSystem(uri, fsConf);
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystem.java
@@ -93,42 +93,31 @@ public class CredScopedFileSystem extends FilterFileSystem {
 
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
-    String namespace = selectNamespace(uri, conf);
-    FileSystemCredId key = FileSystemCredId.create(conf, uri, namespace);
-    // Deriving the namespace and key does not copy the conf, delaying expensive copy
-    // operation until it is needed in newFileSystem.
-    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, namespace));
+    int multiCredCount = conf.getInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 0);
+    if (multiCredCount > 1) {
+      FileSystemCredId key = getMultiCredFileSystemKey(uri, conf, multiCredCount);
+      this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf, key.prefix()));
+      return;
+    }
+
+    FileSystemCredId key = FileSystemCredId.create(conf, uri);
+    this.fs = CACHE.getOrLoad(key, () -> newFileSystem(uri, conf));
   }
 
-  /**
-   * Returns the namespace key for the credential that covers the given URI, or null if no namespace
-   * is needed (when there is only one credential). When there are multiple credentials, each
-   * credential's details in the Hadoop configuration are prefixed with the namespace key to avoid
-   * key collisions. These namespaced keys cannot be picked up downstream; they must be extracted
-   * and restored to top-level keys prior to file system initialization.
-   */
-  private static String selectNamespace(URI uri, Configuration conf) {
-    int count = conf.getInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 0);
-    if (count == 0) {
-      return null; // Single credentials should not use a namespace. Key remains at top-level.
-    }
-    // Multiple credentials require a namespace and should always contain more than one credential.
-    // Otherwise, this is a single credential and should not set UC_MULTI_CRED_COUNT_KEY.
+  private static FileSystemCredId getMultiCredFileSystemKey(
+      URI uri, Configuration conf, int multiCredCount) {
     Preconditions.checkArgument(
-        count > 1 && count <= MAX_MULTI_CRED_COUNT,
-        "Number of credentials must be greater than 1 and at most %s: %s",
+        multiCredCount <= MAX_MULTI_CRED_COUNT,
+        "Number of credentials must be at most %s: got %s",
         MAX_MULTI_CRED_COUNT,
-        count);
+        multiCredCount);
 
-    List<String> prefixes = new ArrayList<>(count);
-    for (int i = 0; i < count; i++) {
-      String credNamespace = CredentialUtil.hadoopConfNamespaceForIndex(i);
-      String credPrefixKey = credNamespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
-      String prefix = conf.get(credPrefixKey);
-      // Each credential must include the prefix it covers to be selectable.
+    List<String> prefixes = new ArrayList<>(multiCredCount);
+    for (int i = 0; i < multiCredCount; i++) {
+      String prefix = conf.get(CredentialUtil.multiCredPrefixKeyForIndex(i));
       Preconditions.checkArgument(
-          prefix != null,
-          "Namespaced credential %s is missing its prefix for storage location %s",
+          prefix != null && !prefix.isEmpty(),
+          "Credential prefixes cannot be null or empty: index %s for storage location %s",
           i,
           uri);
       prefixes.add(prefix);
@@ -136,7 +125,8 @@ public class CredScopedFileSystem extends FilterFileSystem {
     int selectedIndex = CredentialUtil.longestCoveringIndex(uri.toString(), prefixes);
     Preconditions.checkArgument(
         selectedIndex >= 0, "No credential covers storage location %s", uri);
-    return CredentialUtil.hadoopConfNamespaceForIndex(selectedIndex);
+    String selectedPrefix = prefixes.get(selectedIndex);
+    return FileSystemCredId.create(conf, uri, selectedPrefix);
   }
 
   /**
@@ -148,44 +138,50 @@ public class CredScopedFileSystem extends FilterFileSystem {
     fsConf.set(key, fsConf.get(key + ".original", defaultImpl));
   }
 
-  private static FileSystem newFileSystem(URI uri, Configuration conf, String namespace) {
+  private static FileSystem newFileSystem(URI uri, Configuration conf, String prefix) {
+    Configuration fsConf = new Configuration(conf);
+    fsConf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
+    return createFileSystem(uri, fsConf);
+  }
+
+  private static FileSystem newFileSystem(URI uri, Configuration conf) {
+    Configuration fsConf = new Configuration(conf);
+    return createFileSystem(uri, fsConf);
+  }
+
+  private static FileSystem createFileSystem(URI uri, Configuration fsConf) {
     try {
-      Configuration fsConf = new Configuration(conf);
-      if (namespace != null) {
-        // Set the namespaced keys to top-level so downstream readers can pick them up.
-        conf.getPropsWithPrefix(namespace).forEach(fsConf::set);
-      }
-
-      // S3: restore impl using the side-channel key saved by CredPropsUtil before it overrode
-      // fs.<scheme>.impl with CredScopedFileSystem. Falls back to S3AFileSystem if not set.
-      restoreImpl(fsConf, "fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-      restoreImpl(fsConf, "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-      restoreImpl(fsConf, "fs.AbstractFileSystem.s3.impl", "org.apache.hadoop.fs.s3a.S3A");
-      restoreImpl(fsConf, "fs.AbstractFileSystem.s3a.impl", "org.apache.hadoop.fs.s3a.S3A");
-      fsConf.set("fs.s3.impl.disable.cache", "true");
-      fsConf.set("fs.s3a.impl.disable.cache", "true");
-
-      // GCS: restore impl using the side-channel key. Falls back to GoogleHadoopFileSystem if not
-      // set (registered via the Java service loader).
-      restoreImpl(fsConf, "fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
-      restoreImpl(
-          fsConf, "fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
-      fsConf.set("fs.gs.impl.disable.cache", "true");
-
-      // Azure: restore impl using the side-channel key. Falls back to AzureBlobFileSystem /
-      // SecureAzureBlobFileSystem if not set (registered via the Java service loader).
-      restoreImpl(fsConf, "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem");
-      restoreImpl(
-          fsConf, "fs.abfss.impl", "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem");
-      restoreImpl(fsConf, "fs.AbstractFileSystem.abfs.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
-      restoreImpl(
-          fsConf, "fs.AbstractFileSystem.abfss.impl", "org.apache.hadoop.fs.azurebfs.Abfss");
-      fsConf.set("fs.abfs.impl.disable.cache", "true");
-      fsConf.set("fs.abfss.impl.disable.cache", "true");
-
+      restoreFileSystemOverrides(fsConf);
       return FileSystem.get(uri, fsConf);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static void restoreFileSystemOverrides(Configuration fsConf) {
+    // S3: restore impl using the side-channel key saved by CredPropsUtil before it overrode
+    // fs.<scheme>.impl with CredScopedFileSystem. Falls back to S3AFileSystem if not set.
+    restoreImpl(fsConf, "fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+    restoreImpl(fsConf, "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+    restoreImpl(fsConf, "fs.AbstractFileSystem.s3.impl", "org.apache.hadoop.fs.s3a.S3A");
+    restoreImpl(fsConf, "fs.AbstractFileSystem.s3a.impl", "org.apache.hadoop.fs.s3a.S3A");
+    fsConf.set("fs.s3.impl.disable.cache", "true");
+    fsConf.set("fs.s3a.impl.disable.cache", "true");
+
+    // GCS: restore impl using the side-channel key. Falls back to GoogleHadoopFileSystem if not
+    // set (registered via the Java service loader).
+    restoreImpl(fsConf, "fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
+    restoreImpl(
+        fsConf, "fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
+    fsConf.set("fs.gs.impl.disable.cache", "true");
+
+    // Azure: restore impl using the side-channel key. Falls back to AzureBlobFileSystem /
+    // SecureAzureBlobFileSystem if not set (registered via the Java service loader).
+    restoreImpl(fsConf, "fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem");
+    restoreImpl(fsConf, "fs.abfss.impl", "org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem");
+    restoreImpl(fsConf, "fs.AbstractFileSystem.abfs.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
+    restoreImpl(fsConf, "fs.AbstractFileSystem.abfss.impl", "org.apache.hadoop.fs.azurebfs.Abfss");
+    fsConf.set("fs.abfs.impl.disable.cache", "true");
+    fsConf.set("fs.abfss.impl.disable.cache", "true");
   }
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
@@ -36,7 +36,8 @@ public final class FileSystemCredId {
 
   public static FileSystemCredId create(Configuration conf, URI uri) {
     CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    return new FileSystemCredId(credId, getCredPrefix(conf));
+    String prefix = getCredPrefix(conf);
+    return new FileSystemCredId(credId, prefix);
   }
 
   public static FileSystemCredId create(Configuration conf, URI uri, String prefix) {

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
@@ -34,30 +34,18 @@ public final class FileSystemCredId {
     return new FileSystemCredId(credId, prefix);
   }
 
-  /**
-   * Like {@link #create(Configuration)} but for a filesystem being initialized on {@code uri}: when
-   * the configuration carries no Unity Catalog credential type, falls back to a {@link
-   * DefaultCredId} derived from the URI's scheme and authority. Reads the prefix from a namespaced
-   * key when the selected credential's config is prefixed with {@code namespace} (multi-credential
-   * layout); a {@code null} namespace reads the top-level {@link
-   * UCHadoopConfConstants#UC_CREDENTIAL_PREFIX_KEY prefix} key.
-   */
-  public static FileSystemCredId create(Configuration conf, URI uri, String namespace) {
+  public static FileSystemCredId create(Configuration conf, URI uri) {
     CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    String prefix = getCredPrefix(conf, namespace);
+    return new FileSystemCredId(credId, getCredPrefix(conf));
+  }
+
+  public static FileSystemCredId create(Configuration conf, URI uri, String prefix) {
+    CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
     return new FileSystemCredId(credId, prefix);
   }
 
   private static String getCredPrefix(Configuration conf) {
     return conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
-  }
-
-  private static String getCredPrefix(Configuration conf, String namespace) {
-    String prefixKey =
-        namespace == null
-            ? UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY
-            : namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
-    return conf.get(prefixKey);
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
@@ -37,16 +37,27 @@ public final class FileSystemCredId {
   /**
    * Like {@link #create(Configuration)} but for a filesystem being initialized on {@code uri}: when
    * the configuration carries no Unity Catalog credential type, falls back to a {@link
-   * DefaultCredId} derived from the URI's scheme and authority.
+   * DefaultCredId} derived from the URI's scheme and authority. Reads the prefix from a namespaced
+   * key when the selected credential's config is prefixed with {@code namespace} (multi-credential
+   * layout); a {@code null} namespace reads the top-level {@link
+   * UCHadoopConfConstants#UC_CREDENTIAL_PREFIX_KEY prefix} key.
    */
-  public static FileSystemCredId create(Configuration conf, URI uri) {
+  public static FileSystemCredId create(Configuration conf, URI uri, String namespace) {
     CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    String prefix = getCredPrefix(conf);
+    String prefix = getCredPrefix(conf, namespace);
     return new FileSystemCredId(credId, prefix);
   }
 
   private static String getCredPrefix(Configuration conf) {
     return conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
+  }
+
+  private static String getCredPrefix(Configuration conf, String namespace) {
+    String prefixKey =
+        namespace == null
+            ? UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY
+            : namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
+    return conf.get(prefixKey);
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/FileSystemCredId.java
@@ -34,12 +34,6 @@ public final class FileSystemCredId {
     return new FileSystemCredId(credId, prefix);
   }
 
-  public static FileSystemCredId create(Configuration conf, URI uri) {
-    CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
-    String prefix = getCredPrefix(conf);
-    return new FileSystemCredId(credId, prefix);
-  }
-
   public static FileSystemCredId create(Configuration conf, URI uri, String prefix) {
     CredId credId = CredId.create(conf, () -> new DefaultCredId(uri, conf));
     return new FileSystemCredId(credId, prefix);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -48,44 +48,6 @@ class CredentialUtilTest {
         .containsExactlyElementsOf(prefixes);
   }
 
-  @ParameterizedTest
-  @MethodSource("malformedPrefixesToEncode")
-  void encodeMultiCredPrefixesRejectsMalformedInput(List<String> prefixes, String expectedMessage) {
-    assertThatThrownBy(() -> CredentialUtil.encodeMultiCredPrefixes(prefixes))
-        .hasMessageContaining(expectedMessage);
-  }
-
-  private static Stream<Arguments> malformedPrefixesToEncode() {
-    return Stream.of(
-        Arguments.of(null, "cannot be null or empty"),
-        Arguments.of(Collections.emptyList(), "cannot be null or empty"),
-        Arguments.of(Collections.singletonList(null), "cannot be null or empty"),
-        Arguments.of(List.of(""), "cannot be null or empty"),
-        Arguments.of(Arrays.asList("s3://bucket/valid", null), "cannot be null or empty"),
-        Arguments.of(List.of("s3://bucket/valid", ""), "cannot be null or empty"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("malformedPrefixesToDecode")
-  void decodeMultiCredPrefixesRejectsMalformedInput(
-      String[] encodedPrefixes, String expectedMessage) {
-    assertThatThrownBy(() -> CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
-        .hasMessageContaining(expectedMessage);
-  }
-
-  private static Stream<Arguments> malformedPrefixesToDecode() {
-    String validPrefix = CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket/valid"))[0];
-    return Stream.of(
-        Arguments.of(null, "cannot be null or empty"),
-        Arguments.of(new String[0], "cannot be null or empty"),
-        Arguments.of(new String[] {null}, "cannot be null"),
-        Arguments.of(new String[] {""}, "cannot be empty"),
-        Arguments.of(new String[] {"not-base64!"}, "Illegal base64"),
-        Arguments.of(new String[] {validPrefix, null}, "cannot be null"),
-        Arguments.of(new String[] {validPrefix, ""}, "cannot be empty"),
-        Arguments.of(new String[] {validPrefix, "not-base64!"}, "Illegal base64"));
-  }
-
   @ParameterizedTest(name = "{0}")
   @MethodSource("validCredentials")
   void convertsTemporaryCredentials(

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -158,28 +158,24 @@ class CredentialUtilTest {
   void selectorRejectsMissingResponse() {
     assertThatThrownBy(() -> CredentialUtil.selectForLocation("s3://bucket/t", null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("has no storage credentials");
+        .hasMessageContaining("requires multiple storage credentials");
     assertThatThrownBy(
             () -> CredentialUtil.selectForLocation("s3://bucket/t", Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("has no storage credentials");
+        .hasMessageContaining("requires multiple storage credentials");
   }
 
   @Test
-  void selectorRejectsSingleWithoutPrefixMatch() {
-    GenericCredential only = credAt("s3://other-bucket");
-    assertThatThrownBy(() -> CredentialUtil.selectForLocation("s3://bucket/t", List.of(only)))
+  void selectorRejectsSingleCredential() {
+    assertThatThrownBy(
+            () -> CredentialUtil.selectForLocation("s3://bucket/t", List.of(credAt("s3://bucket"))))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("No vended credential covers location");
-  }
-
-  @Test
-  void selectorRejectsSingleNull() {
+        .hasMessageContaining("requires multiple storage credentials");
     assertThatThrownBy(
             () ->
                 CredentialUtil.selectForLocation("s3://bucket/t", Collections.singletonList(null)))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("contains null");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires multiple storage credentials");
   }
 
   @Test
@@ -223,7 +219,8 @@ class CredentialUtilTest {
     // Scheme aliases are not normalized; otherwise, the s3 prefix would cover the s3a location.
     assertThatThrownBy(
             () ->
-                CredentialUtil.selectForLocation("s3a://bucket/t", List.of(credAt("s3://bucket"))))
+                CredentialUtil.selectForLocation(
+                    "s3a://bucket/t", Arrays.asList(credAt("s3://bucket"), credAt("gs://other"))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No vended credential covers location");
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -40,11 +40,11 @@ class CredentialUtilTest {
             "s3://bucket/table?key=value&other=a+b#fragment",
             "s3://bucket/café");
 
-    String[] encodedPrefixes = CredentialUtil.encodeMultiCredPrefixes(prefixes);
+    String[] encodedPrefixes = CredentialUtil.encodeCredPrefixes(prefixes);
 
     assertThat(encodedPrefixes).doesNotContainAnyElementsOf(prefixes);
     assertThat(encodedPrefixes).allMatch(prefix -> !prefix.contains(","));
-    assertThat(CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
+    assertThat(CredentialUtil.decodeCredPrefixes(encodedPrefixes))
         .containsExactlyElementsOf(prefixes);
   }
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -26,6 +26,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 class CredentialUtilTest {
   private static final long EXPIRATION = 123L;
 
+  @Test
+  void buildsHadoopConfNamespaceForIndex() {
+    assertThat(CredentialUtil.hadoopConfNamespaceForIndex(2))
+        .isEqualTo("fs.unitycatalog.multi.cred.2.");
+
+    assertThat(CredentialUtil.hadoopConfNamespaceForIndex(0))
+        .isEqualTo("fs.unitycatalog.multi.cred.0.");
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("validCredentials")
   void convertsTemporaryCredentials(

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -41,6 +41,7 @@ class CredentialUtilTest {
 
     String[] encodedPrefixes = CredentialUtil.encodeMultiCredPrefixes(prefixes);
 
+    assertThat(encodedPrefixes).doesNotContainAnyElementsOf(prefixes);
     assertThat(CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
         .containsExactlyElementsOf(prefixes);
   }
@@ -344,13 +345,6 @@ class CredentialUtilTest {
     assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(-1);
   }
 
-  @Test
-  void longestCoveringIndexRejectsNullPrefixList() {
-    assertThatThrownBy(() -> CredentialUtil.longestCoveringIndex("s3://bucket/table", null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("List of prefixes cannot be null.");
-  }
-
   private static Stream<Arguments> nonCoveringPrefixCases() {
     return Stream.of(
         Arguments.of("empty prefix list", List.of(), "s3://bucket/table"),
@@ -373,6 +367,13 @@ class CredentialUtilTest {
             "no covering prefix",
             Arrays.asList("s3://other", "s3://bucket/sibling"),
             "s3://bucket/t"));
+  }
+
+  @Test
+  void longestCoveringIndexRejectsNullPrefixList() {
+    assertThatThrownBy(() -> CredentialUtil.longestCoveringIndex("s3://bucket/table", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("List of prefixes cannot be null.");
   }
 
   private static GenericCredential credAt(String location) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -27,9 +27,60 @@ class CredentialUtilTest {
   private static final long EXPIRATION = 123L;
 
   @Test
-  void multiCredPrefixKeyForIndexReturnsIndexedPrefixKey() {
-    assertThat(CredentialUtil.multiCredPrefixKeyForIndex(2))
-        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_PREFIX_KEY + "2");
+  void multiCredPrefixesRoundTripInOrder() {
+    List<String> prefixes =
+        List.of(
+            "s3://bucket/table,archive",
+            "s3://bucket/table/%20/${credential}",
+            "s3://bucket/table/%2C/%25/%2F",
+            "s3://bucket/table with spaces",
+            "s3://bucket/table\twith\ttabs",
+            "s3://bucket/table-name_with.parts~",
+            "s3://bucket/table?key=value&other=a+b#fragment",
+            "s3://bucket/café");
+
+    String[] encodedPrefixes = CredentialUtil.encodeMultiCredPrefixes(prefixes);
+
+    assertThat(CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
+        .containsExactlyElementsOf(prefixes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("malformedPrefixesToEncode")
+  void encodeMultiCredPrefixesRejectsMalformedInput(List<String> prefixes, String expectedMessage) {
+    assertThatThrownBy(() -> CredentialUtil.encodeMultiCredPrefixes(prefixes))
+        .hasMessageContaining(expectedMessage);
+  }
+
+  private static Stream<Arguments> malformedPrefixesToEncode() {
+    return Stream.of(
+        Arguments.of(null, "cannot be null or empty"),
+        Arguments.of(Collections.emptyList(), "cannot be null or empty"),
+        Arguments.of(Collections.singletonList(null), "cannot be null or empty"),
+        Arguments.of(List.of(""), "cannot be null or empty"),
+        Arguments.of(Arrays.asList("s3://bucket/valid", null), "cannot be null or empty"),
+        Arguments.of(List.of("s3://bucket/valid", ""), "cannot be null or empty"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("malformedPrefixesToDecode")
+  void decodeMultiCredPrefixesRejectsMalformedInput(
+      String[] encodedPrefixes, String expectedMessage) {
+    assertThatThrownBy(() -> CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
+        .hasMessageContaining(expectedMessage);
+  }
+
+  private static Stream<Arguments> malformedPrefixesToDecode() {
+    String validPrefix = CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket/valid"))[0];
+    return Stream.of(
+        Arguments.of(null, "cannot be null or empty"),
+        Arguments.of(new String[0], "cannot be null or empty"),
+        Arguments.of(new String[] {null}, "cannot be null"),
+        Arguments.of(new String[] {""}, "cannot be empty"),
+        Arguments.of(new String[] {"not-base64!"}, "Illegal base64"),
+        Arguments.of(new String[] {validPrefix, null}, "cannot be null"),
+        Arguments.of(new String[] {validPrefix, ""}, "cannot be empty"),
+        Arguments.of(new String[] {validPrefix, "not-base64!"}, "Illegal base64"));
   }
 
   @ParameterizedTest(name = "{0}")

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -167,7 +167,7 @@ class CredentialUtilTest {
   }
 
   @Test
-  void selectorRejectsSingleCredential() {
+  void selectorRequiresMultipleCreds() {
     assertThatThrownBy(
             () -> CredentialUtil.selectForLocation("s3://bucket/t", List.of(credAt("s3://bucket"))))
         .isInstanceOf(IllegalArgumentException.class)
@@ -221,7 +221,8 @@ class CredentialUtilTest {
     assertThatThrownBy(
             () ->
                 CredentialUtil.selectForLocation(
-                    "s3a://bucket/t", Arrays.asList(credAt("s3://bucket"), credAt("gs://other"))))
+                    "s3a://bucket/t",
+                    Arrays.asList(credAt("s3://bucket"), credAt("s3://bucket/t"))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No vended credential covers location");
   }
@@ -306,10 +307,10 @@ class CredentialUtilTest {
         .hasMessageContaining("AWS access key is missing");
   }
 
-  @ParameterizedTest(name = "{0}")
+  @ParameterizedTest
   @MethodSource("coveringPrefixCases")
   void longestCoveringIndexMatchesLocationToPrefix(
-      String description, List<String> prefixes, String location, int expectedIndex) {
+      List<String> prefixes, String location, int expectedIndex) {
     assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(expectedIndex);
   }
 
@@ -318,55 +319,40 @@ class CredentialUtilTest {
         Arrays.asList("s3://bucket/table", "s3://bucket/table/child", "s3://bucket");
     return Stream.of(
         // Longest (most specific) covering prefix wins over shorter ancestors.
-        Arguments.of("most specific prefix wins", nested, "s3://bucket/table/child/data", 1),
+        Arguments.of(nested, "s3://bucket/table/child/data", 1),
         // A location under only the broader prefix selects it, not the deeper sibling.
-        Arguments.of("shorter prefix when deeper does not cover", nested, "s3://bucket/table/x", 0),
+        Arguments.of(nested, "s3://bucket/table/x", 0),
         // Trailing slashes on the prefix are normalized away.
-        Arguments.of(
-            "trailing slashes ignored", List.of("s3://bucket/t///"), "s3://bucket/t/data", 0),
+        Arguments.of(List.of("s3://bucket/t///"), "s3://bucket/t/data", 0),
         // Null and empty prefixes are skipped; the covering one is chosen.
-        Arguments.of(
-            "null and empty prefixes skipped",
-            Arrays.asList(null, "", "s3://bucket/t"),
-            "s3://bucket/t/data",
-            2),
+        Arguments.of(Arrays.asList(null, "", "s3://bucket/t"), "s3://bucket/t/data", 2),
         // On equal-length normalized prefixes, the first covering one wins.
         Arguments.of(
-            "first of equal-length prefixes wins",
-            Arrays.asList("s3://bucket/table/", "s3://bucket/table"),
-            "s3://bucket/table/data",
-            0));
+            Arrays.asList("s3://bucket/table/", "s3://bucket/table"), "s3://bucket/table/data", 0));
   }
 
-  @ParameterizedTest(name = "{0}")
+  @ParameterizedTest
   @MethodSource("nonCoveringPrefixCases")
   void longestCoveringIndexReturnsNegativeOneWhenNoPrefixMatches(
-      String description, List<String> prefixes, String location) {
+      List<String> prefixes, String location) {
     assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(-1);
   }
 
   private static Stream<Arguments> nonCoveringPrefixCases() {
     return Stream.of(
-        Arguments.of("empty prefix list", List.of(), "s3://bucket/table"),
-        Arguments.of("only null and empty prefixes", Arrays.asList(null, ""), "s3://bucket/table"),
+        Arguments.of(List.of(), "s3://bucket/table"),
+        Arguments.of(Arrays.asList(null, ""), "s3://bucket/table"),
         // Scheme aliases are compared literally.
-        Arguments.of(
-            "s3a location does not match s3 prefix",
-            List.of("s3://bucket/table"),
-            "s3a://bucket/table/data"),
-        Arguments.of(
-            "abfss location does not match abfs prefix", List.of("abfs://c@a/t"), "abfss://c@a/t"),
+        Arguments.of(List.of("s3://bucket/table"), "s3a://bucket/table/data"),
+        Arguments.of(List.of("abfs://c@a/t"), "abfss://c@a/t"),
         // Scheme comparison is case-sensitive.
-        Arguments.of("uppercase scheme does not match", List.of("s3://bucket/t"), "S3://bucket/t"),
+        Arguments.of(List.of("s3://bucket/t"), "S3://bucket/t"),
         // Different clouds never match, even with the same bucket/path.
-        Arguments.of("cross-cloud does not match", List.of("s3://bucket/t"), "gs://bucket/t"),
+        Arguments.of(List.of("s3://bucket/t"), "gs://bucket/t"),
         // Unknown schemes are compared literally (case-sensitive), so a case mismatch fails.
-        Arguments.of("unknown scheme is case-sensitive", List.of("hdfs://nn/t"), "HDFS://nn/t"),
+        Arguments.of(List.of("hdfs://nn/t"), "HDFS://nn/t"),
         // No prefix covers the location.
-        Arguments.of(
-            "no covering prefix",
-            Arrays.asList("s3://other", "s3://bucket/sibling"),
-            "s3://bucket/t"));
+        Arguments.of(Arrays.asList("s3://other", "s3://bucket/sibling"), "s3://bucket/t"));
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -43,6 +43,7 @@ class CredentialUtilTest {
     String[] encodedPrefixes = CredentialUtil.encodeMultiCredPrefixes(prefixes);
 
     assertThat(encodedPrefixes).doesNotContainAnyElementsOf(prefixes);
+    assertThat(encodedPrefixes).allMatch(prefix -> !prefix.contains(","));
     assertThat(CredentialUtil.decodeMultiCredPrefixes(encodedPrefixes))
         .containsExactlyElementsOf(prefixes);
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -30,6 +30,7 @@ class CredentialUtilTest {
   void multiCredPrefixesRoundTripInOrder() {
     List<String> prefixes =
         List.of(
+            "s3://bucket/table",
             "s3://bucket/table,archive",
             "s3://bucket/table/%20/${credential}",
             "s3://bucket/table/%2C/%25/%2F",

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -27,12 +27,9 @@ class CredentialUtilTest {
   private static final long EXPIRATION = 123L;
 
   @Test
-  void hadoopConfNamespaceForIndexReturnsNamespace() {
-    assertThat(CredentialUtil.hadoopConfNamespaceForIndex(2))
-        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + "2.");
-
-    assertThat(CredentialUtil.hadoopConfNamespaceForIndex(0))
-        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + "0.");
+  void multiCredPrefixKeyForIndexReturnsIndexedPrefixKey() {
+    assertThat(CredentialUtil.multiCredPrefixKeyForIndex(2))
+        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_PREFIX_KEY + "2");
   }
 
   @ParameterizedTest(name = "{0}")

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -251,6 +251,63 @@ class CredentialUtilTest {
         .hasMessageContaining("AWS access key is missing");
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("longestCoveringIndexCases")
+  void longestCoveringIndexMatchesLocationToPrefix(
+      String description, List<String> prefixes, String location, int expectedIndex) {
+    assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(expectedIndex);
+  }
+
+  private static Stream<Arguments> longestCoveringIndexCases() {
+    List<String> nested =
+        Arrays.asList("s3://bucket/table", "s3://bucket/table/clone", "s3://bucket");
+    return Stream.of(
+        // Longest (most specific) covering prefix wins over shorter ancestors.
+        Arguments.of("most specific prefix wins", nested, "s3://bucket/table/clone/data", 1),
+        // A location under only the broader prefix selects it, not the deeper sibling.
+        Arguments.of("shorter prefix when deeper does not cover", nested, "s3://bucket/table/x", 0),
+        // Scheme aliases are compared literally.
+        Arguments.of(
+            "s3a location does not match s3 prefix",
+            List.of("s3://bucket/table"),
+            "s3a://bucket/table/data",
+            -1),
+        Arguments.of(
+            "abfss location does not match abfs prefix",
+            List.of("abfs://c@a/t"),
+            "abfss://c@a/t/data",
+            -1),
+        // Scheme comparison is case-sensitive.
+        Arguments.of(
+            "uppercase scheme does not match", List.of("s3://bucket/t"), "S3://bucket/t/data", -1),
+        // Trailing slashes on the prefix are normalized away.
+        Arguments.of(
+            "trailing slashes ignored", List.of("s3://bucket/t///"), "s3://bucket/t/data", 0),
+        // Different clouds never match, even with the same bucket/path.
+        Arguments.of(
+            "cross-cloud does not match", List.of("s3://bucket/t"), "gs://bucket/t/data", -1),
+        // Unknown schemes are compared literally (case-sensitive), so a case mismatch fails.
+        Arguments.of("unknown scheme is case-sensitive", List.of("hdfs://nn/t"), "HDFS://nn/t", -1),
+        // Null and empty prefixes are skipped; the covering one is chosen.
+        Arguments.of(
+            "null and empty prefixes skipped",
+            Arrays.asList(null, "", "s3://bucket/t"),
+            "s3://bucket/t/data",
+            2),
+        // No prefix covers the location.
+        Arguments.of(
+            "no covering prefix",
+            Arrays.asList("s3://other", "s3://bucket/sibling"),
+            "s3://bucket/t",
+            -1),
+        // On equal-length normalized prefixes, the first covering one wins.
+        Arguments.of(
+            "first of equal-length prefixes wins",
+            Arrays.asList("s3://bucket/table/", "s3://bucket/table"),
+            "s3://bucket/table/data",
+            0));
+  }
+
   private static GenericCredential credAt(String location) {
     return new AwsCredential("ak", "sk", "st", 1L, location);
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -269,10 +269,10 @@ class CredentialUtilTest {
 
   private static Stream<Arguments> coveringPrefixCases() {
     List<String> nested =
-        Arrays.asList("s3://bucket/table", "s3://bucket/table/clone", "s3://bucket");
+        Arrays.asList("s3://bucket/table", "s3://bucket/table/child", "s3://bucket");
     return Stream.of(
         // Longest (most specific) covering prefix wins over shorter ancestors.
-        Arguments.of("most specific prefix wins", nested, "s3://bucket/table/clone/data", 1),
+        Arguments.of("most specific prefix wins", nested, "s3://bucket/table/child/data", 1),
         // A location under only the broader prefix selects it, not the deeper sibling.
         Arguments.of("shorter prefix when deeper does not cover", nested, "s3://bucket/table/x", 0),
         // Trailing slashes on the prefix are normalized away.

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -27,12 +27,12 @@ class CredentialUtilTest {
   private static final long EXPIRATION = 123L;
 
   @Test
-  void buildsHadoopConfNamespaceForIndex() {
+  void hadoopConfNamespaceForIndexReturnsNamespace() {
     assertThat(CredentialUtil.hadoopConfNamespaceForIndex(2))
-        .isEqualTo("fs.unitycatalog.multi.cred.2.");
+        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + "2.");
 
     assertThat(CredentialUtil.hadoopConfNamespaceForIndex(0))
-        .isEqualTo("fs.unitycatalog.multi.cred.0.");
+        .isEqualTo(UCHadoopConfConstants.UC_MULTI_CRED_NAMESPACE_PREFIX + "0.");
   }
 
   @ParameterizedTest(name = "{0}")
@@ -261,13 +261,13 @@ class CredentialUtilTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @MethodSource("longestCoveringIndexCases")
+  @MethodSource("coveringPrefixCases")
   void longestCoveringIndexMatchesLocationToPrefix(
       String description, List<String> prefixes, String location, int expectedIndex) {
     assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(expectedIndex);
   }
 
-  private static Stream<Arguments> longestCoveringIndexCases() {
+  private static Stream<Arguments> coveringPrefixCases() {
     List<String> nested =
         Arrays.asList("s3://bucket/table", "s3://bucket/table/clone", "s3://bucket");
     return Stream.of(
@@ -275,46 +275,59 @@ class CredentialUtilTest {
         Arguments.of("most specific prefix wins", nested, "s3://bucket/table/clone/data", 1),
         // A location under only the broader prefix selects it, not the deeper sibling.
         Arguments.of("shorter prefix when deeper does not cover", nested, "s3://bucket/table/x", 0),
-        // Scheme aliases are compared literally.
-        Arguments.of(
-            "s3a location does not match s3 prefix",
-            List.of("s3://bucket/table"),
-            "s3a://bucket/table/data",
-            -1),
-        Arguments.of(
-            "abfss location does not match abfs prefix",
-            List.of("abfs://c@a/t"),
-            "abfss://c@a/t/data",
-            -1),
-        // Scheme comparison is case-sensitive.
-        Arguments.of(
-            "uppercase scheme does not match", List.of("s3://bucket/t"), "S3://bucket/t/data", -1),
         // Trailing slashes on the prefix are normalized away.
         Arguments.of(
             "trailing slashes ignored", List.of("s3://bucket/t///"), "s3://bucket/t/data", 0),
-        // Different clouds never match, even with the same bucket/path.
-        Arguments.of(
-            "cross-cloud does not match", List.of("s3://bucket/t"), "gs://bucket/t/data", -1),
-        // Unknown schemes are compared literally (case-sensitive), so a case mismatch fails.
-        Arguments.of("unknown scheme is case-sensitive", List.of("hdfs://nn/t"), "HDFS://nn/t", -1),
         // Null and empty prefixes are skipped; the covering one is chosen.
         Arguments.of(
             "null and empty prefixes skipped",
             Arrays.asList(null, "", "s3://bucket/t"),
             "s3://bucket/t/data",
             2),
-        // No prefix covers the location.
-        Arguments.of(
-            "no covering prefix",
-            Arrays.asList("s3://other", "s3://bucket/sibling"),
-            "s3://bucket/t",
-            -1),
         // On equal-length normalized prefixes, the first covering one wins.
         Arguments.of(
             "first of equal-length prefixes wins",
             Arrays.asList("s3://bucket/table/", "s3://bucket/table"),
             "s3://bucket/table/data",
             0));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonCoveringPrefixCases")
+  void longestCoveringIndexReturnsNegativeOneWhenNoPrefixMatches(
+      String description, List<String> prefixes, String location) {
+    assertThat(CredentialUtil.longestCoveringIndex(location, prefixes)).isEqualTo(-1);
+  }
+
+  @Test
+  void longestCoveringIndexRejectsNullPrefixList() {
+    assertThatThrownBy(() -> CredentialUtil.longestCoveringIndex("s3://bucket/table", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("List of prefixes cannot be null.");
+  }
+
+  private static Stream<Arguments> nonCoveringPrefixCases() {
+    return Stream.of(
+        Arguments.of("empty prefix list", List.of(), "s3://bucket/table"),
+        Arguments.of("only null and empty prefixes", Arrays.asList(null, ""), "s3://bucket/table"),
+        // Scheme aliases are compared literally.
+        Arguments.of(
+            "s3a location does not match s3 prefix",
+            List.of("s3://bucket/table"),
+            "s3a://bucket/table/data"),
+        Arguments.of(
+            "abfss location does not match abfs prefix", List.of("abfs://c@a/t"), "abfss://c@a/t"),
+        // Scheme comparison is case-sensitive.
+        Arguments.of("uppercase scheme does not match", List.of("s3://bucket/t"), "S3://bucket/t"),
+        // Different clouds never match, even with the same bucket/path.
+        Arguments.of("cross-cloud does not match", List.of("s3://bucket/t"), "gs://bucket/t"),
+        // Unknown schemes are compared literally (case-sensitive), so a case mismatch fails.
+        Arguments.of("unknown scheme is case-sensitive", List.of("hdfs://nn/t"), "HDFS://nn/t"),
+        // No prefix covers the location.
+        Arguments.of(
+            "no covering prefix",
+            Arrays.asList("s3://other", "s3://bucket/sibling"),
+            "s3://bucket/t"));
   }
 
   private static GenericCredential credAt(String location) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -96,6 +96,8 @@ class CredPropsRoundTripTest {
 
   @Test
   void multipleCredentialPrefixesRoundTripThroughCredScopedFileSystem() throws Exception {
+    // TODO: Once CredPropsUtil can encode multi-creds, initialCredential should be a list
+    // that matches the AwsVendedTokenProvider step at the end of the test.
     AwsCredential initialCredential =
         new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION);
     CredPropsUtil.genericCredFetcherFactory =
@@ -120,12 +122,14 @@ class CredPropsRoundTripTest {
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
 
-    // TODO: Delete this manual step when CredPropsBuilder supports producing
+    // TODO: Delete the manual steps below when CredPropsBuilder supports producing
     // properties for multiple vended credentials. This is a temporary test
     // workaround until the encoder side changes land.
+    // Unset the initialCredential that was set for multi-cred encodings.
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY);
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SECRET_KEY);
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
+    // Encode the list of prefixes.
     confWithCreds.setStrings(
         UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
         CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket", LOCATION)));

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -1,6 +1,9 @@
 package io.unitycatalog.hadoop.internal.fs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
@@ -10,6 +13,7 @@ import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +22,7 @@ import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 /** Round-trip tests for credential properties produced and consumed during filesystem setup. */
@@ -70,10 +75,11 @@ class CredPropsRoundTripTest {
   }
 
   @Test
-  void multipleCredentialsRoundTripThroughCredScopedFileSystemAndProvider() throws Exception {
-    AwsCredential credential =
+  void multipleCredentialPrefixesRoundTripThroughCredScopedFileSystem() throws Exception {
+    AwsCredential initialCredential =
         new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION);
-    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(credential);
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> () -> List.of(initialCredential);
 
     Configuration initialConf = new Configuration(false);
     initialConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
@@ -94,36 +100,50 @@ class CredPropsRoundTripTest {
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
 
+    // TODO: Delete this manual step when CredPropsBuilder supports producing
+    // properties for multiple vended credentials. This is a temporary test
+    // workaround until the encoder side changes land.
+    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY);
+    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SECRET_KEY);
+    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
     confWithCreds.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
-
-    // TODO: Replace these manually encoded properties with CredPropsUtil when it supports
-    // producing properties for multiple vended credentials.
-    setScopedAwsCredential(confWithCreds, 0, "s3://bucket", "parent-ak", "parent-sk", "parent-st");
-    setScopedAwsCredential(confWithCreds, 1, LOCATION, "child-ak", "child-sk", "child-st");
+    confWithCreds.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "s3://bucket");
+    confWithCreds.set(CredentialUtil.multiCredPrefixKeyForIndex(1), LOCATION);
 
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
 
-    AwsVendedTokenProvider provider = new AwsVendedTokenProvider(fs.getDelegate().getConf());
-    AwsSessionCredentials resolved = (AwsSessionCredentials) provider.resolveCredentials();
+    Configuration delegateConf = fs.getDelegate().getConf();
+    assertThat(delegateConf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
+        .isEqualTo(LOCATION);
+    assertThat(delegateConf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY)).isNull();
+    assertThat(delegateConf.get(UCHadoopConfConstants.S3A_INIT_SECRET_KEY)).isNull();
+    assertThat(delegateConf.get(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN)).isNull();
 
-    assertThat(provider.accessCredentials().prefix()).isEqualTo(LOCATION);
-    assertThat(resolved.accessKeyId()).isEqualTo("child-ak");
-    assertThat(resolved.secretAccessKey()).isEqualTo("child-sk");
-    assertThat(resolved.sessionToken()).isEqualTo("child-st");
-  }
+    TableCredId expectedCredId =
+        new TableCredId(
+            delegateConf.get(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY), "table-id", "READ");
+    expectedCredId
+        .props()
+        .forEach((key, value) -> assertThat(delegateConf.get(key)).isEqualTo(value));
 
-  private static void setScopedAwsCredential(
-      Configuration conf,
-      int index,
-      String location,
-      String accessKey,
-      String secretKey,
-      String sessionToken) {
-    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(index);
-    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
-    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, accessKey);
-    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_SECRET_KEY, secretKey);
-    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, sessionToken);
+    AwsCredential parent =
+        new AwsCredential("parent-ak", "parent-sk", "parent-st", null, "s3://bucket");
+    AwsCredential child = new AwsCredential("child-ak", "child-sk", "child-st", null, LOCATION);
+    GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
+    when(fetcher.createCredentials()).thenReturn(List.of(parent, child));
+
+    try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
+        mockStatic(GenericCredentialFetcher.class)) {
+      mockedFetcher.when(() -> GenericCredentialFetcher.create(delegateConf)).thenReturn(fetcher);
+
+      AwsVendedTokenProvider provider = new AwsVendedTokenProvider(delegateConf);
+      AwsSessionCredentials resolved = (AwsSessionCredentials) provider.resolveCredentials();
+
+      assertThat(provider.accessCredentials().prefix()).isEqualTo(LOCATION);
+      assertThat(resolved.accessKeyId()).isEqualTo("child-ak");
+      assertThat(resolved.secretAccessKey()).isEqualTo("child-sk");
+      assertThat(resolved.sessionToken()).isEqualTo("child-st");
+    }
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -64,7 +64,7 @@ class CredPropsRoundTripTest {
     // TODO: this MUST be set in the CredPropsUtil. Temporary workaround.
     confWithCreds.setStrings(
         UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(List.of(LOCATION)));
+        CredentialUtil.encodeCredPrefixes(List.of(LOCATION)));
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
 
@@ -116,7 +116,7 @@ class CredPropsRoundTripTest {
     // Encode the list of prefixes.
     confWithCreds.setStrings(
         UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket", LOCATION)));
+        CredentialUtil.encodeCredPrefixes(List.of("s3://bucket", LOCATION)));
 
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -61,6 +61,10 @@ class CredPropsRoundTripTest {
 
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
+    // TODO: this MUST be set in the CredPropsUtil. Temporary workaround.
+    confWithCreds.setStrings(
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(List.of(LOCATION)));
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
 
@@ -111,7 +115,7 @@ class CredPropsRoundTripTest {
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
     // Encode the list of prefixes.
     confWithCreds.setStrings(
-        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
         CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket", LOCATION)));
 
     CredScopedFileSystem fs = new CredScopedFileSystem();

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -67,4 +67,62 @@ class CredPropsRoundTripTest {
     assertThat(resolved.secretAccessKey()).isEqualTo("secret-key");
     assertThat(resolved.sessionToken()).isEqualTo("session-token");
   }
+
+  @Test
+  void multipleCredentialsRoundTripThroughCredScopedFileSystemAndProvider() throws Exception {
+    AwsCredential credential =
+        new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION);
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(credential);
+
+    Configuration initialConf = new Configuration(false);
+    initialConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+    initialConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            /* renewCredEnabled= */ true,
+            /* credScopedFsEnabled= */ true,
+            initialConf,
+            "s3",
+            /* apiClient= */ null,
+            "http://uc",
+            TokenProvider.create(Map.of("type", "static", "token", "token")),
+            "table-id",
+            UCCredentialHadoopConfs.TableOperation.READ,
+            Map.of());
+
+    Configuration confWithCreds = new Configuration(false);
+    props.forEach(confWithCreds::set);
+
+    confWithCreds.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 2);
+
+    // TODO: Replace these manually encoded properties with CredPropsUtil when it supports
+    // producing properties for multiple vended credentials.
+    setScopedAwsCredential(confWithCreds, 0, "s3://bucket", "parent-ak", "parent-sk", "parent-st");
+    setScopedAwsCredential(confWithCreds, 1, LOCATION, "child-ak", "child-sk", "child-st");
+
+    CredScopedFileSystem fs = new CredScopedFileSystem();
+    fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
+
+    AwsVendedTokenProvider provider = new AwsVendedTokenProvider(fs.getDelegate().getConf());
+    AwsSessionCredentials resolved = (AwsSessionCredentials) provider.resolveCredentials();
+
+    assertThat(provider.accessCredentials().prefix()).isEqualTo(LOCATION);
+    assertThat(resolved.accessKeyId()).isEqualTo("child-ak");
+    assertThat(resolved.secretAccessKey()).isEqualTo("child-sk");
+    assertThat(resolved.sessionToken()).isEqualTo("child-st");
+  }
+
+  private static void setScopedAwsCredential(
+      Configuration conf,
+      int index,
+      String location,
+      String accessKey,
+      String secretKey,
+      String sessionToken) {
+    String namespace = UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
+    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
+    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, accessKey);
+    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_SECRET_KEY, secretKey);
+    conf.set(namespace + UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN, sessionToken);
+  }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -30,26 +30,6 @@ class CredPropsRoundTripTest {
 
   private static final String LOCATION = "s3://bucket/table";
 
-  @Test
-  void multiCredentialPrefixesRoundTripThroughHadoopConfiguration() {
-    Configuration conf = new Configuration(false);
-    List<String> prefixes =
-        List.of(
-            "s3://bucket/table",
-            "s3://bucket/table,archive",
-            "s3://bucket/table/%20/${credential}",
-            "s3://bucket/table/%2C/%25/%2F");
-
-    conf.setStrings(
-        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(prefixes));
-
-    assertThat(
-            CredentialUtil.decodeMultiCredPrefixes(
-                conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY)))
-        .containsExactlyElementsOf(prefixes);
-  }
-
   @BeforeEach
   @AfterEach
   void reset() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -30,6 +30,26 @@ class CredPropsRoundTripTest {
 
   private static final String LOCATION = "s3://bucket/table";
 
+  @Test
+  void multiCredentialPrefixesRoundTripThroughHadoopConfiguration() {
+    Configuration conf = new Configuration(false);
+    List<String> prefixes =
+        List.of(
+            "s3://bucket/table",
+            "s3://bucket/table,archive",
+            "s3://bucket/table/%20/${credential}",
+            "s3://bucket/table/%2C/%25/%2F");
+
+    conf.setStrings(
+        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(prefixes));
+
+    assertThat(
+            CredentialUtil.decodeMultiCredPrefixes(
+                conf.getStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY)))
+        .containsExactlyElementsOf(prefixes);
+  }
+
   @BeforeEach
   @AfterEach
   void reset() {
@@ -106,9 +126,9 @@ class CredPropsRoundTripTest {
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY);
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SECRET_KEY);
     confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
-    confWithCreds.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
-    confWithCreds.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "s3://bucket");
-    confWithCreds.set(CredentialUtil.multiCredPrefixKeyForIndex(1), LOCATION);
+    confWithCreds.setStrings(
+        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(List.of("s3://bucket", LOCATION)));
 
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
@@ -93,7 +94,7 @@ class CredPropsRoundTripTest {
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
 
-    confWithCreds.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 2);
+    confWithCreds.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
 
     // TODO: Replace these manually encoded properties with CredPropsUtil when it supports
     // producing properties for multiple vended credentials.
@@ -119,7 +120,7 @@ class CredPropsRoundTripTest {
       String accessKey,
       String secretKey,
       String sessionToken) {
-    String namespace = UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
+    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(index);
     conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
     conf.set(namespace + UCHadoopConfConstants.S3A_INIT_ACCESS_KEY, accessKey);
     conf.set(namespace + UCHadoopConfConstants.S3A_INIT_SECRET_KEY, secretKey);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -167,7 +167,7 @@ class CredScopedFileSystemCacheTest {
   }
 
   @Test
-  void namespacedSelectedPrefixDeterminesDelegateIdentity() throws Exception {
+  void multiCredSelectionDeterminesDelegateIdentity() throws Exception {
     Configuration conf = tableConf("tid-1", "READ");
     conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
     setNamespacedCredential(conf, 0, "file:///tmp/a");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -61,7 +61,7 @@ class CredScopedFileSystemCacheTest {
   private static void setCredPrefixes(Configuration conf, String... prefixes) {
     conf.setStrings(
         UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(List.of(prefixes)));
+        CredentialUtil.encodeCredPrefixes(List.of(prefixes)));
   }
 
   @Test
@@ -171,7 +171,7 @@ class CredScopedFileSystemCacheTest {
     Configuration conf = tableConf("tid-1", "READ");
     conf.setStrings(
         UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/a", "file:///tmp/b")));
+        CredentialUtil.encodeCredPrefixes(List.of("file:///tmp/a", "file:///tmp/b")));
 
     // URIs covered by the same credential resolve to one delegate; different ones do not.
     CredScopedFileSystem fsA1 = init(new URI("file:///tmp/a/one"), conf);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -57,13 +57,6 @@ class CredScopedFileSystemCacheTest {
     return conf;
   }
 
-  /** Encodes a namespaced credential's location and a placeholder key at {@code index}. */
-  private static void setNamespacedCredential(Configuration conf, int index, String location) {
-    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(index);
-    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
-    conf.set(namespace + "fs.unitycatalog.test.credential", "credential-" + index);
-  }
-
   @Test
   void sameScopeReusesSameDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
@@ -170,8 +163,8 @@ class CredScopedFileSystemCacheTest {
   void multiCredSelectionDeterminesDelegateIdentity() throws Exception {
     Configuration conf = tableConf("tid-1", "READ");
     conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
-    setNamespacedCredential(conf, 0, "file:///tmp/a");
-    setNamespacedCredential(conf, 1, "file:///tmp/b");
+    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "file:///tmp/a");
+    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(1), "file:///tmp/b");
 
     // URIs covered by the same credential resolve to one delegate; different ones do not.
     CredScopedFileSystem fsA1 = init(new URI("file:///tmp/a/one"), conf);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -56,6 +56,13 @@ class CredScopedFileSystemCacheTest {
     return conf;
   }
 
+  /** Encodes a scoped credential's location and a placeholder credential key at {@code index}. */
+  private static void setScopedLocation(Configuration conf, int index, String location) {
+    String namespace = UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
+    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
+    conf.set(namespace + "fs.unitycatalog.test.credential", "credential-" + index);
+  }
+
   @Test
   void sameScopeReusesSameDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
@@ -156,6 +163,22 @@ class CredScopedFileSystemCacheTest {
     CredScopedFileSystem fsB = init(uri, confB);
 
     assertThat(fsA.getDelegate()).isNotSameAs(fsB.getDelegate());
+  }
+
+  @Test
+  void namespacedSelectedPrefixDeterminesDelegateIdentity() throws Exception {
+    Configuration conf = tableConf("tid-1", "READ");
+    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 2);
+    setScopedLocation(conf, 0, "file:///tmp/a");
+    setScopedLocation(conf, 1, "file:///tmp/b");
+
+    // URIs covered by the same credential resolve to one delegate; different ones do not.
+    CredScopedFileSystem fsA1 = init(new URI("file:///tmp/a/one"), conf);
+    CredScopedFileSystem fsA2 = init(new URI("file:///tmp/a/two"), conf);
+    CredScopedFileSystem fsB = init(new URI("file:///tmp/b/one"), conf);
+
+    assertThat(fsA1.getDelegate()).isSameAs(fsA2.getDelegate());
+    assertThat(fsA1.getDelegate()).isNotSameAs(fsB.getDelegate());
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -58,6 +58,12 @@ class CredScopedFileSystemCacheTest {
     return conf;
   }
 
+  private static void setCredPrefixes(Configuration conf, String... prefixes) {
+    conf.setStrings(
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(List.of(prefixes)));
+  }
+
   @Test
   void sameScopeReusesSameDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
@@ -100,9 +106,9 @@ class CredScopedFileSystemCacheTest {
   void differentScopeSamePrefixGetsDifferentDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
     Configuration confRead = tableConf("tid-1", "READ");
-    confRead.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a");
+    setCredPrefixes(confRead, "file:///tmp/a");
     Configuration confWrite = tableConf("tid-1", "WRITE");
-    confWrite.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a");
+    setCredPrefixes(confWrite, "file:///tmp/a");
 
     CredScopedFileSystem fsRead = init(uri, confRead);
     CredScopedFileSystem fsWrite = init(uri, confWrite);
@@ -124,9 +130,9 @@ class CredScopedFileSystemCacheTest {
   void sameScopeDifferentPrefixGetsDifferentDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
     Configuration confA = tableConf("tid-1", "READ");
-    confA.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a");
+    setCredPrefixes(confA, "file:///tmp/a");
     Configuration confB = tableConf("tid-1", "READ");
-    confB.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/b");
+    setCredPrefixes(confB, "file:///tmp/b");
 
     CredScopedFileSystem fsA = init(uri, confA);
     CredScopedFileSystem fsB = init(uri, confB);
@@ -138,7 +144,7 @@ class CredScopedFileSystemCacheTest {
   void sameScopeSamePrefixReusesSameDelegate() throws Exception {
     URI uri = new URI("file:///tmp");
     Configuration conf = tableConf("tid-1", "READ");
-    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a");
+    setCredPrefixes(conf, "file:///tmp/a");
 
     CredScopedFileSystem fs1 = init(uri, conf);
     CredScopedFileSystem fs2 = init(uri, conf);
@@ -150,9 +156,9 @@ class CredScopedFileSystemCacheTest {
   void differentlyFormattedPrefixesGetDifferentDelegates() throws Exception {
     URI uri = new URI("file:///tmp");
     Configuration confA = tableConf("tid-1", "READ");
-    confA.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a");
+    setCredPrefixes(confA, "file:///tmp/a");
     Configuration confB = tableConf("tid-1", "READ");
-    confB.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "file:///tmp/a/");
+    setCredPrefixes(confB, "file:///tmp/a/");
 
     CredScopedFileSystem fsA = init(uri, confA);
     CredScopedFileSystem fsB = init(uri, confB);
@@ -164,7 +170,7 @@ class CredScopedFileSystemCacheTest {
   void multiCredSelectionDeterminesDelegateIdentity() throws Exception {
     Configuration conf = tableConf("tid-1", "READ");
     conf.setStrings(
-        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
         CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/a", "file:///tmp/b")));
 
     // URIs covered by the same credential resolve to one delegate; different ones do not.

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.FileSystemCredId;
 import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
@@ -56,9 +57,9 @@ class CredScopedFileSystemCacheTest {
     return conf;
   }
 
-  /** Encodes a scoped credential's location and a placeholder credential key at {@code index}. */
-  private static void setScopedLocation(Configuration conf, int index, String location) {
-    String namespace = UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + ".";
+  /** Encodes a namespaced credential's location and a placeholder key at {@code index}. */
+  private static void setNamespacedCredential(Configuration conf, int index, String location) {
+    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(index);
     conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location);
     conf.set(namespace + "fs.unitycatalog.test.credential", "credential-" + index);
   }
@@ -168,9 +169,9 @@ class CredScopedFileSystemCacheTest {
   @Test
   void namespacedSelectedPrefixDeterminesDelegateIdentity() throws Exception {
     Configuration conf = tableConf("tid-1", "READ");
-    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, 2);
-    setScopedLocation(conf, 0, "file:///tmp/a");
-    setScopedLocation(conf, 1, "file:///tmp/b");
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
+    setNamespacedCredential(conf, 0, "file:///tmp/a");
+    setNamespacedCredential(conf, 1, "file:///tmp/b");
 
     // URIs covered by the same credential resolve to one delegate; different ones do not.
     CredScopedFileSystem fsA1 = init(new URI("file:///tmp/a/one"), conf);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemCacheTest.java
@@ -10,6 +10,7 @@ import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.FileSystemCredId;
 import io.unitycatalog.hadoop.internal.util.MapIdGenerator;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -162,9 +163,9 @@ class CredScopedFileSystemCacheTest {
   @Test
   void multiCredSelectionDeterminesDelegateIdentity() throws Exception {
     Configuration conf = tableConf("tid-1", "READ");
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, 2);
-    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "file:///tmp/a");
-    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(1), "file:///tmp/b");
+    conf.setStrings(
+        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/a", "file:///tmp/b")));
 
     // URIs covered by the same credential resolve to one delegate; different ones do not.
     CredScopedFileSystem fsA1 = init(new URI("file:///tmp/a/one"), conf);

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -4,6 +4,7 @@ import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_I
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.HashMap;
@@ -56,7 +57,7 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static void setScopedKey(Configuration conf, int index, String key, String value) {
-    conf.set(UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + "." + key, value);
+    conf.set(CredentialUtil.hadoopConfNamespaceForIndex(index) + key, value);
   }
 
   /** A snapshot of every entry in {@code conf}, for asserting the source config is not mutated. */
@@ -68,13 +69,12 @@ class CredScopedFileSystemNamespaceTest {
     return entries;
   }
 
-  // --- count == 0 (legacy top-level layout, no prefix matching)
+  // --- count == 0 (single-credential top-level layout, no prefix matching)
   // -----------------------------------------------------
 
   @Test
-  void legacyLayoutNeitherLiftsNorOverridesWithNamespacedKeys() throws Exception {
+  void singleCredentialLayoutNeitherLiftsNorOverridesWithNamespacedKeys() throws Exception {
     Configuration conf = tableConf();
-    // Backwards compatibility test, scoped cred count not set.
     conf.set(TEST_CREDENTIAL_KEY, "top-level-credential");
     setScopedKey(conf, 0, LOCATION_KEY, "file:///tmp/table");
     setScopedKey(conf, 0, TEST_CREDENTIAL_KEY, "namespaced-0");
@@ -101,10 +101,10 @@ class CredScopedFileSystemNamespaceTest {
    */
   @ParameterizedTest(name = "creds={0} uri={1} selects index {2}")
   @MethodSource("multiCredentialSelectionCases")
-  void multipleScopedCredentialsSelectAndOverlayCoveringCredential(
+  void multipleNamespacedCredentialsSelectAndOverlayCoveringCredential(
       List<Map<String, String>> credentials, String uri, int expectedIndex) throws Exception {
     Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, credentials.size());
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, credentials.size());
     for (int i = 0; i < credentials.size(); i++) {
       for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
         setScopedKey(conf, i, key.getKey(), key.getValue());
@@ -163,7 +163,7 @@ class CredScopedFileSystemNamespaceTest {
   void malformedConfigurationIsRejected(
       int count, List<Map<String, String>> credentials, String uri, String expectedMessage) {
     Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, count);
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, count);
     for (int i = 0; i < credentials.size(); i++) {
       for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
         setScopedKey(conf, i, key.getKey(), key.getValue());
@@ -189,8 +189,8 @@ class CredScopedFileSystemNamespaceTest {
             "missing its prefix"),
         // Count claims more credentials than are encoded; index 2 is a phantom with no keys.
         Arguments.of(
-            3, twoCreds, "file:///tmp/a/data", "Scoped credential 2 is missing its prefix"),
-        // Count of one: a single credential must use the legacy top-level layout, not a namespace.
+            3, twoCreds, "file:///tmp/a/data", "Namespaced credential 2 is missing its prefix"),
+        // Count of one: a single credential must use the top-level layout, not a namespace.
         Arguments.of(
             1,
             List.of(credential(0, "file:///tmp/table")),
@@ -204,6 +204,6 @@ class CredScopedFileSystemNamespaceTest {
             Integer.MAX_VALUE,
             List.<Map<String, String>>of(),
             "file:///tmp/table/data",
-            "must be greater than 1"));
+            "at most 10"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,23 +59,24 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static void setPrefixes(Configuration conf, List<String> prefixes) {
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, prefixes.size());
-    for (int i = 0; i < prefixes.size(); i++) {
-      conf.set(CredentialUtil.multiCredPrefixKeyForIndex(i), prefixes.get(i));
-    }
+    conf.setStrings(
+        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
+        CredentialUtil.encodeMultiCredPrefixes(prefixes));
   }
 
   @Test
-  void withoutMultiCredentialCountIndexedPrefixesAreIgnored() throws Exception {
-    Configuration conf = tableConf();
-    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "file:///tmp/table");
-    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(1), "file:///tmp/table/child");
-    Map<String, String> before = snapshot(conf);
+  void missingOrEmptyMultiCredentialPrefixesUseSingleCredentialPath() throws Exception {
+    Configuration missing = tableConf();
+    Configuration empty = tableConf();
+    empty.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, "");
 
-    FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
+    for (Configuration conf : List.of(missing, empty)) {
+      Map<String, String> before = snapshot(conf);
+      FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 
-    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isNull();
-    assertThat(snapshot(conf)).isEqualTo(before);
+      assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isNull();
+      assertThat(snapshot(conf)).isEqualTo(before);
+    }
   }
 
   @ParameterizedTest(name = "prefixes={0} uri={1} selects {2}")
@@ -107,6 +109,10 @@ class CredScopedFileSystemNamespaceTest {
             "file:///tmp/a/b/data",
             "file:///tmp/a/b"),
         Arguments.of(
+            List.of("file:///tmp/a", "file:///tmp/a/b", "file:///tmp/c"),
+            "file:///tmp/c/data",
+            "file:///tmp/c"),
+        Arguments.of(
             List.of("file:///tmp/table", "file:///tmp/table,archive"),
             "file:///tmp/table,archive/data",
             "file:///tmp/table,archive"));
@@ -128,44 +134,36 @@ class CredScopedFileSystemNamespaceTest {
         .isEqualTo("file:///tmp/credential-" + (MAX_COUNT - 1));
   }
 
-  @ParameterizedTest(name = "{3}")
-  @MethodSource("malformedPrefixLists")
-  void malformedPrefixListIsRejected(
-      int count, List<String> prefixes, String uri, String expectedMessage) {
+  @Test
+  void maximumCredentialCountIsCheckedBeforeDecoding() {
     Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, count);
-    for (int i = 0; i < prefixes.size(); i++) {
-      conf.set(CredentialUtil.multiCredPrefixKeyForIndex(i), prefixes.get(i));
-    }
+    String[] invalidEncodedPrefixes =
+        Collections.nCopies(MAX_COUNT + 1, "not-base64!").toArray(String[]::new);
+    conf.setStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, invalidEncodedPrefixes);
+
+    assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential/data"), conf))
+        .hasMessageContaining("between 2 and " + MAX_COUNT);
+  }
+
+  @ParameterizedTest(name = "{2}")
+  @MethodSource("malformedPrefixLists")
+  void malformedPrefixListIsRejected(List<String> prefixes, String uri, String expectedMessage) {
+    Configuration conf = tableConf();
+    setPrefixes(conf, prefixes);
 
     assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
-        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(expectedMessage);
   }
 
   private static Stream<Arguments> malformedPrefixLists() {
     return Stream.of(
         Arguments.of(
-            2,
             List.of("file:///tmp/a", "file:///tmp/b"),
             "file:///tmp/other/data",
             "No credential covers storage location"),
         Arguments.of(
-            2,
-            List.of("file:///tmp/a", ""),
-            "file:///tmp/a/data",
-            "Credential prefixes cannot be null or empty: index 1"),
-        Arguments.of(
-            2,
             List.of("file:///tmp/table"),
             "file:///tmp/table/data",
-            "Credential prefixes cannot be null or empty: index 1"),
-        Arguments.of(
-            MAX_COUNT + 1,
-            IntStream.rangeClosed(0, MAX_COUNT)
-                .mapToObj(i -> "file:///tmp/credential-" + i)
-                .collect(Collectors.toList()),
-            "file:///tmp/credential-0/data",
-            "at most " + MAX_COUNT));
+            "Number of credentials must be between 2 and " + MAX_COUNT + ": got 1"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -54,11 +54,9 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static void setPrefixes(Configuration conf, List<String> prefixes) {
-    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, encodePrefixes(prefixes));
-  }
-
-  private static String encodePrefixes(List<String> prefixes) {
-    return String.join(",", CredentialUtil.encodeCredPrefixes(prefixes));
+    conf.setStrings(
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+        CredentialUtil.encodeCredPrefixes(prefixes));
   }
 
   @Test
@@ -77,7 +75,7 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   @Test
-  void singleCredPrefixUsesSingleCredPath() throws Exception {
+  void singleCredPrefixDoesNotDoSelection() throws Exception {
     Configuration conf = tableConf();
     String prefix = "file:///tmp/other";
     setPrefixes(conf, List.of(prefix));
@@ -142,7 +140,6 @@ class CredScopedFileSystemNamespaceTest {
 
   private static Stream<Arguments> uncoveredLocationCases() {
     return Stream.of(
-        Arguments.of(List.of("", "", "", ""), "file:///tmp/table/data"),
         Arguments.of(List.of("file:///tmp/a", "file:///tmp/b"), "file:///tmp/other/data"),
         Arguments.of(
             List.of("file:///tmp/table", "file:///tmp/table/child"),

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -66,10 +66,15 @@ class CredScopedFileSystemNamespaceTest {
     Configuration missing = tableConf();
     Configuration empty = tableConf();
     empty.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, "");
+
+    // Assert single cred path is taken as prefix matching would throw.
+    Configuration onlySeparators = tableConf();
+    onlySeparators.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, ",,,");
+
     Configuration single = tableConf();
     setPrefixes(single, List.of("file:///tmp/other"));
 
-    for (Configuration conf : List.of(missing, empty, single)) {
+    for (Configuration conf : List.of(missing, empty, onlySeparators, single)) {
       Map<String, String> before = snapshot(conf);
       FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -1,0 +1,209 @@
+package io.unitycatalog.hadoop.internal.fs;
+
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the namespaced-credential mechanism of {@link CredScopedFileSystem}: reading the count,
+ * selecting the credential whose location covers the accessed URI, and overlaying that credential's
+ * keys (and only that credential's keys) onto the delegate filesystem's configuration.
+ *
+ * <p>Uses {@code file://} URIs with the local filesystem so no cloud SDK is required. The
+ * delegate's effective configuration is inspected via {@link CredScopedFileSystem#getDelegate()}.
+ */
+class CredScopedFileSystemNamespaceTest {
+
+  private static final String TEST_CREDENTIAL_KEY = "fs.unitycatalog.test.credential";
+  private static final String ACCESS_KEY = "fs.cloud.access.key";
+  private static final String LOCATION_KEY = UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
+
+  @AfterEach
+  void clearCache() {
+    CredScopedFileSystem.clearCacheForTesting();
+  }
+
+  private static FileSystem initDelegate(URI uri, Configuration conf) throws Exception {
+    CredScopedFileSystem fs = new CredScopedFileSystem();
+    fs.initialize(uri, conf);
+    return fs.getDelegate();
+  }
+
+  private static Configuration tableConf() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, EMPTY_CRED_CONTEXT_ID);
+    conf.set(
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+        UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE);
+    conf.set(UCHadoopConfConstants.UC_TABLE_ID_KEY, "tid-1");
+    conf.set(UCHadoopConfConstants.UC_TABLE_OPERATION_KEY, "READ");
+    conf.set("fs.file.impl.disable.cache", "true");
+    return conf;
+  }
+
+  private static void setScopedKey(Configuration conf, int index, String key, String value) {
+    conf.set(UCHadoopConfConstants.UC_SCOPED_CRED_PREFIX + index + "." + key, value);
+  }
+
+  /** A snapshot of every entry in {@code conf}, for asserting the source config is not mutated. */
+  private static Map<String, String> snapshot(Configuration conf) {
+    Map<String, String> entries = new HashMap<>();
+    for (Map.Entry<String, String> entry : conf) {
+      entries.put(entry.getKey(), entry.getValue());
+    }
+    return entries;
+  }
+
+  // --- count == 0 (legacy top-level layout, no prefix matching)
+  // -----------------------------------------------------
+
+  @Test
+  void legacyLayoutNeitherLiftsNorOverridesWithNamespacedKeys() throws Exception {
+    Configuration conf = tableConf();
+    // Backwards compatibility test, scoped cred count not set.
+    conf.set(TEST_CREDENTIAL_KEY, "top-level-credential");
+    setScopedKey(conf, 0, LOCATION_KEY, "file:///tmp/table");
+    setScopedKey(conf, 0, TEST_CREDENTIAL_KEY, "namespaced-0");
+    setScopedKey(conf, 1, LOCATION_KEY, "file:///tmp/b");
+    setScopedKey(conf, 1, TEST_CREDENTIAL_KEY, "namespaced-1");
+    setScopedKey(conf, 2, LOCATION_KEY, "file:///tmp/c");
+    setScopedKey(conf, 2, TEST_CREDENTIAL_KEY, "namespaced-2");
+    Map<String, String> before = snapshot(conf);
+
+    FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
+
+    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("top-level-credential");
+    // The source configuration is not mutated by initialization.
+    assertThat(snapshot(conf)).isEqualTo(before);
+  }
+
+  // --- count > 1 requires selection and overlay
+  // ----------------------------------------------------------
+
+  /**
+   * Across credential sets of varying size, the one whose location is the longest prefix covering
+   * the URI is selected, and exactly that credential's keys are lifted to the top level (overriding
+   * any stale top-level placeholder), while the source configuration is left unchanged.
+   */
+  @ParameterizedTest(name = "creds={0} uri={1} selects index {2}")
+  @MethodSource("multiCredentialSelectionCases")
+  void multipleScopedCredentialsSelectAndOverlayCoveringCredential(
+      List<Map<String, String>> credentials, String uri, int expectedIndex) throws Exception {
+    Configuration conf = tableConf();
+    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, credentials.size());
+    for (int i = 0; i < credentials.size(); i++) {
+      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
+        setScopedKey(conf, i, key.getKey(), key.getValue());
+      }
+    }
+    Map<String, String> before = snapshot(conf);
+
+    FileSystem delegate = initDelegate(new URI(uri), conf);
+
+    // The selected credential's keys are lifted to the top level.
+    Configuration delegateConf = delegate.getConf();
+    credentials
+        .get(expectedIndex)
+        .forEach((key, value) -> assertThat(delegateConf.get(key)).isEqualTo(value));
+    // The source configuration is not mutated by the overlay.
+    assertThat(snapshot(conf)).isEqualTo(before);
+  }
+
+  private static Map<String, String> credential(int i, String location) {
+    Map<String, String> keys = new HashMap<>();
+    if (location != null) {
+      keys.put(LOCATION_KEY, location);
+    }
+    keys.put(TEST_CREDENTIAL_KEY, "cred-" + i);
+    keys.put(ACCESS_KEY, "ak-" + i);
+    return keys;
+  }
+
+  private static Stream<Arguments> multiCredentialSelectionCases() {
+    return Stream.of(
+        Arguments.of(
+            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/clone")),
+            "file:///tmp/table/clone/data",
+            1),
+        Arguments.of(
+            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/clone")),
+            "file:///tmp/table/other",
+            0),
+        Arguments.of(
+            List.of(
+                credential(0, "file:///tmp/a"),
+                credential(1, "file:///tmp/a/b"),
+                credential(2, "file:///tmp/c")),
+            "file:///tmp/a/b/data",
+            1));
+  }
+
+  // --- malformed configuration ------------------------------------------------------------------
+
+  /**
+   * Malformed namespaced configurations are rejected with a descriptive {@link
+   * IllegalArgumentException}.
+   */
+  @ParameterizedTest(name = "{3}")
+  @MethodSource("malformedConfigurationCases")
+  void malformedConfigurationIsRejected(
+      int count, List<Map<String, String>> credentials, String uri, String expectedMessage) {
+    Configuration conf = tableConf();
+    conf.setInt(UCHadoopConfConstants.UC_SCOPED_CRED_COUNT_KEY, count);
+    for (int i = 0; i < credentials.size(); i++) {
+      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
+        setScopedKey(conf, i, key.getKey(), key.getValue());
+      }
+    }
+
+    assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(expectedMessage);
+  }
+
+  private static Stream<Arguments> malformedConfigurationCases() {
+    List<Map<String, String>> twoCreds =
+        List.of(credential(0, "file:///tmp/a"), credential(1, "file:///tmp/b"));
+    return Stream.of(
+        // No encoded credential covers the accessed location.
+        Arguments.of(2, twoCreds, "file:///tmp/other/data", "file:///tmp/other/data"),
+        // A credential in the set is missing its prefix key.
+        Arguments.of(
+            2,
+            List.of(credential(0, "file:///tmp/a"), credential(1, null)),
+            "file:///tmp/a/data",
+            "missing its prefix"),
+        // Count claims more credentials than are encoded; index 2 is a phantom with no keys.
+        Arguments.of(
+            3, twoCreds, "file:///tmp/a/data", "Scoped credential 2 is missing its prefix"),
+        // Count of one: a single credential must use the legacy top-level layout, not a namespace.
+        Arguments.of(
+            1,
+            List.of(credential(0, "file:///tmp/table")),
+            "file:///tmp/table/data",
+            "must be greater than 1"),
+        // Negative count.
+        Arguments.of(
+            -1, List.<Map<String, String>>of(), "file:///tmp/table/data", "must be greater than 1"),
+        // Count above the hard ceiling.
+        Arguments.of(
+            Integer.MAX_VALUE,
+            List.<Map<String, String>>of(),
+            "file:///tmp/table/data",
+            "must be greater than 1"));
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -7,12 +7,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -24,8 +21,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /** Verifies prefix selection for multi-credential configurations. */
 class CredScopedFileSystemNamespaceTest {
-
-  private static final int MAX_COUNT = 10;
 
   @AfterEach
   void clearCache() {
@@ -67,12 +62,14 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   @Test
-  void missingOrEmptyMultiCredentialPrefixesUseSingleCredentialPath() throws Exception {
+  void missingOrSingleCredPrefixUsesSingleCredPath() throws Exception {
     Configuration missing = tableConf();
     Configuration empty = tableConf();
     empty.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, "");
+    Configuration single = tableConf();
+    setPrefixes(single, List.of("file:///tmp/other"));
 
-    for (Configuration conf : List.of(missing, empty)) {
+    for (Configuration conf : List.of(missing, empty, single)) {
       Map<String, String> before = snapshot(conf);
       FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 
@@ -120,33 +117,6 @@ class CredScopedFileSystemNamespaceTest {
             "file:///tmp/table,archive"));
   }
 
-  @Test
-  void defaultMaximumCredentialCountIsAccepted() throws Exception {
-    List<String> prefixes =
-        IntStream.range(0, MAX_COUNT)
-            .mapToObj(i -> "file:///tmp/credential-" + i)
-            .collect(Collectors.toList());
-    Configuration conf = tableConf();
-    setPrefixes(conf, prefixes);
-
-    FileSystem delegate =
-        initDelegate(new URI("file:///tmp/credential-" + (MAX_COUNT - 1) + "/data"), conf);
-
-    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
-        .isEqualTo("file:///tmp/credential-" + (MAX_COUNT - 1));
-  }
-
-  @Test
-  void maximumCredentialCountIsCheckedBeforeDecoding() {
-    Configuration conf = tableConf();
-    String[] invalidEncodedPrefixes =
-        Collections.nCopies(MAX_COUNT + 1, "not-base64!").toArray(String[]::new);
-    conf.setStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, invalidEncodedPrefixes);
-
-    assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential/data"), conf))
-        .hasMessageContaining("between 2 and " + MAX_COUNT);
-  }
-
   @ParameterizedTest
   @MethodSource("uncoveredLocationCases")
   void multiCredentialPrefixesRejectUncoveredLocation(List<String> prefixes, String uri) {
@@ -167,26 +137,13 @@ class CredScopedFileSystemNamespaceTest {
         Arguments.of(List.of("s3://bucket/a", "s3://bucket/b"), "gs://bucket/a/data"));
   }
 
-  @ParameterizedTest(name = "{2}")
-  @MethodSource("malformedPrefixLists")
-  void malformedPrefixListIsRejected(String encodedPrefixes, String uri, String expectedMessage) {
+  @Test
+  void malformedPrefixListIsRejected() {
     Configuration conf = tableConf();
-    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodedPrefixes);
+    String validPrefix = CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/valid"))[0];
+    conf.setStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, validPrefix, "not-base64!");
 
-    assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
-        .hasMessageContaining(expectedMessage);
-  }
-
-  private static Stream<Arguments> malformedPrefixLists() {
-    return Stream.of(
-        Arguments.of(
-            encodePrefixes(List.of("file:///tmp/table")),
-            "file:///tmp/table/data",
-            "Number of credentials must be between 2 and " + MAX_COUNT + ": got 1"),
-        Arguments.of("not-base64!,also-invalid!", "file:///tmp/credential/data", "Illegal base64"),
-        Arguments.of(
-            encodePrefixes(List.of("file:///tmp/credential-a", "file:///tmp/credential-b")) + ",",
-            "file:///tmp/credential-a/data",
-            "Credential prefixes cannot be empty"));
+    assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential/data"), conf))
+        .hasMessageContaining("Illegal base64");
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -54,7 +54,7 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static void setPrefixes(Configuration conf, List<String> prefixes) {
-    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodePrefixes(prefixes));
+    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, encodePrefixes(prefixes));
   }
 
   private static String encodePrefixes(List<String> prefixes) {
@@ -62,25 +62,35 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   @Test
-  void missingOrSingleCredPrefixUsesSingleCredPath() throws Exception {
+  void missingOrEmptyCredPrefixesDoesNotSetPrefix() throws Exception {
     Configuration missing = tableConf();
     Configuration empty = tableConf();
-    empty.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, "");
-
-    // Assert single cred path is taken as prefix matching would throw.
+    empty.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, "");
     Configuration onlySeparators = tableConf();
-    onlySeparators.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, ",,,");
+    onlySeparators.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, ",,,");
 
-    Configuration single = tableConf();
-    setPrefixes(single, List.of("file:///tmp/other"));
-
-    for (Configuration conf : List.of(missing, empty, onlySeparators, single)) {
+    for (Configuration conf : List.of(missing, empty, onlySeparators)) {
       Map<String, String> before = snapshot(conf);
       FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 
-      assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isNull();
+      assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isEmpty();
       assertThat(snapshot(conf)).isEqualTo(before);
     }
+  }
+
+  @Test
+  void singleCredPrefixUsesSingleCredPath() throws Exception {
+    Configuration conf = tableConf();
+    String prefix = "file:///tmp/other";
+    setPrefixes(conf, List.of(prefix));
+    Map<String, String> before = snapshot(conf);
+
+    // The prefix does not cover the URI, so multi-credential selection would throw.
+    FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
+
+    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
+        .isEqualTo(prefix);
+    assertThat(snapshot(conf)).isEqualTo(before);
   }
 
   @ParameterizedTest(name = "prefixes={0} uri={1} selects {2}")
@@ -146,7 +156,7 @@ class CredScopedFileSystemNamespaceTest {
   void malformedPrefixListIsRejected() {
     Configuration conf = tableConf();
     String validPrefix = CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/valid"))[0];
-    conf.setStrings(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, validPrefix, "not-base64!");
+    conf.setStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, validPrefix, "not-base64!");
 
     assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential/data"), conf))
         .hasMessageContaining("Illegal base64");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class CredScopedFileSystemNamespaceTest {
 
   private static final String TEST_CREDENTIAL_KEY = "fs.unitycatalog.test.credential";
+  private static final String UNSELECTED_ONLY_KEY = "fs.unitycatalog.test.unselected-only";
   private static final String ACCESS_KEY = "fs.cloud.access.key";
   private static final String LOCATION_KEY = UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
 
@@ -110,6 +112,8 @@ class CredScopedFileSystemNamespaceTest {
         setScopedKey(conf, i, key.getKey(), key.getValue());
       }
     }
+    int unselectedIndex = (expectedIndex + 1) % credentials.size();
+    setScopedKey(conf, unselectedIndex, UNSELECTED_ONLY_KEY, "must-not-be-copied");
     Map<String, String> before = snapshot(conf);
 
     FileSystem delegate = initDelegate(new URI(uri), conf);
@@ -119,18 +123,9 @@ class CredScopedFileSystemNamespaceTest {
     credentials
         .get(expectedIndex)
         .forEach((key, value) -> assertThat(delegateConf.get(key)).isEqualTo(value));
+    assertThat(delegateConf.get(UNSELECTED_ONLY_KEY)).isNull();
     // The source configuration is not mutated by the overlay.
     assertThat(snapshot(conf)).isEqualTo(before);
-  }
-
-  private static Map<String, String> credential(int i, String location) {
-    Map<String, String> keys = new HashMap<>();
-    if (location != null) {
-      keys.put(LOCATION_KEY, location);
-    }
-    keys.put(TEST_CREDENTIAL_KEY, "cred-" + i);
-    keys.put(ACCESS_KEY, "ak-" + i);
-    return keys;
   }
 
   private static Stream<Arguments> multiCredentialSelectionCases() {
@@ -150,6 +145,40 @@ class CredScopedFileSystemNamespaceTest {
                 credential(2, "file:///tmp/c")),
             "file:///tmp/a/b/data",
             1));
+  }
+
+  @Test
+  void defaultMaximumCredentialCountIsAccepted() throws Exception {
+    List<Map<String, String>> credentials = credentials(10);
+    Configuration conf = tableConf();
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, credentials.size());
+    for (int i = 0; i < credentials.size(); i++) {
+      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
+        setScopedKey(conf, i, key.getKey(), key.getValue());
+      }
+    }
+
+    FileSystem delegate = initDelegate(new URI("file:///tmp/credential-9/data"), conf);
+
+    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("cred-9");
+  }
+
+  private static Map<String, String> credential(int i, String location) {
+    Map<String, String> keys = new HashMap<>();
+    if (location != null) {
+      keys.put(LOCATION_KEY, location);
+    }
+    keys.put(TEST_CREDENTIAL_KEY, "cred-" + i);
+    keys.put(ACCESS_KEY, "ak-" + i);
+    return keys;
+  }
+
+  private static List<Map<String, String>> credentials(int count) {
+    List<Map<String, String>> credentials = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      credentials.add(credential(i, "file:///tmp/credential-" + i));
+    }
+    return credentials;
   }
 
   // --- malformed configuration ------------------------------------------------------------------

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -66,14 +66,12 @@ class CredScopedFileSystemNamespaceTest {
     Configuration missing = tableConf();
     Configuration empty = tableConf();
     empty.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, "");
-    Configuration onlySeparators = tableConf();
-    onlySeparators.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, ",,,");
 
-    for (Configuration conf : List.of(missing, empty, onlySeparators)) {
+    for (Configuration conf : List.of(missing, empty)) {
       Map<String, String> before = snapshot(conf);
       FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 
-      assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isEmpty();
+      assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isNull();
       assertThat(snapshot(conf)).isEqualTo(before);
     }
   }
@@ -144,6 +142,7 @@ class CredScopedFileSystemNamespaceTest {
 
   private static Stream<Arguments> uncoveredLocationCases() {
     return Stream.of(
+        Arguments.of(List.of("", "", "", ""), "file:///tmp/table/data"),
         Arguments.of(List.of("file:///tmp/a", "file:///tmp/b"), "file:///tmp/other/data"),
         Arguments.of(
             List.of("file:///tmp/table", "file:///tmp/table/child"),

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -58,7 +58,7 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static String encodePrefixes(List<String> prefixes) {
-    return String.join(",", CredentialUtil.encodeMultiCredPrefixes(prefixes));
+    return String.join(",", CredentialUtil.encodeCredPrefixes(prefixes));
   }
 
   @Test
@@ -155,7 +155,7 @@ class CredScopedFileSystemNamespaceTest {
   @Test
   void malformedPrefixListIsRejected() {
     Configuration conf = tableConf();
-    String validPrefix = CredentialUtil.encodeMultiCredPrefixes(List.of("file:///tmp/valid"))[0];
+    String validPrefix = CredentialUtil.encodeCredPrefixes(List.of("file:///tmp/valid"))[0];
     conf.setStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, validPrefix, "not-base64!");
 
     assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential/data"), conf))

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -145,6 +145,21 @@ class CredScopedFileSystemNamespaceTest {
         .hasMessageContaining("between 2 and " + MAX_COUNT);
   }
 
+  @Test
+  void trailingEmptyEncodedPrefixIsRejected() {
+    Configuration conf = tableConf();
+    String encodedPrefixes =
+        String.join(
+                ",",
+                CredentialUtil.encodeMultiCredPrefixes(
+                    List.of("file:///tmp/credential-a", "file:///tmp/credential-b")))
+            + ",";
+    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodedPrefixes);
+
+    assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential-a/data"), conf))
+        .hasMessageContaining("Credential prefixes cannot be empty");
+  }
+
   @ParameterizedTest(name = "{2}")
   @MethodSource("malformedPrefixLists")
   void malformedPrefixListIsRejected(List<String> prefixes, String uri, String expectedMessage) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -147,19 +147,24 @@ class CredScopedFileSystemNamespaceTest {
         .hasMessageContaining("between 2 and " + MAX_COUNT);
   }
 
-  @Test
-  void trailingEmptyEncodedPrefixIsRejected() {
+  @ParameterizedTest
+  @MethodSource("uncoveredLocationCases")
+  void multiCredentialPrefixesRejectUncoveredLocation(List<String> prefixes, String uri) {
     Configuration conf = tableConf();
-    String encodedPrefixes =
-        String.join(
-                ",",
-                CredentialUtil.encodeMultiCredPrefixes(
-                    List.of("file:///tmp/credential-a", "file:///tmp/credential-b")))
-            + ",";
-    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodedPrefixes);
+    setPrefixes(conf, prefixes);
 
-    assertThatThrownBy(() -> initDelegate(new URI("file:///tmp/credential-a/data"), conf))
-        .hasMessageContaining("Credential prefixes cannot be empty");
+    assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
+        .hasMessageContaining("No credential covers storage location");
+  }
+
+  private static Stream<Arguments> uncoveredLocationCases() {
+    return Stream.of(
+        Arguments.of(List.of("file:///tmp/a", "file:///tmp/b"), "file:///tmp/other/data"),
+        Arguments.of(
+            List.of("file:///tmp/table", "file:///tmp/table/child"),
+            "file:///tmp/table-other/data"),
+        Arguments.of(List.of("s3://bucket/a", "s3://bucket/b"), "s3a://bucket/a/data"),
+        Arguments.of(List.of("s3://bucket/a", "s3://bucket/b"), "gs://bucket/a/data"));
   }
 
   @ParameterizedTest(name = "{2}")
@@ -175,13 +180,13 @@ class CredScopedFileSystemNamespaceTest {
   private static Stream<Arguments> malformedPrefixLists() {
     return Stream.of(
         Arguments.of(
-            encodePrefixes(List.of("file:///tmp/a", "file:///tmp/b")),
-            "file:///tmp/other/data",
-            "No credential covers storage location"),
-        Arguments.of(
             encodePrefixes(List.of("file:///tmp/table")),
             "file:///tmp/table/data",
             "Number of credentials must be between 2 and " + MAX_COUNT + ": got 1"),
-        Arguments.of("not-base64!,also-invalid!", "file:///tmp/credential/data", "Illegal base64"));
+        Arguments.of("not-base64!,also-invalid!", "file:///tmp/credential/data", "Illegal base64"),
+        Arguments.of(
+            encodePrefixes(List.of("file:///tmp/credential-a", "file:///tmp/credential-b")) + ",",
+            "file:///tmp/credential-a/data",
+            "Credential prefixes cannot be empty"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class CredScopedFileSystemNamespaceTest {
 
+  private static final int MAX_COUNT = 10;
   private static final String TEST_CREDENTIAL_KEY = "fs.unitycatalog.test.credential";
   private static final String UNSELECTED_ONLY_KEY = "fs.unitycatalog.test.unselected-only";
   private static final String ACCESS_KEY = "fs.cloud.access.key";
@@ -131,11 +132,11 @@ class CredScopedFileSystemNamespaceTest {
   private static Stream<Arguments> multiCredentialSelectionCases() {
     return Stream.of(
         Arguments.of(
-            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/clone")),
-            "file:///tmp/table/clone/data",
+            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/child")),
+            "file:///tmp/table/child/data",
             1),
         Arguments.of(
-            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/clone")),
+            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/child")),
             "file:///tmp/table/other",
             0),
         Arguments.of(
@@ -149,7 +150,7 @@ class CredScopedFileSystemNamespaceTest {
 
   @Test
   void defaultMaximumCredentialCountIsAccepted() throws Exception {
-    List<Map<String, String>> credentials = credentials(10);
+    List<Map<String, String>> credentials = credentials(MAX_COUNT);
     Configuration conf = tableConf();
     conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, credentials.size());
     for (int i = 0; i < credentials.size(); i++) {
@@ -158,9 +159,27 @@ class CredScopedFileSystemNamespaceTest {
       }
     }
 
-    FileSystem delegate = initDelegate(new URI("file:///tmp/credential-9/data"), conf);
+    FileSystem delegate =
+        initDelegate(new URI("file:///tmp/credential-" + (MAX_COUNT - 1) + "/data"), conf);
 
-    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("cred-9");
+    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("cred-" + (MAX_COUNT - 1));
+  }
+
+  @Test
+  void credentialsBeyondDeclaredCountAreIgnored() {
+    List<Map<String, String>> credentials = credentials(MAX_COUNT + 1);
+    Configuration conf = tableConf();
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, MAX_COUNT);
+    for (int i = 0; i < credentials.size(); i++) {
+      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
+        setScopedKey(conf, i, key.getKey(), key.getValue());
+      }
+    }
+    // The covering credential is past the declared count.
+    assertThatThrownBy(
+            () -> initDelegate(new URI("file:///tmp/credential-" + MAX_COUNT + "/data"), conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No credential covers storage location");
   }
 
   private static Map<String, String> credential(int i, String location) {
@@ -233,6 +252,6 @@ class CredScopedFileSystemNamespaceTest {
             Integer.MAX_VALUE,
             List.<Map<String, String>>of(),
             "file:///tmp/table/data",
-            "at most 10"));
+            "at most " + MAX_COUNT));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -7,10 +7,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -20,21 +21,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Verifies the namespaced-credential mechanism of {@link CredScopedFileSystem}: reading the count,
- * selecting the credential whose location covers the accessed URI, and overlaying that credential's
- * keys (and only that credential's keys) onto the delegate filesystem's configuration.
- *
- * <p>Uses {@code file://} URIs with the local filesystem so no cloud SDK is required. The
- * delegate's effective configuration is inspected via {@link CredScopedFileSystem#getDelegate()}.
- */
+/** Verifies prefix selection for multi-credential configurations. */
 class CredScopedFileSystemNamespaceTest {
 
   private static final int MAX_COUNT = 10;
-  private static final String TEST_CREDENTIAL_KEY = "fs.unitycatalog.test.credential";
-  private static final String UNSELECTED_ONLY_KEY = "fs.unitycatalog.test.unselected-only";
-  private static final String ACCESS_KEY = "fs.cloud.access.key";
-  private static final String LOCATION_KEY = UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY;
 
   @AfterEach
   void clearCache() {
@@ -59,11 +49,6 @@ class CredScopedFileSystemNamespaceTest {
     return conf;
   }
 
-  private static void setScopedKey(Configuration conf, int index, String key, String value) {
-    conf.set(CredentialUtil.hadoopConfNamespaceForIndex(index) + key, value);
-  }
-
-  /** A snapshot of every entry in {@code conf}, for asserting the source config is not mutated. */
   private static Map<String, String> snapshot(Configuration conf) {
     Map<String, String> entries = new HashMap<>();
     for (Map.Entry<String, String> entry : conf) {
@@ -72,150 +57,85 @@ class CredScopedFileSystemNamespaceTest {
     return entries;
   }
 
-  // --- count == 0 (single-credential top-level layout, no prefix matching)
-  // -----------------------------------------------------
+  private static void setPrefixes(Configuration conf, List<String> prefixes) {
+    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, prefixes.size());
+    for (int i = 0; i < prefixes.size(); i++) {
+      conf.set(CredentialUtil.multiCredPrefixKeyForIndex(i), prefixes.get(i));
+    }
+  }
 
   @Test
-  void singleCredentialLayoutNeitherLiftsNorOverridesWithNamespacedKeys() throws Exception {
+  void withoutMultiCredentialCountIndexedPrefixesAreIgnored() throws Exception {
     Configuration conf = tableConf();
-    conf.set(TEST_CREDENTIAL_KEY, "top-level-credential");
-    setScopedKey(conf, 0, LOCATION_KEY, "file:///tmp/table");
-    setScopedKey(conf, 0, TEST_CREDENTIAL_KEY, "namespaced-0");
-    setScopedKey(conf, 1, LOCATION_KEY, "file:///tmp/b");
-    setScopedKey(conf, 1, TEST_CREDENTIAL_KEY, "namespaced-1");
-    setScopedKey(conf, 2, LOCATION_KEY, "file:///tmp/c");
-    setScopedKey(conf, 2, TEST_CREDENTIAL_KEY, "namespaced-2");
+    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(0), "file:///tmp/table");
+    conf.set(CredentialUtil.multiCredPrefixKeyForIndex(1), "file:///tmp/table/child");
     Map<String, String> before = snapshot(conf);
 
     FileSystem delegate = initDelegate(new URI("file:///tmp/table/data"), conf);
 
-    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("top-level-credential");
-    // The source configuration is not mutated by initialization.
+    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)).isNull();
     assertThat(snapshot(conf)).isEqualTo(before);
   }
 
-  // --- count > 1 requires selection and overlay
-  // ----------------------------------------------------------
-
-  /**
-   * Across credential sets of varying size, the one whose location is the longest prefix covering
-   * the URI is selected, and exactly that credential's keys are lifted to the top level (overriding
-   * any stale top-level placeholder), while the source configuration is left unchanged.
-   */
-  @ParameterizedTest(name = "creds={0} uri={1} selects index {2}")
+  @ParameterizedTest(name = "prefixes={0} uri={1} selects {2}")
   @MethodSource("multiCredentialSelectionCases")
-  void multipleNamespacedCredentialsSelectAndOverlayCoveringCredential(
-      List<Map<String, String>> credentials, String uri, int expectedIndex) throws Exception {
+  void multiCredentialPrefixListSelectsLongestCoveringPrefix(
+      List<String> prefixes, String uri, String expectedPrefix) throws Exception {
     Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, credentials.size());
-    for (int i = 0; i < credentials.size(); i++) {
-      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
-        setScopedKey(conf, i, key.getKey(), key.getValue());
-      }
-    }
-    int unselectedIndex = (expectedIndex + 1) % credentials.size();
-    setScopedKey(conf, unselectedIndex, UNSELECTED_ONLY_KEY, "must-not-be-copied");
+    setPrefixes(conf, prefixes);
     Map<String, String> before = snapshot(conf);
 
     FileSystem delegate = initDelegate(new URI(uri), conf);
 
-    // The selected credential's keys are lifted to the top level.
-    Configuration delegateConf = delegate.getConf();
-    credentials
-        .get(expectedIndex)
-        .forEach((key, value) -> assertThat(delegateConf.get(key)).isEqualTo(value));
-    assertThat(delegateConf.get(UNSELECTED_ONLY_KEY)).isNull();
-    // The source configuration is not mutated by the overlay.
+    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
+        .isEqualTo(expectedPrefix);
     assertThat(snapshot(conf)).isEqualTo(before);
   }
 
   private static Stream<Arguments> multiCredentialSelectionCases() {
     return Stream.of(
         Arguments.of(
-            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/child")),
+            List.of("file:///tmp/table", "file:///tmp/table/child"),
             "file:///tmp/table/child/data",
-            1),
+            "file:///tmp/table/child"),
         Arguments.of(
-            List.of(credential(0, "file:///tmp/table"), credential(1, "file:///tmp/table/child")),
+            List.of("file:///tmp/table", "file:///tmp/table/child"),
             "file:///tmp/table/other",
-            0),
+            "file:///tmp/table"),
         Arguments.of(
-            List.of(
-                credential(0, "file:///tmp/a"),
-                credential(1, "file:///tmp/a/b"),
-                credential(2, "file:///tmp/c")),
+            List.of("file:///tmp/a", "file:///tmp/a/b", "file:///tmp/c"),
             "file:///tmp/a/b/data",
-            1));
+            "file:///tmp/a/b"),
+        Arguments.of(
+            List.of("file:///tmp/table", "file:///tmp/table,archive"),
+            "file:///tmp/table,archive/data",
+            "file:///tmp/table,archive"));
   }
 
   @Test
   void defaultMaximumCredentialCountIsAccepted() throws Exception {
-    List<Map<String, String>> credentials = credentials(MAX_COUNT);
+    List<String> prefixes =
+        IntStream.range(0, MAX_COUNT)
+            .mapToObj(i -> "file:///tmp/credential-" + i)
+            .collect(Collectors.toList());
     Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, credentials.size());
-    for (int i = 0; i < credentials.size(); i++) {
-      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
-        setScopedKey(conf, i, key.getKey(), key.getValue());
-      }
-    }
+    setPrefixes(conf, prefixes);
 
     FileSystem delegate =
         initDelegate(new URI("file:///tmp/credential-" + (MAX_COUNT - 1) + "/data"), conf);
 
-    assertThat(delegate.getConf().get(TEST_CREDENTIAL_KEY)).isEqualTo("cred-" + (MAX_COUNT - 1));
+    assertThat(delegate.getConf().get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
+        .isEqualTo("file:///tmp/credential-" + (MAX_COUNT - 1));
   }
 
-  @Test
-  void credentialsBeyondDeclaredCountAreIgnored() {
-    List<Map<String, String>> credentials = credentials(MAX_COUNT + 1);
-    Configuration conf = tableConf();
-    conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, MAX_COUNT);
-    for (int i = 0; i < credentials.size(); i++) {
-      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
-        setScopedKey(conf, i, key.getKey(), key.getValue());
-      }
-    }
-    // The covering credential is past the declared count.
-    assertThatThrownBy(
-            () -> initDelegate(new URI("file:///tmp/credential-" + MAX_COUNT + "/data"), conf))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("No credential covers storage location");
-  }
-
-  private static Map<String, String> credential(int i, String location) {
-    Map<String, String> keys = new HashMap<>();
-    if (location != null) {
-      keys.put(LOCATION_KEY, location);
-    }
-    keys.put(TEST_CREDENTIAL_KEY, "cred-" + i);
-    keys.put(ACCESS_KEY, "ak-" + i);
-    return keys;
-  }
-
-  private static List<Map<String, String>> credentials(int count) {
-    List<Map<String, String>> credentials = new ArrayList<>(count);
-    for (int i = 0; i < count; i++) {
-      credentials.add(credential(i, "file:///tmp/credential-" + i));
-    }
-    return credentials;
-  }
-
-  // --- malformed configuration ------------------------------------------------------------------
-
-  /**
-   * Malformed namespaced configurations are rejected with a descriptive {@link
-   * IllegalArgumentException}.
-   */
   @ParameterizedTest(name = "{3}")
-  @MethodSource("malformedConfigurationCases")
-  void malformedConfigurationIsRejected(
-      int count, List<Map<String, String>> credentials, String uri, String expectedMessage) {
+  @MethodSource("malformedPrefixLists")
+  void malformedPrefixListIsRejected(
+      int count, List<String> prefixes, String uri, String expectedMessage) {
     Configuration conf = tableConf();
     conf.setInt(UCHadoopConfConstants.UC_MULTI_CRED_COUNT_KEY, count);
-    for (int i = 0; i < credentials.size(); i++) {
-      for (Map.Entry<String, String> key : credentials.get(i).entrySet()) {
-        setScopedKey(conf, i, key.getKey(), key.getValue());
-      }
+    for (int i = 0; i < prefixes.size(); i++) {
+      conf.set(CredentialUtil.multiCredPrefixKeyForIndex(i), prefixes.get(i));
     }
 
     assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
@@ -223,35 +143,29 @@ class CredScopedFileSystemNamespaceTest {
         .hasMessageContaining(expectedMessage);
   }
 
-  private static Stream<Arguments> malformedConfigurationCases() {
-    List<Map<String, String>> twoCreds =
-        List.of(credential(0, "file:///tmp/a"), credential(1, "file:///tmp/b"));
+  private static Stream<Arguments> malformedPrefixLists() {
     return Stream.of(
-        // No encoded credential covers the accessed location.
-        Arguments.of(2, twoCreds, "file:///tmp/other/data", "file:///tmp/other/data"),
-        // A credential in the set is missing its prefix key.
         Arguments.of(
             2,
-            List.of(credential(0, "file:///tmp/a"), credential(1, null)),
+            List.of("file:///tmp/a", "file:///tmp/b"),
+            "file:///tmp/other/data",
+            "No credential covers storage location"),
+        Arguments.of(
+            2,
+            List.of("file:///tmp/a", ""),
             "file:///tmp/a/data",
-            "missing its prefix"),
-        // Count claims more credentials than are encoded; index 2 is a phantom with no keys.
+            "Credential prefixes cannot be null or empty: index 1"),
         Arguments.of(
-            3, twoCreds, "file:///tmp/a/data", "Namespaced credential 2 is missing its prefix"),
-        // Count of one: a single credential must use the top-level layout, not a namespace.
-        Arguments.of(
-            1,
-            List.of(credential(0, "file:///tmp/table")),
+            2,
+            List.of("file:///tmp/table"),
             "file:///tmp/table/data",
-            "must be greater than 1"),
-        // Negative count.
+            "Credential prefixes cannot be null or empty: index 1"),
         Arguments.of(
-            -1, List.<Map<String, String>>of(), "file:///tmp/table/data", "must be greater than 1"),
-        // Count above the hard ceiling.
-        Arguments.of(
-            Integer.MAX_VALUE,
-            List.<Map<String, String>>of(),
-            "file:///tmp/table/data",
+            MAX_COUNT + 1,
+            IntStream.rangeClosed(0, MAX_COUNT)
+                .mapToObj(i -> "file:///tmp/credential-" + i)
+                .collect(Collectors.toList()),
+            "file:///tmp/credential-0/data",
             "at most " + MAX_COUNT));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredScopedFileSystemNamespaceTest.java
@@ -59,9 +59,11 @@ class CredScopedFileSystemNamespaceTest {
   }
 
   private static void setPrefixes(Configuration conf, List<String> prefixes) {
-    conf.setStrings(
-        UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY,
-        CredentialUtil.encodeMultiCredPrefixes(prefixes));
+    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodePrefixes(prefixes));
+  }
+
+  private static String encodePrefixes(List<String> prefixes) {
+    return String.join(",", CredentialUtil.encodeMultiCredPrefixes(prefixes));
   }
 
   @Test
@@ -106,7 +108,7 @@ class CredScopedFileSystemNamespaceTest {
             "file:///tmp/table"),
         Arguments.of(
             List.of("file:///tmp/a", "file:///tmp/a/b", "file:///tmp/c"),
-            "file:///tmp/a/b/data",
+            "file:///tmp/a/b",
             "file:///tmp/a/b"),
         Arguments.of(
             List.of("file:///tmp/a", "file:///tmp/a/b", "file:///tmp/c"),
@@ -162,9 +164,9 @@ class CredScopedFileSystemNamespaceTest {
 
   @ParameterizedTest(name = "{2}")
   @MethodSource("malformedPrefixLists")
-  void malformedPrefixListIsRejected(List<String> prefixes, String uri, String expectedMessage) {
+  void malformedPrefixListIsRejected(String encodedPrefixes, String uri, String expectedMessage) {
     Configuration conf = tableConf();
-    setPrefixes(conf, prefixes);
+    conf.set(UCHadoopConfConstants.UC_MULTI_CRED_PREFIXES_KEY, encodedPrefixes);
 
     assertThatThrownBy(() -> initDelegate(new URI(uri), conf))
         .hasMessageContaining(expectedMessage);
@@ -173,12 +175,13 @@ class CredScopedFileSystemNamespaceTest {
   private static Stream<Arguments> malformedPrefixLists() {
     return Stream.of(
         Arguments.of(
-            List.of("file:///tmp/a", "file:///tmp/b"),
+            encodePrefixes(List.of("file:///tmp/a", "file:///tmp/b")),
             "file:///tmp/other/data",
             "No credential covers storage location"),
         Arguments.of(
-            List.of("file:///tmp/table"),
+            encodePrefixes(List.of("file:///tmp/table")),
             "file:///tmp/table/data",
-            "Number of credentials must be between 2 and " + MAX_COUNT + ": got 1"));
+            "Number of credentials must be between 2 and " + MAX_COUNT + ": got 1"),
+        Arguments.of("not-base64!,also-invalid!", "file:///tmp/credential/data", "Illegal base64"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
@@ -20,16 +20,16 @@ class FileSystemCredIdTest {
     if (prefix != null) {
       conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
     }
-    return FileSystemCredId.create(conf, TEST_URI);
+    return FileSystemCredId.create(conf, TEST_URI, null);
   }
 
   @Test
   void uriFallbackKeysBySchemeAndAuthority() {
     Configuration conf = new Configuration(false);
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a")))
-        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b")))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a")));
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a"), null))
+        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b"), null))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a"), null));
   }
 
   @Test
@@ -37,11 +37,12 @@ class FileSystemCredIdTest {
     Configuration conf = new Configuration(false);
 
     // The prefix is null when it is not configured.
-    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isNull();
+    assertThat(FileSystemCredId.create(conf, TEST_URI, null).prefix()).isNull();
 
     conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/prefix");
 
-    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isEqualTo("s3://bucket/prefix");
+    assertThat(FileSystemCredId.create(conf, TEST_URI, null).prefix())
+        .isEqualTo("s3://bucket/prefix");
   }
 
   @Test
@@ -57,8 +58,8 @@ class FileSystemCredIdTest {
     Configuration conf = new Configuration(false);
     conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/shared");
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path")))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path")));
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path"), null))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path"), null));
   }
 
   @ParameterizedTest

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
@@ -54,6 +54,16 @@ class FileSystemCredIdTest {
   }
 
   @Test
+  void createWithProvidedPrefixFallsBackToUriIdentity() {
+    Configuration conf = new Configuration(false);
+    String prefix = "s3://bucket/selected";
+
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a"), prefix))
+        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b"), prefix))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a"), prefix));
+  }
+
+  @Test
   void equivalentPrefixesAreEqualAndHaveSameHashCode() {
     FileSystemCredId idA = createId("s3://bucket/a");
     FileSystemCredId idB = createId("s3://bucket/a");

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
@@ -2,6 +2,7 @@ package io.unitycatalog.hadoop.internal.id;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.stream.Stream;
@@ -43,6 +44,20 @@ class FileSystemCredIdTest {
 
     assertThat(FileSystemCredId.create(conf, TEST_URI, null).prefix())
         .isEqualTo("s3://bucket/prefix");
+  }
+
+  @Test
+  void createReadsPrefixFromNamespace() {
+    Configuration conf = new Configuration(false);
+    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/top-level");
+    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(1);
+
+    assertThat(FileSystemCredId.create(conf, TEST_URI, namespace).prefix()).isNull();
+
+    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/namespaced");
+
+    assertThat(FileSystemCredId.create(conf, TEST_URI, namespace).prefix())
+        .isEqualTo("s3://bucket/namespaced");
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
@@ -2,7 +2,6 @@ package io.unitycatalog.hadoop.internal.id;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import java.net.URI;
 import java.util.stream.Stream;
@@ -21,16 +20,16 @@ class FileSystemCredIdTest {
     if (prefix != null) {
       conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
     }
-    return FileSystemCredId.create(conf, TEST_URI, null);
+    return FileSystemCredId.create(conf, TEST_URI);
   }
 
   @Test
   void uriFallbackKeysBySchemeAndAuthority() {
     Configuration conf = new Configuration(false);
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a"), null))
-        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b"), null))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a"), null));
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a")))
+        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b")))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a")));
   }
 
   @Test
@@ -38,26 +37,20 @@ class FileSystemCredIdTest {
     Configuration conf = new Configuration(false);
 
     // The prefix is null when it is not configured.
-    assertThat(FileSystemCredId.create(conf, TEST_URI, null).prefix()).isNull();
+    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isNull();
 
     conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/prefix");
 
-    assertThat(FileSystemCredId.create(conf, TEST_URI, null).prefix())
-        .isEqualTo("s3://bucket/prefix");
+    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isEqualTo("s3://bucket/prefix");
   }
 
   @Test
-  void createReadsPrefixFromNamespace() {
+  void createUsesProvidedPrefix() {
     Configuration conf = new Configuration(false);
     conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/top-level");
-    String namespace = CredentialUtil.hadoopConfNamespaceForIndex(1);
 
-    assertThat(FileSystemCredId.create(conf, TEST_URI, namespace).prefix()).isNull();
-
-    conf.set(namespace + UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/namespaced");
-
-    assertThat(FileSystemCredId.create(conf, TEST_URI, namespace).prefix())
-        .isEqualTo("s3://bucket/namespaced");
+    assertThat(FileSystemCredId.create(conf, TEST_URI, "s3://bucket/selected").prefix())
+        .isEqualTo("s3://bucket/selected");
   }
 
   @Test
@@ -73,8 +66,8 @@ class FileSystemCredIdTest {
     Configuration conf = new Configuration(false);
     conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/shared");
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path"), null))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path"), null));
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path")))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path")));
   }
 
   @ParameterizedTest

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/FileSystemCredIdTest.java
@@ -17,31 +17,16 @@ class FileSystemCredIdTest {
 
   private static FileSystemCredId createId(String prefix) {
     Configuration conf = new Configuration(false);
-    if (prefix != null) {
-      conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
-    }
-    return FileSystemCredId.create(conf, TEST_URI);
+    return FileSystemCredId.create(conf, TEST_URI, prefix);
   }
 
   @Test
   void uriFallbackKeysBySchemeAndAuthority() {
     Configuration conf = new Configuration(false);
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a")))
-        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b")))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a")));
-  }
-
-  @Test
-  void createReadsPrefixFromConfiguration() {
-    Configuration conf = new Configuration(false);
-
-    // The prefix is null when it is not configured.
-    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isNull();
-
-    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/prefix");
-
-    assertThat(FileSystemCredId.create(conf, TEST_URI).prefix()).isEqualTo("s3://bucket/prefix");
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket/a"), null))
+        .isEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket/b"), null))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://other/a"), null));
   }
 
   @Test
@@ -72,12 +57,12 @@ class FileSystemCredIdTest {
   }
 
   @Test
-  void samePrefixWithDifferentCredentialIdsIsDifferent() {
+  void samePrefixWithDifferentUriFallbackCredIdsIsDifferent() {
     Configuration conf = new Configuration(false);
-    conf.set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, "s3://bucket/shared");
+    String prefix = "s3://bucket/shared";
 
-    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path")))
-        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path")));
+    assertThat(FileSystemCredId.create(conf, URI.create("s3://bucket-a/path"), prefix))
+        .isNotEqualTo(FileSystemCredId.create(conf, URI.create("s3://bucket-b/path"), prefix));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1704/files) to review incremental changes.
- [**stack/scoped-credential-namespaces**](https://github.com/unitycatalog/unitycatalog/pull/1704) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1704/files)] ← _this PR_
  - [stack/encode-scoped-vended-credentials](https://github.com/unitycatalog/unitycatalog/pull/1705) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1705/files/fbc9dc5a47c525d311d5e11a8f62b629494f913e..9733d97a6a10df04b74cadffce1415c6fa0957d2)]

---------
## Summary

- Add indexed Hadoop configuration namespaces for scoped credentials.
- Select the namespace whose location is the longest covering prefix for the requested URI, then overlay only that credential onto the delegate filesystem configuration.
- Preserve legacy and single-credential behavior while isolating delegate filesystem cache entries by the selected credential location.
- Validate namespace counts and reject incomplete or non-covering multi-credential configurations.

## Testing

- Added unit coverage for longest-prefix selection, legacy and single-credential layouts, multi-credential overlays, malformed configurations, source configuration immutability, and cache isolation.

## Issue

https://github.com/unitycatalog/unitycatalog/issues/1694