### PR TITLE
Extract server assembly into `ArmeriaServerBuilder`

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -113,15 +113,19 @@ public class ArmeriaServerBuilder {
    * disabled); this method only knows how to attach the decorators it is given -- path prefixes,
    * the {@code auth/tokens} exclusion, and that the exception handler must sit at the bottom of the
    * chain.
+   *
+   * <p>Both decorators are attached to the same path prefixes. Armeria runs decorators in the
+   * reverse of their registration order, so {@code authDecorator} (authentication) runs before
+   * {@code accessDecorator} (authorization) at request time -- the opposite of the parameter order.
+   *
+   * @param accessDecorator authorization decorator; runs second at request time
+   * @param authDecorator authentication decorator; runs first at request time
    */
   ArmeriaServerBuilder withSecurityDecorators(
       DecoratingHttpServiceFunction accessDecorator,
       DecoratingHttpServiceFunction authDecorator) {
     Objects.requireNonNull(accessDecorator, "accessDecorator");
     Objects.requireNonNull(authDecorator, "authDecorator");
-    // Both decorators are wired onto the same path prefixes. Armeria applies decorators in reverse
-    // registration order, so listing accessDecorator before authDecorator makes authDecorator
-    // (authentication) run first at request time, then accessDecorator (authorization).
     for (DecoratingHttpServiceFunction decorator : List.of(accessDecorator, authDecorator)) {
       armeriaServerBuilder.routeDecorator().pathPrefix(basePath).build(decorator);
       armeriaServerBuilder

--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -1,0 +1,201 @@
+package io.unitycatalog.server;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
+import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import com.linecorp.armeria.server.docs.DocService;
+import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
+import io.unitycatalog.server.exception.ExceptionHandlingDecorator;
+import io.unitycatalog.server.exception.GlobalExceptionHandler;
+import io.unitycatalog.server.service.AuthService;
+import io.unitycatalog.server.service.IcebergRestCatalogService;
+import io.unitycatalog.server.service.delta.DeltaApiMappers;
+import io.unitycatalog.server.service.delta.DeltaApiService;
+import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Wraps Armeria's {@link ServerBuilder} with Unity-Catalog-aware registration. Callers register
+ * each annotated service through a protocol-specific {@code annotate*} method ({@link
+ * #annotateUc}, {@link #annotateAuth}, {@link #annotateScim}, {@link #annotateIceberg},
+ * {@link #annotateDelta}). Those methods funnel through the single private {@link #register}, the
+ * only place this class registers an annotated service, and it always installs the PAYLOAD-source
+ * authorization gate in front of the body converter -- so no annotated service can reach the server
+ * ungated. {@link #withSecurityDecorators} attaches caller-supplied access/auth decorators to the
+ * API path prefixes, and {@link #build()} builds the server.
+ *
+ * <p>{@link UnityCatalogServer} bootstraps the collaborators (Hibernate, authorizer, repositories),
+ * constructs the service handlers, and decides whether authorization is enabled; this class turns
+ * registration + assembly into a running {@link Server} and does not itself know about server
+ * properties or security context.
+ */
+public class ArmeriaServerBuilder {
+
+  private final ServerBuilder armeriaServerBuilder;
+  private final String basePath;
+  private final String controlPath;
+
+  // Body mappers and response converters, created once and reused across registrations. The
+  // request converter is always the gated wrapper (see gatedJackson); only the wrapped mapper and
+  // the response converter vary by protocol.
+  private final ObjectMapper ucMapper;
+  private final JacksonResponseConverterFunction scimResponseConverter;
+  private final ObjectMapper icebergMapper;
+  private final JacksonResponseConverterFunction icebergResponseConverter;
+  private final ObjectMapper deltaMapper;
+  private final JacksonResponseConverterFunction deltaResponseConverter;
+
+  ArmeriaServerBuilder(int port, String basePath, String controlPath) {
+    this.armeriaServerBuilder = Server.builder().http(port).serviceUnder("/docs", new DocService());
+    this.armeriaServerBuilder.service(
+        "/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
+    this.basePath = basePath;
+    this.controlPath = controlPath;
+    this.ucMapper =
+        JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
+    this.scimResponseConverter =
+        new JacksonResponseConverterFunction(
+            JsonMapper.builder()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .build());
+    this.icebergMapper = IcebergObjectMapper.mapper();
+    this.icebergResponseConverter = new JacksonResponseConverterFunction(icebergMapper);
+    this.deltaMapper = DeltaApiMappers.MAPPER;
+    this.deltaResponseConverter = new JacksonResponseConverterFunction(deltaMapper);
+  }
+
+  /** Registers a control-plane auth service at {@code controlPath + relativePath}. */
+  ArmeriaServerBuilder annotateAuth(String relativePath, AuthService service) {
+    register(ServiceProtocol.AUTH, relativePath, service);
+    return this;
+  }
+
+  // TODO: introduce an interface for the two SCIM services and replace Object here with it.
+  /** Registers a SCIM2 service (UC body + SCIM response converter) under the control path. */
+  ArmeriaServerBuilder annotateScim(String relativePath, Object service) {
+    register(ServiceProtocol.SCIM, relativePath, service);
+    return this;
+  }
+
+  // TODO: introduce an interface for all UC REST services and replace Object here with it.
+  /** Registers a standard Unity Catalog REST service at {@code basePath + relativePath}. */
+  ArmeriaServerBuilder annotateUc(String relativePath, Object service) {
+    register(ServiceProtocol.UC, relativePath, service);
+    return this;
+  }
+
+  /** Registers an Iceberg REST catalog service (Iceberg mapper) under the base path. */
+  ArmeriaServerBuilder annotateIceberg(String relativePath, IcebergRestCatalogService service) {
+    register(ServiceProtocol.ICEBERG, relativePath, service);
+    return this;
+  }
+
+  /** Registers a UC Delta REST service (Delta mapper) under the base path. */
+  ArmeriaServerBuilder annotateDelta(String relativePath, DeltaApiService service) {
+    register(ServiceProtocol.DELTA, relativePath, service);
+    return this;
+  }
+
+  /**
+   * Wires the access and authentication decorators onto the API path prefixes. The caller owns the
+   * decision of whether to enable authorization (and simply skips calling this when it is
+   * disabled); this method only knows how to attach the decorators it is given -- path prefixes,
+   * the {@code auth/tokens} exclusion, and that the exception handler must sit at the bottom of the
+   * chain.
+   */
+  ArmeriaServerBuilder withSecurityDecorators(
+      DecoratingHttpServiceFunction accessDecorator,
+      DecoratingHttpServiceFunction authDecorator) {
+    Objects.requireNonNull(accessDecorator, "accessDecorator");
+    Objects.requireNonNull(authDecorator, "authDecorator");
+    // Both decorators are wired onto the same path prefixes. Armeria applies decorators in reverse
+    // registration order, so listing accessDecorator before authDecorator makes authDecorator
+    // (authentication) run first at request time, then accessDecorator (authorization).
+    for (DecoratingHttpServiceFunction decorator : List.of(accessDecorator, authDecorator)) {
+      armeriaServerBuilder.routeDecorator().pathPrefix(basePath).build(decorator);
+      armeriaServerBuilder
+          .routeDecorator()
+          .pathPrefix(controlPath)
+          .exclude(controlPath + "auth/tokens")
+          .build(decorator);
+    }
+
+    armeriaServerBuilder.decorator(new ExceptionHandlingDecorator(new GlobalExceptionHandler()));
+    return this;
+  }
+
+  /** Builds the Armeria {@link Server}. */
+  Server build() {
+    return armeriaServerBuilder.build();
+  }
+
+  /**
+   * The wire protocol an annotated service speaks: which path family it mounts under (control-plane
+   * vs. the main API base path) plus, in {@link #register}, its body and response converters.
+   */
+  private enum ServiceProtocol {
+    AUTH(true),
+    SCIM(true),
+    UC(false),
+    ICEBERG(false),
+    DELTA(false);
+
+    private final boolean underControlPath;
+
+    ServiceProtocol(boolean underControlPath) {
+      this.underControlPath = underControlPath;
+    }
+
+    /** Resolves this protocol's base path against the caller-supplied path prefixes. */
+    String basePath(String basePath, String controlPath) {
+      return underControlPath ? controlPath : basePath;
+    }
+  }
+
+  /**
+   * The single registration point behind every {@code annotate*} method, and the only place this
+   * class calls {@code annotatedService}. It selects the protocol-specific body mapper and response
+   * converter, wraps the request converter with {@link AuthorizationGateConverter} (so the
+   * PAYLOAD-source authorization gate fires before body binding for every route without exception),
+   * and registers the service at {@code basePath + relativePath} ({@code ""} mounts at the base
+   * path root). Because this is the sole registration path and it always wraps with the gate, no
+   * annotated service can reach the server ungated.
+   *
+   * <p>The per-protocol converter selection is a switch expression with no default, so it is
+   * checked for exhaustiveness: adding a {@link ServiceProtocol} constant without a corresponding
+   * arm is a compile error, and a new service kind cannot be registered without also deciding its
+   * (still gated) converters.
+   */
+  private void register(ServiceProtocol protocol, String relativePath, Object service) {
+    List<Object> converters = switch (protocol) {
+      // Auth and UC services do not have response converter. They return HttpResponse.ofJson
+      // directly.
+      case AUTH, UC -> List.of(gatedJackson(ucMapper));
+      case SCIM -> List.of(gatedJackson(ucMapper), scimResponseConverter);
+      case ICEBERG -> List.of(gatedJackson(icebergMapper), icebergResponseConverter);
+      case DELTA -> List.of(gatedJackson(deltaMapper), deltaResponseConverter);
+    };
+    armeriaServerBuilder.annotatedService(
+        protocol.basePath(basePath, controlPath) + relativePath, service, converters.toArray());
+  }
+
+  /**
+   * Wraps a Jackson body converter with {@link AuthorizationGateConverter}. Every annotated
+   * service's request converter goes through this (via {@link #register}) so the PAYLOAD-source
+   * auth check fires before body binding.
+   */
+  private static RequestConverterFunction gatedJackson(ObjectMapper mapper) {
+    return new AuthorizationGateConverter(new JacksonRequestConverterFunction(mapper));
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -2,29 +2,15 @@ package io.unitycatalog.server;
 
 import static io.unitycatalog.server.security.SecurityContext.Issuers.INTERNAL;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
-import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
-import com.linecorp.armeria.server.annotation.RequestConverterFunction;
-import com.linecorp.armeria.server.docs.DocService;
 import io.unitycatalog.server.auth.AllowingAuthorizer;
 import io.unitycatalog.server.auth.JCasbinAuthorizer;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
-import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
 import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
 import io.unitycatalog.server.auth.decorator.UnityAccessUtil;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.BaseExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.ExceptionHandlingDecorator;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.utils.HibernateConfigurator;
 import io.unitycatalog.server.security.SecurityConfiguration;
@@ -52,10 +38,8 @@ import io.unitycatalog.server.service.TemporaryVolumeCredentialsService;
 import io.unitycatalog.server.service.VolumeService;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
-import io.unitycatalog.server.service.delta.DeltaApiMappers;
 import io.unitycatalog.server.service.delta.DeltaApiService;
 import io.unitycatalog.server.service.iceberg.FileIOFactory;
-import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.OptionParser;
@@ -75,7 +59,6 @@ public class UnityCatalogServer implements AutoCloseable {
   private static final int DEFAULT_PORT = 8080;
   public static final String SERVER_PROPERTIES_FILE = "etc/conf/server.properties";
   private final Server server;
-  private final ServerProperties serverProperties;
   private final SecurityContext securityContext;
   private final HibernateConfigurator hibernateConfigurator;
   /** True when this server built the configurator itself and must therefore close it. */
@@ -93,12 +76,11 @@ public class UnityCatalogServer implements AutoCloseable {
 
     this.securityContext =
         new SecurityContext(configurationFolder, securityConfiguration, "server", INTERNAL);
-    this.serverProperties = unityCatalogServerBuilder.serverProperties;
     // An injected configurator stays the caller's to close; only a self-built one is ours.
     this.ownsHibernateConfigurator = unityCatalogServerBuilder.hibernateConfigurator == null;
     this.hibernateConfigurator =
         ownsHibernateConfigurator
-            ? new HibernateConfigurator(serverProperties)
+            ? new HibernateConfigurator(unityCatalogServerBuilder.serverProperties)
             : unityCatalogServerBuilder.hibernateConfigurator;
     try {
       this.server = initializeServer(unityCatalogServerBuilder);
@@ -136,14 +118,13 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   private Server initializeServer(UnityCatalogServer.Builder unityCatalogServerBuilder) {
-    ServerBuilder armeriaServerBuilder =
-        Server.builder()
-            .http(unityCatalogServerBuilder.port)
-            .serviceUnder("/docs", new DocService());
+    ArmeriaServerBuilder armeriaServerBuilder =
+        new ArmeriaServerBuilder(unityCatalogServerBuilder.port, BASE_PATH, CONTROL_PATH);
 
     // Init all repositories
     Repositories repositories =
-        new Repositories(hibernateConfigurator.getSessionFactory(), serverProperties);
+        new Repositories(
+            hibernateConfigurator.getSessionFactory(), unityCatalogServerBuilder.serverProperties);
     // Init metastore
     repositories.getMetastoreRepository().initMetastoreIfNeeded();
     // Init authorizer
@@ -154,12 +135,7 @@ public class UnityCatalogServer implements AutoCloseable {
     BaseExceptionHandler.setIncludeStackTrace(
         unityCatalogServerBuilder.serverProperties.isIncludeStackTraceInError());
     // Init services
-    addApiServices(
-        armeriaServerBuilder,
-        unityCatalogServerBuilder,
-        unityCatalogServerBuilder.serverProperties,
-        authorizer,
-        repositories);
+    addApiServices(armeriaServerBuilder, unityCatalogServerBuilder, authorizer, repositories);
     // Init security decorators
     addSecurityDecorators(
         armeriaServerBuilder, unityCatalogServerBuilder.serverProperties, authorizer, repositories);
@@ -187,12 +163,12 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   private void addApiServices(
-      ServerBuilder armeriaServerBuilder,
+      ArmeriaServerBuilder armeriaServerBuilder,
       UnityCatalogServer.Builder unityCatalogServerBuilder,
-      ServerProperties serverProperties,
       UnityCatalogAuthorizer authorizer,
       Repositories repositories) {
     LOGGER.info("Adding Unity Catalog API services...");
+    ServerProperties serverProperties = unityCatalogServerBuilder.serverProperties;
     CloudCredentialVendor cloudCredentialVendor =
         unityCatalogServerBuilder.cloudCredentialVendor != null
             ? unityCatalogServerBuilder.cloudCredentialVendor
@@ -200,146 +176,78 @@ public class UnityCatalogServer implements AutoCloseable {
     StorageCredentialVendor storageCredentialVendor =
         new StorageCredentialVendor(cloudCredentialVendor, repositories.getExternalLocationUtils());
 
-    // Add support for Unity Catalog APIs
-    AuthService authService = new AuthService(securityContext, serverProperties, repositories);
-    PermissionService permissionService = new PermissionService(authorizer, repositories);
-    Scim2UserService scim2UserService = new Scim2UserService(authorizer, repositories);
-    Scim2SelfService scim2SelfService = new Scim2SelfService(authorizer, repositories);
-    CatalogService catalogService = new CatalogService(authorizer, repositories, serverProperties);
     SchemaService schemaService = new SchemaService(authorizer, repositories, serverProperties);
-    VolumeService volumeService = new VolumeService(authorizer, repositories, serverProperties);
-    TableService tableService = new TableService(authorizer, repositories, serverProperties);
-    StagingTableService stagingTableService =
-        new StagingTableService(authorizer, repositories, serverProperties);
-    FunctionService functionService =
-        new FunctionService(authorizer, repositories, serverProperties);
-    ModelService modelService = new ModelService(authorizer, repositories, serverProperties);
-    CredentialService credentialService =
-        new CredentialService(authorizer, repositories, serverProperties);
-    ExternalLocationService externalLocationService =
-        new ExternalLocationService(authorizer, repositories, serverProperties);
-    DeltaCommitsService deltaCommitsService =
-        new DeltaCommitsService(authorizer, repositories, serverProperties);
-    MetastoreService metastoreService = new MetastoreService(repositories);
-    // TODO: combine these into a single service in a follow-up PR
-    TemporaryTableCredentialsService temporaryTableCredentialsService =
-        new TemporaryTableCredentialsService(
-            storageCredentialVendor, repositories, serverProperties);
-    TemporaryVolumeCredentialsService temporaryVolumeCredentialsService =
-        new TemporaryVolumeCredentialsService(storageCredentialVendor, repositories);
-    TemporaryModelVersionCredentialsService temporaryModelVersionCredentialsService =
-        new TemporaryModelVersionCredentialsService(storageCredentialVendor, repositories);
-    TemporaryPathCredentialsService temporaryPathCredentialsService =
-        new TemporaryPathCredentialsService(storageCredentialVendor);
 
-    RequestConverterFunction requestConverterFunction =
-        gatedJackson(
-            JsonMapper.builder()
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                .build());
-    JacksonResponseConverterFunction scimResponseConverterFunction =
-        new JacksonResponseConverterFunction(
-            JsonMapper.builder()
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .serializationInclusion(JsonInclude.Include.NON_NULL)
-                .build());
+    // Each annotate* call registers one service. Order is not significant (Armeria routes by path
+    // specificity); relative paths are resolved against the protocol's base path ("" mounts at the
+    // base path root).
     armeriaServerBuilder
-        .service("/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"))
-        .annotatedService(CONTROL_PATH + "auth", authService, requestConverterFunction)
-        .annotatedService(
-            CONTROL_PATH + "scim2/Users",
-            scim2UserService,
-            requestConverterFunction,
-            scimResponseConverterFunction)
-        .annotatedService(
-            CONTROL_PATH + "scim2/Me",
-            scim2SelfService,
-            requestConverterFunction,
-            scimResponseConverterFunction)
-        .annotatedService(BASE_PATH + "permissions", permissionService)
-        .annotatedService(BASE_PATH + "catalogs", catalogService, requestConverterFunction)
-        .annotatedService(BASE_PATH + "schemas", schemaService, requestConverterFunction)
-        .annotatedService(BASE_PATH + "volumes", volumeService, requestConverterFunction)
-        .annotatedService(BASE_PATH + "tables", tableService, requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "staging-tables", stagingTableService, requestConverterFunction)
-        .annotatedService(BASE_PATH + "functions", functionService, requestConverterFunction)
-        .annotatedService(BASE_PATH + "models", modelService, requestConverterFunction)
-        .annotatedService(BASE_PATH, metastoreService, requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "temporary-table-credentials",
-            temporaryTableCredentialsService,
-            requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "temporary-volume-credentials",
-            temporaryVolumeCredentialsService,
-            requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "temporary-model-version-credentials",
-            temporaryModelVersionCredentialsService,
-            requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "temporary-path-credentials",
-            temporaryPathCredentialsService,
-            requestConverterFunction)
-        .annotatedService(BASE_PATH + "credentials", credentialService, requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "delta/preview/commits", deltaCommitsService, requestConverterFunction)
-        .annotatedService(
-            BASE_PATH + "external-locations", externalLocationService, requestConverterFunction);
+        .annotateAuth("auth", new AuthService(securityContext, serverProperties, repositories))
+        .annotateScim("scim2/Users", new Scim2UserService(authorizer, repositories))
+        .annotateScim("scim2/Me", new Scim2SelfService(authorizer, repositories))
+        .annotateUc("permissions", new PermissionService(authorizer, repositories))
+        .annotateUc("catalogs", new CatalogService(authorizer, repositories, serverProperties))
+        .annotateUc("schemas", schemaService)
+        .annotateUc("volumes", new VolumeService(authorizer, repositories, serverProperties))
+        .annotateUc("tables", new TableService(authorizer, repositories, serverProperties))
+        .annotateUc(
+            "staging-tables", new StagingTableService(authorizer, repositories, serverProperties))
+        .annotateUc("functions", new FunctionService(authorizer, repositories, serverProperties))
+        .annotateUc("models", new ModelService(authorizer, repositories, serverProperties))
+        .annotateUc("", new MetastoreService(repositories))
+        .annotateUc(
+            "temporary-table-credentials",
+            new TemporaryTableCredentialsService(
+                storageCredentialVendor, repositories, serverProperties))
+        .annotateUc(
+            "temporary-volume-credentials",
+            new TemporaryVolumeCredentialsService(storageCredentialVendor, repositories))
+        .annotateUc(
+            "temporary-model-version-credentials",
+            new TemporaryModelVersionCredentialsService(storageCredentialVendor, repositories))
+        .annotateUc(
+            "temporary-path-credentials",
+            new TemporaryPathCredentialsService(storageCredentialVendor))
+        .annotateUc(
+            "credentials", new CredentialService(authorizer, repositories, serverProperties))
+        .annotateUc(
+            "delta/preview/commits",
+            new DeltaCommitsService(authorizer, repositories, serverProperties))
+        .annotateUc(
+            "external-locations",
+            new ExternalLocationService(authorizer, repositories, serverProperties));
     addIcebergApiServices(
         armeriaServerBuilder,
         serverProperties,
         storageCredentialVendor,
-        catalogService,
         schemaService,
-        tableService,
         repositories);
     addDeltaApiServices(
         armeriaServerBuilder, authorizer, repositories, serverProperties, storageCredentialVendor);
   }
 
-  /**
-   * Wraps a Jackson body converter with {@link AuthorizationGateConverter}. Every annotated
-   * service's request converter must go through this so the PAYLOAD-source auth check fires before
-   * body binding. Using a wrapper (rather than registering the gate as a separate chain element per
-   * {@code annotatedService(...)} call) makes the gate impossible to forget when a new service is
-   * added.
-   */
-  private static RequestConverterFunction gatedJackson(ObjectMapper mapper) {
-    return new AuthorizationGateConverter(new JacksonRequestConverterFunction(mapper));
-  }
-
   private void addIcebergApiServices(
-      ServerBuilder armeriaServerBuilder,
+      ArmeriaServerBuilder armeriaServerBuilder,
       ServerProperties serverProperties,
       StorageCredentialVendor storageCredentialVendor,
-      CatalogService catalogService,
       SchemaService schemaService,
-      TableService tableService,
       Repositories repositories) {
     LOGGER.info("Adding Iceberg services...");
 
     // Add support for Iceberg REST APIs
-    ObjectMapper icebergMapper = IcebergObjectMapper.mapper();
-    RequestConverterFunction icebergRequestConverter = gatedJackson(icebergMapper);
-    JacksonResponseConverterFunction icebergResponseConverter =
-        new JacksonResponseConverterFunction(icebergMapper);
     MetadataService metadataService =
         new MetadataService(new FileIOFactory(storageCredentialVendor, serverProperties));
     TableConfigService tableConfigService =
         new TableConfigService(storageCredentialVendor, serverProperties);
 
-    armeriaServerBuilder.annotatedService(
-        BASE_PATH + "iceberg",
+    armeriaServerBuilder.annotateIceberg(
+        "iceberg",
         new IcebergRestCatalogService(
-            schemaService, tableConfigService, metadataService, repositories),
-        icebergRequestConverter,
-        icebergResponseConverter);
+            schemaService, tableConfigService, metadataService, repositories));
   }
 
   private void addDeltaApiServices(
-      ServerBuilder armeriaServerBuilder,
+      ArmeriaServerBuilder armeriaServerBuilder,
       UnityCatalogAuthorizer authorizer,
       Repositories repositories,
       ServerProperties serverProperties,
@@ -347,43 +255,20 @@ public class UnityCatalogServer implements AutoCloseable {
     LOGGER.info("Adding UC Delta API services...");
     DeltaApiService deltaApiService =
         new DeltaApiService(authorizer, repositories, serverProperties, storageCredentialVendor);
-    ObjectMapper deltaMapper = DeltaApiMappers.MAPPER;
-    armeriaServerBuilder.annotatedService(
-        BASE_PATH,
-        deltaApiService,
-        gatedJackson(deltaMapper),
-        new JacksonResponseConverterFunction(deltaMapper));
+    armeriaServerBuilder.annotateDelta("", deltaApiService);
   }
 
   private void addSecurityDecorators(
-      ServerBuilder armeriaServerBuilder,
+      ArmeriaServerBuilder armeriaServerBuilder,
       ServerProperties serverProperties,
       UnityCatalogAuthorizer authorizer,
       Repositories repositories) {
     // TODO: eventually might want to make this secure-by-default.
     if (serverProperties.isAuthorizationEnabled()) {
       LOGGER.info("Enabling security decorators...");
-
-      // Note: Decorators are applied in reverse order.
-      UnityAccessDecorator accessDecorator = new UnityAccessDecorator(authorizer, repositories);
-      armeriaServerBuilder.routeDecorator().pathPrefix(BASE_PATH).build(accessDecorator);
-      armeriaServerBuilder
-          .routeDecorator()
-          .pathPrefix(CONTROL_PATH)
-          .exclude(CONTROL_PATH + "auth/tokens")
-          .build(accessDecorator);
-
-      AuthDecorator authDecorator = new AuthDecorator(securityContext, repositories);
-      armeriaServerBuilder.routeDecorator().pathPrefix(BASE_PATH).build(authDecorator);
-      armeriaServerBuilder
-          .routeDecorator()
-          .pathPrefix(CONTROL_PATH)
-          .exclude(CONTROL_PATH + "auth/tokens")
-          .build(authDecorator);
-
-      ExceptionHandlingDecorator exceptionDecorator =
-          new ExceptionHandlingDecorator(new GlobalExceptionHandler());
-      armeriaServerBuilder.decorator(exceptionDecorator);
+      armeriaServerBuilder.withSecurityDecorators(
+          new UnityAccessDecorator(authorizer, repositories),
+          new AuthDecorator(securityContext, repositories));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -69,6 +69,7 @@ public class IcebergRestCatalogService {
       TableConfigService tableConfigService,
       MetadataService metadataService,
       Repositories repositories) {
+    // TODO: avoid this service to service dependency
     this.schemaService = schemaService;
     this.tableConfigService = tableConfigService;
     this.metadataService = metadataService;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1724/files) to review incremental changes.
- [stack/armeria_builder](https://github.com/unitycatalog/unitycatalog/pull/1724) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1724/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Move Armeria `ServerBuilder` wiring out of `UnityCatalogServer` into a dedicated `ArmeriaServerBuilder`, so `UnityCatalogServer` only bootstraps collaborators and builds the service handlers.

- Register services via protocol-specific `annotate*` methods, chained in `addApiServices`.
- All registration funnels through one private `register`, which always wraps the body converter with `AuthorizationGateConverter` -- so no service can be registered ungated.
- Pass base/control paths in as constructor args instead of hard-coding them.

No behavior change: same routes, converters, and decorator ordering.
