### PR TITLE
Fix GCS path escaping in credential access boundaries

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -85,6 +85,13 @@ public class GcpCredentialVendor {
     return new ServiceAccountCredentialGenerator(jsonKeyFilePath);
   }
 
+  private static String toCelStringLiteral(String value) {
+    // Escape existing backslashes first so they cannot consume escapes added below.
+    String escaped =
+        value.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r").replace("\n", "\\n");
+    return "'" + escaped + "'";
+  }
+
   OAuth2Credentials downscopeGcpCreds(GoogleCredentials credentials, CredentialContext context) {
     CredentialAccessBoundary.Builder boundaryBuilder = CredentialAccessBoundary.newBuilder();
     List<String> roles = resolvePrivilegesToRoles(context.getPrivileges());
@@ -100,16 +107,16 @@ public class GcpCredentialVendor {
                   format("//storage.googleapis.com/projects/_/buckets/%s", locationUri.getHost());
 
               // for reading/writing objects
+              String resourceName =
+                  format("projects/_/buckets/%s/objects/%s", locationUri.getHost(), path);
               String resourceNameStartsWithExpr =
-                  format(
-                      "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
-                      locationUri.getHost(), path);
+                  format("resource.name.startsWith(%s)", toCelStringLiteral(resourceName));
 
               // for listing objects
               String objectListPrefixStartsWithExpr =
                   format(
-                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s')",
-                      path);
+                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith(%s)",
+                      toCelStringLiteral(path));
 
               String combinedExpr =
                   resourceNameStartsWithExpr + " || " + objectListPrefixStartsWithExpr;

--- a/server/src/test/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendorTest.java
@@ -1,0 +1,82 @@
+package io.unitycatalog.server.service.credential.gcp;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class GcpCredentialVendorTest {
+
+  private final GcpCredentialVendor credentialVendor =
+      new GcpCredentialVendor(new ServerProperties(new Properties()));
+  private final GoogleCredentials sourceCredentials =
+      GoogleCredentials.create(new AccessToken("test-token", null));
+
+  private String availabilityConditionFor(String location) {
+    CredentialContext context =
+        CredentialContext.create(
+            NormalizedURL.from(location),
+            Set.of(CredentialContext.Privilege.SELECT),
+            Optional.empty());
+    DownscopedCredentials downscopedCredentials =
+        (DownscopedCredentials) credentialVendor.downscopeGcpCreds(sourceCredentials, context);
+    CredentialAccessBoundary credentialAccessBoundary =
+        downscopedCredentials.getCredentialAccessBoundary();
+
+    assertThat(credentialAccessBoundary.getAccessBoundaryRules()).hasSize(1);
+    return credentialAccessBoundary
+        .getAccessBoundaryRules()
+        .get(0)
+        .getAvailabilityCondition()
+        .getExpression();
+  }
+
+  private String expectedCondition(String bucket, String escapedPath) {
+    return format(
+        "resource.name.startsWith('projects/_/buckets/%s/objects/%s')"
+            + " || api.getAttribute('storage.googleapis.com/objectListPrefix', '')"
+            + ".startsWith('%s')",
+        bucket, escapedPath, escapedPath);
+  }
+
+  @Test
+  public void testOrdinaryPathConditionIsUnchanged() {
+    assertThat(availabilityConditionFor("gs://victim-bucket/team/x"))
+        .isEqualTo(expectedCondition("victim-bucket", "team/x"));
+  }
+
+  @Test
+  public void testCelExpressionInjectionCharactersAreEscaped() {
+    String maliciousLocation = "gs://victim-bucket/team/x')%20%7C%7C%20('1'%3D%3D'1";
+    String escapedPath = "team/x\\') || (\\'1\\'==\\'1";
+
+    assertThat(availabilityConditionFor(maliciousLocation))
+        .isEqualTo(expectedCondition("victim-bucket", escapedPath));
+  }
+
+  @Test
+  public void testBackslashCannotConsumeQuoteEscape() {
+    String maliciousLocation =
+        "gs://victim-bucket/public/inj%5C%27)%7C%7Ctrue%7C%7C" + "resource.name.startsWith(%27";
+    String escapedPath = "public/inj" + "\\".repeat(3) + "')||true||resource.name.startsWith(\\'";
+
+    assertThat(availabilityConditionFor(maliciousLocation))
+        .isEqualTo(expectedCondition("victim-bucket", escapedPath));
+  }
+
+  @Test
+  public void testLineBreaksAreEscaped() {
+    assertThat(availabilityConditionFor("gs://victim-bucket/team/line%0D%0Abreak"))
+        .isEqualTo(expectedCondition("victim-bucket", "team/line\\r\\nbreak"));
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] Tests cover the fixed behavior.
- [x] No documentation update is needed because this does not change the public API or supported behavior.

**Description of changes**

Encode decoded GCS paths as CEL string literals before inserting them into Credential Access Boundary conditions. This keeps quotes, backslashes, and line breaks inside the intended literal for both object-name and list-prefix checks while preserving ordinary paths unchanged.

Add focused tests for the existing expression, quote/operator input, an odd-backslash-before-quote case, and encoded line breaks.

**Testing**

- `build/sbt server/'testOnly io.unitycatalog.server.service.credential.gcp.GcpCredentialVendorTest io.unitycatalog.server.service.credential.CloudCredentialVendorTest'`
- 9 tests passed; compilation and checkstyle passed.
