### PR TITLE
[Hadoop] Encode credentials for multi-location table support

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -5,7 +5,6 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.internal.Clock;
-import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
@@ -195,19 +194,15 @@ public class CredPropsUtil {
     List<GenericCredential> credentials =
         fetchGenericCredentials(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
-    // TODO: Support encoding multiple vended credentials in CredPropsBuilder.
-    Preconditions.checkState(
-        credentials.size() == 1,
-        "Only single credential responses are supported, got %s",
-        credentials.size());
-    GenericCredential cred = credentials.get(0);
     CredPropsBuilder builder =
         CredPropsBuilder.forCloud(cloudType.get(), hadoopConf)
             .credScopedFsEnabled(credScopedFsEnabled)
-            .initialCredential(cred);
+            .initialCredentials(credentials);
+
     if (renewCredEnabled) {
       builder.enableRenewCred(catalogUri, tokenProvider, credId, appVersions);
     }
+
     return builder.build();
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/AbfsCredPropsBuilder.java
@@ -44,7 +44,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setRenewableCredKeys(GenericCredential cred) {
+  protected void setInitRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AzureCredential,
         "Expected AzureCredential, but got %s",
@@ -60,7 +60,7 @@ final class AbfsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFixedCredKeys(GenericCredential cred) {
+  protected void setInitFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AzureCredential,
         "Expected AzureCredential, but got %s",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -116,7 +116,7 @@ public abstract class CredPropsBuilder {
       }
     } else {
       // Do not set initial credentials when there are multiple credentials to minimize the
-      // number of key that need to be encoded. Instead, token providers fetch credentials
+      // number of keys that need to be encoded. Instead, token providers fetch credentials
       // at file system initialization time.
       Preconditions.checkState(
           credScopedFsEnabled,

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -110,9 +110,9 @@ public abstract class CredPropsBuilder {
     if (initialCredentials.size() == 1) {
       GenericCredential credential = initialCredentials.get(0);
       if (renewCredEnabled) {
-        setRenewableCredKeys(credential);
+        setInitRenewableCredKeys(credential);
       } else {
-        setFixedCredKeys(credential);
+        setInitFixedCredKeys(credential);
       }
     } else {
       // Do not set initial credentials when there are multiple credentials to minimize the
@@ -166,8 +166,8 @@ public abstract class CredPropsBuilder {
   protected abstract void setVendedProviderKeys();
 
   /** Writes the renewable-path credential secrets (the {@code init.*} keys) for this cloud. */
-  protected abstract void setRenewableCredKeys(GenericCredential cred);
+  protected abstract void setInitRenewableCredKeys(GenericCredential cred);
 
   /** Writes the fixed-path credential secrets for this cloud. */
-  protected abstract void setFixedCredKeys(GenericCredential cred);
+  protected abstract void setInitFixedCredKeys(GenericCredential cred);
 }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -3,6 +3,7 @@ package io.unitycatalog.hadoop.internal.props;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.internal.CloudType;
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.fs.CredScopedFileSystem;
@@ -10,7 +11,9 @@ import io.unitycatalog.hadoop.internal.fs.CredScopedFs;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 
 /** Builds the cloud-provider specific Hadoop configuration credential properties. */
@@ -29,7 +32,7 @@ public abstract class CredPropsBuilder {
   private TokenProvider tokenProvider;
   private CredId credId;
   private Map<String, String> appVersions;
-  private GenericCredential initialCredential;
+  private List<GenericCredential> initialCredentials;
 
   protected CredPropsBuilder(Configuration hadoopConf) {
     Preconditions.checkNotNull(hadoopConf, "hadoopConf is required");
@@ -73,19 +76,19 @@ public abstract class CredPropsBuilder {
     return this;
   }
 
-  /** Records the fetched credential whose secrets are written by {@link #build()}. */
-  public CredPropsBuilder initialCredential(GenericCredential initialCredential) {
-    this.initialCredential = initialCredential;
+  /** Records the fetched credentials used by {@link #build()}. */
+  public CredPropsBuilder initialCredentials(List<GenericCredential> initialCredentials) {
+    this.initialCredentials = initialCredentials;
     return this;
   }
 
   public Map<String, String> build() {
-    Preconditions.checkNotNull(initialCredential, "initialCredential is required");
+    Preconditions.checkState(
+        initialCredentials != null && !initialCredentials.isEmpty(),
+        "Initial credentials cannot be null or empty");
+
     if (credScopedFsEnabled) {
       setCredScopedFsKeys();
-    }
-    if (initialCredential.prefix() != null) {
-      set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, initialCredential.prefix());
     }
     if (renewCredEnabled) {
       setVendedProviderKeys();
@@ -97,10 +100,45 @@ public abstract class CredPropsBuilder {
       credId.props().forEach(this::set);
       appVersions.forEach(
           (key, value) -> set(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + key, value));
-      setRenewableCredKeys(initialCredential);
-    } else {
-      setFixedCredKeys(initialCredential);
     }
+    List<String> credPrefixes =
+        initialCredentials.stream()
+            .map(GenericCredential::prefix)
+            .filter(prefix -> prefix != null && !prefix.isEmpty())
+            .collect(Collectors.toList());
+
+    if (initialCredentials.size() == 1) {
+      GenericCredential credential = initialCredentials.get(0);
+      if (renewCredEnabled) {
+        setRenewableCredKeys(credential);
+      } else {
+        setFixedCredKeys(credential);
+      }
+    } else {
+      // Do not set initial credentials when there are multiple credentials to minimize the
+      // number of key that need to be encoded. Instead, token providers fetch credentials
+      // at file system initialization time.
+      Preconditions.checkState(
+          credScopedFsEnabled,
+          "%s credentials were vended but the credential-scoped filesystem is disabled.",
+          initialCredentials.size());
+      Preconditions.checkState(
+          renewCredEnabled,
+          "%s credentials were vended but credential renewal is disabled.",
+          initialCredentials.size());
+      // Since there are multiple credentials, each credential's prefix must be non-null
+      // and non-empty to differentiate between credentials.
+      Preconditions.checkArgument(
+          credPrefixes.size() == initialCredentials.size(),
+          "Credential prefixes cannot be null or empty when multiple credentials are vended");
+    }
+
+    if (!credPrefixes.isEmpty()) {
+      String commaSeparatedPrefixes =
+          String.join(",", CredentialUtil.encodeCredPrefixes(credPrefixes));
+      set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, commaSeparatedPrefixes);
+    }
+
     return Collections.unmodifiableMap(new HashMap<>(props));
   }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/CredPropsBuilder.java
@@ -83,13 +83,12 @@ public abstract class CredPropsBuilder {
   }
 
   public Map<String, String> build() {
-    Preconditions.checkState(
-        initialCredentials != null && !initialCredentials.isEmpty(),
-        "Initial credentials cannot be null or empty");
-
+    // Set the props when credential scoped filesystem enabled.
     if (credScopedFsEnabled) {
       setCredScopedFsKeys();
     }
+
+    // Set the props when renewal credential enabled.
     if (renewCredEnabled) {
       setVendedProviderKeys();
       set(UCHadoopConfConstants.UC_URI_KEY, catalogUri);
@@ -101,42 +100,32 @@ public abstract class CredPropsBuilder {
       appVersions.forEach(
           (key, value) -> set(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + key, value));
     }
-    List<String> credPrefixes =
-        initialCredentials.stream()
-            .map(GenericCredential::prefix)
-            .filter(prefix -> prefix != null && !prefix.isEmpty())
-            .collect(Collectors.toList());
 
+    // Set the props for initial credentials.
+    Preconditions.checkState(
+        initialCredentials != null && !initialCredentials.isEmpty(),
+        "Initial credentials cannot be null or empty");
     if (initialCredentials.size() == 1) {
+      // Seed the initial credential only in the common single-credential case. In the uncommon
+      // multiple-credential case, skip this optimization to keep the code and configuration simple.
       GenericCredential credential = initialCredentials.get(0);
       if (renewCredEnabled) {
         setInitRenewableCredKeys(credential);
       } else {
         setInitFixedCredKeys(credential);
       }
-    } else {
-      // Do not set initial credentials when there are multiple credentials to minimize the
-      // number of keys that need to be encoded. Instead, token providers fetch credentials
-      // at file system initialization time.
-      Preconditions.checkState(
-          credScopedFsEnabled,
-          "%s credentials were vended but the credential-scoped filesystem is disabled.",
-          initialCredentials.size());
-      Preconditions.checkState(
-          renewCredEnabled,
-          "%s credentials were vended but credential renewal is disabled.",
-          initialCredentials.size());
-      // Since there are multiple credentials, each credential's prefix must be non-null
-      // and non-empty to differentiate between credentials.
-      Preconditions.checkArgument(
-          credPrefixes.size() == initialCredentials.size(),
-          "Credential prefixes cannot be null or empty when multiple credentials are vended");
     }
 
+    // Set the props for initial credential prefixes.
+    List<String> credPrefixes =
+        initialCredentials.stream()
+            .map(GenericCredential::prefix)
+            .filter(prefix -> prefix != null && !prefix.isEmpty())
+            .collect(Collectors.toList());
     if (!credPrefixes.isEmpty()) {
-      String commaSeparatedPrefixes =
-          String.join(",", CredentialUtil.encodeCredPrefixes(credPrefixes));
-      set(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY, commaSeparatedPrefixes);
+      set(
+          UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+          String.join(",", CredentialUtil.encodeCredPrefixes(credPrefixes)));
     }
 
     return Collections.unmodifiableMap(new HashMap<>(props));

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/GcsCredPropsBuilder.java
@@ -44,7 +44,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setRenewableCredKeys(GenericCredential cred) {
+  protected void setInitRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof GcsCredential,
         "Expected GcsCredential, but got %s",
@@ -60,7 +60,7 @@ final class GcsCredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFixedCredKeys(GenericCredential cred) {
+  protected void setInitFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof GcsCredential,
         "Expected GcsCredential, but got %s",

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/props/S3CredPropsBuilder.java
@@ -37,7 +37,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setRenewableCredKeys(GenericCredential cred) {
+  protected void setInitRenewableCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AwsCredential,
         "Expected AwsCredential, but got %s",
@@ -55,7 +55,7 @@ final class S3CredPropsBuilder extends CredPropsBuilder {
   }
 
   @Override
-  protected void setFixedCredKeys(GenericCredential cred) {
+  protected void setInitFixedCredKeys(GenericCredential cred) {
     Preconditions.checkArgument(
         cred instanceof AwsCredential,
         "Expected AwsCredential, but got %s",

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
@@ -450,7 +450,9 @@ abstract class CredPropsBaseTest {
     String validPrefix = location() + "/valid";
     return List.of(
         List.of(validPrefix, ""),
+        List.of("", validPrefix),
         Arrays.asList(validPrefix, null),
+        Arrays.asList(null, validPrefix),
         List.of("", ""),
         Arrays.asList(null, null));
   }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
@@ -14,10 +14,13 @@ import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
@@ -139,6 +142,56 @@ abstract class CredPropsBaseTest {
             expected(kind, renew, credScoped, conf, expiration, appVersions));
   }
 
+  @ParameterizedTest(
+      name = "{0} renew={1} credScoped={2} customImpl={3} expiring={4} appVersions={5}")
+  @MethodSource("testCaseMatrix")
+  void multipleCredPropsMatchExactlyAcrossMatrix(
+      CredKind kind,
+      boolean renew,
+      boolean credScoped,
+      boolean customImpl,
+      boolean expiring,
+      Map<String, String> appVersions)
+      throws Exception {
+    for (int prefixCount : List.of(2, 3, 5)) {
+      List<String> prefixes = createPrefixes(prefixCount);
+      setupMockFetcher(expiring, prefixes);
+      Configuration conf = createConf(customImpl);
+      Map<String, String> created = createCredPropsFor(kind, renew, credScoped, conf, appVersions);
+      Map<String, String> expected =
+          expectedForMultipleCredentials(kind, renew, credScoped, conf, prefixes, appVersions);
+      assertThat(created).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+  }
+
+  @ParameterizedTest(
+      name = "{0} renew={1} credScoped={2} customImpl={3} expiring={4} appVersions={5}")
+  @MethodSource("testCaseMatrix")
+  void malformedCredentialPrefixesSkippedDoesNotThrow(
+      CredKind kind,
+      boolean renew,
+      boolean credScoped,
+      boolean customImpl,
+      boolean expiring,
+      Map<String, String> appVersions)
+      throws Exception {
+    for (List<String> prefixes : malformedPrefixLists()) {
+      setupMockFetcher(expiring, prefixes);
+      Configuration conf = createConf(customImpl);
+      Map<String, String> created = createCredPropsFor(kind, renew, credScoped, conf, appVersions);
+      List<String> expectedPrefixes = nonEmptyPrefixes(prefixes);
+      Map<String, String> expected =
+          expectedForMultipleCredentials(
+              kind,
+              renew,
+              credScoped,
+              conf,
+              expectedPrefixes.isEmpty() ? null : expectedPrefixes,
+              appVersions);
+      assertThat(created).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+  }
+
   static Stream<Arguments> testCaseMatrix() {
     Stream.Builder<Arguments> cases = Stream.builder();
     for (CredKind kind : CredKind.values()) {
@@ -208,31 +261,6 @@ abstract class CredPropsBaseTest {
   void returnedCredMapIsUnmodifiable(CredKind kind) throws Exception {
     Map<String, String> props = createCredPropsFor(kind, false, false);
     assertThatThrownBy(() -> props.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
-  }
-
-  @ParameterizedTest(name = "{0}")
-  @EnumSource(CredKind.class)
-  void multipleRenewableCredentialsEncodeOnlyPrefixList(CredKind kind) throws Exception {
-    String firstLocation = location() + "/first";
-    String secondLocation = location() + "/second";
-    CredPropsUtil.genericCredFetcherFactory =
-        (apiClient, credId) ->
-            mockGenericCredentialFetcher(
-                vendedCred(null, firstLocation), vendedCred(null, secondLocation));
-
-    Configuration conf = new Configuration(false);
-    Map<String, String> actual = createCredPropsFor(kind, true, true, conf, Map.of());
-
-    Map<String, String> expected = new HashMap<>(defaultKeys());
-    expected.putAll(renewableProviderKeys());
-    expected.putAll(requestContext(kind, Map.of()));
-    expected.putAll(customImplKeys(conf));
-    expected.put(
-        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        String.join(
-            ",", CredentialUtil.encodeCredPrefixes(List.of(firstLocation, secondLocation))));
-
-    assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -308,6 +336,29 @@ abstract class CredPropsBaseTest {
   }
 
   // ---- expected-map composition --------------------------------------------------------------
+
+  private Map<String, String> expectedForMultipleCredentials(
+      CredKind kind,
+      boolean renew,
+      boolean credScoped,
+      Configuration conf,
+      List<String> prefixes,
+      Map<String, String> appVersions) {
+    Map<String, String> expected = new HashMap<>(defaultKeys());
+    if (renew) {
+      expected.putAll(renewableProviderKeys());
+      expected.putAll(requestContext(kind, appVersions));
+    }
+    if (prefixes != null) {
+      expected.put(
+          UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+          String.join(",", CredentialUtil.encodeCredPrefixes(prefixes)));
+    }
+    if (credScoped) {
+      expected.putAll(customImplKeys(conf));
+    }
+    return expected;
+  }
 
   private Map<String, String> expected(
       CredKind kind,
@@ -388,6 +439,38 @@ abstract class CredPropsBaseTest {
   }
 
   // ---- entry-point dispatch ------------------------------------------------------------------
+
+  private List<String> createPrefixes(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(index -> location() + "/" + index)
+        .collect(Collectors.toList());
+  }
+
+  private List<List<String>> malformedPrefixLists() {
+    String validPrefix = location() + "/valid";
+    return List.of(
+        List.of(validPrefix, ""),
+        Arrays.asList(validPrefix, null),
+        List.of("", ""),
+        Arrays.asList(null, null));
+  }
+
+  private static List<String> nonEmptyPrefixes(List<String> prefixes) {
+    return prefixes.stream()
+        .filter(prefix -> prefix != null && !prefix.isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  private void setupMockFetcher(boolean expiring, List<String> prefixes) {
+    Long expiration = expiring ? EXPIRATION_MILLIS : null;
+    CredPropsUtil.initialCredCache.clear();
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) ->
+            mockGenericCredentialFetcher(
+                prefixes.stream()
+                    .map(prefix -> vendedCred(expiration, prefix))
+                    .toArray(GenericCredential[]::new));
+  }
 
   /** A fresh conf, pre-seeded with this cloud's custom impl keys iff {@code customImpl}. */
   private Configuration createConf(boolean customImpl) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsBaseTest.java
@@ -189,10 +189,17 @@ abstract class CredPropsBaseTest {
         (apiClient, credId) -> mockGenericCredentialFetcher(vendedCred(null, prefix));
 
     Map<String, String> props = createCredPropsFor(CredKind.TABLE, true, false);
-    if (prefix == null) {
-      assertThat(props).doesNotContainKey(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY);
+    if (prefix == null || prefix.isEmpty()) {
+      assertThat(props)
+          .doesNotContainKeys(
+              UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY,
+              UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY);
     } else {
-      assertThat(props).containsEntry(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, prefix);
+      assertThat(props)
+          .doesNotContainKey(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY)
+          .containsEntry(
+              UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+              CredentialUtil.encodeCredPrefixes(List.of(prefix))[0]);
     }
   }
 
@@ -201,6 +208,31 @@ abstract class CredPropsBaseTest {
   void returnedCredMapIsUnmodifiable(CredKind kind) throws Exception {
     Map<String, String> props = createCredPropsFor(kind, false, false);
     assertThatThrownBy(() -> props.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(CredKind.class)
+  void multipleRenewableCredentialsEncodeOnlyPrefixList(CredKind kind) throws Exception {
+    String firstLocation = location() + "/first";
+    String secondLocation = location() + "/second";
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) ->
+            mockGenericCredentialFetcher(
+                vendedCred(null, firstLocation), vendedCred(null, secondLocation));
+
+    Configuration conf = new Configuration(false);
+    Map<String, String> actual = createCredPropsFor(kind, true, true, conf, Map.of());
+
+    Map<String, String> expected = new HashMap<>(defaultKeys());
+    expected.putAll(renewableProviderKeys());
+    expected.putAll(requestContext(kind, Map.of()));
+    expected.putAll(customImplKeys(conf));
+    expected.put(
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+        String.join(
+            ",", CredentialUtil.encodeCredPrefixes(List.of(firstLocation, secondLocation))));
+
+    assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -292,7 +324,9 @@ abstract class CredPropsBaseTest {
     } else {
       expected.putAll(staticCredKeys(expiration));
     }
-    expected.put(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY, location());
+    expected.put(
+        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
+        CredentialUtil.encodeCredPrefixes(List.of(location()))[0]);
     if (credScoped) {
       expected.putAll(customImplKeys(conf));
     }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -39,33 +39,56 @@ class CredPropsUtilTest {
         .isNotEqualTo(base);
   }
 
-  // TODO: Remove this test once CredPropsBuilder supports multiple vended credentials.
   @Test
-  void multipleDeltaCredentialsAreRejected() {
+  void noVendedCredentialsIsRejected() {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> CredPropsBaseTest.mockGenericCredentialFetcher();
+
+    assertThatThrownBy(() -> createTableCredProps(true, true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Initial credentials cannot be null or empty");
+  }
+
+  @Test
+  void invalidMultipleCredentialConfigurationsAreRejected() {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) ->
             CredPropsBaseTest.mockGenericCredentialFetcher(
-                new AwsCredential(
-                    "parent-ak", "parent-sk", "parent-st", Long.MAX_VALUE, "s3://bucket"),
-                new AwsCredential(
-                    "child-ak", "child-sk", "child-st", Long.MAX_VALUE, "s3://bucket/table"));
+                s3CredAt("1", "s3://bucket/a"), s3CredAt("2", ""), s3CredAt("3", null));
 
-    assertThatThrownBy(
-            () ->
-                CredPropsUtil.createDeltaTableCredProps(
-                    false,
-                    false,
-                    new Configuration(false),
-                    "s3",
-                    null,
-                    "http://uc",
-                    tokenProvider(),
-                    UCDeltaTableIdentifier.of("catalog", "schema", "table"),
-                    "s3://bucket/table/child",
-                    UCCredentialHadoopConfs.TableOperation.READ,
-                    Map.of()))
+    assertThatThrownBy(() -> createTableCredProps(true, false))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Only single credential responses are supported, got 2");
+        .hasMessageContaining("3 credentials were vended but the credential-scoped filesystem");
+
+    assertThatThrownBy(() -> createTableCredProps(false, true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("credential renewal is disabled");
+
+    assertThatThrownBy(() -> createTableCredProps(true, true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Credential prefixes cannot be null or empty when multiple credentials are vended");
+  }
+
+  private static Map<String, String> createTableCredProps(
+      boolean renewCredEnabled, boolean credScopedFsEnabled) throws Exception {
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+    return CredPropsUtil.createTableCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        conf,
+        "s3",
+        null,
+        "http://uc",
+        tokenProvider(),
+        "tid",
+        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+        Map.of());
+  }
+
+  private static AwsCredential s3CredAt(String id, String location) {
+    return new AwsCredential("ak" + id, "sk" + id, "st" + id, null, location);
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -43,26 +43,22 @@ class CredPropsUtilTest {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> CredPropsBaseTest.mockGenericCredentialFetcher();
 
-    assertThatThrownBy(() -> createTableCredProps(true, true))
+    assertThatThrownBy(
+            () ->
+                CredPropsUtil.createDeltaTableCredProps(
+                    false,
+                    false,
+                    new Configuration(false),
+                    "s3",
+                    null,
+                    "http://uc",
+                    tokenProvider(),
+                    UCDeltaTableIdentifier.of("catalog", "schema", "table"),
+                    "s3://bucket/table/child",
+                    UCCredentialHadoopConfs.TableOperation.READ,
+                    Map.of()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Initial credentials cannot be null or empty");
-  }
-
-  private static Map<String, String> createTableCredProps(
-      boolean renewCredEnabled, boolean credScopedFsEnabled) throws Exception {
-    Configuration conf = new Configuration(false);
-    conf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
-    return CredPropsUtil.createTableCredProps(
-        renewCredEnabled,
-        credScopedFsEnabled,
-        conf,
-        "s3",
-        null,
-        "http://uc",
-        tokenProvider(),
-        "tid",
-        UCCredentialHadoopConfs.TableOperation.READ_WRITE,
-        Map.of());
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
-import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -49,27 +48,6 @@ class CredPropsUtilTest {
         .hasMessageContaining("Initial credentials cannot be null or empty");
   }
 
-  @Test
-  void invalidMultipleCredentialConfigurationsAreRejected() {
-    CredPropsUtil.genericCredFetcherFactory =
-        (apiClient, credId) ->
-            CredPropsBaseTest.mockGenericCredentialFetcher(
-                s3CredAt("1", "s3://bucket/a"), s3CredAt("2", ""), s3CredAt("3", null));
-
-    assertThatThrownBy(() -> createTableCredProps(true, false))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("3 credentials were vended but the credential-scoped filesystem");
-
-    assertThatThrownBy(() -> createTableCredProps(false, true))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("credential renewal is disabled");
-
-    assertThatThrownBy(() -> createTableCredProps(true, true))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "Credential prefixes cannot be null or empty when multiple credentials are vended");
-  }
-
   private static Map<String, String> createTableCredProps(
       boolean renewCredEnabled, boolean credScopedFsEnabled) throws Exception {
     Configuration conf = new Configuration(false);
@@ -85,10 +63,6 @@ class CredPropsUtilTest {
         "tid",
         UCCredentialHadoopConfs.TableOperation.READ_WRITE,
         Map.of());
-  }
-
-  private static AwsCredential s3CredAt(String id, String location) {
-    return new AwsCredential("ak" + id, "sk" + id, "st" + id, null, location);
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredentialUtilTest.java
@@ -27,7 +27,7 @@ class CredentialUtilTest {
   private static final long EXPIRATION = 123L;
 
   @Test
-  void multiCredPrefixesRoundTripInOrder() {
+  void credPrefixesRoundTripInOrder() {
     List<String> prefixes =
         List.of(
             "s3://bucket/table",

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -161,13 +161,13 @@ class CredPropsRoundTripTest {
       throws Exception {
     AwsCredential credential =
         new AwsCredential("access-key", "secret-key", "session-token", null, credentialPrefix);
-    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(credential);
+    mockFetcher(credential);
 
     Configuration confWithCreds = createTableCredProps();
 
-    CredScopedFileSystem fs = new CredScopedFileSystem();
-    fs.initialize(new URI("s3://totally-different-bucket/uncovered/part-0.parquet"), confWithCreds);
-    Configuration delegateConf = fs.getDelegate().getConf();
+    Configuration delegateConf =
+        getDelegateFileSystemConf(
+            new URI("s3://totally-different-bucket/uncovered/part-0.parquet"), confWithCreds);
 
     AwsVendedTokenProvider provider = new AwsVendedTokenProvider(delegateConf);
     assertResolvedCreds(
@@ -183,7 +183,9 @@ class CredPropsRoundTripTest {
 
   @Test
   void multiCredentialRequiresCoveringPrefix() throws Exception {
-    mockFetcher(awsCred("a", "s3://bucket/a"), awsCred("b", "s3://bucket/b"));
+    mockFetcher(
+        new AwsCredential("ak-a", "sk-a", "st-a", null, "s3://bucket/a"),
+        new AwsCredential("ak-b", "sk-b", "st-b", null, "s3://bucket/b"));
     Configuration conf = createTableCredProps();
 
     assertThatThrownBy(
@@ -194,7 +196,7 @@ class CredPropsRoundTripTest {
 
   /** Performs a renewal to ensure the provider supplies the correct credential. */
   private static void assertProviderRenews(
-      Configuration delegateConf, AwsCredential expected, GenericCredential... vended)
+      Configuration delegateConf, AwsCredential expected, GenericCredential... vendedCredentials)
       throws Exception {
     String clockName = UUID.randomUUID().toString();
     Clock clock = Clock.getManualClock(clockName);
@@ -210,7 +212,7 @@ class CredPropsRoundTripTest {
           UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME, clock.now().toEpochMilli() + 500L);
 
       GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
-      when(fetcher.createCredentials()).thenReturn(List.of(vended));
+      when(fetcher.createCredentials()).thenReturn(List.of(vendedCredentials));
 
       try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
           mockStatic(GenericCredentialFetcher.class)) {
@@ -250,7 +252,7 @@ class CredPropsRoundTripTest {
             "s3",
             /* apiClient= */ null,
             "http://uc",
-            tokenProvider(),
+            TokenProvider.create(Map.of("type", "static", "token", "tok")),
             "tid-1",
             UCCredentialHadoopConfs.TableOperation.READ_WRITE,
             Map.of());
@@ -269,24 +271,16 @@ class CredPropsRoundTripTest {
   }
 
   private static void mockFetcher(GenericCredential... credentials) {
-    List<GenericCredential> vended = List.of(credentials);
+    List<GenericCredential> vendedCredentials = List.of(credentials);
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> {
           GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
           try {
-            when(fetcher.createCredentials()).thenReturn(vended);
+            when(fetcher.createCredentials()).thenReturn(vendedCredentials);
           } catch (Exception e) {
             throw new RuntimeException(e);
           }
           return fetcher;
         };
-  }
-
-  private static AwsCredential awsCred(String id, String location) {
-    return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
-  }
-
-  private static TokenProvider tokenProvider() {
-    return TokenProvider.create(Map.of("type", "static", "token", "tok"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -35,12 +35,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 /** Round-trip tests for credential properties produced and consumed during filesystem setup. */
 class CredPropsRoundTripTest {
 
-  private static final String CATALOG_URI = "http://uc";
-  private static final String SCHEME = "s3";
-  private static final String TABLE_ID = "tid-1";
   private static final String LOCATION = "s3://bucket/table";
-  private static final String LOCATION_A = "s3://bucket/shared-prefix/location-a";
-  private static final String LOCATION_B = "s3://bucket/shared-prefix/location-b";
 
   @BeforeEach
   @AfterEach
@@ -186,7 +181,7 @@ class CredPropsRoundTripTest {
 
   @Test
   void multiCredentialRequiresCoveringPrefix() throws Exception {
-    mockFetcher(awsCred("a", LOCATION_A), awsCred("b", LOCATION_B));
+    mockFetcher(awsCred("a", "s3://bucket/a"), awsCred("b", "s3://bucket/b"));
     Configuration conf = createTableCredProps();
 
     assertThatThrownBy(
@@ -252,11 +247,11 @@ class CredPropsRoundTripTest {
             /* renewCredEnabled= */ true,
             /* credScopedFsEnabled= */ true,
             encoderConf,
-            SCHEME,
+            "s3",
             /* apiClient= */ null,
-            CATALOG_URI,
+            "http://uc",
             tokenProvider(),
-            TABLE_ID,
+            "tid-1",
             UCCredentialHadoopConfs.TableOperation.READ_WRITE,
             Map.of());
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -177,6 +177,11 @@ class CredPropsRoundTripTest {
     assertResolvedCreds(
         delegateConf,
         credentialPrefix == null || credentialPrefix.isEmpty() ? null : credentialPrefix);
+
+    // A single vended credential renews without selection, regardless of prefix coverage.
+    AwsCredential renewed =
+        new AwsCredential("renewed-ak", "renewed-sk", "renewed-st", null, credentialPrefix);
+    assertProviderRenews(delegateConf, renewed, renewed);
   }
 
   @Test

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -241,17 +241,17 @@ class CredPropsRoundTripTest {
     assertThat(resolved.sessionToken()).isEqualTo("session-token");
   }
 
-  /** Runs the real driver encoder for a renewable table request against the current fetcher. */
+  /** Runs the real encoder for a renewable table request against the current fetcher. */
   private static Configuration createTableCredProps() throws Exception {
-    Configuration driverConf = new Configuration(false);
+    Configuration encoderConf = new Configuration(false);
     // Disable the credential cache so each test uses a fresh fetcher.
-    driverConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
-    driverConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
+    encoderConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+    encoderConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
     Map<String, String> props =
         CredPropsUtil.createTableCredProps(
             /* renewCredEnabled= */ true,
             /* credScopedFsEnabled= */ true,
-            driverConf,
+            encoderConf,
             SCHEME,
             /* apiClient= */ null,
             CATALOG_URI,
@@ -265,7 +265,7 @@ class CredPropsRoundTripTest {
     return conf;
   }
 
-  /** Runs the real executor decoder and returns the selected delegate's effective configuration. */
+  /** Runs the real decoder and returns the selected delegate's effective configuration. */
   private static Configuration getDelegateFileSystemConf(URI uri, Configuration conf)
       throws Exception {
     CredScopedFileSystem fs = new CredScopedFileSystem();

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.internal.Clock;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
@@ -16,8 +17,10 @@ import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.junit.jupiter.api.AfterEach;
@@ -81,6 +84,9 @@ class CredPropsRoundTripTest {
     assertThat(resolved.accessKeyId()).isEqualTo("access-key");
     assertThat(resolved.secretAccessKey()).isEqualTo("secret-key");
     assertThat(resolved.sessionToken()).isEqualTo("session-token");
+
+    // The seeded single credential renews once it enters the renewal lead window.
+    assertProviderRenews(delegateConf, LOCATION);
   }
 
   @Test
@@ -141,6 +147,9 @@ class CredPropsRoundTripTest {
       assertThat(resolved.secretAccessKey()).isEqualTo("child-sk");
       assertThat(resolved.sessionToken()).isEqualTo("child-st");
     }
+
+    // The selected child credential re-fetches and re-selects when it enters the renewal window.
+    assertProviderRenews(delegateConf, LOCATION);
   }
 
   @ParameterizedTest
@@ -175,6 +184,52 @@ class CredPropsRoundTripTest {
             () -> getDelegateFileSystemConf(new URI("s3://bucket/uncovered/part-0.parquet"), conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No credential covers storage location");
+  }
+
+  /**
+   * Drives a full credential renewal through {@code delegateConf} and asserts the provider
+   * re-fetches and re-selects the credential covering {@code prefix}. Works for both credential
+   * paths: it forces any seeded initial credential to expire and vends a fresh list, so the seeded
+   * single-credential path and the fetch-and-select multi-credential path both converge on the
+   * re-fetched credential.
+   */
+  private static void assertProviderRenews(Configuration delegateConf, String prefix)
+      throws Exception {
+    String clockName = UUID.randomUUID().toString();
+    Clock clock = Clock.getManualClock(clockName);
+    try {
+      Configuration conf = new Configuration(delegateConf);
+      // Disable the JVM-wide read-time cache so renewal fetches directly and no static cache
+      // state leaks across tests.
+      conf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+      conf.set(UCHadoopConfConstants.UC_TEST_CLOCK_NAME, clockName);
+      conf.setLong(UCHadoopConfConstants.UC_RENEWAL_LEAD_TIME_KEY, 1_000L);
+      // Expire any seeded initial credential so the first access must renew from the fetcher.
+      conf.setLong(
+          UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME, clock.now().toEpochMilli() + 500L);
+
+      // Vend a fresh list on renewal: a non-covering sibling plus the covering credential, so the
+      // provider must both re-fetch and re-select the one covering the prefix.
+      AwsCredential sibling =
+          awsCredExpiring("sibling", "s3://uncovered-sibling", clock.now().toEpochMilli() + 20_000);
+      AwsCredential renewed =
+          awsCredExpiring("renewed", prefix, clock.now().toEpochMilli() + 20_000L);
+      GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
+      when(fetcher.createCredentials()).thenReturn(List.of(sibling, renewed));
+
+      try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
+          mockStatic(GenericCredentialFetcher.class)) {
+        mockedFetcher.when(() -> GenericCredentialFetcher.create(conf)).thenReturn(fetcher);
+        AwsVendedTokenProvider provider = new AwsVendedTokenProvider(conf);
+
+        // Advance past the seeded credential's expiry so the next access renews from the fetcher.
+        clock.sleep(Duration.ofMillis(1_000L));
+        assertThat(accessKeyId(provider)).isEqualTo("ak-renewed");
+        assertThat(provider.accessCredentials().prefix()).isEqualTo(prefix);
+      }
+    } finally {
+      Clock.removeManualClock(clockName);
+    }
   }
 
   private static Map<String, String> createCredProps() throws Exception {
@@ -253,6 +308,14 @@ class CredPropsRoundTripTest {
 
   private static AwsCredential awsCred(String id, String location) {
     return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
+  }
+
+  private static AwsCredential awsCredExpiring(String id, String location, long expiryMillis) {
+    return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, expiryMillis, location);
+  }
+
+  private static String accessKeyId(AwsVendedTokenProvider provider) {
+    return ((AwsSessionCredentials) provider.resolveCredentials()).accessKeyId();
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -86,7 +86,9 @@ class CredPropsRoundTripTest {
     assertThat(resolved.sessionToken()).isEqualTo("session-token");
 
     // The seeded single credential renews once it enters the renewal lead window.
-    assertProviderRenews(delegateConf, LOCATION);
+    AwsCredential renewed =
+        new AwsCredential("renewed-ak", "renewed-sk", "renewed-st", null, LOCATION);
+    assertProviderRenews(delegateConf, renewed, renewed);
   }
 
   @Test
@@ -149,7 +151,12 @@ class CredPropsRoundTripTest {
     }
 
     // The selected child credential re-fetches and re-selects when it enters the renewal window.
-    assertProviderRenews(delegateConf, LOCATION);
+    // Vend a non-covering sibling plus the covering child so the provider re-selects on renewal.
+    AwsCredential sibling =
+        new AwsCredential("sibling-ak", "sibling-sk", "sibling-st", null, "s3://uncovered-sibling");
+    AwsCredential renewedChild =
+        new AwsCredential("child2-ak", "child2-sk", "child2-st", null, LOCATION);
+    assertProviderRenews(delegateConf, renewedChild, sibling, renewedChild);
   }
 
   @ParameterizedTest
@@ -161,10 +168,7 @@ class CredPropsRoundTripTest {
         new AwsCredential("access-key", "secret-key", "session-token", null, credentialPrefix);
     CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(credential);
 
-    Map<String, String> props = createCredProps();
-
-    Configuration confWithCreds = new Configuration(false);
-    props.forEach(confWithCreds::set);
+    Configuration confWithCreds = createTableCredProps();
 
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI("s3://totally-different-bucket/uncovered/part-0.parquet"), confWithCreds);
@@ -186,14 +190,9 @@ class CredPropsRoundTripTest {
         .hasMessageContaining("No credential covers storage location");
   }
 
-  /**
-   * Drives a full credential renewal through {@code delegateConf} and asserts the provider
-   * re-fetches and re-selects the credential covering {@code prefix}. Works for both credential
-   * paths: it forces any seeded initial credential to expire and vends a fresh list, so the seeded
-   * single-credential path and the fetch-and-select multi-credential path both converge on the
-   * re-fetched credential.
-   */
-  private static void assertProviderRenews(Configuration delegateConf, String prefix)
+  /** Performs a renewal to ensure the provider supplies the correct credential. */
+  private static void assertProviderRenews(
+      Configuration delegateConf, AwsCredential expected, GenericCredential... vended)
       throws Exception {
     String clockName = UUID.randomUUID().toString();
     Clock clock = Clock.getManualClock(clockName);
@@ -208,14 +207,8 @@ class CredPropsRoundTripTest {
       conf.setLong(
           UCHadoopConfConstants.S3A_INIT_CRED_EXPIRED_TIME, clock.now().toEpochMilli() + 500L);
 
-      // Vend a fresh list on renewal: a non-covering sibling plus the covering credential, so the
-      // provider must both re-fetch and re-select the one covering the prefix.
-      AwsCredential sibling =
-          awsCredExpiring("sibling", "s3://uncovered-sibling", clock.now().toEpochMilli() + 20_000);
-      AwsCredential renewed =
-          awsCredExpiring("renewed", prefix, clock.now().toEpochMilli() + 20_000L);
       GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
-      when(fetcher.createCredentials()).thenReturn(List.of(sibling, renewed));
+      when(fetcher.createCredentials()).thenReturn(List.of(vended));
 
       try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
           mockStatic(GenericCredentialFetcher.class)) {
@@ -224,29 +217,12 @@ class CredPropsRoundTripTest {
 
         // Advance past the seeded credential's expiry so the next access renews from the fetcher.
         clock.sleep(Duration.ofMillis(1_000L));
-        assertThat(accessKeyId(provider)).isEqualTo("ak-renewed");
-        assertThat(provider.accessCredentials().prefix()).isEqualTo(prefix);
+        assertThat(accessKeyId(provider)).isEqualTo(expected.accessKeyId());
+        assertThat(provider.accessCredentials().prefix()).isEqualTo(expected.prefix());
       }
     } finally {
       Clock.removeManualClock(clockName);
     }
-  }
-
-  private static Map<String, String> createCredProps() throws Exception {
-    Configuration initialConf = new Configuration(false);
-    initialConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
-    initialConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
-    return CredPropsUtil.createTableCredProps(
-        /* renewCredEnabled= */ true,
-        /* credScopedFsEnabled= */ true,
-        initialConf,
-        "s3",
-        /* apiClient= */ null,
-        "http://uc",
-        TokenProvider.create(Map.of("type", "static", "token", "token")),
-        "table-id",
-        UCCredentialHadoopConfs.TableOperation.READ,
-        Map.of());
   }
 
   private static void assertResolvedCreds(Configuration conf, String credentialPrefix)
@@ -308,10 +284,6 @@ class CredPropsRoundTripTest {
 
   private static AwsCredential awsCred(String id, String location) {
     return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
-  }
-
-  private static AwsCredential awsCredExpiring(String id, String location, long expiryMillis) {
-    return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, expiryMillis, location);
   }
 
   private static String accessKeyId(AwsVendedTokenProvider provider) {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.internal.CredPropsUtil;
-import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
@@ -24,6 +23,9 @@ import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
@@ -141,24 +143,31 @@ class CredPropsRoundTripTest {
     }
   }
 
-  @Test
-  void singleVendedCredentialRoundTripsWithoutRequiringUriCoverage() throws Exception {
-    mockFetcher(awsCred("a", LOCATION_A));
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = LOCATION)
+  void singleVendedCredentialRoundTripsWithoutRequiringUriCoverage(String credentialPrefix)
+      throws Exception {
+    AwsCredential credential =
+        new AwsCredential("access-key", "secret-key", "session-token", null, credentialPrefix);
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(credential);
 
-    Configuration conf = createTableCredProps();
-    assertThat(
-            CredentialUtil.decodeCredPrefixes(
-                conf.getStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY)))
-        .containsExactly(LOCATION_A);
-    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY)).isEqualTo("ak-a");
+    Map<String, String> props = createCredProps();
 
-    Configuration uncoveredDelegate =
-        getDelegateFileSystemConf(new URI("s3://bucket/uncovered/part-0.parquet"), conf);
-    assertInitialCredential(uncoveredDelegate, "a", LOCATION_A);
+    Configuration confWithCreds = new Configuration(false);
+    props.forEach(confWithCreds::set);
+
+    CredScopedFileSystem fs = new CredScopedFileSystem();
+    fs.initialize(new URI("s3://totally-different-bucket/uncovered/part-0.parquet"), confWithCreds);
+    Configuration delegateConf = fs.getDelegate().getConf();
+
+    assertResolvedCreds(
+        delegateConf,
+        credentialPrefix == null || credentialPrefix.isEmpty() ? null : credentialPrefix);
   }
 
   @Test
-  void decodeRejectsUriCoveredByNoVendedCredentials() throws Exception {
+  void multiCredentialRequiresCoveringPrefix() throws Exception {
     mockFetcher(awsCred("a", LOCATION_A), awsCred("b", LOCATION_B));
     Configuration conf = createTableCredProps();
 
@@ -166,6 +175,34 @@ class CredPropsRoundTripTest {
             () -> getDelegateFileSystemConf(new URI("s3://bucket/uncovered/part-0.parquet"), conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("No credential covers storage location");
+  }
+
+  private static Map<String, String> createCredProps() throws Exception {
+    Configuration initialConf = new Configuration(false);
+    initialConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+    initialConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
+    return CredPropsUtil.createTableCredProps(
+        /* renewCredEnabled= */ true,
+        /* credScopedFsEnabled= */ true,
+        initialConf,
+        "s3",
+        /* apiClient= */ null,
+        "http://uc",
+        TokenProvider.create(Map.of("type", "static", "token", "token")),
+        "table-id",
+        UCCredentialHadoopConfs.TableOperation.READ,
+        Map.of());
+  }
+
+  private static void assertResolvedCreds(Configuration conf, String credentialPrefix)
+      throws Exception {
+    AwsVendedTokenProvider provider = new AwsVendedTokenProvider(conf);
+    AwsSessionCredentials resolved = (AwsSessionCredentials) provider.resolveCredentials();
+
+    assertThat(provider.accessCredentials().prefix()).isEqualTo(credentialPrefix);
+    assertThat(resolved.accessKeyId()).isEqualTo("access-key");
+    assertThat(resolved.secretAccessKey()).isEqualTo("secret-key");
+    assertThat(resolved.sessionToken()).isEqualTo("session-token");
   }
 
   /** Runs the real driver encoder for a renewable table request against the current fetcher. */
@@ -216,19 +253,6 @@ class CredPropsRoundTripTest {
 
   private static AwsCredential awsCred(String id, String location) {
     return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
-  }
-
-  private static void assertInitialCredential(
-      Configuration conf, String id, String credentialPrefix) {
-    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY)).isEqualTo("ak-" + id);
-    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_SECRET_KEY)).isEqualTo("sk-" + id);
-    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN)).isEqualTo("st-" + id);
-    assertThat(conf.get(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER))
-        .isEqualTo(AwsVendedTokenProvider.class.getName());
-    assertThat(conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
-        .isEqualTo(credentialPrefix);
-    assertThat(conf.get("fs.s3.impl")).isEqualTo(RawLocalFileSystem.class.getName());
-    assertThat(conf.getBoolean("fs.s3.impl.disable.cache", false)).isTrue();
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.hadoop.internal.fs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.net.URI;
@@ -28,7 +30,12 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 /** Round-trip tests for credential properties produced and consumed during filesystem setup. */
 class CredPropsRoundTripTest {
 
+  private static final String CATALOG_URI = "http://uc";
+  private static final String SCHEME = "s3";
+  private static final String TABLE_ID = "tid-1";
   private static final String LOCATION = "s3://bucket/table";
+  private static final String LOCATION_A = "s3://bucket/shared-prefix/location-a";
+  private static final String LOCATION_B = "s3://bucket/shared-prefix/location-b";
 
   @BeforeEach
   @AfterEach
@@ -61,10 +68,6 @@ class CredPropsRoundTripTest {
 
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
-    // TODO: this MUST be set in the CredPropsUtil. Temporary workaround.
-    confWithCreds.setStrings(
-        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeCredPrefixes(List.of(LOCATION)));
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
 
@@ -80,12 +83,10 @@ class CredPropsRoundTripTest {
 
   @Test
   void multipleCredentialPrefixesRoundTripThroughCredScopedFileSystem() throws Exception {
-    // TODO: Once CredPropsUtil can encode multi-creds, initialCredential should be a list
-    // that matches the AwsVendedTokenProvider step at the end of the test.
-    AwsCredential initialCredential =
-        new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION);
-    CredPropsUtil.genericCredFetcherFactory =
-        (apiClient, credId) -> () -> List.of(initialCredential);
+    AwsCredential parent =
+        new AwsCredential("parent-ak", "parent-sk", "parent-st", null, "s3://bucket");
+    AwsCredential child = new AwsCredential("child-ak", "child-sk", "child-st", null, LOCATION);
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> () -> List.of(parent, child);
 
     Configuration initialConf = new Configuration(false);
     initialConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
@@ -106,18 +107,6 @@ class CredPropsRoundTripTest {
     Configuration confWithCreds = new Configuration(false);
     props.forEach(confWithCreds::set);
 
-    // TODO: Delete the manual steps below when CredPropsBuilder supports producing
-    // properties for multiple vended credentials. This is a temporary test
-    // workaround until the encoder side changes land.
-    // Unset the initialCredential that was set for multi-cred encodings.
-    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY);
-    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SECRET_KEY);
-    confWithCreds.unset(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN);
-    // Encode the list of prefixes.
-    confWithCreds.setStrings(
-        UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY,
-        CredentialUtil.encodeCredPrefixes(List.of("s3://bucket", LOCATION)));
-
     CredScopedFileSystem fs = new CredScopedFileSystem();
     fs.initialize(new URI(LOCATION + "/part-0.parquet"), confWithCreds);
 
@@ -135,9 +124,6 @@ class CredPropsRoundTripTest {
         .props()
         .forEach((key, value) -> assertThat(delegateConf.get(key)).isEqualTo(value));
 
-    AwsCredential parent =
-        new AwsCredential("parent-ak", "parent-sk", "parent-st", null, "s3://bucket");
-    AwsCredential child = new AwsCredential("child-ak", "child-sk", "child-st", null, LOCATION);
     GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
     when(fetcher.createCredentials()).thenReturn(List.of(parent, child));
 
@@ -153,5 +139,99 @@ class CredPropsRoundTripTest {
       assertThat(resolved.secretAccessKey()).isEqualTo("child-sk");
       assertThat(resolved.sessionToken()).isEqualTo("child-st");
     }
+  }
+
+  @Test
+  void singleVendedCredentialRoundTripsWithoutRequiringUriCoverage() throws Exception {
+    mockFetcher(awsCred("a", LOCATION_A));
+
+    Configuration conf = createTableCredProps();
+    assertThat(
+            CredentialUtil.decodeCredPrefixes(
+                conf.getStrings(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY)))
+        .containsExactly(LOCATION_A);
+    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY)).isEqualTo("ak-a");
+
+    Configuration uncoveredDelegate =
+        getDelegateFileSystemConf(new URI("s3://bucket/uncovered/part-0.parquet"), conf);
+    assertInitialCredential(uncoveredDelegate, "a", LOCATION_A);
+  }
+
+  @Test
+  void decodeRejectsUriCoveredByNoVendedCredentials() throws Exception {
+    mockFetcher(awsCred("a", LOCATION_A), awsCred("b", LOCATION_B));
+    Configuration conf = createTableCredProps();
+
+    assertThatThrownBy(
+            () -> getDelegateFileSystemConf(new URI("s3://bucket/uncovered/part-0.parquet"), conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No credential covers storage location");
+  }
+
+  /** Runs the real driver encoder for a renewable table request against the current fetcher. */
+  private static Configuration createTableCredProps() throws Exception {
+    Configuration driverConf = new Configuration(false);
+    // Disable the credential cache so each test uses a fresh fetcher.
+    driverConf.setBoolean(UCHadoopConfConstants.UC_CREDENTIAL_CACHE_ENABLED_KEY, false);
+    driverConf.set("fs.s3.impl", RawLocalFileSystem.class.getName());
+    Map<String, String> props =
+        CredPropsUtil.createTableCredProps(
+            /* renewCredEnabled= */ true,
+            /* credScopedFsEnabled= */ true,
+            driverConf,
+            SCHEME,
+            /* apiClient= */ null,
+            CATALOG_URI,
+            tokenProvider(),
+            TABLE_ID,
+            UCCredentialHadoopConfs.TableOperation.READ_WRITE,
+            Map.of());
+
+    Configuration conf = new Configuration(false);
+    props.forEach(conf::set);
+    return conf;
+  }
+
+  /** Runs the real executor decoder and returns the selected delegate's effective configuration. */
+  private static Configuration getDelegateFileSystemConf(URI uri, Configuration conf)
+      throws Exception {
+    CredScopedFileSystem fs = new CredScopedFileSystem();
+    fs.initialize(uri, conf);
+    return fs.getDelegate().getConf();
+  }
+
+  private static void mockFetcher(GenericCredential... credentials) {
+    List<GenericCredential> vended = List.of(credentials);
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
+          try {
+            when(fetcher.createCredentials()).thenReturn(vended);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+          return fetcher;
+        };
+  }
+
+  private static AwsCredential awsCred(String id, String location) {
+    return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
+  }
+
+  private static void assertInitialCredential(
+      Configuration conf, String id, String credentialPrefix) {
+    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_ACCESS_KEY)).isEqualTo("ak-" + id);
+    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_SECRET_KEY)).isEqualTo("sk-" + id);
+    assertThat(conf.get(UCHadoopConfConstants.S3A_INIT_SESSION_TOKEN)).isEqualTo("st-" + id);
+    assertThat(conf.get(UCHadoopConfConstants.S3A_CREDENTIALS_PROVIDER))
+        .isEqualTo(AwsVendedTokenProvider.class.getName());
+    assertThat(conf.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIX_KEY))
+        .isEqualTo(credentialPrefix);
+    assertThat(conf.get("fs.s3.impl")).isEqualTo(RawLocalFileSystem.class.getName());
+    assertThat(conf.getBoolean("fs.s3.impl.disable.cache", false)).isTrue();
+  }
+
+  private static TokenProvider tokenProvider() {
+    return TokenProvider.create(Map.of("type", "static", "token", "tok"));
   }
 }

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/fs/CredPropsRoundTripTest.java
@@ -169,8 +169,10 @@ class CredPropsRoundTripTest {
     fs.initialize(new URI("s3://totally-different-bucket/uncovered/part-0.parquet"), confWithCreds);
     Configuration delegateConf = fs.getDelegate().getConf();
 
+    AwsVendedTokenProvider provider = new AwsVendedTokenProvider(delegateConf);
     assertResolvedCreds(
-        delegateConf,
+        provider,
+        credential,
         credentialPrefix == null || credentialPrefix.isEmpty() ? null : credentialPrefix);
 
     // A single vended credential renews without selection, regardless of prefix coverage.
@@ -217,23 +219,21 @@ class CredPropsRoundTripTest {
 
         // Advance past the seeded credential's expiry so the next access renews from the fetcher.
         clock.sleep(Duration.ofMillis(1_000L));
-        assertThat(accessKeyId(provider)).isEqualTo(expected.accessKeyId());
-        assertThat(provider.accessCredentials().prefix()).isEqualTo(expected.prefix());
+        assertResolvedCreds(provider, expected, expected.prefix());
       }
     } finally {
       Clock.removeManualClock(clockName);
     }
   }
 
-  private static void assertResolvedCreds(Configuration conf, String credentialPrefix)
-      throws Exception {
-    AwsVendedTokenProvider provider = new AwsVendedTokenProvider(conf);
+  private static void assertResolvedCreds(
+      AwsVendedTokenProvider provider, AwsCredential expected, String expectedPrefix) {
     AwsSessionCredentials resolved = (AwsSessionCredentials) provider.resolveCredentials();
 
-    assertThat(provider.accessCredentials().prefix()).isEqualTo(credentialPrefix);
-    assertThat(resolved.accessKeyId()).isEqualTo("access-key");
-    assertThat(resolved.secretAccessKey()).isEqualTo("secret-key");
-    assertThat(resolved.sessionToken()).isEqualTo("session-token");
+    assertThat(provider.accessCredentials().prefix()).isEqualTo(expectedPrefix);
+    assertThat(resolved.accessKeyId()).isEqualTo(expected.accessKeyId());
+    assertThat(resolved.secretAccessKey()).isEqualTo(expected.secretAccessKey());
+    assertThat(resolved.sessionToken()).isEqualTo(expected.sessionToken());
   }
 
   /** Runs the real encoder for a renewable table request against the current fetcher. */
@@ -284,10 +284,6 @@ class CredPropsRoundTripTest {
 
   private static AwsCredential awsCred(String id, String location) {
     return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, null, location);
-  }
-
-  private static String accessKeyId(AwsVendedTokenProvider provider) {
-    return ((AwsSessionCredentials) provider.resolveCredentials()).accessKeyId();
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/MultiCredentialScopedFsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/MultiCredentialScopedFsTest.java
@@ -1,0 +1,117 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.hadoop.internal.CredPropsUtil;
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that one Spark query can read a UC-registered Parquet table whose files span two
+ * credential-scoped paths in the same bucket.
+ *
+ * <pre>
+ * s3://bucket/location-a/    credential A
+ * ├── part-*.parquet
+ * └── location-b/            credential B (more specific)
+ *     └── part-*.parquet
+ * </pre>
+ */
+public class MultiCredentialScopedFsTest extends BaseSparkIntegrationTest {
+
+  private static final String LOCATION_A = "location-a";
+  private static final String LOCATION_B = "location-b";
+  private static final String TABLE_NAME = "multi_credential_scoped_fs";
+  private static final String FULL_TABLE_NAME = CATALOG_NAME + "." + SCHEMA_NAME + "." + TABLE_NAME;
+  private static final String QUERY = "SELECT * FROM %s ORDER BY i";
+
+  @TempDir private Path dataDir;
+  private String locationA;
+  private String locationB;
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    session
+        .sparkContext()
+        .hadoopConfiguration()
+        .set("fs.s3.impl", PerPathCredentialTestFileSystem.class.getName());
+    locationA = "s3://bucket" + dataDir.resolve(LOCATION_A).normalize();
+    locationB = locationA + "/" + LOCATION_B;
+  }
+
+  @AfterEach
+  @Override
+  public void cleanUp() {
+    try {
+      super.cleanUp();
+    } finally {
+      CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
+      CredentialTestFileSystem.credentialCheckEnabled = true;
+      PerPathCredentialTestFileSystem.clearExpectedCredentials();
+    }
+  }
+
+  @Test
+  public void bothCredentialsAreRequiredToReadBothLocations() {
+    CredentialTestFileSystem.credentialCheckEnabled = false;
+    try {
+      sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", locationA);
+      sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 2 AS i, 'b' AS s", locationB);
+    } finally {
+      CredentialTestFileSystem.credentialCheckEnabled = true;
+    }
+
+    PerPathCredentialTestFileSystem.setRequiredCredential(
+        locationA, credential(LOCATION_A, locationA));
+    PerPathCredentialTestFileSystem.setRequiredCredential(
+        locationB, credential(LOCATION_B, locationB));
+
+    vend(credential(LOCATION_A, locationA));
+
+    sql(
+        "CREATE TABLE %s (i INT, s STRING) USING PARQUET "
+            + "OPTIONS (recursiveFileLookup 'true') LOCATION '%s'",
+        FULL_TABLE_NAME, locationA);
+
+    assertThatThrownBy(() -> sql(QUERY, FULL_TABLE_NAME))
+        .rootCause()
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("expected access key ak-" + LOCATION_B + " for " + locationB);
+
+    vend(credential(LOCATION_A, locationA), credential(LOCATION_B, locationB));
+
+    assertThat(sql(QUERY, FULL_TABLE_NAME))
+        .extracting(row -> row.getInt(0), row -> row.getString(1))
+        .containsExactly(tuple(1, "a"), tuple(2, "b"));
+  }
+
+  private static AwsCredential credential(String id, String location) {
+    return new AwsCredential("ak-" + id, "sk-" + id, "st-" + id, 1L, location);
+  }
+
+  private static void vend(GenericCredential... credentials) {
+    GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
+    try {
+      when(fetcher.createCredentials()).thenReturn(List.of(credentials));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> fetcher;
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PerPathCredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PerPathCredentialTestFileSystem.java
@@ -1,0 +1,70 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
+import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+/**
+ * A fake S3 filesystem that validates the vended credential against the path <em>prefix</em> being
+ * accessed. Tests register the expected credential for each URI prefix, which supports arbitrary
+ * sibling and nested layouts.
+ */
+public class PerPathCredentialTestFileSystem extends CredentialTestFileSystem {
+
+  private static final Map<String, AwsCredential> EXPECTED_CREDENTIALS = new ConcurrentHashMap<>();
+
+  static void setRequiredCredential(String prefix, AwsCredential credential) {
+    EXPECTED_CREDENTIALS.put(new Path(prefix).toString(), credential);
+  }
+
+  static void clearExpectedCredentials() {
+    EXPECTED_CREDENTIALS.clear();
+  }
+
+  @Override
+  protected void checkCredentials(Path f) {
+    if (!credentialCheckEnabled) {
+      return;
+    }
+    String uri = new Path(f.toUri()).toString();
+    String expectedPrefix =
+        EXPECTED_CREDENTIALS.keySet().stream()
+            .filter(prefix -> covers(uri, prefix))
+            .max(Comparator.comparingInt(String::length))
+            .orElseThrow(() -> new AssertionError("no expected credential registered for " + f));
+    String expectedAccessKey = EXPECTED_CREDENTIALS.get(expectedPrefix).accessKeyId();
+    Configuration conf = getConf();
+
+    GenericCredentialFetcher fetcher = () -> new ArrayList<>(EXPECTED_CREDENTIALS.values());
+    try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
+        mockStatic(GenericCredentialFetcher.class)) {
+      mockedFetcher.when(() -> GenericCredentialFetcher.create(conf)).thenReturn(fetcher);
+
+      AwsSessionCredentials credentials =
+          (AwsSessionCredentials) new AwsVendedTokenProvider(conf).resolveCredentials();
+      assertThat(credentials.accessKeyId())
+          .as("expected access key %s for %s", expectedAccessKey, f)
+          .isEqualTo(expectedAccessKey);
+    }
+  }
+
+  @Override
+  protected String scheme() {
+    return "s3:";
+  }
+
+  private static boolean covers(String uri, String prefix) {
+    return (uri + "/").startsWith(prefix + "/");
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1705/files) to review incremental changes.
- [stack/encode-scoped-vended-credentials](https://github.com/unitycatalog/unitycatalog/pull/1705) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1705/files)]

---------
## Summary

- Encode vended prefixes, whether single, or multiple credential
- Preserve the legacy top-level layout for a single credential.

## Testing

Added Spark integration test for multi location table.

## Issue

Fixes https://github.com/unitycatalog/unitycatalog/issues/1694