### PR TITLE
fix(server): validate AWS storage locations for IAM policies

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import lombok.SneakyThrows;
@@ -108,11 +110,22 @@ public class AwsPolicyGenerator {
         .map(NormalizedURL::toUri)
         .collect(Collectors.toMap(
             URI::getHost,
-            uri -> new LinkedList<>(List.of(uri.getPath())),
+            uri -> new LinkedList<>(List.of(getValidatedPath(uri))),
             (map, newPaths) -> {
               map.addAll(newPaths);
               return map;
             }));
+  }
+
+  private static String getValidatedPath(URI uri) {
+    String path = uri.getPath();
+    if (uri.getRawQuery() != null
+        || (path != null && (path.contains("*") || path.contains("?")))) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "S3 storage locations cannot contain IAM wildcard characters '*' or '?'");
+    }
+    return path;
   }
 
   @SneakyThrows

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -7,10 +7,13 @@ import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.O
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.POLICY_STATEMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +21,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class AwsPolicyGeneratorTest {
 
@@ -80,5 +85,24 @@ public class AwsPolicyGeneratorTest {
         .doesNotContain("s3:PutO*")
         .doesNotContain("s3:DeleteO*")
         .contains("s3:GetO*");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "s3://my-bucket/*",
+        "s3://my-bucket/path*",
+        "s3://my-bucket/%2A",
+        "s3://my-bucket/%3F",
+        "s3://my-bucket/path?query"
+      })
+  public void testRejectsIamWildcardsInStorageLocations(String url) {
+    assertThatThrownBy(
+            () ->
+                AwsPolicyGenerator.generatePolicy(Set.of(SELECT), List.of(NormalizedURL.from(url))))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("IAM wildcard")
+        .extracting(e -> ((BaseException) e).getErrorCode())
+        .isEqualTo(ErrorCode.INVALID_ARGUMENT);
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] Regression tests cover the fixed behavior.
- [x] Documentation is not required for this validation-only server fix.

**Description of changes**

Validate S3 storage locations before using their paths in generated AWS IAM session policies. Storage locations containing `*` or `?`, including percent-encoded forms and query-bearing URIs, now fail with `INVALID_ARGUMENT` instead of being emitted as IAM resource patterns.

The validation stays at the policy-generation boundary so generic URL parsing behavior remains unchanged.

**Testing**

- `build/sbt 'server/testOnly io.unitycatalog.server.service.credential.aws.AwsPolicyGeneratorTest io.unitycatalog.server.utils.NormalizedURLTest io.unitycatalog.server.sdk.delta.SdkCreateTableTest'` (11 passed)
- `build/sbt 'server/test'` (325 passed)
