### PR TITLE
[Server] Reject cloud storage roots for external data

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -658,7 +658,8 @@ public class TableRepository {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
             ValidationUtils.checkArgument(
                 !storageLocation.isCloudStorageRoot(),
-                "External table storage location must include a non-empty path prefix");
+                "External table storage location must include a non-empty path prefix: %s",
+                createTable.getStorageLocation());
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
             tableUUID = UUID.randomUUID();
           } else if (tableType == TableType.MANAGED) {

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -656,6 +656,9 @@ public class TableRepository {
           NormalizedURL storageLocation;
           if (tableType == TableType.EXTERNAL) {
             storageLocation = NormalizedURL.from(createTable.getStorageLocation());
+            ValidationUtils.checkArgument(
+                !storageLocation.isCloudStorageRoot(),
+                "External table storage location must include a non-empty path prefix");
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
             tableUUID = UUID.randomUUID();
           } else if (tableType == TableType.MANAGED) {

--- a/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
@@ -79,6 +79,9 @@ public class VolumeRepository {
                   ErrorCode.INVALID_ARGUMENT, "Storage location is required for external volume");
             }
             storageLocation = NormalizedURL.from(createVolumeRequest.getStorageLocation());
+            ValidationUtils.checkArgument(
+                !storageLocation.isCloudStorageRoot(),
+                "External volume storage location must include a non-empty path prefix");
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
           }
           Date now = new Date();

--- a/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
@@ -81,7 +81,8 @@ public class VolumeRepository {
             storageLocation = NormalizedURL.from(createVolumeRequest.getStorageLocation());
             ValidationUtils.checkArgument(
                 !storageLocation.isCloudStorageRoot(),
-                "External volume storage location must include a non-empty path prefix");
+                "External volume storage location must include a non-empty path prefix: %s",
+                createVolumeRequest.getStorageLocation());
             ExternalLocationUtils.validateNotOverlapWithManagedStorage(session, storageLocation);
           }
           Date now = new Date();

--- a/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
@@ -6,6 +6,7 @@ import io.unitycatalog.server.model.TemporaryCredentials;
 import io.unitycatalog.server.persist.dao.CredentialDAO;
 import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ValidationUtils;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,13 +38,18 @@ public class StorageCredentialVendor {
    * @param path the normalized storage location URL (e.g., s3://bucket/path)
    * @param privileges the set of privileges required (SELECT, UPDATE)
    * @return temporary credentials scoped to the requested path and privileges
-   * @throws BaseException if the path is null or credentials cannot be generated
+   * @throws BaseException if the path is null or a cloud storage root, or credentials cannot be
+   *     generated
    */
   public TemporaryCredentials vendCredential(
       NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
     if (path == null) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Storage location is null.");
     }
+    ValidationUtils.checkArgument(
+        !path.isCloudStorageRoot(),
+        "Storage location must include a non-empty path prefix before credentials can be vended: %s",
+        path);
     if (privileges == null || privileges.isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Privileges cannot be null or empty.");
     }

--- a/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
@@ -94,6 +94,23 @@ public final class NormalizedURL {
   }
 
   /**
+   * Returns whether this URL identifies an entire cloud storage bucket or container.
+   *
+   * <p>The decoded path is checked so equivalent root forms such as a trailing slash, normalized
+   * dot segments, and encoded slashes are treated consistently.
+   */
+  public boolean isCloudStorageRoot() {
+    URI uri = toUri();
+    return switch (UriScheme.fromURI(uri)) {
+      case S3, GS, ABFS, ABFSS -> {
+        String path = uri.getPath();
+        yield path == null || path.chars().allMatch(character -> character == '/');
+      }
+      default -> false;
+    };
+  }
+
+  /**
    * Converts a given input path or URI into a standardized URI string. This method ensures that
    * local file paths are correctly formatted as file URIs and that URIs for different storage
    * providers (e.g., S3, Azure, GCS) are handled appropriately.

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -95,7 +95,8 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
             exception ->
                 assertThat(exception.getCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
-        .withMessageContaining("must include a non-empty path prefix");
+        .withMessageContaining("must include a non-empty path prefix")
+        .withMessageContaining("s3://bucket/");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -78,6 +78,27 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
   }
 
   @Test
+  public void testCreateExternalTableRejectsCloudStorageRoot() {
+    CreateTable request =
+        new CreateTable()
+            .name("root_location_table")
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(columns)
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation("s3://bucket/");
+
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> localTablesApi.createTable(request))
+        .satisfies(
+            exception ->
+                assertThat(exception.getCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
+        .withMessageContaining("must include a non-empty path prefix");
+  }
+
+  @Test
   public void testListTablesWithNoNextPageTokenShouldReturnNull() throws Exception {
     TableInfo testingTable =
         createTestingTable(

--- a/server/src/test/java/io/unitycatalog/server/sdk/volume/SdkVolumeCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/volume/SdkVolumeCRUDTest.java
@@ -51,6 +51,7 @@ public class SdkVolumeCRUDTest extends BaseVolumeCRUDTest {
             exception ->
                 assertThat(exception.getCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
-        .withMessageContaining("must include a non-empty path prefix");
+        .withMessageContaining("must include a non-empty path prefix")
+        .withMessageContaining("s3://bucket/");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/volume/SdkVolumeCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/volume/SdkVolumeCRUDTest.java
@@ -1,13 +1,21 @@
 package io.unitycatalog.server.sdk.volume;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.CreateVolumeRequestContent;
+import io.unitycatalog.client.model.VolumeType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.volume.BaseVolumeCRUDTest;
 import io.unitycatalog.server.base.volume.VolumeOperations;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.utils.TestUtils;
+import org.junit.jupiter.api.Test;
 
 public class SdkVolumeCRUDTest extends BaseVolumeCRUDTest {
 
@@ -24,5 +32,25 @@ public class SdkVolumeCRUDTest extends BaseVolumeCRUDTest {
   @Override
   protected VolumeOperations createVolumeOperations(ServerConfig config) {
     return new SdkVolumeOperations(TestUtils.createApiClient(config));
+  }
+
+  @Test
+  public void testCreateExternalVolumeRejectsCloudStorageRoot() throws ApiException {
+    createCommonResources();
+    CreateVolumeRequestContent request =
+        new CreateVolumeRequestContent()
+            .name("root_location_volume")
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .volumeType(VolumeType.EXTERNAL)
+            .storageLocation("s3://bucket/");
+
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> volumeOperations.createVolume(request))
+        .satisfies(
+            exception ->
+                assertThat(exception.getCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT.getHttpStatus().code()))
+        .withMessageContaining("must include a non-empty path prefix");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.AwsCredentials;
 import io.unitycatalog.server.model.AwsIamRoleRequest;
 import io.unitycatalog.server.model.CreateCredentialRequest;
@@ -64,6 +65,20 @@ public class CloudCredentialVendorTest {
     StorageCredentialVendor storageCredentialVendor =
         new StorageCredentialVendor(credentialsOperations, externalLocationUtils);
     return storageCredentialVendor.vendCredential(NormalizedURL.from(path), privileges);
+  }
+
+  @Test
+  public void testRejectsCloudStorageRootBeforeVendingCredentials() {
+    reset(externalLocationUtils);
+    credentialsOperations = new CloudCredentialVendor(null, null, null);
+
+    assertThatThrownBy(
+            () -> vendCredential("s3://storageBase/", Set.of(CredentialContext.Privilege.SELECT)))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("must include a non-empty path prefix")
+        .hasMessageContaining("s3://storageBase")
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.INVALID_ARGUMENT);
   }
 
   @Test
@@ -131,7 +146,8 @@ public class CloudCredentialVendorTest {
     credentialsOperations = new CloudCredentialVendor(null, azureCredentialVendor, null);
     TemporaryCredentials azureTemporaryCredentials =
         vendCredential(
-            "abfss://test@uctest.dfs.core.windows.net", Set.of(CredentialContext.Privilege.UPDATE));
+            "abfss://test@uctest.dfs.core.windows.net/abc",
+            Set.of(CredentialContext.Privilege.UPDATE));
     assertThat(azureTemporaryCredentials.getAzureUserDelegationSas().getSasToken()).isNotNull();
 
     // Use datalake service client
@@ -148,7 +164,9 @@ public class CloudCredentialVendorTest {
     azureCredentialVendor = new AzureCredentialVendor(serverProperties);
     credentialsOperations = new CloudCredentialVendor(null, azureCredentialVendor, null);
     assertThatThrownBy(
-            () -> vendCredential("abfss://test@uctest", Set.of(CredentialContext.Privilege.UPDATE)))
+            () ->
+                vendCredential(
+                    "abfss://test@uctest/abc", Set.of(CredentialContext.Privilege.UPDATE)))
         .isInstanceOf(CompletionException.class);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/utils/NormalizedURLTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/NormalizedURLTest.java
@@ -8,6 +8,8 @@ import io.unitycatalog.server.exception.BaseException;
 import java.net.URI;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class NormalizedURLTest {
 
@@ -107,5 +109,37 @@ public class NormalizedURLTest {
             NormalizedURL.from("abfss://container@account.dfs.core.windows.net/path")
                 .getStorageBase())
         .isEqualTo(NormalizedURL.from("abfss://container@account.dfs.core.windows.net"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "s3://bucket",
+        "s3://bucket/",
+        "s3://bucket///",
+        "s3://bucket/.",
+        "s3://bucket/a/..",
+        "s3://bucket/%2F",
+        "s3://bucket?query",
+        "s3://bucket#fragment",
+        "gs://bucket/",
+        "abfs://container@account.dfs.core.windows.net/",
+        "abfss://container@account.dfs.core.windows.net/"
+      })
+  public void testIdentifiesCloudStorageRoots(String location) {
+    assertThat(NormalizedURL.from(location).isCloudStorageRoot()).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "s3://bucket/path",
+        "gs://bucket/path",
+        "abfs://container@account.dfs.core.windows.net/path",
+        "abfss://container@account.dfs.core.windows.net/path",
+        "file:///"
+      })
+  public void testDoesNotIdentifyScopedOrLocalLocationsAsCloudStorageRoots(String location) {
+    assertThat(NormalizedURL.from(location).isCloudStorageRoot()).isFalse();
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [x] If you have added or modified a feature, documentation in `docs` is updated. (Not applicable: validation-only bug fix.)

**Description of changes**

Reject bucket- or container-root storage locations when creating external tables and volumes. Cloud roots remain valid for external-location coverage and server storage configuration.

The validation operates on the decoded normalized path, so equivalent root forms such as trailing slashes, normalized dot segments, and encoded slashes are handled consistently across S3, GCS, ABFS, and ABFSS.

**Testing**

- `build/sbt "server/Compile/javafmtAll" "server/Test/javafmtAll"`
- `build/sbt "server/testOnly io.unitycatalog.server.utils.NormalizedURLTest io.unitycatalog.server.sdk.tables.SdkTableCRUDTest io.unitycatalog.server.sdk.volume.SdkVolumeCRUDTest" "server/checkstyle" "server/Test/checkstyle"`
- 31 targeted tests passed; checkstyle reported no issues.