### PR TITLE
[Server] Escape IAM wildcard characters in generated S3 session policies

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -82,9 +82,8 @@ public class AwsPolicyGenerator {
 
       ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
       paths.forEach(path -> {
-        // remove any preceding forward slashes
-        // TODO: potentially sanitize/encode the whole path to deal with problematic chars
-        String sanitizedPath = path.replaceAll("^/+", "");
+        // remove any preceding forward slashes, then make the path match literally
+        String sanitizedPath = escapeIamSpecialChars(path.replaceAll("^/+", ""));
 
         if (sanitizedPath.isEmpty()) {
           conditionalPrefixes.add("*");
@@ -101,6 +100,17 @@ public class AwsPolicyGenerator {
     });
 
     return JSON_MAPPER.writeValueAsString(policyRoot);
+  }
+
+  /**
+   * Escapes the characters IAM treats specially in resource ARNs and string conditions, so that a
+   * storage location path is matched literally. {@code *} and {@code ?} are legal S3 key characters
+   * but IAM wildcards, so a path like {@code /*} would otherwise widen the generated policy to the
+   * whole bucket. IAM expresses these literals as the policy variables {@code ${*}}, {@code ${?}}
+   * and {@code ${$}}; {@code $} is escaped first so it doesn't mangle the escapes added after it.
+   */
+  private static String escapeIamSpecialChars(String path) {
+    return path.replace("$", "${$}").replace("*", "${*}").replace("?", "${?}");
   }
 
   private static Map<String, List<String>> getBucketToPathsMap(List<NormalizedURL> locations) {

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -81,4 +81,55 @@ public class AwsPolicyGeneratorTest {
         .doesNotContain("s3:DeleteO*")
         .contains("s3:GetO*");
   }
+
+  @Test
+  public void testWildcardsInPathAreEscapedToLiterals() {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT, UPDATE), List.of(NormalizedURL.from("s3://victim-bucket/*")));
+
+    // The path must match the literal key "*", not every object in the bucket.
+    assertThat(policy)
+        .contains("arn:aws:s3:::victim-bucket/${*}")
+        .doesNotContain("arn:aws:s3:::victim-bucket/*");
+  }
+
+  @Test
+  public void testSingleCharWildcardInPathIsEscapedToLiteral() {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            // "%3F" is the percent-encoding of "?", which IAM treats as a single-char wildcard.
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path%3Fx/table")));
+
+    assertThat(policy)
+        .contains("arn:aws:s3:::my-bucket/path${?}x/table")
+        .doesNotContain("arn:aws:s3:::my-bucket/path?x/table");
+  }
+
+  @Test
+  public void testDollarSignCannotForgeAnEscapeSequence() {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            // A path that already spells out an IAM escape sequence must stay literal text.
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/$%7B*%7D")));
+
+    assertThat(policy).contains("arn:aws:s3:::my-bucket/${$}{${*}}");
+  }
+
+  @SneakyThrows
+  @Test
+  public void testOrdinaryPathIsNotEscaped() {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode node = JSON_MAPPER.readTree(policy);
+    assertThat(node.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::my-bucket/path1/table1/*", "arn:aws:s3:::my-bucket/path1/table1");
+    assertThat(node.findPath("s3:prefix"))
+        .map(JsonNode::asText)
+        .containsExactly("path1/table1", "path1/table1/", "path1/table1/*");
+  }
 }


### PR DESCRIPTION
## Summary

`AwsPolicyGenerator` embeds the storage location path verbatim into the resource ARNs and the `s3:prefix` `StringLike` condition of the vended session policy. `*` and `?` are legal S3 key characters but IAM wildcards, so a storage location of `s3://bucket/*` produced a policy granting read/write/delete on **every** object the assumed role can reach in the bucket, rather than on the single object named `*`:

```json
{"Effect":"Allow","Action":["s3:GetO*","s3:PutO*","s3:DeleteO*","s3:*Multipart*"],
 "Resource":["arn:aws:s3:::bucket/*/*","arn:aws:s3:::bucket/*"]},
{"Effect":"Allow","Action":["s3:ListBucket"],"Resource":["arn:aws:s3:::bucket"],
 "Condition":{"StringLike":{"s3:prefix":["*","*/","*/*"]}}}
```

Such a path also passes the existing overlap/containment check, since that check treats the path as a literal rather than as a wildcard pattern.

This escapes the path using IAM's literal policy variables (`${*}`, `${?}`, `${$}`) before it is interpolated, so the generated policy always matches exactly the location it names. `$` is escaped first so a path cannot spell out an escape sequence itself (e.g. a literal `${*}` in a key becomes `${$}{${*}}`). This also replaces the pre-existing `TODO` about sanitizing problematic characters.

Ordinary paths are unaffected — they contain none of these characters, so their generated ARNs and prefixes are byte-for-byte identical to before.

## Testing

Added unit tests to `AwsPolicyGeneratorTest` covering `*`, `?` (percent-encoded in the location), a path that spells out an escape sequence, and an ordinary path whose ARNs and prefixes must stay unchanged.

```
build/sbt "server/testOnly io.unitycatalog.server.service.credential.aws.AwsPolicyGeneratorTest"
[info] Test run finished: 0 failed, 0 ignored, 7 total
```