### PR TITLE
[Spark] Fix Spark tests against Delta master-SNAPSHOT

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ServerSidePlanningTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ServerSidePlanningTest.java
@@ -117,16 +117,12 @@ public class ServerSidePlanningTest extends BaseSparkIntegrationTest {
       assertThat(session.conf().get("spark.databricks.delta.catalog.enableServerSidePlanning"))
           .isEqualTo("true");
 
-      // The load outcome then differs by Delta version. Delta >= 4.3.0 eagerly reads table
-      // properties on the SSP load path, so loadTable() still throws even though credential vending
-      // was skipped. Delta < 4.3.0 does not read them here, so loadTable() succeeds with empty
-      // credentials (no exception).
-      if (DeltaVersionUtils.isDeltaAtLeast(MIN_DELTA_VERSION_FOR_UC_DELTA_API)) {
-        assertThat(caughtException).isNotNull();
-      } else {
-        assertThat(caughtException).isNull();
-        assertThat(loadedTable).isNotNull();
-      }
+      // SSP is the fallback for tables with no vended credentials, so on this load path Delta must
+      // not force a credentialed `_delta_log` read while deciding to use it. It therefore does not
+      // read table properties here for any supported Delta version, and loadTable() succeeds with
+      // empty credentials (no exception) rather than throwing.
+      assertThat(caughtException).isNull();
+      assertThat(loadedTable).isNotNull();
     }
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
@@ -30,7 +30,13 @@ public class AbfsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    return Map.of("fs.abfs.impl", AbfsCredFileSystem.class.getName());
+    // Register the tracking filesystem as a `spark.hadoop.fs.<scheme>.impl` property (not a bare
+    // catalog option) so it lands in the session Hadoop configuration. With credScopedFs enabled
+    // (the default), CredPropsUtil reads it there and saves it under `fs.<scheme>.impl.original`
+    // before installing CredScopedFileSystem, which then restores and delegates to it.
+    return Map.of(
+        "spark.hadoop.fs.abfs.impl", AbfsCredFileSystem.class.getName(),
+        "spark.hadoop.fs.abfss.impl", AbfsCredFileSystem.class.getName());
   }
 
   public static class AzureCredGenerator extends TimeBasedCredGenerator<AzureCredential>

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AbfsCredRenewITTest.java
@@ -30,10 +30,6 @@ public class AbfsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    // Register the tracking filesystem as a `spark.hadoop.fs.<scheme>.impl` property (not a bare
-    // catalog option) so it lands in the session Hadoop configuration. With credScopedFs enabled
-    // (the default), CredPropsUtil reads it there and saves it under `fs.<scheme>.impl.original`
-    // before installing CredScopedFileSystem, which then restores and delegates to it.
     return Map.of(
         "spark.hadoop.fs.abfs.impl", AbfsCredFileSystem.class.getName(),
         "spark.hadoop.fs.abfss.impl", AbfsCredFileSystem.class.getName());

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
@@ -35,10 +35,6 @@ public class AwsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    // Register the tracking filesystem as a `spark.hadoop.fs.<scheme>.impl` property (not a bare
-    // catalog option) so it lands in the session Hadoop configuration. With credScopedFs enabled
-    // (the default), CredPropsUtil reads it there and saves it under `fs.<scheme>.impl.original`
-    // before installing CredScopedFileSystem, which then restores and delegates to it.
     return Map.of(
         "spark.hadoop.fs.s3.impl", S3CredFileSystem.class.getName(),
         "spark.hadoop.fs.s3a.impl", S3CredFileSystem.class.getName());

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/AwsCredRenewITTest.java
@@ -35,7 +35,13 @@ public class AwsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    return Map.of("fs.s3.impl", S3CredFileSystem.class.getName());
+    // Register the tracking filesystem as a `spark.hadoop.fs.<scheme>.impl` property (not a bare
+    // catalog option) so it lands in the session Hadoop configuration. With credScopedFs enabled
+    // (the default), CredPropsUtil reads it there and saves it under `fs.<scheme>.impl.original`
+    // before installing CredScopedFileSystem, which then restores and delegates to it.
+    return Map.of(
+        "spark.hadoop.fs.s3.impl", S3CredFileSystem.class.getName(),
+        "spark.hadoop.fs.s3a.impl", S3CredFileSystem.class.getName());
   }
 
   public static class AwsCredGenerator extends TimeBasedCredGenerator<Credentials>

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/GcsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/GcsCredRenewITTest.java
@@ -31,11 +31,6 @@ public class GcsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    // Register the tracking filesystem as a `spark.hadoop.fs.gs.impl` property (not a bare catalog
-    // option) so it lands in the session Hadoop configuration. With credScopedFs enabled (the
-    // default), CredPropsUtil reads it there and saves it under `fs.gs.impl.original` before
-    // installing CredScopedFileSystem, which then restores and delegates to it.
-    // Note: fs.gs.impl.disable.cache is already set by CredPropsUtil.GcsPropsBuilder.
     return Map.of("spark.hadoop.fs.gs.impl", GcsCredFileSystem.class.getName());
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/GcsCredRenewITTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/auth/storage/GcsCredRenewITTest.java
@@ -31,9 +31,12 @@ public class GcsCredRenewITTest extends BaseCredRenewITTest {
 
   @Override
   protected Map<String, String> catalogExtraProps() {
-    // Override fs.gs.impl to use our testing filesystem that tracks credential renewals
-    // Note: fs.gs.impl.disable.cache is already set by CredPropsUtil.GcsPropsBuilder
-    return Map.of("fs.gs.impl", GcsCredFileSystem.class.getName());
+    // Register the tracking filesystem as a `spark.hadoop.fs.gs.impl` property (not a bare catalog
+    // option) so it lands in the session Hadoop configuration. With credScopedFs enabled (the
+    // default), CredPropsUtil reads it there and saves it under `fs.gs.impl.original` before
+    // installing CredScopedFileSystem, which then restores and delegates to it.
+    // Note: fs.gs.impl.disable.cache is already set by CredPropsUtil.GcsPropsBuilder.
+    return Map.of("spark.hadoop.fs.gs.impl", GcsCredFileSystem.class.getName());
   }
 
   public static class GcsCredGenerator extends TimeBasedCredGenerator<AccessToken>


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Align the Spark connector tests with current Delta `master` behavior:

- `ServerSidePlanningTest`: SSP-enabled `loadTable()` no longer forces a `_delta_log` read, so it succeeds without throwing on all supported Delta versions.
- `AwsCredRenewITTest` / `AbfsCredRenewITTest` / `GcsCredRenewITTest`: register the tracking filesystem as `spark.hadoop.fs.<scheme>.impl` so `CredScopedFileSystem` captures it as `fs.<scheme>.impl.original` and delegates to it (`credScopedFs.enabled` stays at its default `true`).