### PR TITLE
[Server] Validate Iceberg table location before vending credentials

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -17,12 +17,14 @@ import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
 import io.unitycatalog.server.model.ListSchemasResponse;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.service.iceberg.MetadataService;
 import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.JsonUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ValidationUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -174,8 +176,10 @@ public class IcebergRestCatalogService {
       @Param("namespace") String namespace,
       @Param("table") String table) {
     String metadataLocation;
+    NormalizedURL tableLocation;
     try (Session session = sessionFactory.openSession()) {
-      tableRepository.getTable(catalog + "." + namespace + "." + table);
+      TableInfo tableInfo = tableRepository.getTable(catalog + "." + namespace + "." + table);
+      tableLocation = NormalizedURL.from(tableInfo.getStorageLocation());
       metadataLocation =
           tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
     }
@@ -186,7 +190,10 @@ public class IcebergRestCatalogService {
 
     TableMetadata tableMetadata =
         metadataService.readTableMetadata(NormalizedURL.from(metadataLocation));
-    Map<String, String> config = tableConfigService.getTableConfig(tableMetadata);
+    ValidationUtils.checkArgument(
+        tableLocation.equals(NormalizedURL.from(tableMetadata.location())),
+        "Iceberg table location must match the registered table location.");
+    Map<String, String> config = tableConfigService.getTableConfig(tableLocation);
 
     return LoadTableResponse.builder()
         .withTableMetadata(tableMetadata)

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/TableConfigService.java
@@ -3,7 +3,6 @@ package io.unitycatalog.server.service.iceberg;
 import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Map;
-import org.apache.iceberg.TableMetadata;
 
 /**
  * Builds the per-table FileIO configuration (credentials, region, etc.) returned to clients in the
@@ -17,15 +16,15 @@ public class TableConfigService {
   }
 
   /**
-   * Returns the FileIO config for the given table. Note this vends temporary storage credentials
-   * for the table's location as a side effect.
+   * Returns the FileIO config for the given table location. Note this vends temporary storage
+   * credentials for the location as a side effect.
    *
-   * @param tableMetadata the Iceberg table metadata whose location is used to scope credentials
+   * @param location the registered table location used to scope credentials
    */
-  public Map<String, String> getTableConfig(TableMetadata tableMetadata) {
+  public Map<String, String> getTableConfig(NormalizedURL location) {
     // TODO: metadataService.readTableMetadata called fileOperations.getFileIO already. It already
     //  generated this config but not passed back. For best efficiency the result from
     //  readTableMetadata should be reused.
-    return fileOperations.getFileIOConfig(NormalizedURL.from(tableMetadata.location()));
+    return fileOperations.getFileIOConfig(location);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -25,9 +25,12 @@ import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,12 +49,14 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class IcebergRestCatalogTest extends BaseServerTest {
 
   private static final String TEST_BASE_PREFIX = "/v1/catalogs/" + TestUtils.CATALOG_NAME;
   private static final String TEST_BASE_NON_PREFIX = "/v1";
-  private static final String ICEBERG_TABLE_LOCATION = "/tmp/uniform_iceberg_table";
+
+  @TempDir private Path icebergTableLocation;
 
   protected CatalogOperations catalogOperations;
   protected SchemaOperations schemaOperations;
@@ -176,6 +181,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
   @Test
   public void testTable() throws ApiException, IOException, URISyntaxException {
+    Path metadataFile = writeIcebergMetadata();
     CreateCatalog createCatalog =
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
     catalogOperations.createCatalog(createCatalog);
@@ -211,7 +217,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             .schemaName(TestUtils.SCHEMA_NAME)
             .columns(List.of(columnInfo1, columnInfo2))
             .comment(TestUtils.COMMENT)
-            .storageLocation(ICEBERG_TABLE_LOCATION)
+            .storageLocation(icebergTableLocation.toString())
             .tableType(TableType.EXTERNAL)
             .dataSourceFormat(DataSourceFormat.DELTA);
     TableInfo tableInfo = tableOperations.createTable(createTableRequest);
@@ -252,11 +258,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       TableInfoDAO tableInfoDAO = TableInfoDAO.builder().build();
       assertThat(tableInfo.getTableId()).isNotNull();
       session.load(tableInfoDAO, UUID.fromString(tableInfo.getTableId()));
-      String metadataLocation =
-          Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
-              .toURI()
-              .toString();
-      tableInfoDAO.setUniformIcebergMetadataLocation(metadataLocation);
+      tableInfoDAO.setUniformIcebergMetadataLocation(metadataFile.toUri().toString());
       session.merge(tableInfoDAO);
       tx.commit();
     }
@@ -291,9 +293,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       LoadTableResponse loadTableResponse =
           IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
-          .isEqualTo(
-              Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json"))
-                  .getPath());
+          .isEqualTo(metadataFile.toString());
 
       // non-prefixed URL should result in 404
       resp =
@@ -337,7 +337,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       TableInfoDAO tableInfoDAO =
           session.get(TableInfoDAO.class, UUID.fromString(tableInfo.getTableId()));
       assertThat(tableInfoDAO).isNotNull();
-      tableInfoDAO.setUrl("/tmp/other_table");
+      tableInfoDAO.setUrl(icebergTableLocation.resolve("other_table").toString());
       tx.commit();
     }
     AggregatedHttpResponse resp =
@@ -353,5 +353,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(resp.status().code()).isEqualTo(400);
     assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).message())
         .contains("must match the registered table location");
+  }
+
+  private Path writeIcebergMetadata() throws IOException, URISyntaxException {
+    Path source =
+        Path.of(
+            Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json")).toURI());
+    Path metadataFile = icebergTableLocation.resolve("iceberg.metadata.json");
+    String tableLocation = NormalizedURL.from(icebergTableLocation.toUri()).toString();
+    String metadata =
+        Files.readString(source).replace("file:/tmp/uniform_iceberg_table", tableLocation);
+    return Files.writeString(metadataFile, metadata);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -51,6 +51,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
   private static final String TEST_BASE_PREFIX = "/v1/catalogs/" + TestUtils.CATALOG_NAME;
   private static final String TEST_BASE_NON_PREFIX = "/v1";
+  private static final String ICEBERG_TABLE_LOCATION = "/tmp/uniform_iceberg_table";
 
   protected CatalogOperations catalogOperations;
   protected SchemaOperations schemaOperations;
@@ -210,7 +211,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             .schemaName(TestUtils.SCHEMA_NAME)
             .columns(List.of(columnInfo1, columnInfo2))
             .comment(TestUtils.COMMENT)
-            .storageLocation("/tmp/stagingLocation")
+            .storageLocation(ICEBERG_TABLE_LOCATION)
             .tableType(TableType.EXTERNAL)
             .dataSourceFormat(DataSourceFormat.DELTA);
     TableInfo tableInfo = tableOperations.createTable(createTableRequest);
@@ -329,5 +330,28 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
+
+    // Credentials must never be scoped by a conflicting location in the metadata payload.
+    try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+      Transaction tx = session.beginTransaction();
+      TableInfoDAO tableInfoDAO =
+          session.get(TableInfoDAO.class, UUID.fromString(tableInfo.getTableId()));
+      assertThat(tableInfoDAO).isNotNull();
+      tableInfoDAO.setUrl("/tmp/other_table");
+      tx.commit();
+    }
+    AggregatedHttpResponse resp =
+        client
+            .get(
+                TEST_BASE_PREFIX
+                    + "/namespaces/"
+                    + TestUtils.SCHEMA_NAME
+                    + "/tables/"
+                    + TestUtils.TABLE_NAME)
+            .aggregate()
+            .join();
+    assertThat(resp.status().code()).isEqualTo(400);
+    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).message())
+        .contains("must match the registered table location");
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The server stores a location for each table. An Iceberg metadata file also contains a table location. These two locations should describe the same table before the server creates temporary storage credentials.

Before this change, `loadTable` trusted the location inside the metadata file. For example, the registered table could point to `/tables/orders` while the metadata file pointed to `/tables/other`. The server could then create credentials for `/tables/other`.

This change compares the two normalized locations and rejects the request when they do not match. When they do match, credentials are created only for the registered table location.

The existing Iceberg table test now covers the mismatch case and checks that the request is rejected.

Tests: `sbt -batch "server/testOnly io.unitycatalog.server.service.IcebergRestCatalogTest"`
