### PR TITLE
[Spark] Round-trip view creation context (query-output columns + catalog/namespace)

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -36,14 +36,21 @@ trait UCProxyViewSupport { self: UCProxy =>
     // Spark 4.2 surfaces these through the View API (withQueryColumnNames / withSchemaMode); on v1
     // they are read from properties (viewQueryColumnNames / viewSchemaModeFromProperties), so
     // populate them here for parity. The `view.sqlConfig.*` keys are already carried in `base`.
+    //
+    // The query-output column names (what the SELECT list produces) can differ from the declared
+    // column names -- e.g. `CREATE VIEW v(a, b) AS SELECT x, y` or a literal `SELECT 1111`. Spark
+    // matches the parsed query output against the declared schema BY these names, so prefer the
+    // persisted `view.query.out.*` already in `base`; deriving from the declared `fields` would
+    // break resolution with INCOMPATIBLE_VIEW_SCHEMA_CHANGE. Only synthesize them (from the
+    // declared columns) when the row never persisted them.
     val queryOut =
-      if (fields.nonEmpty) {
+      if (base.contains(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS) || fields.isEmpty) {
+        Map.empty[String, String]
+      } else {
         Map(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS -> fields.length.toString) ++
           fields.zipWithIndex.map { case (f, i) =>
             s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$i" -> f.name
           }
-      } else {
-        Map.empty[String, String]
       }
     val schemaModeDefault =
       if (base.contains(CatalogTable.VIEW_SCHEMA_MODE)) Map.empty[String, String]

--- a/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -55,8 +55,14 @@ trait UCProxyViewSupport { self: UCProxy =>
     val schemaModeDefault =
       if (base.contains(CatalogTable.VIEW_SCHEMA_MODE)) Map.empty[String, String]
       else Map(CatalogTable.VIEW_SCHEMA_MODE -> SchemaCompensation.toString)
+    // Unqualified table references in the view body resolve against the current catalog/namespace
+    // captured at creation time, which can differ from the view's own location. Prefer the
+    // persisted `view.catalogAndNamespace.*` already in `base`; only synthesize it (from the view's
+    // location) when the row never persisted it. Note `self.name()` is the connector's own catalog
+    // name -- correct only as a fallback for a same-namespace view.
     val viewNamespaceProps =
-      CatalogTable.catalogAndNamespaceToProps(self.name(), Seq(t.getSchemaName))
+      if (base.contains(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)) Map.empty[String, String]
+      else CatalogTable.catalogAndNamespaceToProps(self.name(), Seq(t.getSchemaName))
     val viewTable = CatalogTable(
       identifier = identifier,
       tableType = CatalogTableType.VIEW,

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -173,6 +173,17 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
         propertiesToServer.put(CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX + i, name)
       }
     }
+    // Persist the current catalog/namespace captured at creation time. Unqualified table
+    // references in the view body resolve against this context, which can differ from the view's
+    // own location (a view in `cat.a` created while the session default is `cat.b` resolves
+    // `FROM t` as `cat.b.t`). Stored as `view.catalogAndNamespace.*`, mirroring Spark's own v1
+    // `CatalogTable` encoding; the read path restores it instead of assuming the view's location.
+    Option(view.currentCatalog()).filter(_.nonEmpty).foreach { currentCatalog =>
+      val namespace = Option(view.currentNamespace()).map(_.toSeq).getOrElse(Seq.empty)
+      CatalogTable.catalogAndNamespaceToProps(currentCatalog, namespace).foreach {
+        case (k, v) => propertiesToServer.put(k, v)
+      }
+    }
     // `UNSUPPORTED` is the metric-view sentinel, not a persistable mode; skip it and let the read
     // path default to compensation.
     Option(view.schemaMode())
@@ -249,12 +260,21 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     // written by an older/non-Spark client that never persisted them).
     val queryColumnNames =
       UCViewTypes.extractQueryColumnNames(props).getOrElse(columns.map(_.name()).toSeq)
-    // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE / VIEW_QUERY_OUTPUT keys are surfaced via
-    // `withSqlConfigs` / `withSchemaMode` / `withQueryColumnNames`; drop them from `props` so they
-    // don't also leak into the user-visible `properties()` map and get re-persisted
-    // (double-counted) on a createView/replace round-trip.
+    // Unqualified table references in the view body resolve against the current catalog/namespace
+    // captured at creation time, which can differ from the view's own location. Restore the
+    // persisted `view.catalogAndNamespace.*`; only fall back to the view's own location when absent
+    // (a row written by an older/non-Spark client that never persisted the resolution context).
+    val (currentCatalog, currentNamespace) =
+      UCViewTypes.extractCatalogAndNamespace(props)
+        .getOrElse((t.getCatalogName, Seq(t.getSchemaName)))
+    // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE / VIEW_QUERY_OUTPUT / VIEW_CATALOG_AND_NAMESPACE
+    // keys are surfaced via `withSqlConfigs` / `withSchemaMode` / `withQueryColumnNames` /
+    // `withCurrentCatalog` + `withCurrentNamespace`; drop them from `props` so they don't also leak
+    // into the user-visible `properties()` map and get re-persisted (double-counted) on a
+    // createView/replace round-trip.
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_PREFIX))
+    props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_PREFIX + "catalogAndNamespace."))
     props.remove(CatalogTable.VIEW_SCHEMA_MODE)
 
     val builder = new View.Builder()
@@ -262,8 +282,8 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       .withProperties(props)
       .withTableType(UCViewTypes.ucTableTypeToSparkViewType(t.getTableType))
       .withQueryText(t.getViewDefinition)
-      .withCurrentCatalog(t.getCatalogName)
-      .withCurrentNamespace(Array(t.getSchemaName))
+      .withCurrentCatalog(currentCatalog)
+      .withCurrentNamespace(currentNamespace.toArray)
       .withSqlConfigs(sqlConfigs)
       .withSchemaMode(schemaMode)
       .withQueryColumnNames(queryColumnNames.toArray)

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -159,6 +159,20 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     view.sqlConfigs().asScala.foreach { case (k, v) =>
       propertiesToServer.put(CatalogTable.VIEW_SQL_CONFIG_PREFIX + k, v)
     }
+    // Persist the query-output column names (the names the SELECT list produces, which can differ
+    // from the declared column names -- e.g. `CREATE VIEW v(a, b) AS SELECT x, y`). Spark resolves
+    // the view by matching the parsed query output against the declared schema BY these names, so
+    // they must round-trip; without them the read path can only guess from the declared names and
+    // resolution fails with INCOMPATIBLE_VIEW_SCHEMA_CHANGE. Stored as `view.query.out.*`, mirroring
+    // Spark's own v1 `CatalogTable` encoding.
+    val queryColumnNames = view.queryColumnNames()
+    if (queryColumnNames.nonEmpty) {
+      propertiesToServer.put(
+        CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS, queryColumnNames.length.toString)
+      queryColumnNames.zipWithIndex.foreach { case (name, i) =>
+        propertiesToServer.put(CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX + i, name)
+      }
+    }
     // `UNSUPPORTED` is the metric-view sentinel, not a persistable mode; skip it and let the read
     // path default to compensation.
     Option(view.schemaMode())
@@ -226,10 +240,21 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       if (t.getTableType == TableType.METRIC_VIEW) SchemaUnsupported.toString
       else SchemaCompensation.toString
     val schemaMode = Option(props.get(CatalogTable.VIEW_SCHEMA_MODE)).getOrElse(defaultSchemaMode)
-    // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE keys are surfaced via `withSqlConfigs` /
-    // `withSchemaMode`; drop them from `props` so they don't also leak into the user-visible
-    // `properties()` map and get re-persisted (double-counted) on a createView/replace round-trip.
+    // The query-output column names (what the view's SELECT list produces) can legitimately differ
+    // from the view's declared column names -- e.g. `CREATE VIEW v(a, b) AS SELECT x, y`, or a
+    // literal like `SELECT 1111`. Spark matches the parsed query output against the declared schema
+    // BY these names, so they must be the persisted `view.query.out.*` values rather than the
+    // declared column names; regenerating from the declared names breaks resolution with
+    // INCOMPATIBLE_VIEW_SCHEMA_CHANGE. Fall back to the declared names only when absent (a row
+    // written by an older/non-Spark client that never persisted them).
+    val queryColumnNames =
+      UCViewTypes.extractQueryColumnNames(props).getOrElse(columns.map(_.name()).toSeq)
+    // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE / VIEW_QUERY_OUTPUT keys are surfaced via
+    // `withSqlConfigs` / `withSchemaMode` / `withQueryColumnNames`; drop them from `props` so they
+    // don't also leak into the user-visible `properties()` map and get re-persisted
+    // (double-counted) on a createView/replace round-trip.
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
+    props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_PREFIX))
     props.remove(CatalogTable.VIEW_SCHEMA_MODE)
 
     val builder = new View.Builder()
@@ -241,7 +266,7 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       .withCurrentNamespace(Array(t.getSchemaName))
       .withSqlConfigs(sqlConfigs)
       .withSchemaMode(schemaMode)
-      .withQueryColumnNames(columns.map(_.name()))
+      .withQueryColumnNames(queryColumnNames.toArray)
     Option(t.getComment).foreach(builder.withComment)
     Option(t.getViewDependencies).foreach { ucDeps =>
       builder.withViewDependencies(fromUcDependencyList(ucDeps))

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -267,11 +267,14 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     val (currentCatalog, currentNamespace) =
       UCViewTypes.extractCatalogAndNamespace(props)
         .getOrElse((t.getCatalogName, Seq(t.getSchemaName)))
-    // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE / VIEW_QUERY_OUTPUT / VIEW_CATALOG_AND_NAMESPACE
-    // keys are surfaced via `withSqlConfigs` / `withSchemaMode` / `withQueryColumnNames` /
-    // `withCurrentCatalog` + `withCurrentNamespace`; drop them from `props` so they don't also leak
-    // into the user-visible `properties()` map and get re-persisted (double-counted) on a
-    // createView/replace round-trip.
+    // These four key families are surfaced through the typed `View` accessors (`withSqlConfigs` /
+    // `withQueryColumnNames` / `withCurrentCatalog` + `withCurrentNamespace` / `withSchemaMode`),
+    // so drop them from `props` to keep them out of the user-visible `properties()` map and avoid
+    // re-persisting (double-counting) them on a createView/replace round-trip. Stripping is lossless
+    // *only* for these: on view resolution Spark rebuilds the v1 CatalogTable from the typed fields
+    // (`V1Table.toCatalogTable`) and reads the metadata from there, never from this bag. Other
+    // `view.*` keys (e.g. `view.referredTemp*`) have no typed accessor and are carried to Spark
+    // *only* through `properties()`, so they must be left in place.
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_PREFIX))
     props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_PREFIX + "catalogAndNamespace."))

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -144,4 +144,25 @@ private[spark] object UCViewTypes {
     }
     configs
   }
+
+  /**
+   * Reads the persisted query-output column names of a view -- the names the view's SELECT list
+   * produces, which Spark uses to match the parsed query output against the declared view schema.
+   * These are stored as `view.query.out.numCols` plus `view.query.out.col.<i>` (Spark's
+   * `CatalogTable.VIEW_QUERY_OUTPUT_*`); returns them in ordinal order, or `None` when the count
+   * key is absent (a row that never persisted them). Shared by the view-load paths (`toView` on
+   * 4.2, `buildV1ViewTable` on 4.0/4.1); kept here so it stays free of Spark-4.2-only types and
+   * compiles on all supported Spark versions.
+   */
+  def extractQueryColumnNames(properties: util.Map[String, String]): Option[Seq[String]] = {
+    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).map { numColsStr =>
+      val numCols = numColsStr.toInt
+      (0 until numCols).map { i =>
+        val key = CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX + i
+        Option(properties.get(key)).getOrElse(
+          throw new IllegalStateException(
+            s"Corrupted view metadata: expected $numCols query-output columns but $key is missing"))
+      }
+    }
+  }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -165,4 +165,28 @@ private[spark] object UCViewTypes {
       }
     }
   }
+
+  /**
+   * Reads the current catalog + namespace captured when the view was created, against which
+   * unqualified table references in the view body are resolved. Spark persists these as
+   * `view.catalogAndNamespace.numParts` plus `view.catalogAndNamespace.part.<i>` (part 0 is the
+   * catalog, the rest the namespace). Returns `(catalog, namespace)`, or `None` when the count key
+   * is absent (a row that never persisted the resolution context). Shared by the view-load paths;
+   * kept here so it stays free of Spark-4.2-only types and compiles on all supported Spark versions.
+   */
+  def extractCatalogAndNamespace(
+      properties: util.Map[String, String]): Option[(String, Seq[String])] = {
+    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).flatMap { numPartsStr =>
+      val parts = (0 until numPartsStr.toInt).map { i =>
+        val key = CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX + i
+        Option(properties.get(key)).getOrElse(
+          throw new IllegalStateException(
+            s"Corrupted view metadata: expected ${numPartsStr.toInt} catalog/namespace parts " +
+              s"but $key is missing"))
+      }
+      // part 0 is the catalog; the remainder is the namespace. A degenerate 0-part list has no
+      // catalog to resolve against, so treat it as absent.
+      parts.headOption.map(catalog => (catalog, parts.tail))
+    }
+  }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewQueryColumnNamesReadOnlyTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewQueryColumnNamesReadOnlyTest.java
@@ -1,0 +1,114 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.DependencyList;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Spark 4.0/4.1 can only read views (no v2 {@code ViewCatalog}), and {@code buildV1ViewTable}
+ * reconstructs a v1 VIEW {@code CatalogTable} from the UC row. This pins that the view's persisted
+ * query-output column names ({@code view.query.out.*}) -- the names the SELECT list produces, which
+ * can differ from the declared column names -- are carried through rather than regenerated from the
+ * declared columns. Regenerating breaks Spark's by-name view-column matching with
+ * INCOMPATIBLE_VIEW_SCHEMA_CHANGE (the same bug the Spark 4.2 {@code UCJoinViewE2ETest} covers on
+ * the create+read path; here the view is created server-side since 4.0/4.1 cannot create it).
+ */
+public class UCViewQueryColumnNamesReadOnlyTest extends BaseSparkIntegrationTest {
+
+  private static final String SRC_TABLE = "src_tbl";
+  private static final String VIEW = "renamed_col_view";
+
+  private String tbl(String name) {
+    return CATALOG_NAME + "." + SCHEMA_NAME + "." + name;
+  }
+
+  /** Registers an external parquet source table so the view's query can resolve against it. */
+  @SneakyThrows
+  private void createSourceTable() {
+    new SdkTableOperations(createApiClient(serverConfig))
+        .createTable(
+            new CreateTable()
+                .name(SRC_TABLE)
+                .catalogName(CATALOG_NAME)
+                .schemaName(SCHEMA_NAME)
+                .tableType(TableType.EXTERNAL)
+                .dataSourceFormat(DataSourceFormat.PARQUET)
+                .storageLocation(Files.createTempDirectory("uc_src").toUri().toString())
+                .columns(
+                    List.of(
+                        new ColumnInfo()
+                            .name("name")
+                            .typeName(ColumnTypeName.STRING)
+                            .typeText("string")
+                            .typeJson(
+                                "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,"
+                                    + "\"metadata\":{}}")
+                            .nullable(true)
+                            .position(0))));
+  }
+
+  /**
+   * Creates a VIEW whose declared column is {@code emp} but whose query output is {@code name}
+   * ({@code SELECT name FROM src_tbl}), with the {@code view.query.out.*} properties Spark persists
+   * for such a view. This is the shape that triggers the bug when the connector regenerates the
+   * query-output names from the declared columns.
+   */
+  @SneakyThrows
+  private void createRenamedColumnView() {
+    new SdkTableOperations(createApiClient(serverConfig))
+        .createTable(
+            new CreateTable()
+                .name(VIEW)
+                .catalogName(CATALOG_NAME)
+                .schemaName(SCHEMA_NAME)
+                .tableType(TableType.VIEW)
+                .viewDefinition("SELECT name FROM " + tbl(SRC_TABLE))
+                .viewDependencies(new DependencyList().dependencies(List.of()))
+                .properties(
+                    Map.of(
+                        "view.query.out.numCols", "1",
+                        "view.query.out.col.0", "name",
+                        "view.catalogAndNamespace.numParts", "2",
+                        "view.catalogAndNamespace.part.0", CATALOG_NAME,
+                        "view.catalogAndNamespace.part.1", SCHEMA_NAME))
+                .columns(
+                    List.of(
+                        new ColumnInfo()
+                            .name("emp")
+                            .typeName(ColumnTypeName.STRING)
+                            .typeText("string")
+                            .typeJson(
+                                "{\"name\":\"emp\",\"type\":\"string\",\"nullable\":true,"
+                                    + "\"metadata\":{}}")
+                            .nullable(true)
+                            .position(0))));
+  }
+
+  @Test
+  public void testReadViewWithRenamedColumnResolvesThroughSpark() {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    createSourceTable();
+    createRenamedColumnView();
+
+    // Reading the view resolves its stored query text against the base table and matches the query
+    // output column `name` to the declared view column `emp` via the persisted query-output names.
+    // The declared name is what the reader sees.
+    assertThat(sql("SELECT emp FROM %s", tbl(VIEW))).isEmpty();
+    assertThat(sql("DESCRIBE %s", tbl(VIEW)))
+        .anyMatch(row -> "emp".equals(row.getString(0)));
+  }
+}

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCJoinViewE2ETest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCJoinViewE2ETest.java
@@ -154,4 +154,36 @@ public class UCJoinViewE2ETest extends BaseSparkIntegrationTest {
             .collect(Collectors.toList());
     assertThat(employees).containsExactlyInAnyOrder("alice", "bob", "carol");
   }
+
+  /**
+   * A view body's UNQUALIFIED table references resolve against the current catalog/namespace at
+   * creation time, which Spark persists as {@code view.catalogAndNamespace.*} -- and which can
+   * differ from the view's own location. Here the view lives in {@code other_schema} but is created
+   * while the session default namespace is {@code SCHEMA_NAME}, and its body references
+   * {@code employees} / {@code departments} unqualified. The connector must round-trip the
+   * creation-time namespace; if it instead substitutes the view's own location
+   * ({@code other_schema}, where those tables do not exist), resolution fails.
+   */
+  @Test
+  public void testViewResolvesUnqualifiedRefsAgainstCreationNamespace() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    createSourceTables(); // employees + departments live in SCHEMA_NAME
+    String otherSchema = "other_schema";
+    sql("CREATE SCHEMA %s.%s", CATALOG_NAME, otherSchema);
+
+    // Session default namespace is SCHEMA_NAME; the view is created in a DIFFERENT schema, and its
+    // body references the base tables UNQUALIFIED (so resolution depends on the creation ns).
+    sql("USE %s.%s", CATALOG_NAME, SCHEMA_NAME);
+    String viewInOtherSchema = CATALOG_NAME + "." + otherSchema + ".unqualified_ref_view";
+    sql(
+        "CREATE VIEW %s AS SELECT e.name AS emp FROM employees e "
+            + "JOIN departments d ON e.dept_id = d.dept_id",
+        viewInOtherSchema);
+
+    List<String> employees =
+        sql("SELECT emp FROM %s ORDER BY emp", viewInOtherSchema).stream()
+            .map(r -> r.getString(0))
+            .collect(Collectors.toList());
+    assertThat(employees).containsExactly("alice", "bob", "carol");
+  }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCJoinViewE2ETest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCJoinViewE2ETest.java
@@ -1,0 +1,157 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end test for a non-trivial view whose query joins two real UC-backed tables. The existing
+ * {@code UCViewDDLIntegrationTest} only exercises the constant {@code SELECT 1 AS c} body, which
+ * never resolves a base relation; this drives the full analyzer path -- multi-table resolution,
+ * projection of columns from both sides, a filter, and column aliasing -- against a real embedded
+ * {@code UnityCatalogServer}. Spark 4.2 only, since {@code CREATE VIEW} against the v2 UC catalog
+ * requires the {@code ViewCatalog} surface that 4.0/4.1 lack.
+ */
+public class UCJoinViewE2ETest extends BaseSparkIntegrationTest {
+
+  @TempDir private File employeesDir;
+  @TempDir private File departmentsDir;
+
+  private static final String JOIN_VIEW = "employee_department_view";
+
+  private String tbl(String name) {
+    return CATALOG_NAME + "." + SCHEMA_NAME + "." + name;
+  }
+
+  /**
+   * Creates the two UC-backed source tables the view joins. Plain parquet external tables keep the
+   * source setup independent of the Delta managed-create path (like {@code MetricViewE2ETest}).
+   *
+   * <p>{@code employees(id, name, dept_id)} joined to {@code departments(dept_id, dept_name)} on
+   * {@code dept_id}. One employee ({@code dave}, dept 99) has no matching department, so an inner
+   * join must drop them -- letting the test prove the join predicate is actually applied, not that
+   * rows happen to line up.
+   */
+  private void createSourceTables() {
+    sql(
+        "CREATE TABLE %s (id INT, name STRING, dept_id INT) USING parquet LOCATION '%s'",
+        tbl("employees"), employeesDir.toURI());
+    sql(
+        "INSERT INTO %s VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'carol', 10), (4, 'dave', 99)",
+        tbl("employees"));
+
+    sql(
+        "CREATE TABLE %s (dept_id INT, dept_name STRING) USING parquet LOCATION '%s'",
+        tbl("departments"), departmentsDir.toURI());
+    sql(
+        "INSERT INTO %s VALUES (10, 'engineering'), (20, 'sales'), (30, 'marketing')",
+        tbl("departments"));
+  }
+
+  /**
+   * Creates the join view with an explicit column list ({@code emp}, {@code dept}) whose names
+   * differ from the query's output names ({@code name}, {@code dept_name}). Spark persists the
+   * declared names as the view schema and the query-output names under
+   * {@code view.query.out.col.*}; view resolution matches the parsed query output against the
+   * schema BY the persisted query-output names, so the connector must round-trip
+   * {@code view.query.out.*} rather than regenerate it from the declared columns.
+   */
+  private void createJoinView() {
+    sql(
+        "CREATE VIEW %s (emp, dept) AS "
+            + "SELECT e.name, d.dept_name "
+            + "FROM %s e JOIN %s d ON e.dept_id = d.dept_id",
+        tbl(JOIN_VIEW), tbl("employees"), tbl("departments"));
+  }
+
+  @SneakyThrows
+  private TableInfo getServerTable(String fullName) {
+    return new SdkTableOperations(createApiClient(serverConfig)).getTable(fullName);
+  }
+
+  @Test
+  public void testJoinViewIsCreatedAndReadableThroughSpark() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    createSourceTables();
+
+    // A view whose body joins both source tables, projects columns from each side, and filters --
+    // a real analyzer workload, unlike the constant `SELECT 1 AS c` view. Crucially, the view
+    // declares an explicit column list (emp, dept) whose names DIFFER from the query's output
+    // names (name, dept_name). Spark persists both: the declared names as the view schema and the
+    // query-output names under `view.query.out.col.*`. View resolution matches the parsed query
+    // output against the declared schema BY the persisted query-output names, so the connector
+    // must round-trip `view.query.out.*` from UC rather than regenerate it from the declared
+    // columns -- otherwise Spark looks for a query column named `emp`, the query produces `name`,
+    // and resolution fails with INCOMPATIBLE_VIEW_SCHEMA_CHANGE.
+    sql(
+        "CREATE VIEW %s (emp, dept) AS "
+            + "SELECT e.name, d.dept_name "
+            + "FROM %s e JOIN %s d ON e.dept_id = d.dept_id "
+            + "WHERE d.dept_name <> 'sales'",
+        tbl(JOIN_VIEW), tbl("employees"), tbl("departments"));
+
+    // The view's stored schema uses the DECLARED column names, not the query output names.
+    List<Row> describe = sql("DESCRIBE %s", tbl(JOIN_VIEW));
+    assertThat(describe.stream().map(r -> r.getString(0) + ":" + r.getString(1)))
+        .contains("emp:string", "dept:string");
+
+    // Reading through the view resolves both base relations, applies the join + filter, and
+    // returns only the projected columns under their declared names. alice/carol (engineering,
+    // dept 10) survive; bob (sales) is removed by the WHERE; dave (dept 99) is removed by the
+    // inner join (no matching dept).
+    List<Row> rows =
+        sql("SELECT emp, dept FROM %s ORDER BY emp", tbl(JOIN_VIEW));
+    assertThat(rows.stream().map(r -> r.getString(0) + ":" + r.getString(1)))
+        .containsExactly("alice:engineering", "carol:engineering");
+  }
+
+  @Test
+  public void testJoinViewPersistsBothBaseTablesAsDependencies() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    createSourceTables();
+
+    createJoinView();
+
+    // The connector currently sends an empty dependency list (query-text derivation was reverted),
+    // so the server records no dependencies. Pin that so the behavior is explicit: if dependency
+    // derivation is reintroduced, this assertion is the reminder to update it to expect both
+    // `employees` and `departments`. Tolerate either null or an empty list, since the two encode
+    // the same "no dependencies" state on the wire.
+    TableInfo view = getServerTable(tbl(JOIN_VIEW));
+    if (view.getViewDependencies() != null) {
+      assertThat(view.getViewDependencies().getDependencies()).isEmpty();
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void testJoinViewSurvivesSessionRestart() {
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+    createSourceTables();
+    createJoinView();
+
+    // Close and rebuild the session so the view is resolved purely from its persisted definition
+    // (fresh catalog, no in-session plan cache) -- the read path parses the stored `viewText`
+    // against the persisted default catalog/namespace and matches its output to the schema via the
+    // persisted query-output column names.
+    session.close();
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME);
+
+    List<String> employees =
+        sql("SELECT emp FROM %s", tbl(JOIN_VIEW)).stream()
+            .map(r -> r.getString(0))
+            .collect(Collectors.toList());
+    assertThat(employees).containsExactlyInAnyOrder("alice", "bob", "carol");
+  }
+}


### PR DESCRIPTION
## Description of changes

Two related bugs where the connector failed to round-trip view **creation-time context** that Spark persists as `view.*` properties, instead fabricating it from the view's own metadata on read. Both cause view resolution to fail when the fabricated value differs from the real one.

### Bug 1 — query-output column names (`view.query.out.*`)

A view whose **declared** column names differ from the names its **SELECT list produces** could not be read back:

- `CREATE VIEW v(a, b) AS SELECT x, y FROM t`
- `CREATE VIEW v AS SELECT 1111, j FROM t`

Spark matches the parsed query output against the declared schema **by the query-output names**. The connector never persisted them on create and regenerated them from the *declared* names on read, so when they differed:

```
[INCOMPATIBLE_VIEW_SCHEMA_CHANGE] ... column <name> cannot be resolved. Expected 1 columns named <name> but got [].
```

### Bug 2 — creation-time catalog/namespace (`view.catalogAndNamespace.*`)

Unqualified table references in a view body resolve against the current catalog/namespace **at creation time**, which can differ from the view's own location (a view in `cat.a` created while the session default is `cat.b` resolves `FROM t` as `cat.b.t`). The connector dropped this on create and substituted the view's own location on read, so such a view failed with:

```
[TABLE_OR_VIEW_NOT_FOUND] The table or view `<t>` cannot be found.
```

### Fix (both bugs, both directions)

- **`createView` (Spark 4.2):** persist `view.queryColumnNames()` as `view.query.out.*`, and `view.currentCatalog()`/`view.currentNamespace()` as `view.catalogAndNamespace.*` — mirroring Spark's own v1 `CatalogTable` encoding (same pattern already used for `schemaMode`/`sqlConfigs`).
- **`toView` (Spark 4.2):** restore both from the persisted properties, falling back to declared names / the view's location only when absent (older/non-Spark-written rows); strip both key families from the user-visible `properties()` so they don't double-persist on round-trip.
- **`buildV1ViewTable` (Spark 4.0/4.1):** prefer the persisted `view.query.out.*` and `view.catalogAndNamespace.*` over regenerating from the view's declared columns / location.
- **`UCViewTypes`:** add shared, version-agnostic `extractQueryColumnNames` and `extractCatalogAndNamespace` helpers.

### Tests

- **`UCJoinViewE2ETest` (Spark 4.2):** views joining two real UC tables, covering (a) declared column names differing from query output, (b) create/read/session-restart, and (c) unqualified refs resolved against a creation namespace that differs from the view's location. Each reproduces its failure before the fix.
- **`UCViewQueryColumnNamesReadOnlyTest` (Spark 4.0/4.1):** server-created view with divergent declared vs query-output names, read back through Spark.

### Testing

- Spark 4.2 view suites (`UCViewProxySuite`, `MetricViewE2ETest`, `UCViewDDLIntegrationTest`, `UCJoinViewE2ETest`): 38 passed.
- Spark 4.1 view suites (`UCViewReadOnlySuite`, `UCViewReadOnlyIntegrationTest`, `UCViewQueryColumnNamesReadOnlyTest`): 14 passed.
- Each new test verified to fail before its fix and pass after; `javafmtCheckAll` clean.

This pull request and its description were written by Isaac.