### PR TITLE
[Server] Restrict SCIM user reads to metastore admins

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
@@ -76,7 +76,7 @@ public class Scim2UserService {
   @Get("")
   @Produces("application/scim+json")
   @StatusCode(200)
-  @AuthorizeExpression("#principal != null")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public ListResponse<UserResource> getScimUsers(
       @Param("filter") Optional<String> filter,
@@ -155,7 +155,7 @@ public class Scim2UserService {
   @Get("/{id}")
   @Produces("application/scim+json")
   @StatusCode(200)
-  @AuthorizeExpression("#principal != null")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public UserResource getUser(@Param("id") String id) {
     return asUserResource(userRepository.getUser(id));

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkScim2UserAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkScim2UserAccessControlTest.java
@@ -1,0 +1,58 @@
+package io.unitycatalog.server.sdk.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.unitycatalog.control.ApiException;
+import io.unitycatalog.control.api.UsersApi;
+import io.unitycatalog.control.model.UserResource;
+import io.unitycatalog.control.model.UserResourceList;
+import io.unitycatalog.server.base.ServerConfig;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+public class SdkScim2UserAccessControlTest extends SdkAccessControlBaseCRUDTest {
+  private static final String REGULAR_USER = "scim-regular@localhost";
+  private static final String OTHER_USER = "scim-other@localhost";
+
+  private UsersApi regularUsersApi;
+  private UserResource otherUser;
+
+  @BeforeEach
+  public void setUpUsers() throws Exception {
+    createTestUser(REGULAR_USER, "Regular User");
+    otherUser = createTestUser(OTHER_USER, "Other User");
+
+    ServerConfig regularUserConfig = createTestUserServerConfig(REGULAR_USER);
+    regularUsersApi = new UsersApi(createControlApiClient(regularUserConfig));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testMetastoreAdminCanListAndGetUsers() {
+    UserResourceList users = usersApi.listUsers(null, null, null);
+    assertThat(users.getResources()).extracting(UserResource::getId).contains(otherUser.getId());
+
+    UserResource fetchedUser = usersApi.getUser(otherUser.getId());
+    assertThat(fetchedUser.getId()).isEqualTo(otherUser.getId());
+    assertThat(fetchedUser.getEmails().get(0).getValue()).isEqualTo(OTHER_USER);
+  }
+
+  @Test
+  public void testRegularUserCannotListUsers() {
+    assertScimPermissionDenied(() -> regularUsersApi.listUsers(null, null, null));
+  }
+
+  @Test
+  public void testRegularUserCannotGetAnotherUserById() {
+    assertScimPermissionDenied(() -> regularUsersApi.getUser(otherUser.getId()));
+  }
+
+  private static void assertScimPermissionDenied(Executable request) {
+    ApiException exception = assertThrows(ApiException.class, request);
+    assertThat(exception.getCode()).isEqualTo(403);
+    assertThat(exception.getResponseBody()).contains("\"error_code\":\"PERMISSION_DENIED\"");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkScim2UserAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkScim2UserAccessControlTest.java
@@ -31,22 +31,15 @@ public class SdkScim2UserAccessControlTest extends SdkAccessControlBaseCRUDTest 
 
   @Test
   @SneakyThrows
-  public void testMetastoreAdminCanListAndGetUsers() {
+  public void testOnlyMetastoreAdminCanListAndGetUsers() {
     UserResourceList users = usersApi.listUsers(null, null, null);
     assertThat(users.getResources()).extracting(UserResource::getId).contains(otherUser.getId());
 
     UserResource fetchedUser = usersApi.getUser(otherUser.getId());
     assertThat(fetchedUser.getId()).isEqualTo(otherUser.getId());
     assertThat(fetchedUser.getEmails().get(0).getValue()).isEqualTo(OTHER_USER);
-  }
 
-  @Test
-  public void testRegularUserCannotListUsers() {
     assertScimPermissionDenied(() -> regularUsersApi.listUsers(null, null, null));
-  }
-
-  @Test
-  public void testRegularUserCannotGetAnotherUserById() {
     assertScimPermissionDenied(() -> regularUsersApi.getUser(otherUser.getId()));
   }
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [ ] If you have added or modified a feature, documentation in `docs` is updated

**Description of changes**

Before this change, any signed-in user could list all Unity Catalog users or look up another user by ID. For example, a regular user could read the admin user's email address.

This change allows those requests only for a metastore owner, which is an administrator. Regular users now receive `403 Forbidden`.

The new tests check that administrators still have access and regular users do not. If the two permission checks are removed, both tests for regular users fail.
