### PR TITLE
[Server] Escape GCS paths in credential access boundary conditions

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -85,6 +85,18 @@ public class GcpCredentialVendor {
     return new ServiceAccountCredentialGenerator(jsonKeyFilePath);
   }
 
+  /**
+   * Renders {@code value} as a single-quoted CEL string literal. Without escaping, a storage
+   * location containing a quote could close the literal and inject CEL operators into the
+   * credential access boundary condition, widening the downscoped token's access.
+   */
+  private static String celStringLiteral(String value) {
+    // Backslashes are escaped first so they cannot consume the escapes added afterwards.
+    return "'"
+        + value.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r").replace("\n", "\\n")
+        + "'";
+  }
+
   OAuth2Credentials downscopeGcpCreds(GoogleCredentials credentials, CredentialContext context) {
     CredentialAccessBoundary.Builder boundaryBuilder = CredentialAccessBoundary.newBuilder();
     List<String> roles = resolvePrivilegesToRoles(context.getPrivileges());
@@ -102,14 +114,15 @@ public class GcpCredentialVendor {
               // for reading/writing objects
               String resourceNameStartsWithExpr =
                   format(
-                      "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
-                      locationUri.getHost(), path);
+                      "resource.name.startsWith(%s)",
+                      celStringLiteral(
+                          format("projects/_/buckets/%s/objects/%s", locationUri.getHost(), path)));
 
               // for listing objects
               String objectListPrefixStartsWithExpr =
                   format(
-                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s')",
-                      path);
+                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith(%s)",
+                      celStringLiteral(path));
 
               String combinedExpr =
                   resourceNameStartsWithExpr + " || " + objectListPrefixStartsWithExpr;

--- a/server/src/test/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendorTest.java
@@ -1,0 +1,80 @@
+package io.unitycatalog.server.service.credential.gcp;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class GcpCredentialVendorTest {
+
+  private final GcpCredentialVendor credentialVendor =
+      new GcpCredentialVendor(new ServerProperties(new Properties()));
+
+  private String availabilityConditionFor(String location) {
+    CredentialContext context =
+        CredentialContext.create(
+            NormalizedURL.from(location),
+            Set.of(CredentialContext.Privilege.SELECT),
+            Optional.empty());
+    DownscopedCredentials credentials =
+        (DownscopedCredentials)
+            credentialVendor.downscopeGcpCreds(
+                GoogleCredentials.create(new AccessToken("test-token", null)), context);
+
+    assertThat(credentials.getCredentialAccessBoundary().getAccessBoundaryRules()).hasSize(1);
+    return credentials
+        .getCredentialAccessBoundary()
+        .getAccessBoundaryRules()
+        .get(0)
+        .getAvailabilityCondition()
+        .getExpression();
+  }
+
+  /** The condition the vendor is expected to emit for a path already escaped for CEL. */
+  private String expectedCondition(String bucket, String escapedPath) {
+    return format(
+        "resource.name.startsWith('projects/_/buckets/%s/objects/%s')"
+            + " || api.getAttribute('storage.googleapis.com/objectListPrefix', '')"
+            + ".startsWith('%s')",
+        bucket, escapedPath, escapedPath);
+  }
+
+  @Test
+  public void testOrdinaryPath() {
+    assertThat(availabilityConditionFor("gs://test-bucket/team/data"))
+        .isEqualTo(expectedCondition("test-bucket", "team/data"));
+  }
+
+  @Test
+  public void testQuoteInPathCannotInjectCelOperators() {
+    // gs://test-bucket/team/data') || ('1'=='1
+    String location = "gs://test-bucket/team/data')%20%7C%7C%20('1'%3D%3D'1";
+
+    assertThat(availabilityConditionFor(location))
+        .isEqualTo(expectedCondition("test-bucket", "team/data\\') || (\\'1\\'==\\'1"));
+  }
+
+  @Test
+  public void testBackslashInPathCannotConsumeTheQuoteEscape() {
+    // gs://test-bucket/team/data\') || ('1'=='1
+    String location = "gs://test-bucket/team/data%5C')%20%7C%7C%20('1'%3D%3D'1";
+
+    assertThat(availabilityConditionFor(location))
+        .isEqualTo(expectedCondition("test-bucket", "team/data\\\\\\') || (\\'1\\'==\\'1"));
+  }
+
+  @Test
+  public void testLineBreaksInPathAreEscaped() {
+    assertThat(availabilityConditionFor("gs://test-bucket/team/two%0D%0Alines"))
+        .isEqualTo(expectedCondition("test-bucket", "team/two\\r\\nlines"));
+  }
+}


### PR DESCRIPTION
## Summary

`GcpCredentialVendor.downscopeGcpCreds` builds the credential access boundary's CEL `availabilityCondition` by interpolating the storage location path directly into single-quoted CEL string literals, with no escaping:

```java
format("resource.name.startsWith('projects/_/buckets/%s/objects/%s')", host, path)
format("api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('%s')", path)
```

A path containing a single quote closes the literal early and the rest becomes CEL syntax. For a location like `gs://bucket/team/x') || ('1'=='1`, the generated condition is:

```
resource.name.startsWith('projects/_/buckets/bucket/objects/team/x') || ('1'=='1')
  || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('team/x') || ('1'=='1')
```

That condition is always true, so the downscoped token grants its role (`roles/storage.objectAdmin` for write access) over the **whole bucket** rather than the requested prefix.

This is the GCS counterpart of the AWS policy generator, which already escapes its interpolated values.

## Change

Route both interpolations through a small `celStringLiteral` helper that escapes backslashes (first, so they cannot consume subsequent escapes), single quotes, and line breaks. Nothing about the emitted condition changes for ordinary paths.

## Testing

New `GcpCredentialVendorTest` asserts the generated `availabilityCondition` for:
- an ordinary path (unchanged output)
- a quote-injection path (`') || ('1'=='1`)
- a backslash-then-quote path, so the backslash cannot escape the escape
- a path containing CR/LF

Verified the injection tests fail against the unpatched vendor — the pre-fix output contains the always-true `('1'=='1')` term — and pass with the fix.