### PR TITLE
Bind the backend server to loopback interfaces

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -56,7 +57,10 @@ public class ArmeriaServerBuilder {
   private final JacksonResponseConverterFunction deltaResponseConverter;
 
   ArmeriaServerBuilder(int port, String basePath, String controlPath) {
-    this.armeriaServerBuilder = Server.builder().http(port).serviceUnder("/docs", new DocService());
+    this.armeriaServerBuilder =
+        Server.builder()
+            .localPort(port, SessionProtocol.HTTP)
+            .serviceUnder("/docs", new DocService());
     this.armeriaServerBuilder.service(
         "/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
     this.basePath = basePath;

--- a/server/src/test/java/io/unitycatalog/server/ArmeriaServerBuilderTest.java
+++ b/server/src/test/java/io/unitycatalog/server/ArmeriaServerBuilderTest.java
@@ -1,0 +1,19 @@
+package io.unitycatalog.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.Test;
+
+public class ArmeriaServerBuilderTest {
+
+  @Test
+  public void bindsToLoopbackInterfaces() {
+    try (Server server = new ArmeriaServerBuilder(0, "/api/", "/control/").build()) {
+      assertThat(server.config().ports())
+          .isNotEmpty()
+          .allSatisfy(
+              port -> assertThat(port.localAddress().getAddress().isLoopbackAddress()).isTrue());
+    }
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The backend HTTP server is meant to receive requests only from the URL transcoder running on the same machine.

Before this change, the backend listened on every network interface. For example, another machine on the same network could try to connect directly to the backend port instead of going through the URL transcoder.

This change binds the backend to loopback interfaces only. The URL transcoder can still reach it, but other machines cannot connect to that port.

A new test checks that every backend listener uses a loopback address. The existing URL transcoder tests still pass.

Tests: `sbt -batch javafmtCheckAll` and `sbt -batch "server/testOnly io.unitycatalog.server.ArmeriaServerBuilderTest io.unitycatalog.server.URLTranscoderVerticleTest"`
