### PR TITLE
[0.5][OAuth] Make auth config lookups case-insensitive

### DIFF
--- a/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
@@ -2,6 +2,7 @@ package io.unitycatalog.client.auth;
 
 import io.unitycatalog.client.internal.Preconditions;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Interface for providing access tokens to authenticate with Unity Catalog.
@@ -107,7 +108,9 @@ public interface TokenProvider {
    *     not found, no default constructor, or instantiation failure)
    */
   static TokenProvider create(Map<String, String> configs) {
-    String authType = configs.get(AuthConfigs.TYPE);
+    Map<String, String> ci = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    ci.putAll(configs);
+    String authType = ci.get(AuthConfigs.TYPE);
     Preconditions.checkArgument(
         authType != null && !authType.trim().isEmpty(),
         "Required configuration key '%s' is missing or empty. "
@@ -140,7 +143,7 @@ public interface TokenProvider {
     }
 
     // Initialize the TokenProvider with configs.
-    tokenProvider.initialize(configs);
+    tokenProvider.initialize(ci);
     return tokenProvider;
   }
 }

--- a/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/auth/TokenProvider.java
@@ -108,9 +108,11 @@ public interface TokenProvider {
    *     not found, no default constructor, or instantiation failure)
    */
   static TokenProvider create(Map<String, String> configs) {
-    Map<String, String> ci = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    ci.putAll(configs);
-    String authType = ci.get(AuthConfigs.TYPE);
+    // Try normalizing to a case-insensitive view if possible so downstream lookups regardless of
+    // casing
+    Map<String, String> normalizedConfigs = toCaseInsensitiveMap(configs);
+
+    String authType = normalizedConfigs.get(AuthConfigs.TYPE);
     Preconditions.checkArgument(
         authType != null && !authType.trim().isEmpty(),
         "Required configuration key '%s' is missing or empty. "
@@ -143,7 +145,22 @@ public interface TokenProvider {
     }
 
     // Initialize the TokenProvider with configs.
-    tokenProvider.initialize(ci);
+    tokenProvider.initialize(normalizedConfigs);
     return tokenProvider;
+  }
+
+  /**
+   * Returns a case-insensitive view of {@code configs} so key lookups succeed regardless of key
+   * casing (some callers pass keys that were lower-cased upstream). If the map is already
+   * case-insensitive it is returned as-is to avoid an unnecessary copy. The check is by simple
+   * class name.
+   */
+  private static Map<String, String> toCaseInsensitiveMap(Map<String, String> configs) {
+    if (configs == null || configs.getClass().getSimpleName().equals("CaseInsensitiveStringMap")) {
+      return configs;
+    }
+    Map<String, String> caseInsensitive = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    caseInsensitive.putAll(configs);
+    return caseInsensitive;
   }
 }

--- a/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
 public class TokenProviderTest {
@@ -108,6 +109,38 @@ public class TokenProviderTest {
         .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
         .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
         .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  @Test
+  public void testCreatePassesThroughAlreadyCaseInsensitiveMap() {
+    // A map whose simple class name is "CaseInsensitiveStringMap" is treated as already
+    // case-insensitive and passed through as-is. Backing it with a
+    // case-insensitive map and using lower-cased keys verifies lookups still resolve.
+    CaseInsensitiveStringMap configs = new CaseInsensitiveStringMap();
+    configs.put(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE);
+    configs.put("oauth.uri", OAUTH_URI);
+    configs.put("oauth.clientid", CLIENT_ID);
+    configs.put("oauth.clientsecret", CLIENT_SECRET);
+
+    TokenProvider provider = TokenProvider.create(configs);
+
+    assertThat(provider).isInstanceOf(OAuthTokenProvider.class);
+    assertThat(provider.configs())
+        .hasSize(4)
+        .containsEntry(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE)
+        .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  /**
+   * Minimal stand-in named to match the class-simple-name check in {@code TokenProvider.create};
+   * backed by a case-insensitive map so lookups are case-insensitive.
+   */
+  private static class CaseInsensitiveStringMap extends TreeMap<String, String> {
+    CaseInsensitiveStringMap() {
+      super(String.CASE_INSENSITIVE_ORDER);
+    }
   }
 
   @Test

--- a/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
+++ b/clients/java/src/test/java/io/unitycatalog/client/auth/TokenProviderTest.java
@@ -89,6 +89,28 @@ public class TokenProviderTest {
   }
 
   @Test
+  public void testCreateResolvesOAuthConfigCaseInsensitively() {
+    // Keys can arrive lower-cased when catalog options pass through a
+    // case-insensitive map (e.g. Spark's CaseInsensitiveStringMap in the
+    // Delta UC integration). create() must still resolve them.
+    Map<String, String> lowerCasedConfigs = new HashMap<>();
+    lowerCasedConfigs.put(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE);
+    lowerCasedConfigs.put("oauth.uri", OAUTH_URI);
+    lowerCasedConfigs.put("oauth.clientid", CLIENT_ID); // lower-cased on purpose
+    lowerCasedConfigs.put("oauth.clientsecret", CLIENT_SECRET); // lower-cased on purpose
+
+    TokenProvider provider = TokenProvider.create(lowerCasedConfigs);
+
+    assertThat(provider).isInstanceOf(OAuthTokenProvider.class);
+    assertThat(provider.configs())
+        .hasSize(4)
+        .containsEntry(AuthConfigs.TYPE, AuthConfigs.OAUTH_TYPE_VALUE)
+        .containsEntry(AuthConfigs.OAUTH_URI, OAUTH_URI)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_ID, CLIENT_ID)
+        .containsEntry(AuthConfigs.OAUTH_CLIENT_SECRET, CLIENT_SECRET);
+  }
+
+  @Test
   public void testCustomTokenProvider() {
     // Test with custom TokenProvider using fully qualified class name
     Map<String, String> customConfigs = new HashMap<>();


### PR DESCRIPTION
**PR Checklist**

* [x] A description of the changes is added to the description of this PR.
* [ ] If there is a related issue, make sure it is linked to this PR.
* [x] If you've fixed a bug or added code that should be tested, add tests!
* [ ] If you've added or modified a feature, documentation in `docs` is updated.

**Description of changes**

This PR backports the OAuth configuration case-insensitive lookup fix from `main` to the `branch-0.5` release branch.
Backport of #1663.

### Changes

* Make OAuth authentication configuration lookups case-insensitive in `TokenProvider`.
* Extract the configuration normalization logic into a reusable helper to avoid duplicated case-insensitive lookups.
* Add unit tests covering mixed-case configuration keys to verify the expected behaviour.

This ensures that OAuth authentication works correctly even when configuration keys are provided with different letter casing, while keeping the implementation consistent with the fix already merged into `main`.
