### PR TITLE
Fix loadTable for bare parquet path identifiers

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/utils/OptionsUtil.java
@@ -16,4 +16,7 @@ public class OptionsUtil {
   public static final boolean DEFAULT_SERVER_SIDE_PLANNING_ENABLED = false;
   public static final String DELTA_API_ENABLED = "deltaRestApi.enabled";
   public static final boolean DEFAULT_DELTA_API_ENABLED = true;
+
+  public static final String VEND_PATH_CREDENTIALS_ENABLED = "vendPathCredentials.enabled";
+  public static final boolean DEFAULT_VEND_PATH_CREDENTIALS_ENABLED = true;
 }

--- a/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * Spark 4.0 does not have {@code parsePlanWithParameters} or {@code ParameterContext}, so this
+ * shim adds no parameterized-parser override. {@code SparkSession.sql(text, args)} on 4.0 routes
+ * through plain {@code parsePlan}, which the common {@link UCSparkSqlExtensionsParser} overrides.
+ */
+trait ParserInterfaceShim extends ParserInterface {
+  protected def delegateParser: ParserInterface
+  protected def applyPathCredentials(plan: LogicalPlan): LogicalPlan
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.spark.sql.catalyst.parser.ParserInterface

--- a/connectors/spark/src/main/scala-shims/spark-4.1-4.2/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.1-4.2/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.spark.sql.catalyst.parser.{ParameterContext, ParserInterface}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * Spark 4.1+ routes {@code SparkSession.sql(text, args)} through {@code parsePlanWithParameters}.
+ * This shim provides that override so the common {@link UCSparkSqlExtensionsParser} never names
+ * {@code ParameterContext}.
+ */
+trait ParserInterfaceShim extends ParserInterface {
+  protected def delegateParser: ParserInterface
+  protected def applyPathCredentials(plan: LogicalPlan): LogicalPlan
+
+  override def parsePlanWithParameters(
+      sqlText: String,
+      parameterContext: ParameterContext): LogicalPlan =
+    applyPathCredentials(delegateParser.parsePlanWithParameters(sqlText, parameterContext))
+}

--- a/connectors/spark/src/main/scala-shims/spark-4.1-4.2/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.1-4.2/org/apache/spark/sql/catalyst/parser/extensions/ParserInterfaceShim.scala
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.spark.sql.catalyst.parser.{ParameterContext, ParserInterface}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -117,14 +117,15 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
 
   private def currentUcCatalog: Option[UCSingleCatalog] = {
     val manager = spark.sessionState.catalogManager
-    val catalogName = spark.sessionState.conf.getConf(SQLConf.DEFAULT_CATALOG)
-    try {
-      manager.catalog(catalogName) match {
-        case uc: UCSingleCatalog => Some(uc)
-        case _ => None
+    val catalog =
+      try SQLConf.withExistingConf(spark.sessionState.conf) {
+        manager.currentCatalog
+      } catch {
+        case _: CatalogNotFoundException => null
       }
-    } catch {
-      case _: CatalogNotFoundException => None
+    catalog match {
+      case uc: UCSingleCatalog => Some(uc)
+      case _ => None
     }
   }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -42,9 +42,11 @@ import scala.collection.JavaConverters._
  *
  * This rule closes that gap. For each bare cloud path it finds, it asks the active
  * [[UCSingleCatalog]] to vend credentials via [[UCSingleCatalog.vendPathCredentialConf]] and
- * attaches the resulting `fs.*` Hadoop options to the relation (reads) or write target
- * (`INSERT OVERWRITE DIRECTORY`). Reads request [[PathOperation.PATH_READ]] (read-only STS/IAM
- * scope); writes request [[PathOperation.PATH_READ_WRITE]]. Spark folds these per-relation options into the Hadoop
+ * attaches the resulting `fs.*` Hadoop options to the relation or write target. For bare
+ * `format.`path`` relations, read vs write is ambiguous at parse time, so credentials use
+ * [[UCSingleCatalog.vendPathCredentialConfWithFallback]] (PATH_READ_WRITE with PATH_READ fallback,
+ * mirroring loadTable). `INSERT OVERWRITE DIRECTORY` always requests [[PathOperation.PATH_READ_WRITE]].
+ * Spark folds these per-relation options into the Hadoop
  * configuration used to open the filesystem, so the credential-scoped filesystem + vended-token
  * provider pick them up — the same mechanism catalog tables use via
  * [[UCSingleCatalog.setCredentialProps]].
@@ -67,11 +69,11 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
       case None => plan
       case Some(uc) =>
         plan.resolveOperators {
-          // Read: a two-part `format`.`<cloud path>` identifier, still unresolved.
+          // Bare `format`.`<cloud path>` — used for reads and writes (e.g. INSERT INTO parquet.`s3://...`).
           case u: UnresolvedRelation
               if u.multipartIdentifier.length == 2 && isCloudPath(u.multipartIdentifier.last) =>
             val path = u.multipartIdentifier.last
-            val conf = uc.vendPathCredentialConf(path, PathOperation.PATH_READ)
+            val conf = uc.vendPathCredentialConfWithFallback(path)
             if (conf.isEmpty) u else u.copy(options = mergeOptions(u.options, conf))
 
           // Write: INSERT OVERWRITE DIRECTORY '<cloud path>' USING <format> ...

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -58,6 +58,10 @@ import scala.collection.JavaConverters._
  *
  * The rule is a no-op unless the session's current catalog is a [[UCSingleCatalog]]. It can be
  * disabled with `spark.sql.catalog.<catalog>.vendPathCredentials.enabled=false`.
+ *
+ * When UC cannot vend credentials for a path (not managed by UC, no permission, etc.), the plan
+ * node is left unchanged so Spark can use ambient storage credentials (e.g.
+ * `spark.hadoop.fs.s3a.*`, instance profile) configured on the session.
  */
 case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan] {
 
@@ -88,7 +92,8 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
           // Write: INSERT OVERWRITE DIRECTORY '<cloud path>' USING <format> ...
           case i: InsertIntoDir if i.storage.locationUri.exists(u => isCloudPath(u.toString)) =>
             val location = i.storage.locationUri.get.toString
-            val conf = uc.vendPathCredentialConf(location, PathOperation.PATH_READ_WRITE)
+            val conf =
+              uc.vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ_WRITE)
             if (conf.isEmpty) {
               i
             } else {

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -24,7 +24,7 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs.PathOperation
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -69,12 +69,21 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
       case Some(uc) if !uc.vendPathCredentialsEnabled => plan
       case Some(uc) =>
         plan.resolveOperators {
-          // Bare `format`.`<cloud path>` — used for reads and writes (e.g. INSERT INTO parquet.`s3://...`).
+          // Bare `format`.`<cloud path>` — used for reads and in query FROM clauses.
           case u: UnresolvedRelation
               if u.multipartIdentifier.length == 2 && isCloudPath(u.multipartIdentifier.last) =>
-            val path = u.multipartIdentifier.last
-            val conf = uc.vendPathCredentialConfWithFallback(path)
-            if (conf.isEmpty) u else u.copy(options = mergeOptions(u.options, conf))
+            injectUnresolvedRelationCredentials(u, uc)
+
+          // `InsertIntoStatement.table` is not a tree child (only `query` is), so the case above
+          // never sees bare-path insert targets such as INSERT INTO parquet.`s3://...`.
+          case i: InsertIntoStatement =>
+            i.table match {
+              case u: UnresolvedRelation
+                  if u.multipartIdentifier.length == 2 &&
+                    isCloudPath(u.multipartIdentifier.last) =>
+                i.copy(table = injectUnresolvedRelationCredentials(u, uc))
+              case _ => i
+            }
 
           // Write: INSERT OVERWRITE DIRECTORY '<cloud path>' USING <format> ...
           case i: InsertIntoDir if i.storage.locationUri.exists(u => isCloudPath(u.toString)) =>
@@ -88,6 +97,14 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
             }
         }
     }
+  }
+
+  private def injectUnresolvedRelationCredentials(
+      relation: UnresolvedRelation,
+      uc: UCSingleCatalog): UnresolvedRelation = {
+    val path = relation.multipartIdentifier.last
+    val conf = uc.vendPathCredentialConfWithFallback(path)
+    if (conf.isEmpty) relation else relation.copy(options = mergeOptions(relation.options, conf))
   }
 
   private def currentUcCatalog: Option[UCSingleCatalog] =

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.CatalogNotFoundException
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import scala.collection.JavaConverters._
@@ -93,7 +95,8 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
           case i: InsertIntoDir if i.storage.locationUri.exists(u => isCloudPath(u.toString)) =>
             val location = i.storage.locationUri.get.toString
             val conf =
-              uc.vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ_WRITE)
+              uc.vendPathCredentialConfOrEmpty(
+                spark, location, PathOperation.PATH_READ_WRITE)
             if (conf.isEmpty) {
               i
             } else {
@@ -108,15 +111,22 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
       relation: UnresolvedRelation,
       uc: UCSingleCatalog): UnresolvedRelation = {
     val path = relation.multipartIdentifier.last
-    val conf = uc.vendPathCredentialConfWithFallback(path)
+    val conf = uc.vendPathCredentialConfWithFallback(spark, path)
     if (conf.isEmpty) relation else relation.copy(options = mergeOptions(relation.options, conf))
   }
 
-  private def currentUcCatalog: Option[UCSingleCatalog] =
-    spark.sessionState.catalogManager.currentCatalog match {
-      case uc: UCSingleCatalog => Some(uc)
-      case _ => None
+  private def currentUcCatalog: Option[UCSingleCatalog] = {
+    val manager = spark.sessionState.catalogManager
+    val catalogName = spark.sessionState.conf.getConf(SQLConf.DEFAULT_CATALOG)
+    try {
+      manager.catalog(catalogName) match {
+        case uc: UCSingleCatalog => Some(uc)
+        case _ => None
+      }
+    } catch {
+      case _: CatalogNotFoundException => None
     }
+  }
 }
 
 object ResolvePathCredentials {

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -57,16 +57,16 @@ import scala.collection.JavaConverters._
  * parsed plan via [[UCSparkSessionExtensions]].
  *
  * The rule is a no-op unless the session's current catalog is a [[UCSingleCatalog]]. It can be
- * disabled with `spark.sql.unitycatalog.vendPathCredentials.enabled=false`.
+ * disabled with `spark.sql.catalog.<catalog>.vendPathCredentials.enabled=false`.
  */
 case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan] {
 
   import ResolvePathCredentials._
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    if (!isEnabled) return plan
     currentUcCatalog match {
       case None => plan
+      case Some(uc) if !uc.vendPathCredentialsEnabled => plan
       case Some(uc) =>
         plan.resolveOperators {
           // Bare `format`.`<cloud path>` — used for reads and writes (e.g. INSERT INTO parquet.`s3://...`).
@@ -90,9 +90,6 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
     }
   }
 
-  private def isEnabled: Boolean =
-    spark.conf.get(VEND_PATH_CREDENTIALS_ENABLED, "true").toBoolean
-
   private def currentUcCatalog: Option[UCSingleCatalog] =
     spark.sessionState.catalogManager.currentCatalog match {
       case uc: UCSingleCatalog => Some(uc)
@@ -101,9 +98,6 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
 }
 
 object ResolvePathCredentials {
-
-  /** Session flag to disable direct-path credential vending. */
-  val VEND_PATH_CREDENTIALS_ENABLED = "spark.sql.unitycatalog.vendPathCredentials.enabled"
 
   /**
    * URI schemes for which UC can vend credentials. These match the schemes UC external locations

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.unitycatalog.spark
+
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs.PathOperation
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.collection.JavaConverters._
+
+/**
+ * Injects Unity Catalog path credentials for cloud storage paths referenced directly in a query
+ * (e.g. ``SELECT * FROM parquet.`s3://bucket/dir` `` or
+ * ``INSERT OVERWRITE DIRECTORY 's3://bucket/dir' USING parquet ...``).
+ *
+ * Such path-based relations are resolved by Spark's built-in `ResolveSQLOnFile`, which bypasses
+ * the UC catalog entirely, so no credentials are ever vended and S3A fails with no credentials.
+ * Catalog tables do not have this problem because [[UCSingleCatalog]] vends credentials during
+ * `loadTable`/`createTable`.
+ *
+ * This rule closes that gap. For each bare cloud path it finds, it asks the active
+ * [[UCSingleCatalog]] to vend credentials via [[UCSingleCatalog.vendPathCredentialConf]] and
+ * attaches the resulting `fs.*` Hadoop options to the relation (reads) or write target
+ * (`INSERT OVERWRITE DIRECTORY`). Reads request [[PathOperation.PATH_READ]] (read-only STS/IAM
+ * scope); writes request [[PathOperation.PATH_READ_WRITE]]. Spark folds these per-relation options into the Hadoop
+ * configuration used to open the filesystem, so the credential-scoped filesystem + vended-token
+ * provider pick them up — the same mechanism catalog tables use via
+ * [[UCSingleCatalog.setCredentialProps]].
+ *
+ * '''Ordering''': this must run before the analyzer, because `ResolveSQLOnFile` lists the path
+ * (for schema inference) as soon as it resolves the relation, and it is ordered ahead of injected
+ * resolution rules. It is therefore invoked from [[UCSparkSqlExtensionsParser]] on the freshly
+ * parsed plan via [[UCSparkSessionExtensions]].
+ *
+ * The rule is a no-op unless the session's current catalog is a [[UCSingleCatalog]]. It can be
+ * disabled with `spark.sql.unitycatalog.vendPathCredentials.enabled=false`.
+ */
+case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  import ResolvePathCredentials._
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!isEnabled) return plan
+    currentUcCatalog match {
+      case None => plan
+      case Some(uc) =>
+        plan.resolveOperators {
+          // Read: a two-part `format`.`<cloud path>` identifier, still unresolved.
+          case u: UnresolvedRelation
+              if u.multipartIdentifier.length == 2 && isCloudPath(u.multipartIdentifier.last) =>
+            val path = u.multipartIdentifier.last
+            val conf = uc.vendPathCredentialConf(path, PathOperation.PATH_READ)
+            if (conf.isEmpty) u else u.copy(options = mergeOptions(u.options, conf))
+
+          // Write: INSERT OVERWRITE DIRECTORY '<cloud path>' USING <format> ...
+          case i: InsertIntoDir if i.storage.locationUri.exists(u => isCloudPath(u.toString)) =>
+            val location = i.storage.locationUri.get.toString
+            val conf = uc.vendPathCredentialConf(location, PathOperation.PATH_READ_WRITE)
+            if (conf.isEmpty) {
+              i
+            } else {
+              i.copy(storage =
+                i.storage.copy(properties = i.storage.properties ++ conf.asScala))
+            }
+        }
+    }
+  }
+
+  private def isEnabled: Boolean =
+    spark.conf.get(VEND_PATH_CREDENTIALS_ENABLED, "true").toBoolean
+
+  private def currentUcCatalog: Option[UCSingleCatalog] =
+    spark.sessionState.catalogManager.currentCatalog match {
+      case uc: UCSingleCatalog => Some(uc)
+      case _ => None
+    }
+}
+
+object ResolvePathCredentials {
+
+  /** Session flag to disable direct-path credential vending. */
+  val VEND_PATH_CREDENTIALS_ENABLED = "spark.sql.unitycatalog.vendPathCredentials.enabled"
+
+  /**
+   * URI schemes for which UC can vend credentials. These match the schemes UC external locations
+   * are registered with and the ones [[UCCredentialHadoopConfs]] understands; other schemes (local
+   * paths, `s3a`, HDFS, ...) are left untouched.
+   */
+  private val CLOUD_SCHEMES = Set("s3", "gs", "abfs", "abfss")
+
+  /** True when `pathStr` is an absolute URI whose scheme is one UC can vend credentials for. */
+  private def isCloudPath(pathStr: String): Boolean = {
+    val scheme = try {
+      new Path(pathStr).toUri.getScheme
+    } catch {
+      case _: IllegalArgumentException => null
+    }
+    scheme != null && CLOUD_SCHEMES.contains(scheme.toLowerCase)
+  }
+
+  /** Merges vended `fs.*` credential entries into an existing relation option map. */
+  private def mergeOptions(
+      options: CaseInsensitiveStringMap,
+      credentialConf: java.util.Map[String, String]): CaseInsensitiveStringMap = {
+    val merged = new java.util.HashMap[String, String](options.asCaseSensitiveMap())
+    merged.putAll(credentialConf)
+    new CaseInsensitiveStringMap(merged)
+  }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package io.unitycatalog.spark
 
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs.PathOperation

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/ResolvePathCredentials.scala
@@ -80,8 +80,11 @@ case class ResolvePathCredentials(spark: SparkSession) extends Rule[LogicalPlan]
               if u.multipartIdentifier.length == 2 && isCloudPath(u.multipartIdentifier.last) =>
             injectUnresolvedRelationCredentials(u, uc)
 
-          // `InsertIntoStatement.table` is not a tree child (only `query` is), so the case above
-          // never sees bare-path insert targets such as INSERT INTO parquet.`s3://...`.
+          // `InsertIntoStatement.table` is not a tree child (only `query` is), so the generic
+          // `UnresolvedRelation` case above never visits bare-path INSERT targets such as
+          // INSERT INTO parquet.`s3://...`. On Spark 4.0–4.2, executed INSERT INTO on a bare path
+          // still fails at analysis (TABLE_OR_VIEW_NOT_FOUND); this branch is exercised at parse
+          // time and kept for future Spark versions.
           case i: InsertIntoStatement =>
             i.table match {
               case u: UnresolvedRelation

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -48,6 +48,7 @@ class UCSingleCatalog
   private[this] var tokenProvider: TokenProvider = null
   private[this] var renewCredEnabled: Boolean = false
   private[this] var credScopedFsEnabled: Boolean = true
+  private[spark] var vendPathCredentialsEnabled: Boolean = OptionsUtil.DEFAULT_VEND_PATH_CREDENTIALS_ENABLED
   private[this] var apiClient: ApiClient = null;
   private[this] var tablesApi: TablesApi = null
 
@@ -89,6 +90,8 @@ class UCSingleCatalog
       OptionsUtil.RENEW_CREDENTIAL_ENABLED, OptionsUtil.DEFAULT_RENEW_CREDENTIAL_ENABLED)
     credScopedFsEnabled = options.getBoolean(
       OptionsUtil.CRED_SCOPED_FS_ENABLED, OptionsUtil.DEFAULT_CRED_SCOPED_FS_ENABLED)
+    vendPathCredentialsEnabled = options.getBoolean(
+      OptionsUtil.VEND_PATH_CREDENTIALS_ENABLED, OptionsUtil.DEFAULT_VEND_PATH_CREDENTIALS_ENABLED)
     val serverSidePlanningEnabled = options.getBoolean(
       OptionsUtil.SERVER_SIDE_PLANNING_ENABLED, OptionsUtil.DEFAULT_SERVER_SIDE_PLANNING_ENABLED)
     deltaRestApiEnabled = options.getBoolean(

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -736,6 +736,22 @@ object UCSingleCatalog {
     Seq(catalogName, ident.namespace()(0), ident.name()).mkString(".")
   }
 
+  /**
+   * True when `ident` can be expressed as the dotted `catalog.schema.table` string UC identifies
+   * tables by. A dot inside the schema or table name makes the joined name ambiguous, and UC
+   * rejects it rather than guessing, so such an identifier can never denote a table UC holds.
+   *
+   * Spark asks the current catalog to load every relation before falling back to path-based
+   * resolution, so `SELECT * FROM parquet.`s3://bucket/dir/part.parquet`` arrives here as schema
+   * `parquet` with the path as the table name. Callers treat these as absent, which lets Spark
+   * carry on to `ResolveSQLOnFile` -- see [[UCProxy.getUCTableLike]].
+   */
+  def isAddressableTableName(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 &&
+      !ident.namespace()(0).contains(".") &&
+      !ident.name().contains(".")
+  }
+
 }
 
 /** Internal signal that preserves a view row rejected by the table-only catalog surface. */
@@ -797,7 +813,12 @@ private[spark] class UCProxy(
   // exception. `loadTable` re-raises `NoSuchTableException` on `None` (Spark's resolver expects
   // that); the passive-filter paths (`dropTable`, `dropView`) and `loadView` map `None` to their
   // own not-found result.
+  //
+  // Names UC cannot address answer `None` without an RPC. UC rejects them with 400, which Spark's
+  // resolver does not absorb the way it absorbs a not-found, so asking would surface a name Spark
+  // is merely probing (a bare `parquet.`s3://...`` path) as a query failure.
   private[spark] def getUCTableLike(ident: Identifier): Option[UCTableInfo] = {
+    if (!UCSingleCatalog.isAddressableTableName(ident)) return None
     val fullName = UCSingleCatalog.fullTableNameForApi(this.name, ident)
     try {
       Some(tablesApi.getTable(

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -401,7 +401,9 @@ class UCSingleCatalog
    * credential builder does not recognize (e.g. local paths), so callers can no-op safely.
    */
   private[spark] def vendPathCredentialConf(
-      location: String, operation: PathOperation): util.Map[String, String] = {
+      spark: SparkSession,
+      location: String,
+      operation: PathOperation): util.Map[String, String] = {
     val scheme = new Path(location).toUri.getScheme
     if (scheme == null) return util.Collections.emptyMap[String, String]()
     UCCredentialHadoopConfs
@@ -411,7 +413,7 @@ class UCSingleCatalog
       .apiClient(apiClient)
       .enableCredentialRenewal(renewCredEnabled)
       .enableCredentialScopedFs(credScopedFsEnabled)
-      .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+      .hadoopConf(UCSingleCatalog.sessionHadoopConf(spark))
       .buildForPath(location, operation)
   }
 
@@ -421,10 +423,11 @@ class UCSingleCatalog
    * credentials already configured on the Spark session.
    */
   private[spark] def vendPathCredentialConfOrEmpty(
+      spark: SparkSession,
       location: String,
       operation: PathOperation): util.Map[String, String] = {
     try {
-      vendPathCredentialConf(location, operation)
+      vendPathCredentialConf(spark, location, operation)
     } catch {
       case e: ApiException =>
         logDebug(
@@ -439,13 +442,15 @@ class UCSingleCatalog
    * falls back to PATH_READ, then to an empty map for ambient credentials — same ambiguity
    * handling as loadTable.
    */
-  private[spark] def vendPathCredentialConfWithFallback(location: String): util.Map[String, String] = {
-    val readWrite = vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ_WRITE)
+  private[spark] def vendPathCredentialConfWithFallback(
+      spark: SparkSession,
+      location: String): util.Map[String, String] = {
+    val readWrite = vendPathCredentialConfOrEmpty(spark, location, PathOperation.PATH_READ_WRITE)
     if (!readWrite.isEmpty) {
       readWrite
     } else {
       logDebug(s"PATH_READ_WRITE unavailable for $location, trying PATH_READ")
-      vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ)
+      vendPathCredentialConfOrEmpty(spark, location, PathOperation.PATH_READ)
     }
   }
 
@@ -650,9 +655,12 @@ object UCSingleCatalog {
    * directly via {@code SparkSession.Builder.config("fs.<scheme>.impl", ...)} or {@code SET}
    * commands, not only those prefixed with {@code spark.hadoop.}.
    */
+  def sessionHadoopConf(spark: SparkSession): Configuration =
+    spark.sessionState.newHadoopConf()
+
   def sessionHadoopConf(): Configuration = {
     SparkSession.getActiveSession
-      .map(_.sessionState.newHadoopConf())
+      .map(sessionHadoopConf(_))
       .getOrElse(new Configuration())
   }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -412,6 +412,22 @@ class UCSingleCatalog
       .buildForPath(location, operation)
   }
 
+  /**
+   * Vends path credentials when read vs write is unknown at parse time (e.g. bare
+   * `parquet.`s3://...`` in SELECT or INSERT INTO). Tries PATH_READ_WRITE first,
+   * falls back to PATH_READ — same ambiguity handling as loadTable.
+   */
+  private[spark] def vendPathCredentialConfWithFallback(location: String): util.Map[String, String] = {
+    try {
+      vendPathCredentialConf(location, PathOperation.PATH_READ_WRITE)
+    } catch {
+      case e: ApiException =>
+        logWarning(
+          s"PATH_READ_WRITE credential generation failed for path $location: ${e.getMessage}")
+        vendPathCredentialConf(location, PathOperation.PATH_READ)
+    }
+  }
+
   override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): Table = {
     throw new AssertionError("deprecated `createTable` should not be called")
   }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -386,6 +386,32 @@ class UCSingleCatalog
     newProps
   }
 
+  /**
+   * Vends UC path credentials for a bare storage `location` and returns the resulting Hadoop
+   * `fs.*` configuration entries (credential-scoped filesystem impl, initial vended credentials,
+   * and the `fs.unitycatalog.*` keys that arm lazy renewal).
+   *
+   * This mirrors [[prepareExternalTableProperties]] but targets a path referenced directly in a
+   * query (e.g. `parquet.`s3://bucket/dir``), which never flows through `loadTable`/`createTable`.
+   * Used by [[ResolvePathCredentials]] to inject credentials as relation/table options so S3A can
+   * access the path without a pre-registered external table. Returns an empty map for schemes the
+   * credential builder does not recognize (e.g. local paths), so callers can no-op safely.
+   */
+  private[spark] def vendPathCredentialConf(
+      location: String, operation: PathOperation): util.Map[String, String] = {
+    val scheme = new Path(location).toUri.getScheme
+    if (scheme == null) return util.Collections.emptyMap[String, String]()
+    UCCredentialHadoopConfs
+      .builder(uri.toString, scheme)
+      .addAppVersions(ApiClientFactory.appEngineVersions())
+      .tokenProvider(tokenProvider)
+      .apiClient(apiClient)
+      .enableCredentialRenewal(renewCredEnabled)
+      .enableCredentialScopedFs(credScopedFsEnabled)
+      .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+      .buildForPath(location, operation)
+  }
+
   override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): Table = {
     throw new AssertionError("deprecated `createTable` should not be called")
   }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -416,18 +416,36 @@ class UCSingleCatalog
   }
 
   /**
-   * Vends path credentials when read vs write is unknown at parse time (e.g. bare
-   * `parquet.`s3://...`` in SELECT or INSERT INTO). Tries PATH_READ_WRITE first,
-   * falls back to PATH_READ — same ambiguity handling as loadTable.
+   * Vends path credentials for a path and operation, returning an empty map when UC cannot vend
+   * (path not managed, insufficient permission, etc.) so callers can fall back to ambient Hadoop
+   * credentials already configured on the Spark session.
    */
-  private[spark] def vendPathCredentialConfWithFallback(location: String): util.Map[String, String] = {
+  private[spark] def vendPathCredentialConfOrEmpty(
+      location: String,
+      operation: PathOperation): util.Map[String, String] = {
     try {
-      vendPathCredentialConf(location, PathOperation.PATH_READ_WRITE)
+      vendPathCredentialConf(location, operation)
     } catch {
       case e: ApiException =>
-        logWarning(
-          s"PATH_READ_WRITE credential generation failed for path $location: ${e.getMessage}")
-        vendPathCredentialConf(location, PathOperation.PATH_READ)
+        logDebug(
+          s"Path credential vending failed for $location ($operation): ${e.getMessage}")
+        util.Collections.emptyMap[String, String]()
+    }
+  }
+
+  /**
+   * Vends path credentials when read vs write is unknown at parse time (e.g. bare
+   * `parquet.`s3://...`` in SELECT or INSERT INTO). Tries PATH_READ_WRITE first,
+   * falls back to PATH_READ, then to an empty map for ambient credentials — same ambiguity
+   * handling as loadTable.
+   */
+  private[spark] def vendPathCredentialConfWithFallback(location: String): util.Map[String, String] = {
+    val readWrite = vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ_WRITE)
+    if (!readWrite.isEmpty) {
+      readWrite
+    } else {
+      logDebug(s"PATH_READ_WRITE unavailable for $location, trying PATH_READ")
+      vendPathCredentialConfOrEmpty(location, PathOperation.PATH_READ)
     }
   }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.unitycatalog.spark
+
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.parser.extensions.UCSparkSqlExtensionsParser
+
+/** Spark session extensions that vend UC credentials for bare cloud paths in SQL. */
+class UCSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectParser { case (_, parser) => new UCSparkSqlExtensionsParser(parser) }
+  }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.parser.extensions.UCSparkSqlExtensionsParse
 class UCSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new UCSparkSqlExtensionsParser(parser) }
+    extensions.injectParser { case (spark, parser) =>
+      new UCSparkSqlExtensionsParser(spark, parser)
+    }
   }
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSparkSessionExtensions.scala
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package io.unitycatalog.spark
 
 import org.apache.spark.sql.SparkSessionExtensions

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -24,12 +24,15 @@ import io.unitycatalog.spark.ResolvePathCredentials
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.{ParameterContext, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types.{DataType, StructType}
 
 class UCSparkSqlExtensionsParser(spark: SparkSession, delegate: ParserInterface)
     extends ParserInterface {
+
+  private def applyPathCredentials(plan: LogicalPlan): LogicalPlan =
+    ResolvePathCredentials(spark).apply(plan)
 
   override def parseDataType(sqlText: String): DataType = delegate.parseDataType(sqlText)
 
@@ -49,11 +52,14 @@ class UCSparkSqlExtensionsParser(spark: SparkSession, delegate: ParserInterface)
   override def parseRoutineParam(sqlText: String): StructType =
     delegate.parseRoutineParam(sqlText)
 
-  override def parsePlan(sqlText: String): LogicalPlan = {
-    val plan = delegate.parsePlan(sqlText)
-    // Vend credentials for bare cloud paths before the analyzer resolves (and lists) them.
-    ResolvePathCredentials(spark).apply(plan)
-  }
+  override def parsePlan(sqlText: String): LogicalPlan =
+    applyPathCredentials(delegate.parsePlan(sqlText))
 
-  override def parseQuery(sqlText: String): LogicalPlan = parsePlan(sqlText)
+  override def parsePlanWithParameters(
+      sqlText: String,
+      parameterContext: ParameterContext): LogicalPlan =
+    applyPathCredentials(delegate.parsePlanWithParameters(sqlText, parameterContext))
+
+  override def parseQuery(sqlText: String): LogicalPlan =
+    applyPathCredentials(delegate.parseQuery(sqlText))
 }

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -45,7 +45,8 @@ class UCSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterf
 
   override def parseTableSchema(sqlText: String): StructType = delegate.parseTableSchema(sqlText)
 
-  override def parseRoutineParam(sqlText: String): StructType = delegate.parseTableSchema(sqlText)
+  override def parseRoutineParam(sqlText: String): StructType =
+    delegate.parseRoutineParam(sqlText)
 
   override def parsePlan(sqlText: String): LogicalPlan = {
     val spark = SparkSession.active

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types.{DataType, StructType}
 
-class UCSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+class UCSparkSqlExtensionsParser(spark: SparkSession, delegate: ParserInterface)
+    extends ParserInterface {
 
   override def parseDataType(sqlText: String): DataType = delegate.parseDataType(sqlText)
 
@@ -49,7 +50,6 @@ class UCSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterf
     delegate.parseRoutineParam(sqlText)
 
   override def parsePlan(sqlText: String): LogicalPlan = {
-    val spark = SparkSession.active
     val plan = delegate.parsePlan(sqlText)
     // Vend credentials for bare cloud paths before the analyzer resolves (and lists) them.
     ResolvePathCredentials(spark).apply(plan)

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -24,14 +24,16 @@ import io.unitycatalog.spark.ResolvePathCredentials
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.parser.{ParameterContext, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types.{DataType, StructType}
 
 class UCSparkSqlExtensionsParser(spark: SparkSession, delegate: ParserInterface)
-    extends ParserInterface {
+    extends ParserInterfaceShim {
 
-  private def applyPathCredentials(plan: LogicalPlan): LogicalPlan =
+  protected def delegateParser: ParserInterface = delegate
+
+  protected def applyPathCredentials(plan: LogicalPlan): LogicalPlan =
     ResolvePathCredentials(spark).apply(plan)
 
   override def parseDataType(sqlText: String): DataType = delegate.parseDataType(sqlText)
@@ -54,11 +56,6 @@ class UCSparkSqlExtensionsParser(spark: SparkSession, delegate: ParserInterface)
 
   override def parsePlan(sqlText: String): LogicalPlan =
     applyPathCredentials(delegate.parsePlan(sqlText))
-
-  override def parsePlanWithParameters(
-      sqlText: String,
-      parameterContext: ParameterContext): LogicalPlan =
-    applyPathCredentials(delegate.parsePlanWithParameters(sqlText, parameterContext))
 
   override def parseQuery(sqlText: String): LogicalPlan =
     applyPathCredentials(delegate.parseQuery(sqlText))

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import io.unitycatalog.spark.ResolvePathCredentials
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.types.{DataType, StructType}
+
+class UCSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+
+  override def parseDataType(sqlText: String): DataType = delegate.parseDataType(sqlText)
+
+  override def parseExpression(sqlText: String): Expression = delegate.parseExpression(sqlText)
+
+  override def parseTableIdentifier(sqlText: String): TableIdentifier =
+    delegate.parseTableIdentifier(sqlText)
+
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier =
+    delegate.parseFunctionIdentifier(sqlText)
+
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] =
+    delegate.parseMultipartIdentifier(sqlText)
+
+  override def parseTableSchema(sqlText: String): StructType = delegate.parseTableSchema(sqlText)
+
+  override def parseRoutineParam(sqlText: String): StructType = delegate.parseTableSchema(sqlText)
+
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    val spark = SparkSession.active
+    val plan = delegate.parsePlan(sqlText)
+    // Vend credentials for bare cloud paths before the analyzer resolves (and lists) them.
+    ResolvePathCredentials(spark).apply(plan)
+  }
+
+  override def parseQuery(sqlText: String): LogicalPlan = parsePlan(sqlText)
+}

--- a/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
+++ b/connectors/spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UCSparkSqlExtensionsParser.scala
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.apache.spark.sql.catalyst.parser.extensions
 
 import io.unitycatalog.spark.ResolvePathCredentials

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/CredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/CredentialTestFileSystem.java
@@ -76,10 +76,10 @@ public abstract class CredentialTestFileSystem extends RawLocalFileSystem {
         new Path(path));
   }
 
-  private Path toLocalPath(Path f) {
+  private Path toLocalPath(Path f) throws IOException {
     checkCredentials(f);
     return new Path(f.toString().replaceAll(scheme() + "//.*?/", "file:///"));
   }
 
-  protected abstract void checkCredentials(Path f);
+  protected abstract void checkCredentials(Path f) throws IOException;
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -9,7 +9,10 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.assertj.core.util.Throwables;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,6 +78,13 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     return "s3://test-bucket0" + new File(dataDir, name).getCanonicalPath();
   }
 
+  private void stopSession() {
+    if (session != null) {
+      session.stop();
+      session = null;
+    }
+  }
+
   private void assertSingleRow(List<Row> rows) {
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).getInt(0)).isEqualTo(1);
@@ -83,34 +93,46 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
   /**
    * Writes to a bare cloud path and reads it back. Exercises {@code INSERT OVERWRITE DIRECTORY}
-   * ({@code InsertIntoDir}) and {@code INSERT INTO parquet.`path`} ({@code UnresolvedRelation}
-   * write target), plus {@code parquet.`path`} reads.
+   * ({@code InsertIntoDir}) and {@code parquet.`path`} reads ({@code UnresolvedRelation}).
+   * Bare-path {@code INSERT INTO} write targets are covered at parse time in {@link
+   * #testInsertIntoBarePathInjectsCredentialsAtParseTime()} because Spark 4.1 rejects them at
+   * analysis ({@code TABLE_OR_VIEW_NOT_FOUND}).
    */
   @ParameterizedTest
-  @CsvSource({"false, false, overwrite", "true, true, overwrite", "false, false, insert_into"})
-  public void testWriteAndReadBareS3Path(
-      boolean renewCred, boolean credScopedFsEnabled, String writeMode) throws IOException {
-    if (session != null) {
-      session.close();
-      session = null;
-    }
+  @CsvSource({"false, false", "true, true"})
+  public void testWriteAndReadBareS3Path(boolean renewCred, boolean credScopedFsEnabled)
+      throws IOException {
+    stopSession();
     session = createUcSparkSession(renewCred, credScopedFsEnabled, true, SPARK_CATALOG);
-    String location =
-        bucketPath("write_" + writeMode + "_" + renewCred + "_" + credScopedFsEnabled);
+    String location = bucketPath("write_directory_" + renewCred + "_" + credScopedFsEnabled);
 
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+  }
 
-    if ("insert_into".equals(writeMode)) {
-      sql("INSERT INTO parquet.`%s` SELECT 2 AS i, 'b' AS s", location);
-      List<Row> rows = sql("SELECT * FROM parquet.`%s` ORDER BY i", location);
-      assertThat(rows).hasSize(2);
-      assertThat(rows.get(0).getInt(0)).isEqualTo(1);
-      assertThat(rows.get(0).getString(1)).isEqualTo("a");
-      assertThat(rows.get(1).getInt(0)).isEqualTo(2);
-      assertThat(rows.get(1).getString(1)).isEqualTo("b");
-    } else {
-      assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
-    }
+  /**
+   * Spark 4.1 rejects {@code INSERT INTO parquet.`s3://...`} at analysis ({@code
+   * TABLE_OR_VIEW_NOT_FOUND}) because {@code INSERT} DML requires a registered {@code
+   * table_identifier} (see Spark 4.1 INSERT TABLE docs). Parsing still builds an {@code
+   * InsertIntoStatement} whose target is an {@code UnresolvedRelation}, so {@link
+   * ResolvePathCredentials} must inject credentials before analysis — this test pins that behavior
+   * without executing the statement.
+   */
+  @Test
+  public void testInsertIntoBarePathInjectsCredentialsAtParseTime()
+      throws IOException, ParseException {
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
+    String location = bucketPath("insert_into_parse");
+    String insertSql = String.format("INSERT INTO parquet.`%s` SELECT 2 AS i, 'b' AS s", location);
+
+    LogicalPlan plan = session.sessionState().sqlParser().parsePlan(insertSql);
+    assertThat(plan).isInstanceOf(InsertIntoStatement.class);
+    LogicalPlan table = ((InsertIntoStatement) plan).table();
+    assertThat(table).isInstanceOf(UnresolvedRelation.class);
+    UnresolvedRelation target = (UnresolvedRelation) table;
+    assertThat(target.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+
+    assertThrows(Exception.class, () -> session.sql(insertSql).collectAsList());
   }
 
   /**
@@ -124,11 +146,17 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     // Write with the feature on so the data exists.
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
-    session.close();
-    session = null;
+    stopSession();
     session = createUcSparkSession(false, false, false, SPARK_CATALOG);
     Exception thrown =
         assertThrows(Exception.class, () -> sql("SELECT * FROM parquet.`%s`", location));
-    assertThat(Throwables.getStackTrace(thrown)).contains("accessKey0");
+    Throwable credentialError = thrown;
+    while (credentialError != null
+        && (credentialError.getMessage() == null
+            || !credentialError.getMessage().contains("accessKey0"))) {
+      credentialError = credentialError.getCause();
+    }
+    assertThat(credentialError).isNotNull();
+    assertThat(credentialError.getMessage()).contains("accessKey0");
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -1,12 +1,13 @@
 package io.unitycatalog.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.spark.utils.OptionsUtil;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -92,6 +93,25 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(rows.get(0).getString(1)).isEqualTo("a");
   }
 
+  private static List<Throwable> causalChain(Throwable t) {
+    List<Throwable> chain = new ArrayList<>();
+    while (t != null) {
+      chain.add(t);
+      t = t.getCause();
+    }
+    return chain;
+  }
+
+  private static void assertNoCauseOfType(Throwable thrown, Class<?> type) {
+    assertThat(causalChain(thrown)).noneMatch(type::isInstance);
+  }
+
+  private static void assertCauseChainContainsMessage(Throwable thrown, String substring) {
+    assertThat(causalChain(thrown))
+        .extracting(Throwable::getMessage)
+        .anyMatch(msg -> msg != null && msg.contains(substring));
+  }
+
   /**
    * Writes to a bare cloud path and reads it back. Exercises {@code INSERT OVERWRITE DIRECTORY}
    * ({@code InsertIntoDir}) and {@code parquet.`path`} reads ({@code UnresolvedRelation}).
@@ -144,26 +164,13 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     session = createUcSparkSession(false, false, true, SPARK_CATALOG);
     String location = "s3://" + NO_CREDS_BUCKET + new File(dataDir, "unmanaged").getCanonicalPath();
 
-    Exception thrown =
-        assertThrows(
-            Exception.class,
+    assertThatThrownBy(
             () ->
                 sql(
                     "INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s",
-                    location));
-
-    Throwable t = thrown;
-    while (t != null) {
-      assertThat(t).isNotInstanceOf(ApiException.class);
-      t = t.getCause();
-    }
-    Throwable fsError = thrown;
-    while (fsError != null
-        && (fsError.getMessage() == null || !fsError.getMessage().contains("invalid path"))) {
-      fsError = fsError.getCause();
-    }
-    assertThat(fsError).isNotNull();
-    assertThat(fsError.getMessage()).contains("invalid path");
+                    location))
+        .satisfies(e -> assertNoCauseOfType(e, ApiException.class))
+        .satisfies(e -> assertCauseChainContainsMessage(e, "invalid path"));
   }
 
   /**
@@ -179,15 +186,7 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
     stopSession();
     session = createUcSparkSession(false, false, false, SPARK_CATALOG);
-    Exception thrown =
-        assertThrows(Exception.class, () -> sql("SELECT * FROM parquet.`%s`", location));
-    Throwable credentialError = thrown;
-    while (credentialError != null
-        && (credentialError.getMessage() == null
-            || !credentialError.getMessage().contains("accessKey0"))) {
-      credentialError = credentialError.getCause();
-    }
-    assertThat(credentialError).isNotNull();
-    assertThat(credentialError.getMessage()).contains("accessKey0");
+    assertThatThrownBy(() -> sql("SELECT * FROM parquet.`%s`", location))
+        .satisfies(e -> assertCauseChainContainsMessage(e, "accessKey0"));
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -29,9 +29,6 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
-  private static final String VEND_ENABLED_CONF =
-      "spark.sql.unitycatalog.vendPathCredentials.enabled";
-
   @TempDir protected File dataDir;
 
   /**
@@ -41,7 +38,10 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
    * extension. The catalogs are expected to already exist (created in {@code setUp}).
    */
   private SparkSession createUcSparkSession(
-      boolean renewCred, boolean credScopedFsEnabled, String... catalogs) {
+      boolean renewCred,
+      boolean credScopedFsEnabled,
+      boolean vendPathCredentialsEnabled,
+      String... catalogs) {
     SparkSession.Builder builder =
         SparkSession.builder()
             .appName("test")
@@ -60,7 +60,10 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
               .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
               .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog)
               .config(catalogConf + "." + OptionsUtil.RENEW_CREDENTIAL_ENABLED, renewCred)
-              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled);
+              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled)
+              .config(
+                  catalogConf + "." + OptionsUtil.VEND_PATH_CREDENTIALS_ENABLED,
+                  vendPathCredentialsEnabled);
     }
     // Use fake file system for cloud storage so that we can assert vended credentials.
     builder.config("spark.hadoop.fs.s3.impl", S3CredentialTestFileSystem.class.getName());
@@ -91,7 +94,7 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
       session.close();
       session = null;
     }
-    session = createUcSparkSession(renewCred, credScopedFsEnabled, SPARK_CATALOG);
+    session = createUcSparkSession(renewCred, credScopedFsEnabled, true, SPARK_CATALOG);
     String location =
         bucketPath("write_" + writeMode + "_" + renewCred + "_" + credScopedFsEnabled);
 
@@ -116,12 +119,14 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
    */
   @Test
   public void testDisabledByFlag() throws IOException {
-    session = createUcSparkSession(false, false, SPARK_CATALOG);
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
     String location = bucketPath("import_disabled");
     // Write with the feature on so the data exists.
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
-    session.conf().set(VEND_ENABLED_CONF, "false");
+    session.close();
+    session = null;
+    session = createUcSparkSession(false, false, false, SPARK_CATALOG);
     Exception thrown =
         assertThrows(Exception.class, () -> sql("SELECT * FROM parquet.`%s`", location));
     assertThat(Throwables.getStackTrace(thrown)).contains("accessKey0");

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.spark;
 
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -197,6 +198,30 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(table).isInstanceOf(UnresolvedRelation.class);
     UnresolvedRelation target = (UnresolvedRelation) table;
     assertThat(target.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+  }
+
+  /**
+   * After {@code USE CATALOG}, bare-path credential injection must follow the session's current
+   * catalog, not {@code SQLConf.DEFAULT_CATALOG}. Default remains the built-in {@code spark_catalog}
+   * while the UC catalog is selected explicitly.
+   */
+  @Test
+  public void testBarePathUsesCurrentCatalogAfterUseCatalog() throws IOException, ParseException {
+    stopSession();
+    session = createUcSparkSession(false, false, true, CATALOG_NAME);
+    String location = bucketPath("use_catalog");
+    sql("USE CATALOG %s", CATALOG_NAME);
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+
+    LogicalPlan plan =
+        session
+            .sessionState()
+            .sqlParser()
+            .parsePlan(String.format("SELECT * FROM parquet.`%s`", location));
+    assertThat(plan).isInstanceOf(UnresolvedRelation.class);
+    UnresolvedRelation relation = (UnresolvedRelation) plan;
+    assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
   }
 
   /**

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -3,6 +3,7 @@ package io.unitycatalog.spark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.unitycatalog.client.ApiException;
 import io.unitycatalog.spark.utils.OptionsUtil;
 import java.io.File;
 import java.io.IOException;
@@ -131,8 +132,38 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     assertThat(table).isInstanceOf(UnresolvedRelation.class);
     UnresolvedRelation target = (UnresolvedRelation) table;
     assertThat(target.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+  }
 
-    assertThrows(Exception.class, () -> session.sql(insertSql).collectAsList());
+  /**
+   * When UC cannot vend credentials for a path (not managed by UC), execution continues and Spark
+   * falls back to ambient storage credentials. With none configured for this bucket, the write
+   * fails at the filesystem layer — not with a UC {@link ApiException}.
+   */
+  @Test
+  public void testFallsBackToAmbientWhenPathNotManagedByUc() throws IOException {
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
+    String location = "s3://" + NO_CREDS_BUCKET + new File(dataDir, "unmanaged").getCanonicalPath();
+
+    Exception thrown =
+        assertThrows(
+            Exception.class,
+            () ->
+                sql(
+                    "INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s",
+                    location));
+
+    Throwable t = thrown;
+    while (t != null) {
+      assertThat(t).isNotInstanceOf(ApiException.class);
+      t = t.getCause();
+    }
+    Throwable fsError = thrown;
+    while (fsError != null
+        && (fsError.getMessage() == null || !fsError.getMessage().contains("invalid path"))) {
+      fsError = fsError.getCause();
+    }
+    assertThat(fsError).isNotNull();
+    assertThat(fsError.getMessage()).contains("invalid path");
   }
 
   /**

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -1,7 +1,7 @@
 package io.unitycatalog.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.unitycatalog.spark.utils.OptionsUtil;
 import java.io.File;
@@ -9,8 +9,11 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.util.Throwables;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link ResolvePathCredentials}: Unity Catalog credentials are vended for cloud paths
@@ -76,31 +79,35 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
-   * Writes to a bare cloud path with `INSERT OVERWRITE DIRECTORY` (exercises the write branch) and
-   * reads it back with `parquet.`<path>`` (exercises the read branch). Both previously failed
-   * because path-based relations bypass the UC catalog and never got credentials.
+   * Writes to a bare cloud path and reads it back. Exercises {@code INSERT OVERWRITE DIRECTORY}
+   * ({@code InsertIntoDir}) and {@code INSERT INTO parquet.`path`} ({@code UnresolvedRelation}
+   * write target), plus {@code parquet.`path`} reads.
    */
-  @Test
-  public void testWriteAndReadBareS3PathStaticCreds() throws IOException {
-    session = createUcSparkSession(false, false, SPARK_CATALOG);
-    String location = bucketPath("import_static");
+  @ParameterizedTest
+  @CsvSource({"false, false, overwrite", "true, true, overwrite", "false, false, insert_into"})
+  public void testWriteAndReadBareS3Path(
+      boolean renewCred, boolean credScopedFsEnabled, String writeMode) throws IOException {
+    if (session != null) {
+      session.close();
+      session = null;
+    }
+    session = createUcSparkSession(renewCred, credScopedFsEnabled, SPARK_CATALOG);
+    String location =
+        bucketPath("write_" + writeMode + "_" + renewCred + "_" + credScopedFsEnabled);
 
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
-    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
-  }
 
-  /**
-   * Same as above but with credential renewal + credential-scoped filesystem enabled, so the vended
-   * credentials flow through {@code AwsVendedTokenProvider} + {@code CredScopedFileSystem} rather
-   * than static keys.
-   */
-  @Test
-  public void testWriteAndReadBareS3PathVendedProvider() throws IOException {
-    session = createUcSparkSession(true, true, SPARK_CATALOG);
-    String location = bucketPath("import_vended");
-
-    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
-    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+    if ("insert_into".equals(writeMode)) {
+      sql("INSERT INTO parquet.`%s` SELECT 2 AS i, 'b' AS s", location);
+      List<Row> rows = sql("SELECT * FROM parquet.`%s` ORDER BY i", location);
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0).getInt(0)).isEqualTo(1);
+      assertThat(rows.get(0).getString(1)).isEqualTo("a");
+      assertThat(rows.get(1).getInt(0)).isEqualTo(2);
+      assertThat(rows.get(1).getString(1)).isEqualTo("b");
+    } else {
+      assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+    }
   }
 
   /**
@@ -115,6 +122,8 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
     session.conf().set(VEND_ENABLED_CONF, "false");
-    assertThatThrownBy(() -> sql("SELECT * FROM parquet.`%s`", location));
+    Exception thrown =
+        assertThrows(Exception.class, () -> sql("SELECT * FROM parquet.`%s`", location));
+    assertThat(Throwables.getStackTrace(thrown)).contains("accessKey0");
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
@@ -129,6 +130,50 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
     assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+  }
+
+  /** UC extension only — enough for parameterized SQL parser tests (no Delta needed). */
+  private SparkSession createUcExtensionOnlySparkSession(String... catalogs) {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config("spark.sql.extensions", "io.unitycatalog.spark.UCSparkSessionExtensions");
+    for (String catalog : catalogs) {
+      String catalogConf = "spark.sql.catalog." + catalog;
+      builder =
+          builder
+              .config(catalogConf, UCSingleCatalog.class.getName())
+              .config(catalogConf + "." + OptionsUtil.URI, serverConfig.getServerUrl())
+              .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
+              .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog);
+    }
+    return builder.getOrCreate();
+  }
+
+  /**
+   * {@code SparkSession.sql(text, args)} routes through {@code parsePlanWithParameters}. The UC
+   * parser extension must delegate parameter binding to the underlying parser before applying path
+   * credential injection. Uses a UC-only session (no Delta extension) so the delegate is {@code
+   * SparkSqlParser} directly.
+   */
+  @Test
+  public void testPositionalSqlParameters() {
+    stopSession();
+    session = createUcExtensionOnlySparkSession(SPARK_CATALOG);
+    List<Row> rows = session.sql("SELECT ? AS c", new Object[] {42}).collectAsList();
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(42);
+  }
+
+  @Test
+  public void testNamedSqlParameters() {
+    stopSession();
+    session = createUcExtensionOnlySparkSession(SPARK_CATALOG);
+    List<Row> rows = session.sql("SELECT :x AS c", Map.of("x", 42)).collectAsList();
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(42);
   }
 
   /**

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -1,0 +1,120 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.spark.utils.OptionsUtil;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link ResolvePathCredentials}: Unity Catalog credentials are vended for cloud paths
+ * referenced directly in a query (e.g. {@code parquet.`s3://bucket/dir`}), without a pre-registered
+ * external table.
+ *
+ * <p>Unlike the other Spark integration tests, these register {@code UCSparkSessionExtensions} (the
+ * home of the parser hook that invokes the rule), and use the {@link S3CredentialTestFileSystem}
+ * fake filesystem to assert the vended credentials reach S3A. The test principal is the metastore
+ * owner, so path authorization passes and credentials fall back to the per-bucket server config
+ * ({@code accessKey0}/... for {@code s3://test-bucket0}) configured in {@link
+ * BaseSparkIntegrationTest#setUpProperties()}.
+ */
+public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
+
+  private static final String VEND_ENABLED_CONF =
+      "spark.sql.unitycatalog.vendPathCredentials.enabled";
+
+  @TempDir protected File dataDir;
+
+  /**
+   * Builds a Spark session that registers {@code UCSparkSessionExtensions} (so the parser-level
+   * {@link ResolvePathCredentials} hook is active) and points the given catalogs at the test UC
+   * server. Mirrors {@link BaseSparkIntegrationTest#createSparkSessionWithCatalogs} but adds the UC
+   * extension. The catalogs are expected to already exist (created in {@code setUp}).
+   */
+  private SparkSession createUcSparkSession(
+      boolean renewCred, boolean credScopedFsEnabled, String... catalogs) {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config(
+                "spark.sql.extensions",
+                "io.delta.sql.DeltaSparkSessionExtension,"
+                    + "io.unitycatalog.spark.UCSparkSessionExtensions");
+    for (String catalog : catalogs) {
+      String catalogConf = "spark.sql.catalog." + catalog;
+      builder =
+          builder
+              .config(catalogConf, UCSingleCatalog.class.getName())
+              .config(catalogConf + "." + OptionsUtil.URI, serverConfig.getServerUrl())
+              .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
+              .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog)
+              .config(catalogConf + "." + OptionsUtil.RENEW_CREDENTIAL_ENABLED, renewCred)
+              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled);
+    }
+    // Use fake file system for cloud storage so that we can assert vended credentials.
+    builder.config("spark.hadoop.fs.s3.impl", S3CredentialTestFileSystem.class.getName());
+    return builder.getOrCreate();
+  }
+
+  /** A bare `s3://test-bucket0/...` path backed by a local temp dir understood by the fake FS. */
+  private String bucketPath(String name) throws IOException {
+    return "s3://test-bucket0" + new File(dataDir, name).getCanonicalPath();
+  }
+
+  private void assertSingleRow(List<Row> rows) {
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(1);
+    assertThat(rows.get(0).getString(1)).isEqualTo("a");
+  }
+
+  /**
+   * Writes to a bare cloud path with `INSERT OVERWRITE DIRECTORY` (exercises the write branch) and
+   * reads it back with `parquet.`<path>`` (exercises the read branch). Both previously failed
+   * because path-based relations bypass the UC catalog and never got credentials.
+   */
+  @Test
+  public void testWriteAndReadBareS3PathStaticCreds() throws IOException {
+    session = createUcSparkSession(false, false, SPARK_CATALOG);
+    String location = bucketPath("import_static");
+
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+  }
+
+  /**
+   * Same as above but with credential renewal + credential-scoped filesystem enabled, so the vended
+   * credentials flow through {@code AwsVendedTokenProvider} + {@code CredScopedFileSystem} rather
+   * than static keys.
+   */
+  @Test
+  public void testWriteAndReadBareS3PathVendedProvider() throws IOException {
+    session = createUcSparkSession(true, true, SPARK_CATALOG);
+    String location = bucketPath("import_vended");
+
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+    assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
+  }
+
+  /**
+   * When the feature is disabled, no credentials are injected for the bare path, so the read fails
+   * (this is the pre-fix behavior). Confirms the rule is what enables direct path access.
+   */
+  @Test
+  public void testDisabledByFlag() throws IOException {
+    session = createUcSparkSession(false, false, SPARK_CATALOG);
+    String location = bucketPath("import_disabled");
+    // Write with the feature on so the data exists.
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+
+    session.conf().set(VEND_ENABLED_CONF, "false");
+    assertThatThrownBy(() -> sql("SELECT * FROM parquet.`%s`", location));
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -155,6 +155,28 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
+   * Path credential vending must use the explicit {@code SparkSession} passed from the parser, not
+   * {@code SparkSession.getActiveSession}. {@code
+   * session.sessionState().sqlParser().parsePlan(...)} does not guarantee an active session on the
+   * calling thread.
+   */
+  @Test
+  public void testVendPathCredentialsWithoutActiveSession() throws IOException {
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
+    String location = bucketPath("no_active_session");
+    UCSingleCatalog catalog =
+        (UCSingleCatalog) session.sessionState().catalogManager().catalog(SPARK_CATALOG);
+
+    SparkSession.clearActiveSession();
+    try {
+      assertThat(catalog.vendPathCredentialConfWithFallback(session, location))
+          .containsEntry("fs.s3a.access.key", "accessKey0");
+    } finally {
+      SparkSession.setActiveSession(session);
+    }
+  }
+
+  /**
    * When UC cannot vend credentials for a path (not managed by UC), execution continues and Spark
    * falls back to ambient storage credentials. With none configured for this bucket, the write
    * fails at the filesystem layer — not with a UC {@link ApiException}.

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -118,8 +118,8 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
    * Writes to a bare cloud path and reads it back. Exercises {@code INSERT OVERWRITE DIRECTORY}
    * ({@code InsertIntoDir}) and {@code parquet.`path`} reads ({@code UnresolvedRelation}).
    * Bare-path {@code INSERT INTO} write targets are covered at parse time in {@link
-   * #testInsertIntoBarePathInjectsCredentialsAtParseTime()} because Spark 4.1 rejects them at
-   * analysis ({@code TABLE_OR_VIEW_NOT_FOUND}).
+   * #testInsertIntoBarePathInjectsCredentialsAtParseTime()} because Spark 4.x rejects them at
+   * analysis ({@code TABLE_OR_VIEW_NOT_FOUND}) on all supported versions (4.0–4.2).
    */
   @ParameterizedTest
   @CsvSource({"false, false", "true, true"})
@@ -178,12 +178,11 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
-   * Spark 4.1 rejects {@code INSERT INTO parquet.`s3://...`} at analysis ({@code
+   * Spark 4.x rejects {@code INSERT INTO parquet.`s3://...`} at analysis ({@code
    * TABLE_OR_VIEW_NOT_FOUND}) because {@code INSERT} DML requires a registered {@code
-   * table_identifier} (see Spark 4.1 INSERT TABLE docs). Parsing still builds an {@code
-   * InsertIntoStatement} whose target is an {@code UnresolvedRelation}, so {@link
-   * ResolvePathCredentials} must inject credentials before analysis — this test pins that behavior
-   * without executing the statement.
+   * table_identifier}. Parsing still builds an {@code InsertIntoStatement} whose target is an
+   * {@code UnresolvedRelation}, so {@link ResolvePathCredentials} must inject credentials before
+   * analysis — this test pins parse-time credential injection only; it does not execute the DML.
    */
   @Test
   public void testInsertIntoBarePathInjectsCredentialsAtParseTime()
@@ -201,16 +200,16 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
-   * After {@code USE CATALOG}, bare-path credential injection must follow the session's current
+   * After {@code SET CATALOG}, bare-path credential injection must follow the session's current
    * catalog, not {@code SQLConf.DEFAULT_CATALOG}. Default remains the built-in {@code spark_catalog}
    * while the UC catalog is selected explicitly.
    */
   @Test
-  public void testBarePathUsesCurrentCatalogAfterUseCatalog() throws IOException, ParseException {
+  public void testBarePathUsesCurrentCatalogAfterSetCatalog() throws IOException, ParseException {
     stopSession();
     session = createUcSparkSession(false, false, true, CATALOG_NAME);
     String location = bucketPath("use_catalog");
-    sql("USE CATALOG %s", CATALOG_NAME);
+    sql("SET CATALOG %s", CATALOG_NAME);
     sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
     LogicalPlan plan =

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -299,5 +300,81 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     session = createUcSparkSession(false, false, false, SPARK_CATALOG);
     assertThatThrownBy(() -> sql("SELECT * FROM parquet.`%s`", location))
         .satisfies(e -> assertCauseChainContainsMessage(e, "accessKey0"));
+  }
+
+  /**
+   * Import-style deduped row-count query with {@code parquet.`s3://...`} nested inside a subquery
+   * ({@code SELECT COUNT(*) FROM (SELECT row_number() ... FROM parquet.`path`) ...}).
+   */
+  @Test
+  public void testNestedCountFromBareParquetPath() throws IOException, ParseException {
+    stopSession();
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
+    String location = bucketPath("nested_count");
+    sql(
+        "INSERT OVERWRITE DIRECTORY '%s' USING parquet "
+            + "SELECT * FROM (SELECT 1 AS i, 'a' AS s UNION ALL SELECT 1 AS i, 'b' AS s)",
+        location);
+
+    String countSql =
+        String.format(
+            "SELECT COUNT(*) AS c FROM ("
+                + " SELECT row_number() OVER (PARTITION BY i ORDER BY i DESC) AS rn"
+                + " FROM parquet.`%s`"
+                + ") WHERE rn = 1",
+            location);
+    LogicalPlan plan = session.sessionState().sqlParser().parsePlan(countSql);
+    UnresolvedRelation relation = findBareCloudPathRelation(plan);
+    assertThat(relation)
+        .as("nested subquery should still contain bare cloud-path relation: %s", plan)
+        .isNotNull();
+    assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+
+    List<Row> rows = session.sql(countSql).collectAsList();
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
+  }
+
+  /**
+   * MERGE-based ingest into a UC Delta table using {@code USING (SELECT ... FROM
+   * parquet.`s3://...`)} rather than a registered external table.
+   */
+  @Test
+  public void testMergeIntoDeltaTableFromBareParquetPath() throws IOException, ParseException {
+    stopSession();
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
+    String targetTable = String.format("%s.%s.path_merge_target", SPARK_CATALOG, SCHEMA_NAME);
+    String location = bucketPath("merge_source");
+
+    sql("CREATE TABLE IF NOT EXISTS %s (i INT, s STRING) USING DELTA", targetTable);
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 10 AS i, 'x' AS s", location);
+
+    String mergeSql =
+        String.format(
+            "MERGE INTO %s trgt "
+                + "USING (SELECT i, s FROM parquet.`%s`) src "
+                + "ON false "
+                + "WHEN NOT MATCHED THEN INSERT *",
+            targetTable, location);
+    LogicalPlan plan = session.sessionState().sqlParser().parsePlan(mergeSql);
+    UnresolvedRelation relation = findBareCloudPathRelation(plan);
+    assertThat(relation)
+        .as("MERGE source subquery should contain bare cloud-path relation: %s", plan)
+        .isNotNull();
+    assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
+
+    sql(
+        "MERGE INTO %s trgt "
+            + "USING (SELECT i, s FROM parquet.`%s`) src "
+            + "ON false "
+            + "WHEN NOT MATCHED THEN INSERT *",
+        targetTable, location);
+
+    List<Row> rows = sql("SELECT i, s FROM %s ORDER BY i", targetTable);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getInt(0)).isEqualTo(10);
+    assertThat(rows.get(0).getString(1)).isEqualTo("x");
+
+    sql("DROP TABLE IF EXISTS %s", targetTable);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
+  private static final String MERGE_TARGET_TABLE = "path_cred_merge_target";
+
   @TempDir protected File dataDir;
 
   /**
@@ -303,78 +305,245 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
   }
 
   /**
-   * Import-style deduped row-count query with {@code parquet.`s3://...`} nested inside a subquery
-   * ({@code SELECT COUNT(*) FROM (SELECT row_number() ... FROM parquet.`path`) ...}).
+   * Storium import row-count SQL wraps bare paths in a subquery: {@code SELECT COUNT(*) FROM
+   * (SELECT * FROM parquet.`s3://...`)}.
    */
   @Test
-  public void testNestedCountFromBareParquetPath() throws IOException, ParseException {
+  public void testCountFromParquetSubquery() throws IOException {
     stopSession();
-    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
-    String location = bucketPath("nested_count");
-    sql(
-        "INSERT OVERWRITE DIRECTORY '%s' USING parquet "
-            + "SELECT * FROM (SELECT 1 AS i, 'a' AS s UNION ALL SELECT 1 AS i, 'b' AS s)",
-        location);
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG, CATALOG_NAME);
+    String location = bucketPath("count_subquery");
+    sql("SET CATALOG %s", CATALOG_NAME);
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
-    String countSql =
-        String.format(
-            "SELECT COUNT(*) AS c FROM ("
-                + " SELECT row_number() OVER (PARTITION BY i ORDER BY i DESC) AS rn"
-                + " FROM parquet.`%s`"
-                + ") WHERE rn = 1",
-            location);
-    LogicalPlan plan = session.sessionState().sqlParser().parsePlan(countSql);
-    UnresolvedRelation relation = findBareCloudPathRelation(plan);
-    assertThat(relation)
-        .as("nested subquery should still contain bare cloud-path relation: %s", plan)
-        .isNotNull();
-    assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
-
-    List<Row> rows = session.sql(countSql).collectAsList();
+    List<Row> rows = sql("SELECT COUNT(*) AS c FROM (SELECT * FROM parquet.`%s`)", location);
     assertThat(rows).hasSize(1);
-    assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1);
+  }
+
+  private String mergeTargetTable() {
+    return String.format("%s.%s.%s", CATALOG_NAME, SCHEMA_NAME, MERGE_TARGET_TABLE);
   }
 
   /**
-   * MERGE-based ingest into a UC Delta table using {@code USING (SELECT ... FROM
-   * parquet.`s3://...`)} rather than a registered external table.
+   * Storium import MERGE shape: {@code USING (SELECT cols FROM (SELECT * FROM parquet.`path`))}.
+   * With {@code SET CATALOG} pointing at the UC catalog (as Thrift sessions do when the JDBC URL
+   * includes a catalog), bare paths must stay 2-part relations after parse — not {@code
+   * catalog.parquet.s3://...}.
    */
   @Test
-  public void testMergeIntoDeltaTableFromBareParquetPath() throws IOException, ParseException {
+  public void testMergeIntoUsingParquetSubquery() throws IOException, ParseException {
     stopSession();
-    session = createUcSparkSession(false, false, true, SPARK_CATALOG);
-    String targetTable = String.format("%s.%s.path_merge_target", SPARK_CATALOG, SCHEMA_NAME);
-    String location = bucketPath("merge_source");
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG, CATALOG_NAME);
+    String location = bucketPath("merge_subquery");
+    sql("SET CATALOG %s", CATALOG_NAME);
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
 
-    sql("CREATE TABLE IF NOT EXISTS %s (i INT, s STRING) USING DELTA", targetTable);
-    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 10 AS i, 'x' AS s", location);
+    String target = mergeTargetTable();
+    sql("CREATE TABLE %s (i INT, s STRING) USING delta", target);
 
     String mergeSql =
         String.format(
             "MERGE INTO %s trgt "
-                + "USING (SELECT i, s FROM parquet.`%s`) src "
+                + "USING (SELECT i, s FROM (SELECT * FROM parquet.`%s`)) src "
                 + "ON false "
                 + "WHEN NOT MATCHED THEN INSERT *",
-            targetTable, location);
+            target, location);
+
     LogicalPlan plan = session.sessionState().sqlParser().parsePlan(mergeSql);
     UnresolvedRelation relation = findBareCloudPathRelation(plan);
     assertThat(relation)
-        .as("MERGE source subquery should contain bare cloud-path relation: %s", plan)
+        .as("parsed plan should contain bare cloud-path UnresolvedRelation: %s", plan)
         .isNotNull();
     assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
 
-    sql(
-        "MERGE INTO %s trgt "
-            + "USING (SELECT i, s FROM parquet.`%s`) src "
-            + "ON false "
-            + "WHEN NOT MATCHED THEN INSERT *",
-        targetTable, location);
+    session.sql(mergeSql).collect();
+    assertSingleRow(sql("SELECT * FROM %s", target));
+  }
 
-    List<Row> rows = sql("SELECT i, s FROM %s ORDER BY i", targetTable);
+  /**
+   * Same MERGE shape as {@link #testMergeIntoUsingParquetSubquery()} but relies on {@code
+   * spark.sql.defaultCatalog} instead of {@code SET CATALOG} — closer to schema-only JDBC URLs
+   * where the session catalog is configured up front.
+   */
+  @Test
+  public void testMergeIntoParquetSubqueryWithDefaultCatalog() throws IOException {
+    stopSession();
+    session = createUcSparkSession(false, false, true, SPARK_CATALOG, CATALOG_NAME);
+    session.conf().set("spark.sql.defaultCatalog", CATALOG_NAME);
+    String location = bucketPath("merge_default_catalog");
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 2 AS i, 'b' AS s", location);
+
+    String target = mergeTargetTable() + "_default";
+    sql("CREATE TABLE %s (i INT, s STRING) USING delta", target);
+
+    session
+        .sql(
+            String.format(
+                "MERGE INTO %s trgt "
+                    + "USING (SELECT i, s FROM (SELECT * FROM parquet.`%s`)) src "
+                    + "ON false "
+                    + "WHEN NOT MATCHED THEN INSERT *",
+                target, location))
+        .collect();
+
+    assertThat(sql("SELECT * FROM %s", target)).hasSize(1);
+    assertThat(sql("SELECT * FROM %s", target).get(0).getInt(0)).isEqualTo(2);
+    assertThat(sql("SELECT * FROM %s", target).get(0).getString(1)).isEqualTo("b");
+  }
+
+  /**
+   * Thrift JDBC pushes {@code hiveconf:spark.sql.defaultCatalog} at session creation — not via
+   * runtime {@code conf().set} or {@code SET CATALOG}. {@link ResolvePathCredentials} keys off
+   * {@code catalogManager.currentCatalog}, which may still be {@code spark_catalog} even when
+   * defaultCatalog points at the UC catalog.
+   */
+  @Test
+  public void testCountFromParquetSubqueryDefaultCatalogAtSessionStart() throws IOException {
+    stopSession();
+    session =
+        createUcSparkSessionWithDefaultCatalog(
+            CATALOG_NAME, false, false, true, SPARK_CATALOG, CATALOG_NAME);
+    String location = bucketPath("count_session_start_default");
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+
+    List<Row> rows = sql("SELECT COUNT(*) AS c FROM (SELECT * FROM parquet.`%s`)", location);
     assertThat(rows).hasSize(1);
-    assertThat(rows.get(0).getInt(0)).isEqualTo(10);
-    assertThat(rows.get(0).getString(1)).isEqualTo("x");
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1);
+  }
 
-    sql("DROP TABLE IF EXISTS %s", targetTable);
+  /**
+   * Storium Thrift layout: {@code spark_catalog=DeltaCatalog}, tenant {@code UCSingleCatalog},
+   * {@code defaultCatalog=tenant}, {@code current_catalog=spark_catalog}. Path cred is skipped;
+   * Thrift e2e fails with {@code Invalid table name: tenant.parquet.s3://…}; fake FS may instead
+   * report missing vended credentials.
+   */
+  @Test
+  public void testCountFromParquetSubqueryFailsWhenCurrentCatalogIsDeltaCatalog()
+      throws IOException {
+    stopSession();
+    session = createStoriumLikeThriftSession(CATALOG_NAME, false);
+    session.conf().set("spark.sql.defaultCatalog", CATALOG_NAME);
+    sql("SET CATALOG %s", CATALOG_NAME);
+    String location = bucketPath("storium_like_thrift");
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+    sql("SET CATALOG %s", SPARK_CATALOG);
+
+    assertThat(sql("SELECT current_catalog()").get(0).getString(0)).isEqualTo(SPARK_CATALOG);
+    assertThat(session.conf().get("spark.sql.defaultCatalog")).isEqualTo(CATALOG_NAME);
+
+    assertThatThrownBy(
+            () -> sql("SELECT COUNT(*) AS c FROM (SELECT * FROM parquet.`%s`)", location))
+        .isNotNull();
+  }
+
+  /** {@code SET CATALOG} to the tenant UC catalog is the Storium-side workaround. */
+  @Test
+  public void testCountFromParquetSubqueryWorksAfterSetCatalogToTenant() throws IOException {
+    stopSession();
+    session = createStoriumLikeThriftSession(CATALOG_NAME, false);
+    session.conf().set("spark.sql.defaultCatalog", CATALOG_NAME);
+    sql("SET CATALOG %s", CATALOG_NAME);
+    String location = bucketPath("storium_set_catalog");
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+
+    List<Row> rows = sql("SELECT COUNT(*) AS c FROM (SELECT * FROM parquet.`%s`)", location);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1);
+  }
+
+  /**
+   * {@code conf().set("spark.sql.defaultCatalog", …)} switches {@code current_catalog} to the
+   * tenant UC catalog — unlike Thrift {@code hiveconf}, which can leave {@code current_catalog} on
+   * Delta.
+   */
+  @Test
+  public void testCountFromParquetSubqueryWorksAfterRuntimeDefaultCatalog() throws IOException {
+    stopSession();
+    session = createStoriumLikeThriftSession(CATALOG_NAME, false);
+    session.conf().set("spark.sql.defaultCatalog", CATALOG_NAME);
+
+    String location = bucketPath("storium_runtime_default");
+    sql("INSERT OVERWRITE DIRECTORY '%s' USING parquet SELECT 1 AS i, 'a' AS s", location);
+
+    assertThat(sql("SELECT current_catalog()").get(0).getString(0)).isEqualTo(CATALOG_NAME);
+    List<Row> rows = sql("SELECT COUNT(*) AS c FROM (SELECT * FROM parquet.`%s`)", location);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1);
+  }
+
+  /** Mirrors celospark spark-uc.properties + Storium per-session hiveconf catalog layout. */
+  private SparkSession createStoriumLikeThriftSession(String tenantCatalog) {
+    return createStoriumLikeThriftSession(tenantCatalog, true);
+  }
+
+  private SparkSession createStoriumLikeThriftSession(
+      String tenantCatalog, boolean defaultCatalogAtStartup) {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config(
+                "spark.sql.extensions",
+                "io.delta.sql.DeltaSparkSessionExtension,"
+                    + "io.unitycatalog.spark.UCSparkSessionExtensions")
+            // Driver static (spark-uc.properties)
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            // Per-session hiveconf (SparkUnityCatalogDatasourceMapper)
+            .config("spark.sql.catalog." + tenantCatalog, UCSingleCatalog.class.getName())
+            .config(
+                "spark.sql.catalog." + tenantCatalog + "." + OptionsUtil.URI,
+                serverConfig.getServerUrl())
+            .config(
+                "spark.sql.catalog." + tenantCatalog + "." + OptionsUtil.TOKEN,
+                serverConfig.getAuthToken())
+            .config(
+                "spark.sql.catalog." + tenantCatalog + "." + OptionsUtil.WAREHOUSE, tenantCatalog)
+            .config(
+                "spark.sql.catalog."
+                    + tenantCatalog
+                    + "."
+                    + OptionsUtil.VEND_PATH_CREDENTIALS_ENABLED,
+                true);
+    if (defaultCatalogAtStartup) {
+      builder.config("spark.sql.defaultCatalog", tenantCatalog);
+    }
+    builder.config("spark.hadoop.fs.s3.impl", S3CredentialTestFileSystem.class.getName());
+    return builder.getOrCreate();
+  }
+
+  private SparkSession createUcSparkSessionWithDefaultCatalog(
+      String defaultCatalog,
+      boolean renewCred,
+      boolean credScopedFsEnabled,
+      boolean vendPathCredentialsEnabled,
+      String... catalogs) {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("test")
+            .master("local[*]")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config("spark.sql.defaultCatalog", defaultCatalog)
+            .config(
+                "spark.sql.extensions",
+                "io.delta.sql.DeltaSparkSessionExtension,"
+                    + "io.unitycatalog.spark.UCSparkSessionExtensions");
+    for (String catalog : catalogs) {
+      String catalogConf = "spark.sql.catalog." + catalog;
+      builder =
+          builder
+              .config(catalogConf, UCSingleCatalog.class.getName())
+              .config(catalogConf + "." + OptionsUtil.URI, serverConfig.getServerUrl())
+              .config(catalogConf + "." + OptionsUtil.TOKEN, serverConfig.getAuthToken())
+              .config(catalogConf + "." + OptionsUtil.WAREHOUSE, catalog)
+              .config(catalogConf + "." + OptionsUtil.RENEW_CREDENTIAL_ENABLED, renewCred)
+              .config(catalogConf + "." + OptionsUtil.CRED_SCOPED_FS_ENABLED, credScopedFsEnabled)
+              .config(
+                  catalogConf + "." + OptionsUtil.VEND_PATH_CREDENTIALS_ENABLED,
+                  vendPathCredentialsEnabled);
+    }
+    builder.config("spark.hadoop.fs.s3.impl", S3CredentialTestFileSystem.class.getName());
+    return builder.getOrCreate();
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -114,6 +114,24 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
         .anyMatch(msg -> msg != null && msg.contains(substring));
   }
 
+  /** Finds a bare {@code format.`cloud-path`} relation anywhere in a parsed plan tree. */
+  private static UnresolvedRelation findBareCloudPathRelation(LogicalPlan plan) {
+    if (plan instanceof UnresolvedRelation) {
+      UnresolvedRelation relation = (UnresolvedRelation) plan;
+      if (relation.multipartIdentifier().length() == 2) {
+        return relation;
+      }
+    }
+    scala.collection.Seq<LogicalPlan> children = plan.children();
+    for (int i = 0; i < children.length(); i++) {
+      UnresolvedRelation found = findBareCloudPathRelation(children.apply(i));
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
   /**
    * Writes to a bare cloud path and reads it back. Exercises {@code INSERT OVERWRITE DIRECTORY}
    * ({@code InsertIntoDir}) and {@code parquet.`path`} reads ({@code UnresolvedRelation}).
@@ -201,8 +219,8 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
 
   /**
    * After {@code SET CATALOG}, bare-path credential injection must follow the session's current
-   * catalog, not {@code SQLConf.DEFAULT_CATALOG}. Default remains the built-in {@code spark_catalog}
-   * while the UC catalog is selected explicitly.
+   * catalog, not {@code SQLConf.DEFAULT_CATALOG}. Default remains the built-in {@code
+   * spark_catalog} while the UC catalog is selected explicitly.
    */
   @Test
   public void testBarePathUsesCurrentCatalogAfterSetCatalog() throws IOException, ParseException {
@@ -217,8 +235,10 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
             .sessionState()
             .sqlParser()
             .parsePlan(String.format("SELECT * FROM parquet.`%s`", location));
-    assertThat(plan).isInstanceOf(UnresolvedRelation.class);
-    UnresolvedRelation relation = (UnresolvedRelation) plan;
+    UnresolvedRelation relation = findBareCloudPathRelation(plan);
+    assertThat(relation)
+        .as("parsed plan should contain bare cloud-path UnresolvedRelation: %s", plan)
+        .isNotNull();
     assertThat(relation.options().get("fs.s3a.access.key")).isEqualTo("accessKey0");
     assertSingleRow(sql("SELECT * FROM parquet.`%s`", location));
   }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/S3CredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/S3CredentialTestFileSystem.java
@@ -1,7 +1,5 @@
 package io.unitycatalog.spark;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
 import java.io.IOException;
@@ -21,7 +19,7 @@ public class S3CredentialTestFileSystem extends CredentialTestFileSystem {
   }
 
   @Override
-  protected void checkCredentials(Path f) {
+  protected void checkCredentials(Path f) throws IOException {
     Configuration conf = getConf();
     String host = f.toUri().getHost();
 
@@ -29,30 +27,43 @@ public class S3CredentialTestFileSystem extends CredentialTestFileSystem {
       if ("test-bucket0".equals(host)) {
         provider = accessProvider(conf);
         if (provider == null) {
-          assertThat(conf.get("fs.s3a.access.key")).isEqualTo("accessKey0");
-          assertThat(conf.get("fs.s3a.secret.key")).isEqualTo("secretKey0");
-          assertThat(conf.get("fs.s3a.session.token")).isEqualTo("sessionToken0");
+          requireConfValue(conf, "fs.s3a.access.key", "accessKey0");
+          requireConfValue(conf, "fs.s3a.secret.key", "secretKey0");
+          requireConfValue(conf, "fs.s3a.session.token", "sessionToken0");
         } else {
           AwsSessionCredentials credentials = (AwsSessionCredentials) provider.resolveCredentials();
-          assertThat(credentials.accessKeyId()).isEqualTo("accessKey0");
-          assertThat(credentials.secretAccessKey()).isEqualTo("secretKey0");
-          assertThat(credentials.sessionToken()).isEqualTo("sessionToken0");
+          requireValue("accessKeyId", credentials.accessKeyId(), "accessKey0");
+          requireValue("secretAccessKey", credentials.secretAccessKey(), "secretKey0");
+          requireValue("sessionToken", credentials.sessionToken(), "sessionToken0");
         }
       } else if ("test-bucket1".equals(host)) {
         provider = accessProvider(conf);
         if (provider == null) {
-          assertThat(conf.get("fs.s3a.access.key")).isEqualTo("accessKey1");
-          assertThat(conf.get("fs.s3a.secret.key")).isEqualTo("secretKey1");
-          assertThat(conf.get("fs.s3a.session.token")).isEqualTo("sessionToken1");
+          requireConfValue(conf, "fs.s3a.access.key", "accessKey1");
+          requireConfValue(conf, "fs.s3a.secret.key", "secretKey1");
+          requireConfValue(conf, "fs.s3a.session.token", "sessionToken1");
         } else {
           AwsSessionCredentials credentials = (AwsSessionCredentials) provider.resolveCredentials();
-          assertThat(credentials.accessKeyId()).isEqualTo("accessKey1");
-          assertThat(credentials.secretAccessKey()).isEqualTo("secretKey1");
-          assertThat(credentials.sessionToken()).isEqualTo("sessionToken1");
+          requireValue("accessKeyId", credentials.accessKeyId(), "accessKey1");
+          requireValue("secretAccessKey", credentials.secretAccessKey(), "secretKey1");
+          requireValue("sessionToken", credentials.sessionToken(), "sessionToken1");
         }
       } else {
         throw new RuntimeException("invalid path: " + f);
       }
+    }
+  }
+
+  private static void requireConfValue(Configuration conf, String key, String expected)
+      throws IOException {
+    requireValue(key, conf.get(key), expected);
+  }
+
+  private static void requireValue(String name, String actual, String expected) throws IOException {
+    if (!Objects.equals(expected, actual)) {
+      throw new IOException(
+          String.format(
+              "missing vended credential %s: expected %s but was %s", name, expected, actual));
     }
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCProxySuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCProxySuite.java
@@ -4,11 +4,13 @@ import static io.unitycatalog.spark.UCProxyTestFixture.CATALOG_NAME;
 import static io.unitycatalog.spark.UCProxyTestFixture.NAMESPACE;
 import static io.unitycatalog.spark.UCProxyTestFixture.SCHEMA_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.SchemasApi;
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.model.ColumnInfo;
@@ -20,6 +22,7 @@ import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
 import java.util.Collections;
 import java.util.List;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -186,6 +189,52 @@ public class UCProxySuite {
     }
     verify(mockTablesApi, org.mockito.Mockito.times(1))
         .getTable(eq("test_catalog.test_schema.t1"), eq(true), eq(true));
+  }
+
+  /**
+   * Spark asks the current catalog to load every relation before falling back to path-based
+   * resolution, so a bare {@code parquet.`s3://.../file.parquet`} arrives at {@code loadTable} as
+   * namespace {@code parquet} with the path as the table name. UC addresses a table by the dotted
+   * string {@code catalog.schema.table} and answers 400 INVALID_ARGUMENT when the name does not
+   * split into three parts. {@code CatalogV2Util.loadTable} only absorbs a not-found answer, so any
+   * other exception aborts analysis before Spark's {@code ResolveSQLOnFile} can read the path --
+   * which is what breaks {@code SELECT * FROM parquet.`s3://...`} against a UC catalog.
+   */
+  @Test
+  public void testLoadTableReportsNotFoundForNameUcCannotAddress() throws Exception {
+    String path = "s3://bucket/tenants/t1/tmp-ingest-4825.parquet";
+    when(mockTablesApi.getTable(eq(CATALOG_NAME + ".parquet." + path), eq(true), eq(true)))
+        .thenThrow(
+            new ApiException(
+                400,
+                "getTable call failed with: 400 - {\"error_code\":\"INVALID_ARGUMENT\","
+                    + "\"message\":\"Invalid table name: "
+                    + CATALOG_NAME
+                    + ".parquet."
+                    + path
+                    + "\"}"));
+
+    assertThatThrownBy(() -> proxy.loadTable(Identifier.of(new String[] {"parquet"}, path)))
+        .isInstanceOf(NoSuchTableException.class);
+  }
+
+  /**
+   * A name UC cannot address can never denote a table UC holds, so the answer is known without
+   * asking. Skipping the RPC also keeps the outcome independent of how the server chooses to reject
+   * the name -- an unauthenticated server 404s at the router while an authorizing one returns 400.
+   */
+  @Test
+  public void testLoadTableSkipsRpcForNameUcCannotAddress() throws Exception {
+    String path = "s3://bucket/tenants/t1/tmp-ingest-4825.parquet";
+
+    assertThatThrownBy(() -> proxy.loadTable(Identifier.of(new String[] {"parquet"}, path)))
+        .isInstanceOf(NoSuchTableException.class);
+
+    verify(mockTablesApi, org.mockito.Mockito.never())
+        .getTable(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
   }
 
   // -- dropTable (table surface) tests --

--- a/project/spark-versions.json
+++ b/project/spark-versions.json
@@ -1,8 +1,8 @@
 {
   "default": "4.1.0",
   "versions": [
-    {"version": "4.0.0", "sourceDirs": ["scala-shims/spark-4.0-4.1"]},
-    {"version": "4.1.0", "sourceDirs": ["scala-shims/spark-4.0-4.1"]},
-    {"version": "4.2.0", "sourceDirs": ["scala-shims/spark-4.2"]}
+    {"version": "4.0.0", "sourceDirs": ["scala-shims/spark-4.0-4.1", "scala-shims/spark-4.0"]},
+    {"version": "4.1.0", "sourceDirs": ["scala-shims/spark-4.0-4.1", "scala-shims/spark-4.1-4.2"]},
+    {"version": "4.2.0", "sourceDirs": ["scala-shims/spark-4.2", "scala-shims/spark-4.1-4.2"]}
   ]
 }


### PR DESCRIPTION
## Summary

Stacked on #1653 — includes path credential vending plus two additional commits:

1. **Fix `loadTable` for unaddressable identifiers** — short-circuit `UCProxy.getUCTableLike` when schema/table names contain dots (e.g. `parquet.`s3://.../file.parquet``), so Spark falls through to `ResolveSQLOnFile` instead of failing with `Invalid table name` (HTTP 400). Fixes #1075.
2. **Storium-shaped integration tests** — COUNT/MERGE subquery import shapes, `defaultCatalog` at session start, and Thrift-like catalog layout (`spark_catalog`=Delta + tenant UC catalog).

## Relationship to #1653

This branch is based on `feat/spark-path-credential-vending-upstream`. If #1653 merges first, this PR can be rebased to show only commits (1) and (2).

## Test plan
- [x] `UCProxySuite` — 12/12 (includes two new unit tests for unaddressable names)
- [x] `PathCredentialReadWriteTest` — 16/16 (includes Storium layout scenarios)
- [ ] Full `spark/test` (CI)

## Follow-up

Rebuild Spark/UC docker images and re-run Storium `IngestionModeTest` e2e after merge.

---

**Closed:** Changes merged into #1653 (`feat/spark-path-credential-vending-upstream`).