### PR TITLE
[Server] Fix metastore-wide model listing page token

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
@@ -73,9 +73,18 @@ public class ModelRepository {
 
   public List<RegisteredModelInfoDAO> getAllRegisteredModelsDao(
       Session session, Optional<String> token, Optional<Integer> maxResults) {
+    if (maxResults.isPresent() && maxResults.get() < 0) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "maxResults must be greater than or equal to 0");
+    }
     UUID tokenToUse = new UUID(0, 0);
     if (token.isPresent()) {
-      tokenToUse = UUID.fromString(token.get());
+      try {
+        tokenToUse = UUID.fromString(token.get());
+      } catch (IllegalArgumentException e) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT, "Invalid page token received: " + token.get());
+      }
     }
     String hql = "FROM RegisteredModelInfoDAO t WHERE t.id > :token ORDER BY t.id ASC";
     Query<RegisteredModelInfoDAO> query = session.createQuery(hql, RegisteredModelInfoDAO.class);
@@ -147,6 +156,17 @@ public class ModelRepository {
     }
     // return the last version
     return entities.get(entities.size() - 1).getVersion().toString();
+  }
+
+  private String getNextPageTokenById(
+      List<RegisteredModelInfoDAO> entities, Optional<Integer> maxResults) {
+    if (entities == null
+        || entities.isEmpty()
+        || entities.size() < PagedListingHelper.getPageSize(maxResults)) {
+      return null;
+    }
+    // return the last id
+    return entities.get(entities.size() - 1).getId().toString();
   }
 
   /** **************** Registered Model handlers ***************** */
@@ -290,9 +310,8 @@ public class ModelRepository {
           LOGGER.info("Listing all registered models in the metastore.");
           List<RegisteredModelInfoDAO> registeredModelInfoDAOList =
               getAllRegisteredModelsDao(session, pageToken, maxResults);
-          String nextPageToken =
-              REGISTERED_MODEL_LISTING_HELPER.getNextPageToken(
-                  registeredModelInfoDAOList, maxResults);
+          // Model names are not unique across the metastore, so this branch pages by id, not name.
+          String nextPageToken = getNextPageTokenById(registeredModelInfoDAOList, maxResults);
           List<RegisteredModelInfo> result = new ArrayList<>();
           for (RegisteredModelInfoDAO registeredModelInfoDAO : registeredModelInfoDAOList) {
             RepositoryUtils.CatalogAndSchemaNames names =

--- a/server/src/test/java/io/unitycatalog/server/sdk/models/SdkModelCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/models/SdkModelCRUDTest.java
@@ -1,13 +1,30 @@
 package io.unitycatalog.server.sdk.models;
 
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME2;
+import static io.unitycatalog.server.utils.TestUtils.COMMENT;
+import static io.unitycatalog.server.utils.TestUtils.MODEL_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.RegisteredModelsApi;
+import io.unitycatalog.client.model.CreateRegisteredModel;
+import io.unitycatalog.client.model.ListRegisteredModelsResponse;
+import io.unitycatalog.client.model.RegisteredModelInfo;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.model.BaseModelCRUDTest;
 import io.unitycatalog.server.base.model.ModelOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 public class SdkModelCRUDTest extends BaseModelCRUDTest {
 
@@ -23,6 +40,66 @@ public class SdkModelCRUDTest extends BaseModelCRUDTest {
 
   @Override
   protected ModelOperations createModelOperations(ServerConfig config) {
+    localRegisteredModelsApi = new RegisteredModelsApi(TestUtils.createApiClient(config));
     return new SdkModelOperations(TestUtils.createApiClient(config));
+  }
+
+  /**
+   * ModelOperations drops the next page token, so the listing tests below use a direct
+   * `RegisteredModelsApi` client to inspect the response object.
+   */
+  private RegisteredModelsApi localRegisteredModelsApi;
+
+  @Test
+  public void testPagingCoversModelsThatShareAName() throws ApiException {
+    // Model names are only unique per schema, so a name keyed cursor would skip one of these.
+    createCommonResources();
+    createModel(CATALOG_NAME, SCHEMA_NAME, MODEL_NAME);
+    createModel(CATALOG_NAME2, SCHEMA_NAME2, MODEL_NAME);
+    createModel(CATALOG_NAME, SCHEMA_NAME, "uc_testmodel_two");
+
+    ListRegisteredModelsResponse firstPage = listAllModels(1, null);
+    ListRegisteredModelsResponse secondPage = listAllModels(1, firstPage.getNextPageToken());
+    ListRegisteredModelsResponse thirdPage = listAllModels(1, secondPage.getNextPageToken());
+
+    assertThat(collectFullNames(firstPage, secondPage, thirdPage))
+        .containsExactlyInAnyOrder(
+            CATALOG_NAME + "." + SCHEMA_NAME + "." + MODEL_NAME,
+            CATALOG_NAME2 + "." + SCHEMA_NAME2 + "." + MODEL_NAME,
+            CATALOG_NAME + "." + SCHEMA_NAME + ".uc_testmodel_two");
+
+    TestUtils.assertApiException(
+        () -> listAllModels(-1, null),
+        ErrorCode.INVALID_ARGUMENT,
+        "maxResults must be greater than or equal to 0");
+    TestUtils.assertApiException(
+        () -> listAllModels(1, "not_a_page_token"),
+        ErrorCode.INVALID_ARGUMENT,
+        "Invalid page token received: not_a_page_token");
+  }
+
+  private ListRegisteredModelsResponse listAllModels(Integer maxResults, String pageToken)
+      throws ApiException {
+    return localRegisteredModelsApi.listRegisteredModels(null, null, maxResults, pageToken);
+  }
+
+  private List<String> collectFullNames(ListRegisteredModelsResponse... pages) {
+    List<String> fullNames = new ArrayList<>();
+    for (ListRegisteredModelsResponse page : pages) {
+      for (RegisteredModelInfo model : page.getRegisteredModels()) {
+        fullNames.add(model.getFullName());
+      }
+    }
+    return fullNames;
+  }
+
+  private void createModel(String catalogName, String schemaName, String modelName)
+      throws ApiException {
+    localRegisteredModelsApi.createRegisteredModel(
+        new CreateRegisteredModel()
+            .name(modelName)
+            .catalogName(catalogName)
+            .schemaName(schemaName)
+            .comment(COMMENT));
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1718

`GET /models` with no catalog or schema pages by row id but returned the last model name as `next_page_token`, so passing that token back failed `UUID.fromString` and returned 400. That branch also skipped the negative `max_results` check.

Model names are not unique across a metastore, so the id ordering stays and the token now matches it.

`testPagingCoversModelsThatShareAName` walks three models sharing a name across a page, then both validations in the same test. Fails without the fix.

