### PR TITLE
Persist view query column names and creation context on Spark 4.2

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -169,6 +169,13 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     Option(view.schemaMode())
       .filter(_ != SchemaUnsupported.toString)
       .foreach(m => propertiesToServer.put(CatalogTable.VIEW_SCHEMA_MODE, m))
+    UCViewTypes.addQueryColumnNames(propertiesToServer, view.queryColumnNames())
+    Option(view.currentCatalog()).foreach { catalog =>
+      UCViewTypes.addCreationContext(
+        propertiesToServer,
+        catalog,
+        view.currentNamespace())
+    }
     ct.setProperties(propertiesToServer)
 
     try {
@@ -231,22 +238,25 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       if (t.getTableType == TableType.METRIC_VIEW) SchemaUnsupported.toString
       else SchemaCompensation.toString
     val schemaMode = Option(props.get(CatalogTable.VIEW_SCHEMA_MODE)).getOrElse(defaultSchemaMode)
+    val queryColumnNames =
+      UCViewTypes.extractQueryColumnNames(props).getOrElse(columns.map(_.name()))
+    val (currentCatalog, currentNamespace) =
+      UCViewTypes.extractCreationContext(props).getOrElse((t.getCatalogName, Array(t.getSchemaName)))
     // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE keys are surfaced via `withSqlConfigs` /
     // `withSchemaMode`; drop them from `props` so they don't also leak into the user-visible
     // `properties()` map and get re-persisted (double-counted) on a createView/replace round-trip.
-    props.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
-    props.remove(CatalogTable.VIEW_SCHEMA_MODE)
+    UCViewTypes.stripInternalViewProperties(props)
 
     val builder = new View.Builder()
       .withColumns(columns)
       .withProperties(props)
       .withTableType(UCViewTypes.ucTableTypeToSparkViewType(t.getTableType))
       .withQueryText(t.getViewDefinition)
-      .withCurrentCatalog(t.getCatalogName)
-      .withCurrentNamespace(Array(t.getSchemaName))
+      .withCurrentCatalog(currentCatalog)
+      .withCurrentNamespace(currentNamespace)
       .withSqlConfigs(sqlConfigs)
       .withSchemaMode(schemaMode)
-      .withQueryColumnNames(columns.map(_.name()))
+      .withQueryColumnNames(queryColumnNames)
     Option(t.getComment).foreach(builder.withComment)
     Option(t.getViewDependencies).foreach { ucDeps =>
       builder.withViewDependencies(fromUcDependencyList(ucDeps))

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -149,6 +149,9 @@ private[spark] object UCViewTypes {
   def addQueryColumnNames(
       properties: util.Map[String, String],
       queryColumnNames: Array[String]): Unit = {
+    if (queryColumnNames.isEmpty) {
+      return
+    }
     properties.put(
       CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS,
       queryColumnNames.length.toString)
@@ -172,23 +175,37 @@ private[spark] object UCViewTypes {
    * written by an older connector and the read path should fall back to the stored column names.
    */
   def extractQueryColumnNames(properties: util.Map[String, String]): Option[Array[String]] = {
-    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).map { numCols =>
+    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).flatMap { numCols =>
       val count = numCols.toInt
-      (0 until count)
-        .map(index => properties.get(s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index"))
-        .toArray
+      if (count == 0) {
+        None
+      } else {
+        Some((0 until count).map { index =>
+          val key = s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index"
+          Option(properties.get(key)).getOrElse(
+            throw new IllegalStateException(
+              s"Corrupted view metadata: expected $count query-output columns but $key is missing"))
+        }.toArray)
+      }
     }
   }
 
   /** Returns the persisted creation-time catalog and namespace when present. */
   def extractCreationContext(
       properties: util.Map[String, String]): Option[(String, Array[String])] = {
-    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).map { numParts =>
+    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).flatMap { numParts =>
       val count = numParts.toInt
-      val parts = (0 until count)
-        .map(index => properties.get(s"${CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX}$index"))
-        .toSeq
-      (parts.head, parts.tail.toArray)
+      if (count == 0) {
+        None
+      } else {
+        val parts = (0 until count).map { index =>
+          val key = s"${CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX}$index"
+          Option(properties.get(key)).getOrElse(
+            throw new IllegalStateException(
+              s"Corrupted view metadata: expected $count catalog/namespace parts but $key is missing"))
+        }.toSeq
+        Some((parts.head, parts.tail.toArray))
+      }
     }
   }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -144,4 +144,64 @@ private[spark] object UCViewTypes {
     }
     configs
   }
+
+  /** Persists Spark's query-output column names into UC view properties. */
+  def addQueryColumnNames(
+      properties: util.Map[String, String],
+      queryColumnNames: Array[String]): Unit = {
+    properties.put(
+      CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS,
+      queryColumnNames.length.toString)
+    queryColumnNames.zipWithIndex.foreach { case (name, index) =>
+      properties.put(s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index", name)
+    }
+  }
+
+  /** Persists the catalog/namespace active when the view was created. */
+  def addCreationContext(
+      properties: util.Map[String, String],
+      currentCatalog: String,
+      currentNamespace: Array[String]): Unit = {
+    CatalogTable.catalogAndNamespaceToProps(currentCatalog, currentNamespace.toSeq).foreach {
+      case (key, value) => properties.put(key, value)
+    }
+  }
+
+  /**
+   * Returns the persisted query-output column names when present. Absent keys mean the view was
+   * written by an older connector and the read path should fall back to the stored column names.
+   */
+  def extractQueryColumnNames(properties: util.Map[String, String]): Option[Array[String]] = {
+    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).map { numCols =>
+      val count = numCols.toInt
+      (0 until count)
+        .map(index => properties.get(s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index"))
+        .toArray
+    }
+  }
+
+  /** Returns the persisted creation-time catalog and namespace when present. */
+  def extractCreationContext(
+      properties: util.Map[String, String]): Option[(String, Array[String])] = {
+    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).map { numParts =>
+      val count = numParts.toInt
+      val parts = (0 until count)
+        .map(index => properties.get(s"${CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX}$index"))
+        .toSeq
+      (parts.head, parts.tail.toArray)
+    }
+  }
+
+  /**
+   * Drops view metadata keys that Spark surfaces through typed {@code View} fields so they do not
+   * leak into user-visible {@code properties()} or get double-persisted on a round trip.
+   */
+  def stripInternalViewProperties(properties: util.Map[String, String]): Unit = {
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
+    properties.remove(CatalogTable.VIEW_SCHEMA_MODE)
+    properties.remove(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX))
+    properties.remove(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX))
+  }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
@@ -20,6 +20,9 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
 
   @TempDir private File sourceTableDir;
 
+  private static final String STAGING_SCHEMA = "staging";
+  private static final String NEUTRAL_SCHEMA = "neutral";
+
   @Override
   protected void createView() {
     sql("CREATE VIEW %s AS %s", VIEW_FULL_NAME, VIEW_QUERY);
@@ -63,6 +66,50 @@ public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
     assertThat(getServerTable(VIEW_FULL_NAME).getViewDependencies().getDependencies())
         .extracting(dependency -> dependency.getTable().getTableFullName())
         .containsExactly(srcFullName);
+  }
+
+  /**
+   * A view created with an explicit column list stores the view's output names separately from the
+   * query's output names. Spark resolves the view using the persisted query-output names, not the
+   * declared column names.
+   */
+  @Test
+  public void testViewWithExplicitColumnListIsReadable() {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    String view = CATALOG_NAME + "." + SCHEMA_NAME + ".v_renamed";
+    sql("CREATE VIEW %s (total) AS SELECT 42 AS my_count", view);
+
+    assertThat(sql("SELECT * FROM %s", view))
+        .extracting(row -> row.getInt(0))
+        .containsExactly(42);
+  }
+
+  /**
+   * Unqualified table references in a view body are resolved using the catalog/namespace active at
+   * creation time, not the view's own schema. Read from a third schema so the result cannot be
+   * explained by the reader's current namespace.
+   */
+  @Test
+  public void testViewResolvesUnqualifiedReferencesUsingCreationContext() {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    sql("CREATE SCHEMA IF NOT EXISTS %s.%s", CATALOG_NAME, STAGING_SCHEMA);
+    sql("CREATE SCHEMA IF NOT EXISTS %s.%s", CATALOG_NAME, NEUTRAL_SCHEMA);
+    sql("CREATE VIEW %s.%s.source AS SELECT 'FROM_STAGING' AS src", CATALOG_NAME, STAGING_SCHEMA);
+    sql(
+        "CREATE VIEW %s.%s.source AS SELECT 'FROM_DEFAULT' AS src",
+        CATALOG_NAME,
+        SCHEMA_NAME);
+
+    sql("USE %s.%s", CATALOG_NAME, STAGING_SCHEMA);
+    sql(
+        "CREATE VIEW %s.%s.v_ctx AS SELECT src FROM source",
+        CATALOG_NAME,
+        SCHEMA_NAME);
+
+    sql("USE %s.%s", CATALOG_NAME, NEUTRAL_SCHEMA);
+    assertThat(sql("SELECT src FROM %s.%s.v_ctx", CATALOG_NAME, SCHEMA_NAME))
+        .extracting(row -> row.getString(0))
+        .containsExactly("FROM_STAGING");
   }
 
   private void createSourceTable(String fullName) {


### PR DESCRIPTION
## Summary

Spark 4.2's `ViewCatalog` passes query-output column names and the creation-time catalog/namespace as typed `View` fields. The UC connector was dropping both on write and re-deriving them on read from the stored columns and the view's own schema. That breaks:

- **Explicit column lists** — `CREATE VIEW v (total) AS SELECT ... AS my_count` fails on read with `INCOMPATIBLE_VIEW_SCHEMA_CHANGE`
- **Unqualified references** — a view created from schema A with `SELECT * FROM t` resolves `t` against the view's own schema on read, which can return wrong data silently when a same-named table exists elsewhere

This PR persists both fields in the existing UC properties map using Spark's v1 key names (`view.query.out.*`, `view.catalogAndNamespace.*`), restores them in `toView`, and falls back to the old derivation when the keys are absent.

## Test plan

- [x] `spark/testOnly io.unitycatalog.spark.UCViewDDLIntegrationTest` on Spark 4.2.0 — 4 passed, 0 failed
- [x] Before fix: 2 new tests failed as expected (column list → `INCOMPATIBLE_VIEW_SCHEMA_CHANGE`; creation context → wrong row)
- [ ] CI Spark 4.2 matrix row (`unit-tests.yml`, non-blocking)


Made with [Cursor](https://cursor.com)