### PR TITLE
[Spark] Keep SHOW TABLES metadata-only on Spark 4.2

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.connector.catalog.{
   RelationCatalog,
   TableCatalog,
   TableDependency,
+  TableSummary,
   View
 }
 import org.apache.spark.sql.types.DataType
@@ -50,6 +51,34 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     listUCTableLikes(namespace)
       .filter(t => UCViewTypes.isViewLikeTableType(t.getTableType))
       .map(table => Identifier.of(namespace, table.getName))
+      .toArray
+  }
+
+  /**
+   * Metadata-only table listing for `SHOW TABLES`.
+   *
+   * Spark 4.2 routes `SHOW TABLES` through `RelationCatalog.listRelationSummaries`, whose default
+   * unions this method's result with `listViews` (so views appear alongside tables, matching v1
+   * `SHOW TABLES` semantics). The default `TableCatalog.listTableSummaries` calls `loadTable` on
+   * every table just to read its type, and `UCProxy.loadTable` -> `loadV1Table` unconditionally
+   * vends storage credentials -- so a single non-externalizable (e.g. `TABLE_STANDARD`/managed)
+   * table would fail the whole listing with a 400 `EXTERNAL_ACCESS_NOT_ALLOWED_FOR_TABLE`.
+   *
+   * Override it to build each `TableSummary` straight from the single `listTables` RPC row (the
+   * same rows `listTables` already reads for filtering), using the row's `getTableType()` and no
+   * `loadTable` -- so listing never vends credentials. View-like rows are excluded here (they are
+   * contributed by `listViews`), exactly mirroring `UCProxy.listTables`. Loading such a table for a
+   * real read (e.g. `SELECT`) still correctly fails, since that genuinely needs credentials.
+   */
+  override def listTableSummaries(namespace: Array[String]): Array[TableSummary] = {
+    UCSingleCatalog.checkUnsupportedNestedNamespace(namespace)
+    listUCTableLikes(namespace)
+      .filterNot(t => UCViewTypes.isViewLikeTableType(t.getTableType))
+      .map { table =>
+        TableSummary.of(
+          Identifier.of(namespace, table.getName),
+          UCViewTypes.ucTableTypeToSparkTableSummaryType(table.getTableType))
+      }
       .toArray
   }
 

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCSingleCatalogViewSupport.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.connector.catalog.{
   Identifier,
   Relation,
   RelationCatalog,
+  TableSummary,
   View
 }
 
@@ -23,6 +24,16 @@ trait UCSingleCatalogViewSupport extends RelationCatalog { self: UCSingleCatalog
 
   override def listViews(namespace: Array[String]): Array[Identifier] =
     ucProxy.listViews(namespace)
+
+  /**
+   * Route `SHOW TABLES` summaries straight to `ucProxy` (bypassing the `delegate`/Delta chain,
+   * like the `listViews` delegate above) so the listing uses the connector's credential-free
+   * `listTableSummaries` override rather than the default that `loadTable`s every table. Spark's
+   * default `listRelationSummaries` composes this with `listViews`; see
+   * [[UCProxyViewSupport.listTableSummaries]] for the credential-vending bug this avoids.
+   */
+  override def listTableSummaries(namespace: Array[String]): Array[TableSummary] =
+    ucProxy.listTableSummaries(namespace)
 
   override def loadView(ident: Identifier): View =
     ucProxy.loadView(ident)

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -101,14 +101,20 @@ private[spark] object UCViewTypes {
    * (not `TableSummary.*` constants) so this stays free of Spark-4.2-only types and compiles on
    * all supported Spark versions, mirroring the `"METRIC_VIEW"` literal in `viewLikeUcTypes`.
    *
-   * The mapping deliberately reproduces the semantics of Spark's default
-   * `TableCatalog.listTableSummaries`, which reads each table's `PROP_TABLE_TYPE` and falls back to
-   * `FOREIGN` when it is absent -- except it derives the type from the list-RPC row's
-   * `getTableType()` instead of a per-table `loadTable`, so no storage credentials are vended:
+   * The mapping stays consistent with what the credential-vending load path
+   * (`getUCTableLike` -> `loadV1Table`) would produce, so a table's summary type matches the type
+   * it would resolve to under the default `listTableSummaries` (which reads `PROP_TABLE_TYPE` off
+   * the loaded table and falls back to `FOREIGN` when absent) -- except it derives the type from
+   * the list-RPC row's `getTableType()` instead of a per-table `loadTable`, so no storage
+   * credentials are vended:
    *
    *   - `MANAGED`          -> `"MANAGED"`   (`TableSummary.MANAGED_TABLE_TYPE`)
+   *   - `STREAMING_TABLE`  -> `"MANAGED"`   -- `getUCTableLike` fetches with
+   *                                            `readStreamingTableAsManaged = true`, so the load
+   *                                            path sees UC `MANAGED` and `loadV1Table` builds a
+   *                                            `CatalogTableType.MANAGED` V1 table (see #1017);
+   *                                            classify it the same way here
    *   - `EXTERNAL`         -> `"EXTERNAL"`  (`TableSummary.EXTERNAL_TABLE_TYPE`)
-   *   - `STREAMING_TABLE`  -> `"EXTERNAL"`  (loaded as an EXTERNAL V1 table by `loadV1Table`)
    *   - anything else      -> `"FOREIGN"`  (`TableSummary.FOREIGN_TABLE_TYPE`), matching the
    *                                         default's absent-property fallback
    *
@@ -117,8 +123,8 @@ private[spark] object UCViewTypes {
    */
   def ucTableTypeToSparkTableSummaryType(tableType: TableType): String = tableType match {
     case TableType.MANAGED => "MANAGED"
+    case TableType.STREAMING_TABLE => "MANAGED"
     case TableType.EXTERNAL => "EXTERNAL"
-    case TableType.STREAMING_TABLE => "EXTERNAL"
     case _ => "FOREIGN"
   }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -96,6 +96,33 @@ private[spark] object UCViewTypes {
     viewLikeUcTypes.get(ucType).exists(_.isDefined)
 
   /**
+   * Maps a *non-view* UC `TableType` onto the Spark `TableSummary` table-type string used by the
+   * metadata-only `SHOW TABLES` listing path (`listTableSummaries`). Kept here as string literals
+   * (not `TableSummary.*` constants) so this stays free of Spark-4.2-only types and compiles on
+   * all supported Spark versions, mirroring the `"METRIC_VIEW"` literal in `viewLikeUcTypes`.
+   *
+   * The mapping deliberately reproduces the semantics of Spark's default
+   * `TableCatalog.listTableSummaries`, which reads each table's `PROP_TABLE_TYPE` and falls back to
+   * `FOREIGN` when it is absent -- except it derives the type from the list-RPC row's
+   * `getTableType()` instead of a per-table `loadTable`, so no storage credentials are vended:
+   *
+   *   - `MANAGED`          -> `"MANAGED"`   (`TableSummary.MANAGED_TABLE_TYPE`)
+   *   - `EXTERNAL`         -> `"EXTERNAL"`  (`TableSummary.EXTERNAL_TABLE_TYPE`)
+   *   - `STREAMING_TABLE`  -> `"EXTERNAL"`  (loaded as an EXTERNAL V1 table by `loadV1Table`)
+   *   - anything else      -> `"FOREIGN"`  (`TableSummary.FOREIGN_TABLE_TYPE`), matching the
+   *                                         default's absent-property fallback
+   *
+   * Callers must have already filtered out view-like rows (via [[isViewLikeTableType]]); this is
+   * the tables-only surface, so view kinds never reach here.
+   */
+  def ucTableTypeToSparkTableSummaryType(tableType: TableType): String = tableType match {
+    case TableType.MANAGED => "MANAGED"
+    case TableType.EXTERNAL => "EXTERNAL"
+    case TableType.STREAMING_TABLE => "EXTERNAL"
+    case _ => "FOREIGN"
+  }
+
+  /**
    * Splits the `VIEW_SQL_CONFIG_PREFIX`-prefixed entries out of a UC properties map and returns
    * them un-prefixed, as Spark's `View.sqlConfigs()` expects. Shared by the view-load path
    * (`UCProxyViewSupport.toView` on Spark 4.2); kept here so it stays free of any

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -544,6 +544,127 @@ public class UCViewProxySuite {
         .isInstanceOf(TableAlreadyExistsException.class);
   }
 
+  // -- listTableSummaries tests (SHOW TABLES metadata-only path; LC-15627) --
+
+  @Test
+  public void testListTableSummariesReturnsTablesOnlyWithoutLoadingAnyTable() throws Exception {
+    // SHOW TABLES must stay metadata-only: build each summary from the single listTables RPC row
+    // (using its tableType), excluding view-like rows, and never call getTable/loadTable -- which
+    // is what vends per-table storage credentials and 400s on a non-externalizable managed table.
+    ListTablesResponse response =
+        new ListTablesResponse()
+            .tables(
+                List.of(
+                    new TableInfo().name("managed1").tableType(TableType.MANAGED),
+                    new TableInfo().name("external1").tableType(TableType.EXTERNAL),
+                    new TableInfo().name("mv1").tableType(TableType.METRIC_VIEW)))
+            .nextPageToken(null);
+    when(mockTablesApi.listTables(eq(CATALOG_NAME), eq(SCHEMA_NAME), eq(0), isNull()))
+        .thenReturn(response);
+
+    TableSummary[] result = proxyRelations.listTableSummaries(NAMESPACE);
+
+    // Only the two real tables, view-like rows excluded (they are contributed by listViews).
+    assertThat(result).hasSize(2);
+    assertThat(result[0].identifier()).isEqualTo(Identifier.of(NAMESPACE, "managed1"));
+    assertThat(result[0].tableType()).isEqualTo(TableSummary.MANAGED_TABLE_TYPE);
+    assertThat(result[1].identifier()).isEqualTo(Identifier.of(NAMESPACE, "external1"));
+    assertThat(result[1].tableType()).isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
+
+    // The regression guard: no per-table load, so no credential vend can 400 the listing.
+    verify(mockTablesApi, org.mockito.Mockito.never())
+        .getTable(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testListTableSummariesMapsStreamingTableToExternalAndUnknownToForeign()
+      throws Exception {
+    // STREAMING_TABLE is loaded as an EXTERNAL V1 table, so it summarizes as EXTERNAL; any other
+    // non-view kind falls back to FOREIGN, mirroring Spark's default absent-PROP_TABLE_TYPE path.
+    ListTablesResponse response =
+        new ListTablesResponse()
+            .tables(
+                List.of(
+                    new TableInfo().name("st1").tableType(TableType.STREAMING_TABLE),
+                    new TableInfo().name("unknown1").tableType(TableType.UNKNOWN_DEFAULT_OPEN_API)))
+            .nextPageToken(null);
+    when(mockTablesApi.listTables(eq(CATALOG_NAME), eq(SCHEMA_NAME), eq(0), isNull()))
+        .thenReturn(response);
+
+    TableSummary[] result = proxyRelations.listTableSummaries(NAMESPACE);
+
+    assertThat(result).hasSize(2);
+    assertThat(result[0].identifier()).isEqualTo(Identifier.of(NAMESPACE, "st1"));
+    assertThat(result[0].tableType()).isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
+    assertThat(result[1].identifier()).isEqualTo(Identifier.of(NAMESPACE, "unknown1"));
+    assertThat(result[1].tableType()).isEqualTo(TableSummary.FOREIGN_TABLE_TYPE);
+  }
+
+  @Test
+  public void testListRelationSummariesUnionsTablesAndViewsMetadataOnly() throws Exception {
+    // Full SHOW TABLES path: Spark's default listRelationSummaries unions listTableSummaries
+    // (tables) with listViews (views). Both are served from the list RPC, no getTable/loadTable.
+    ListTablesResponse response =
+        new ListTablesResponse()
+            .tables(
+                List.of(
+                    new TableInfo().name("managed1").tableType(TableType.MANAGED),
+                    new TableInfo().name("mv1").tableType(TableType.METRIC_VIEW)))
+            .nextPageToken(null);
+    when(mockTablesApi.listTables(eq(CATALOG_NAME), eq(SCHEMA_NAME), eq(0), isNull()))
+        .thenReturn(response);
+
+    TableSummary[] result = proxyRelations.listRelationSummaries(NAMESPACE);
+
+    // Tables first (from listTableSummaries), then views (from listViews) per the default's order.
+    assertThat(result).hasSize(2);
+    assertThat(result[0].identifier()).isEqualTo(Identifier.of(NAMESPACE, "managed1"));
+    assertThat(result[0].tableType()).isEqualTo(TableSummary.MANAGED_TABLE_TYPE);
+    assertThat(result[1].identifier()).isEqualTo(Identifier.of(NAMESPACE, "mv1"));
+    assertThat(result[1].tableType()).isEqualTo(TableSummary.VIEW_TABLE_TYPE);
+
+    verify(mockTablesApi, org.mockito.Mockito.never())
+        .getTable(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testUCSingleCatalogListTableSummariesDelegatesToUcProxy() throws Exception {
+    // UCSingleCatalog routes summaries straight to ucProxy (bypassing the delegate/Delta chain),
+    // like the listViews delegate -- so the credential-free override is used even with Delta wired.
+    ListTablesResponse response =
+        new ListTablesResponse()
+            .tables(List.of(new TableInfo().name("managed1").tableType(TableType.MANAGED)))
+            .nextPageToken(null);
+    when(mockTablesApi.listTables(eq(CATALOG_NAME), eq(SCHEMA_NAME), eq(0), isNull()))
+        .thenReturn(response);
+
+    // A delegate that would fail if consulted for the listing -- proves ucProxy is used instead.
+    TableCatalog delegate = org.mockito.Mockito.mock(TableCatalog.class);
+    when(delegate.listTableSummaries(org.mockito.ArgumentMatchers.any()))
+        .thenThrow(new AssertionError("delegate.listTableSummaries must not be called"));
+
+    UCSingleCatalog catalog = new UCSingleCatalog();
+    setCatalogField(catalog, "delegate", delegate);
+    setCatalogField(catalog, "ucProxy", proxyRelations);
+
+    TableSummary[] result = ((RelationCatalog) catalog).listTableSummaries(NAMESPACE);
+
+    assertThat(result).hasSize(1);
+    assertThat(result[0].identifier()).isEqualTo(Identifier.of(NAMESPACE, "managed1"));
+    assertThat(result[0].tableType()).isEqualTo(TableSummary.MANAGED_TABLE_TYPE);
+    verify(mockTablesApi, org.mockito.Mockito.never())
+        .getTable(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
   private static void setCatalogField(UCSingleCatalog catalog, String fieldName, Object value) {
     try {
       Field field = UCSingleCatalog.class.getDeclaredField(fieldName);

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -580,9 +580,11 @@ public class UCViewProxySuite {
   }
 
   @Test
-  public void testListTableSummariesMapsStreamingTableToExternalAndUnknownToForeign()
+  public void testListTableSummariesMapsStreamingTableToManagedAndUnknownToForeign()
       throws Exception {
-    // STREAMING_TABLE is loaded as an EXTERNAL V1 table, so it summarizes as EXTERNAL; any other
+    // STREAMING_TABLE summarizes as MANAGED: the load path fetches it with
+    // readStreamingTableAsManaged=true, so getUCTableLike -> loadV1Table classifies it as
+    // CatalogTableType.MANAGED (see #1017); the summary stays consistent with that. Any other
     // non-view kind falls back to FOREIGN, mirroring Spark's default absent-PROP_TABLE_TYPE path.
     ListTablesResponse response =
         new ListTablesResponse()
@@ -598,7 +600,7 @@ public class UCViewProxySuite {
 
     assertThat(result).hasSize(2);
     assertThat(result[0].identifier()).isEqualTo(Identifier.of(NAMESPACE, "st1"));
-    assertThat(result[0].tableType()).isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
+    assertThat(result[0].tableType()).isEqualTo(TableSummary.MANAGED_TABLE_TYPE);
     assertThat(result[1].identifier()).isEqualTo(Identifier.of(NAMESPACE, "unknown1"));
     assertThat(result[1].tableType()).isEqualTo(TableSummary.FOREIGN_TABLE_TYPE);
   }


### PR DESCRIPTION
## Description of changes

On Spark 4.2, `SHOW TABLES` against `UCSingleCatalog` fails when the target schema contains a table that cannot be read from outside the compute environment (e.g. a managed / `TABLE_STANDARD` table). A metadata-only listing operation eagerly vends per-table storage credentials, and a single non-externalizable table aborts the whole command:

```
generateTemporaryTableCredentials call failed with: 400 - INVALID_PARAMETER_VALUE
Table with id <id> cannot be accessed from outside of Databricks Compute Environment due to its
kind being TABLE_STANDARD. Only 'TABLE_EXTERNAL', 'TABLE_DELTA_EXTERNAL' and 'TABLE_DELTA'
table kinds can be accessed externally.
reason: EXTERNAL_ACCESS_NOT_ALLOWED_FOR_TABLE
```

### Root cause

Spark 4.2 routes `SHOW TABLES` through `RelationCatalog.listRelationSummaries`, whose default implementation unions `TableCatalog.listTableSummaries` (tables) with `listViews` (views). The default `listTableSummaries` calls `loadTable` on **every** table just to read its `table_type`, and `UCProxy.loadTable` → `loadV1Table` unconditionally vends storage credentials via `buildForTable(READ_WRITE)`. For a non-externalizable table the credential vend returns 400 and the whole `SHOW TABLES` fails.

`SHOW VIEWS` is unaffected because the connector already overrides `listViews` to build identifiers straight from the list response, with no `loadTable` and no credentials. The table-listing path lacked the equivalent override.

This is Spark 4.2 only: on Spark 4.0/4.1 `UCSingleCatalog` is a plain `TableCatalog` (the shim is an empty marker trait), so `ShowTablesExec` takes the cheap `listTables` branch. Only the Spark 4.2 shim mixes in `RelationCatalog`.

### Fix

Override `listTableSummaries` on `UCProxy` (Spark-4.2 shim) so table listing stays metadata-only, mirroring the existing `listViews` override — each `TableSummary` is built from the single `listTables` RPC row using its `getTableType()`, with **no `loadTable` and no credential vend**. A delegating override is added on `UCSingleCatalog` next to the existing `listViews` delegate so it bypasses the `delegate`/Delta chain. Spark's default `listRelationSummaries` composes this with `listViews`.

The UC-type → Spark `TableSummary` type-string mapping lives in `UCViewTypes` (as string literals, so it stays free of Spark-4.2-only types and compiles on all supported Spark versions), reproducing the default's `FOREIGN` fallback.

Loading such a table for a real read (e.g. `SELECT`) still correctly fails, since `TABLE_STANDARD` data genuinely cannot be read externally. This change only stops metadata listing from triggering that path.

## Test plan

- [x] Spark 4.2.0 (GA) connector compile clean (main + test); checkstyle clean.
- [x] `UCViewProxySuite` passes **22/22** (18 pre-existing + 4 new), verified against Spark 4.2.0 GA.
- New Spark-4.2 unit tests assert the listing is tables-only, maps types correctly (`MANAGED`/`EXTERNAL`/`STREAMING_TABLE`→`EXTERNAL`/unknown→`FOREIGN`), unions tables + views, delegates through `UCSingleCatalog`, and — the core regression guard — **never calls `getTable`/`loadTable`**.

This pull request and its description were written by Isaac.