### PR TITLE
Use SyncedEnforcer for thread-safe Casbin authorization

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.casbin.adapter.JDBCAdapter;
 import org.casbin.jcasbin.main.Enforcer;
+import org.casbin.jcasbin.main.SyncedEnforcer;
 import org.casbin.jcasbin.model.Model;
 
 /**
@@ -21,10 +22,13 @@ import org.casbin.jcasbin.model.Model;
  * <p>This class is an implementation of UnityCatalogAuthorizor that uses JCasbin as the back end to
  * both store and enforce access control policies.
  *
- * <p>The implementation stores the policies in a database using the JDBCAdapter class.
+ * <p>The implementation stores the policies in a database using the JDBCAdapter class. A {@link
+ * SyncedEnforcer} is used because the UC server shares one authorizer across concurrent REST
+ * requests; jCasbin's plain {@link Enforcer} is not thread-safe for concurrent {@code enforce()}
+ * and policy mutations.
  */
 public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
-  private final Enforcer enforcer;
+  private final SyncedEnforcer enforcer;
 
   private static final int PRINCIPAL_INDEX = 0;
   private static final int RESOURCE_INDEX = 1;
@@ -47,7 +51,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
     Model model = new Model();
     model.loadModelFromText(string);
 
-    enforcer = new Enforcer(model, adapter);
+    enforcer = new SyncedEnforcer(model, adapter);
     enforcer.enableAutoSave(true);
   }
 


### PR DESCRIPTION
## Summary

Switch `JCasbinAuthorizer` from jCasbin's plain `Enforcer` to `SyncedEnforcer` so concurrent REST authorization checks remain correct while policies are mutated (namespace lifecycle, grants/revokes, user delete).

## Problem

The Unity Catalog server uses a single shared `JCasbinAuthorizer` instance for all REST requests. jCasbin's default `Enforcer` is **not thread-safe** when `enforce()` runs concurrently with policy changes (`addPolicy`, `removePolicy`, `clearPolicy`, etc.). Under load this can yield transient `PERMISSION_DENIED` for principals that should be allowed—matching the class of failures seen when namespace create/delete and steady-state schema reads overlap.

See:
- https://github.com/casbin/jcasbin/issues/30
- https://github.com/casbin/jcasbin/issues/309

## Fix

- Use `org.casbin.jcasbin.main.SyncedEnforcer` (same constructor and API surface as `Enforcer` for our usage).
- Document why synchronization is required in the class Javadoc.

## Test plan

- [x] Existing server auth tests pass (`JCasbinAuthorizerTest` and related suites).