### PR TITLE
Reject unconfigured Azure storage accounts

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialGenerator.java
@@ -4,7 +4,6 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.Context;
 import com.azure.identity.ClientSecretCredentialBuilder;
-import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.file.datalake.DataLakeServiceAsyncClient;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import com.azure.storage.file.datalake.implementation.util.DataLakeSasImplUtil;
@@ -41,16 +40,12 @@ public interface AzureCredentialGenerator {
     private final TokenCredential tokenCredential;
 
     public DatalakeCredentialGenerator(ADLSStorageConfig config) {
-      if (config == null) {
-        this.tokenCredential = new DefaultAzureCredentialBuilder().build();
-      } else {
-        this.tokenCredential =
-            new ClientSecretCredentialBuilder()
-                .tenantId(config.getTenantId())
-                .clientId(config.getClientId())
-                .clientSecret(config.getClientSecret())
-                .build();
-      }
+      this.tokenCredential =
+          new ClientSecretCredentialBuilder()
+              .tenantId(config.getTenantId())
+              .clientId(config.getClientId())
+              .clientSecret(config.getClientSecret())
+              .build();
     }
 
     @Override

--- a/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/azure/AzureCredentialVendor.java
@@ -36,7 +36,8 @@ public class AzureCredentialVendor {
     ADLSStorageConfig config = adlsConfigurations.get(locParts.accountName());
 
     if (config == null) {
-      return new AzureCredentialGenerator.DatalakeCredentialGenerator(null);
+      throw new BaseException(
+          ErrorCode.FAILED_PRECONDITION, "Azure storage account configuration not found.");
     }
 
     if (config.getCredentialGenerator() != null) {

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -149,6 +149,15 @@ public class CloudCredentialVendorTest {
             "abfss://test@uctest.dfs.core.windows.net/abc",
             Set.of(CredentialContext.Privilege.UPDATE));
     assertThat(azureTemporaryCredentials.getAzureUserDelegationSas().getSasToken()).isNotNull();
+    assertThatThrownBy(
+            () ->
+                vendCredential(
+                    "abfss://test@unconfigured.dfs.core.windows.net/abc",
+                    Set.of(CredentialContext.Privilege.UPDATE)))
+        .isInstanceOf(BaseException.class)
+        .hasMessageContaining("Azure storage account configuration not found")
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.FAILED_PRECONDITION);
 
     // Use datalake service client
     when(serverProperties.getAdlsConfigurations())


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

An Azure storage account should only receive temporary credentials when that account is listed in the server configuration.

Before this change, the server tried its own default Azure credentials when it received a request for an account that was not configured. For example, if only `account-a` was configured, a request for `account-b` could still use credentials available to the server.

This change rejects requests for unconfigured accounts with `FAILED_PRECONDITION`. It also removes the default-credential fallback.

The existing Azure credential test now checks both cases:

- A configured account receives temporary credentials.
- An unconfigured account is rejected.

Tests: `build/sbt javafmtCheckAll` and `build/sbt "server/testOnly io.unitycatalog.server.service.credential.CloudCredentialVendorTest"`
