### PR TITLE
[Server] Escape IAM metacharacters in generated S3 access policies

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -83,8 +83,7 @@ public class AwsPolicyGenerator {
       ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
       paths.forEach(path -> {
         // remove any preceding forward slashes
-        // TODO: potentially sanitize/encode the whole path to deal with problematic chars
-        String sanitizedPath = path.replaceAll("^/+", "");
+        String sanitizedPath = escapeIamSpecialCharacters(path.replaceAll("^/+", ""));
 
         if (sanitizedPath.isEmpty()) {
           conditionalPrefixes.add("*");
@@ -101,6 +100,36 @@ public class AwsPolicyGenerator {
     });
 
     return JSON_MAPPER.writeValueAsString(policyRoot);
+  }
+
+  /**
+   * Makes an S3 path safe to include in an IAM policy.
+   *
+   * <p>S3 treats {@code *}, {@code ?}, and {@code $} as ordinary characters in object
+   * names. IAM gives them special meanings:
+   *
+   * <ul>
+   *   <li>{@code *} matches any number of characters. For example, {@code reports/*}
+   *       matches every object under {@code reports/}.
+   *   <li>{@code ?} matches exactly one character. For example, {@code file?.txt}
+   *       matches {@code file1.txt}.
+   *   <li>{@code ${...}} is a policy variable whose value IAM fills in when it evaluates
+   *       the policy. For example, {@code ${aws:username}} is replaced with the caller's
+   *       IAM username.
+   * </ul>
+   *
+   * <p>Therefore, copying an S3 path directly into a policy could grant access to more
+   * objects than the path names. AWS provides {@code ${*}}, {@code ${?}}, and {@code ${$}}
+   * to make IAM match the literal {@code *}, {@code ?}, and {@code $} characters instead.
+   *
+   * <p>We replace {@code $} first because the replacements for {@code *} and {@code ?}
+   * also contain a dollar sign.
+   *
+   * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html">
+   *     AWS documentation for IAM policy variables</a>
+   */
+  private static String escapeIamSpecialCharacters(String keyPrefix) {
+    return keyPrefix.replace("$", "${$}").replace("*", "${*}").replace("?", "${?}");
   }
 
   private static Map<String, List<String>> getBucketToPathsMap(List<NormalizedURL> locations) {

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class AwsPolicyGeneratorTest {
 
@@ -47,6 +49,87 @@ public class AwsPolicyGeneratorTest {
         .isEqualTo("arn:aws:s3:::" + bucket);
 
     node.findPath("s3:prefix").forEach(e -> assertThat(e.asText()).startsWith(prefix));
+  }
+
+  @Test
+  public void testWildcardPathDoesNotProduceBucketWidePolicy() throws Exception {
+    String bucket = "victim-bucket";
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE), List.of(NormalizedURL.from("s3://%s/*".formatted(bucket))));
+
+    JsonNode node = JSON_MAPPER.readTree(policy);
+    assertThat(node.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::%s/${*}/*".formatted(bucket), "arn:aws:s3:::%s/${*}".formatted(bucket))
+        .doesNotContain(
+            "arn:aws:s3:::%s/*/*".formatted(bucket), "arn:aws:s3:::%s/*".formatted(bucket));
+    assertThat(node.get("Statement").get(1).findPath("s3:prefix"))
+        .map(JsonNode::asText)
+        .containsExactly("${*}", "${*}/", "${*}/*")
+        .doesNotContain("*", "*/", "*/*");
+  }
+
+  @ParameterizedTest(name = "{index}: {0} becomes {1}")
+  @CsvSource({
+    "%2A, ${*}",
+    "%2a, ${*}",
+    "%3F, ${?}",
+    "%3f, ${?}",
+    "prefix*middle, prefix${*}middle",
+    "prefix%3Fmiddle, prefix${?}middle",
+    "%24%7Baws:username%7D, ${$}{aws:username}",
+    "$%7B*%7D, ${$}{${*}}"
+  })
+  public void testPolicyEscapesIamSpecialCharacters(String encodedPath, String expectedPath)
+      throws Exception {
+    String bucket = "victim-bucket";
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE),
+            List.of(NormalizedURL.from("s3://%s/%s".formatted(bucket, encodedPath))));
+
+    JsonNode node = JSON_MAPPER.readTree(policy);
+    assertThat(node.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::%s/%s/*".formatted(bucket, expectedPath),
+            "arn:aws:s3:::%s/%s".formatted(bucket, expectedPath));
+    assertThat(node.get("Statement").get(1).findPath("s3:prefix"))
+        .map(JsonNode::asText)
+        .containsExactly(expectedPath, expectedPath + "/", expectedPath + "/*");
+  }
+
+  @Test
+  public void testPolicyLeavesOrdinaryPathUnchanged() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode node = JSON_MAPPER.readTree(policy);
+    assertThat(node.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::my-bucket/path1/table1/*", "arn:aws:s3:::my-bucket/path1/table1");
+    assertThat(node.get("Statement").get(1).findPath("s3:prefix"))
+        .map(JsonNode::asText)
+        .containsExactly("path1/table1", "path1/table1/", "path1/table1/*");
+  }
+
+  @Test
+  public void testPolicyPreservesIntentionalBucketRootWildcard() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket")));
+
+    JsonNode node = JSON_MAPPER.readTree(policy);
+    assertThat(node.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly("arn:aws:s3:::my-bucket/*");
+    assertThat(node.get("Statement").get(1).findPath("s3:prefix"))
+        .map(JsonNode::asText)
+        .containsExactly("*");
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [ ] If you have added or modified a feature, documentation in `docs` is updated

**Description of changes**

(see the javadoc comment for a clearer description)

`AwsPolicyGenerator` inserted S3 paths directly into IAM resource ARNs and `s3:prefix` conditions. Because IAM treats `*` and `?` as wildcards and `${...}` as a policy variable, a valid S3 path such as `s3://victim-bucket/*` could produce a bucket-wide session policy.

Escape `*`, `?`, and `$` using IAM literal variables before adding the path to the policy. The change stays at the AWS policy-generation boundary and does not affect other storage providers.

Tests cover the original exploit, encoded and embedded wildcards, policy-variable injection, ordinary paths, and bucket-root policies. The focused suite passes all 14 tests. As a mutation check, restoring the vulnerable line caused all 9 security tests to fail while the 5 baseline tests continued to pass.