### PR TITLE
Resolve view dependencies if not provided by Spark

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -143,10 +143,15 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       .viewDefinition(view.queryText())
 
     Option(properties.get(TableCatalog.PROP_COMMENT)).foreach(ct.setComment)
-    // The server requires a non-null dependency list; a plain view often has none.
-    val ucDeps = Option(view.viewDependencies())
-      .map(toUcDependencyList)
-      .getOrElse(new UCDependencyList().dependencies(new util.ArrayList[UCDependency]()))
+    // Spark only fills `viewDependencies()` for metric views; for a plain view derive them from the
+    // query text (the server requires a non-null list).
+    val ucDeps = Option(view.viewDependencies()) match {
+      case Some(deps) => toUcDependencyList(deps)
+      case None =>
+        ucDependencyListFromNames(
+          UCViewDependencies.derive(
+            view.queryText(), view.currentCatalog(), view.currentNamespace().toSeq))
+    }
     ct.setViewDependencies(ucDeps)
     ct.setColumns(buildColumnInfos(view, convertDataTypeToTypeName).asJava)
 
@@ -251,9 +256,9 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
 
   /**
    * Converts Spark's typed `DependencyList` into the wire-format UC `DependencyList`.
-   * Only `TableDependency` is currently translated; UC OSS does not persist function
-   * dependencies. The conversion is dot-flatten lossy for identifiers with literal `.`,
-   * matching the wire format already used by the UC server.
+   * Only `TableDependency` is translated; the connector does not yet emit function
+   * dependencies even though the UC server can persist them. The conversion is dot-flatten
+   * lossy for identifiers with literal `.`, matching the wire format used by the UC server.
    */
   private def toUcDependencyList(sparkDeps: DependencyList): UCDependencyList = {
     val ucDeps = new java.util.ArrayList[UCDependency]()
@@ -263,7 +268,16 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
           .table(new UCTableDependency()
             .tableFullName(td.nameParts().mkString("."))))
       case _ =>
-      // UC OSS does not currently persist function dependencies; drop.
+      // Function dependencies are not emitted yet; drop.
+    }
+    new UCDependencyList().dependencies(ucDeps)
+  }
+
+  /** Builds a wire-format UC `DependencyList` from derived `catalog.schema.table` names. */
+  private def ucDependencyListFromNames(fullNames: Seq[String]): UCDependencyList = {
+    val ucDeps = new java.util.ArrayList[UCDependency]()
+    fullNames.foreach { fullName =>
+      ucDeps.add(new UCDependency().table(new UCTableDependency().tableFullName(fullName)))
     }
     new UCDependencyList().dependencies(ucDeps)
   }

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
@@ -1,0 +1,103 @@
+package io.unitycatalog.spark
+
+import java.util.Locale
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnresolvedWith}
+
+/**
+ * Derives the base-table dependency list of a view from its query text, for plain views.
+ *
+ * Works on the *parsed* (unresolved) plan, not the analyzed one: analyzing would read each base
+ * table's log / vend credentials and can rewrite away its catalog identity, dropping the dependency.
+ * Best-effort -- any failure yields an empty list so view creation still succeeds.
+ */
+private[spark] object UCViewDependencies extends Logging {
+
+  def derive(queryText: String, currentCatalog: String, currentNamespace: Seq[String]): Seq[String] = {
+    try {
+      val spark = SparkSession.active
+      val parsed = spark.sessionState.sqlParser.parsePlan(queryText)
+      collectTableDependencies(
+        parsed, currentCatalog, currentNamespace, spark.sessionState.conf.caseSensitiveAnalysis)
+    } catch {
+      case NonFatal(e) =>
+        logWarning(
+          s"Failed to derive view dependencies from query text; persisting an empty list. " +
+            s"Query: $queryText",
+          e)
+        Seq.empty
+    }
+  }
+
+  def collectTableDependencies(
+      parsed: LogicalPlan,
+      currentCatalog: String,
+      currentNamespace: Seq[String],
+      caseSensitive: Boolean): Seq[String] = {
+    baseRelations(parsed, Set.empty, caseSensitive)
+      .flatMap { parts =>
+        val qualified = qualify(parts, currentCatalog, currentNamespace)
+        // A UC full name is exactly catalog.schema.table; drop anything that can't form one
+        // (e.g. a 4-part reference) rather than persisting a name the server would reject.
+        if (qualified.size == 3) {
+          Some(qualified.mkString("."))
+        } else {
+          logWarning(
+            s"Skipping view dependency with unexpected name shape: ${qualified.mkString(".")}")
+          None
+        }
+      }
+      .distinct
+  }
+
+  // `visibleCtes` (normalized) are the CTE names in scope; a single-part relation shadowed by one
+  // is skipped rather than reported as a base table.
+  private def baseRelations(
+      plan: LogicalPlan,
+      visibleCtes: Set[String],
+      caseSensitive: Boolean): Seq[Seq[String]] = plan match {
+    case w: UnresolvedWith =>
+      // CTEs resolve in declaration order: each definition sees the ones before it (plus itself
+      // under WITH RECURSIVE); the main query sees them all.
+      var visible = visibleCtes
+      val fromDefinitions = w.cteRelations.flatMap { cte =>
+        val name = normalize(cte._1, caseSensitive)
+        val bodyScope = if (w.allowRecursion) visible + name else visible
+        val deps = baseRelations(cte._2, bodyScope, caseSensitive)
+        visible += name
+        deps
+      }
+      fromDefinitions ++ baseRelations(w.child, visible, caseSensitive)
+
+    case r: UnresolvedRelation =>
+      val parts = r.multipartIdentifier
+      val shadowedByCte =
+        parts.lengthCompare(1) == 0 && visibleCtes.contains(normalize(parts.head, caseSensitive))
+      if (shadowedByCte) Seq.empty else Seq(parts)
+
+    case other =>
+      (other.children ++ other.subqueries).flatMap(baseRelations(_, visibleCtes, caseSensitive))
+  }
+
+  private def normalize(name: String, caseSensitive: Boolean): String =
+    if (caseSensitive) name else name.toLowerCase(Locale.ROOT)
+
+  // Prefixes an unqualified name with the view's catalog / namespace (UC is catalog.schema.table).
+  private def qualify(
+      parts: Seq[String],
+      currentCatalog: String,
+      currentNamespace: Seq[String]): Seq[String] = {
+    val catalog = Option(currentCatalog).filter(_.nonEmpty).toSeq
+    val namespace = Option(currentNamespace).getOrElse(Seq.empty)
+    parts.size match {
+      case n if n >= 3 => parts
+      case 2 => catalog ++ parts
+      case _ => catalog ++ namespace ++ parts
+    }
+  }
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
@@ -65,10 +65,10 @@ private[spark] object UCViewDependencies extends Logging {
       // CTEs resolve in declaration order: each definition sees the ones before it (plus itself
       // under WITH RECURSIVE); the main query sees them all.
       var visible = visibleCtes
-      val fromDefinitions = w.cteRelations.flatMap { cte =>
-        val name = normalize(cte._1, caseSensitive)
+      val fromDefinitions = w.cteRelations.flatMap { case (cteName, ctePlan, _) =>
+        val name = normalize(cteName, caseSensitive)
         val bodyScope = if (w.allowRecursion) visible + name else visible
-        val deps = baseRelations(cte._2, bodyScope, caseSensitive)
+        val deps = baseRelations(ctePlan, bodyScope, caseSensitive)
         visible += name
         deps
       }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
@@ -2,8 +2,19 @@ package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import java.nio.file.Files;
+import java.util.List;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,5 +37,64 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
     sql("DROP VIEW %s", VIEW_FULL_NAME);
     assertThat(sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME))
         .noneMatch(row -> VIEW_NAME.equals(row.getString(1)));
+  }
+
+  /** A plain view's dependencies, derived from the query text, are persisted on the server. */
+  @Test
+  public void testCreateViewPersistsDerivedDependencies() {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
+    createExternalTable("dep_src");
+    sql("CREATE VIEW %s AS SELECT * FROM %s", VIEW_FULL_NAME, srcFullName);
+
+    TableInfo view = getServerTable(VIEW_FULL_NAME);
+    assertThat(view.getViewDependencies().getDependencies())
+        .extracting(dependency -> dependency.getTable().getTableFullName())
+        .contains(srcFullName);
+  }
+
+  /** A case-differing CTE reference is not leaked as a dependency; only the base table is kept. */
+  @Test
+  public void testCreateViewDerivesDependenciesWithCaseInsensitiveCte() {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
+    createExternalTable("dep_src");
+    sql(
+        "CREATE VIEW %s AS WITH v_cte AS (SELECT * FROM %s) SELECT * FROM V_CTE",
+        VIEW_FULL_NAME, srcFullName);
+
+    assertThat(getServerTable(VIEW_FULL_NAME).getViewDependencies().getDependencies())
+        .extracting(dependency -> dependency.getTable().getTableFullName())
+        .containsExactly(srcFullName);
+  }
+
+  /** Registers an external parquet table server-side so it is resolvable by Spark's analyzer. */
+  @SneakyThrows
+  private void createExternalTable(String name) {
+    new SdkTableOperations(createApiClient(serverConfig))
+        .createTable(
+            new CreateTable()
+                .name(name)
+                .catalogName(CATALOG_NAME)
+                .schemaName(SCHEMA_NAME)
+                .tableType(TableType.EXTERNAL)
+                .dataSourceFormat(DataSourceFormat.PARQUET)
+                .storageLocation(Files.createTempDirectory("uc_" + name).toUri().toString())
+                .columns(
+                    List.of(
+                        new ColumnInfo()
+                            .name("c")
+                            .typeName(ColumnTypeName.INT)
+                            .typeText("int")
+                            .typeJson(
+                                "{\"name\":\"c\",\"type\":\"integer\",\"nullable\":true,"
+                                    + "\"metadata\":{}}")
+                            .nullable(true)
+                            .position(0))));
+  }
+
+  @SneakyThrows
+  private TableInfo getServerTable(String fullName) {
+    return new SdkTableOperations(createApiClient(serverConfig)).getTable(fullName);
   }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
@@ -5,23 +5,20 @@ import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
 import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.unitycatalog.client.model.ColumnInfo;
-import io.unitycatalog.client.model.ColumnTypeName;
-import io.unitycatalog.client.model.CreateTable;
-import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.TableInfo;
-import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
-import java.nio.file.Files;
-import java.util.List;
+import java.io.File;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Spark 4.2 exposes the v2 {@code ViewCatalog}, so CREATE / SHOW / DROP VIEW all route to Unity
  * Catalog. Complements the shared read guarantee with the full DDL round-trip.
  */
 public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
+
+  @TempDir private File sourceTableDir;
 
   @Override
   protected void createView() {
@@ -44,7 +41,7 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
   public void testCreateViewPersistsDerivedDependencies() {
     session = createSparkSessionWithCatalogs(CATALOG_NAME);
     String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
-    createExternalTable("dep_src");
+    createSourceTable(srcFullName);
     sql("CREATE VIEW %s AS SELECT * FROM %s", VIEW_FULL_NAME, srcFullName);
 
     TableInfo view = getServerTable(VIEW_FULL_NAME);
@@ -58,7 +55,7 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
   public void testCreateViewDerivesDependenciesWithCaseInsensitiveCte() {
     session = createSparkSessionWithCatalogs(CATALOG_NAME);
     String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
-    createExternalTable("dep_src");
+    createSourceTable(srcFullName);
     sql(
         "CREATE VIEW %s AS WITH v_cte AS (SELECT * FROM %s) SELECT * FROM V_CTE",
         VIEW_FULL_NAME, srcFullName);
@@ -68,29 +65,8 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
         .containsExactly(srcFullName);
   }
 
-  /** Registers an external parquet table server-side so it is resolvable by Spark's analyzer. */
-  @SneakyThrows
-  private void createExternalTable(String name) {
-    new SdkTableOperations(createApiClient(serverConfig))
-        .createTable(
-            new CreateTable()
-                .name(name)
-                .catalogName(CATALOG_NAME)
-                .schemaName(SCHEMA_NAME)
-                .tableType(TableType.EXTERNAL)
-                .dataSourceFormat(DataSourceFormat.PARQUET)
-                .storageLocation(Files.createTempDirectory("uc_" + name).toUri().toString())
-                .columns(
-                    List.of(
-                        new ColumnInfo()
-                            .name("c")
-                            .typeName(ColumnTypeName.INT)
-                            .typeText("int")
-                            .typeJson(
-                                "{\"name\":\"c\",\"type\":\"integer\",\"nullable\":true,"
-                                    + "\"metadata\":{}}")
-                            .nullable(true)
-                            .position(0))));
+  private void createSourceTable(String fullName) {
+    sql("CREATE TABLE %s (c INT) USING parquet LOCATION '%s'", fullName, sourceTableDir.toURI());
   }
 
   @SneakyThrows

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependenciesSuite.scala
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependenciesSuite.scala
@@ -47,4 +47,25 @@ class UCViewDependenciesSuite {
   @Test
   def dropsReferencesWithMoreThanThreeParts(): Unit =
     assertTrue(deps("SELECT * FROM a.b.c.d").isEmpty)
+
+  @Test
+  def doesNotLeakCteAliasAsDependency(): Unit =
+    assertEquals(Seq("main.default.t"), deps("WITH c AS (SELECT * FROM t) SELECT * FROM c"))
+
+  @Test
+  def resolvesChainedCtesInDeclarationOrderWithoutLeaking(): Unit =
+    assertEquals(
+      Seq("main.default.t1"),
+      deps("WITH a AS (SELECT * FROM t1), b AS (SELECT * FROM a) SELECT * FROM b"))
+
+  @Test
+  def doesNotLeakRecursiveCteSelfReference(): Unit =
+    assertTrue(
+      deps("WITH RECURSIVE r AS (SELECT 1 UNION ALL SELECT * FROM r) SELECT * FROM r").isEmpty)
+
+  @Test
+  def keepsBaseTableInRecursiveCteWithoutLeakingSelfReference(): Unit =
+    assertEquals(
+      Seq("main.default.t"),
+      deps("WITH RECURSIVE r AS (SELECT * FROM t UNION ALL SELECT * FROM r) SELECT * FROM r"))
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependenciesSuite.scala
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependenciesSuite.scala
@@ -1,0 +1,50 @@
+package io.unitycatalog.spark
+
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+class UCViewDependenciesSuite {
+
+  private def deps(sql: String): Seq[String] =
+    UCViewDependencies.collectTableDependencies(
+      CatalystSqlParser.parsePlan(sql), "main", Seq("default"), caseSensitive = false)
+
+  @Test
+  def qualifiesUnqualifiedNameWithCatalogAndNamespace(): Unit =
+    assertEquals(Seq("main.default.numbers"), deps("SELECT * FROM numbers"))
+
+  @Test
+  def qualifiesTwoPartNameWithCatalog(): Unit =
+    assertEquals(Seq("main.sales.numbers"), deps("SELECT * FROM sales.numbers"))
+
+  @Test
+  def keepsThreePartNameAsIs(): Unit =
+    assertEquals(Seq("other.sales.numbers"), deps("SELECT * FROM other.sales.numbers"))
+
+  @Test
+  def collectsBothJoinSources(): Unit =
+    assertEquals(
+      Set("main.default.a", "main.default.b"),
+      deps("SELECT * FROM a JOIN b ON a.id = b.id").toSet)
+
+  @Test
+  def collectsRelationInsideWhereSubquery(): Unit =
+    assertEquals(
+      Set("main.default.a", "main.default.b"),
+      deps("SELECT * FROM a WHERE id IN (SELECT id FROM b)").toSet)
+
+  @Test
+  def collectsBothUnionSources(): Unit =
+    assertEquals(
+      Set("main.default.a", "main.default.b"),
+      deps("SELECT * FROM a UNION SELECT * FROM b").toSet)
+
+  @Test
+  def deduplicatesRepeatedReferences(): Unit =
+    assertEquals(Seq("main.default.a"), deps("SELECT * FROM a UNION ALL SELECT * FROM a"))
+
+  @Test
+  def dropsReferencesWithMoreThanThreeParts(): Unit =
+    assertTrue(deps("SELECT * FROM a.b.c.d").isEmpty)
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Resolved the view dependencies based on parsing the sql.

Related PR: https://github.com/unitycatalog/unitycatalog/pull/1639
Related issue: https://github.com/unitycatalog/unitycatalog/issues/1279

| KEY | VALUE |
| --- | --- |
| NAME | my_view |
| CATALOG_NAME | unity |
| SCHEMA_NAME | default |
| TABLE_TYPE | VIEW |
| DATA_SOURCE_FORMAT | null |
| COLUMNS | `{"name":"as_int","type_text":"int","type_json":"{\"name\":\"as_int\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}","type_name":"INT","type_precision":null,"type_scale":null,"type_interval_type":null,"position":0,"comment":null,"nullable":true,"partition_index":null}` <br> `{"name":"as_double","type_text":"double","type_json":"{\"name\":\"as_double\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}","type_name":"DOUBLE","type_precision":null,"type_scale":null,"type_interval_type":null,"position":1,"comment":null,"nullable":true,"partition_index":null}` |
| STORAGE_LOCATION | null |
| COMMENT | null |
| PROPERTIES | `{"view.sqlConfig.spark.sql.parquet.fieldId.write.enabled":"true","view.sqlConfig.spark.sql.parquet.fieldId.read.enabled":"true","view.sqlConfig.spark.sql.session.timeZone":"Europe/Berlin","view.sqlConfig.spark.sql.catalog.spark_catalog":"io.unitycatalog.spark.UCSingleCatalog","view.sqlConfig.spark.databricks.delta.variant.disableVariantTableFeatureForSpark40":"true","view.sqlConfig.spark.sql.ansi.enabled":"true","view.sqlConfig.spark.sql.defaultCatalog":"unity"}` |
| OWNER | null |
| CREATED_AT | 1785404222292 |
| CREATED_BY | null |
| UPDATED_AT | 1785404222292 |
| UPDATED_BY | null |
| TABLE_ID | bf2ac5f1-2b09-4ba4-93c1-741d78a2a164 |
| VIEW_DEFINITION | ``SELECT * FROM unity.`default`.`numbers` `` |
| VIEW_DEPENDENCIES | `{"dependencies":[{"table":{"table_full_name":"unity.default.numbers"},"function":null}]}` |