### PR TITLE
[Spark] Make plain-view dependencies null-compatible and harden view round-trip

### DIFF
--- a/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -36,20 +36,27 @@ trait UCProxyViewSupport { self: UCProxy =>
     // Spark 4.2 surfaces these through the View API (withQueryColumnNames / withSchemaMode); on v1
     // they are read from properties (viewQueryColumnNames / viewSchemaModeFromProperties), so
     // populate them here for parity. The `view.sqlConfig.*` keys are already carried in `base`.
+    // Query-output names can differ from declared names (e.g. `CREATE VIEW v(a,b) AS SELECT x,y`),
+    // and Spark matches by them; prefer the persisted `view.query.out.*` in `base`, synthesizing
+    // from declared columns only when absent (deriving would risk INCOMPATIBLE_VIEW_SCHEMA_CHANGE).
     val queryOut =
-      if (fields.nonEmpty) {
+      if (base.contains(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS) || fields.isEmpty) {
+        Map.empty[String, String]
+      } else {
         Map(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS -> fields.length.toString) ++
           fields.zipWithIndex.map { case (f, i) =>
             s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$i" -> f.name
           }
-      } else {
-        Map.empty[String, String]
       }
     val schemaModeDefault =
       if (base.contains(CatalogTable.VIEW_SCHEMA_MODE)) Map.empty[String, String]
       else Map(CatalogTable.VIEW_SCHEMA_MODE -> SchemaCompensation.toString)
+    // Unqualified refs resolve against the creation-time catalog/namespace, which can differ from
+    // the view's location; prefer the persisted `view.catalogAndNamespace.*` in `base`, falling
+    // back to the view's location only when absent (`self.name()` is a same-namespace fallback).
     val viewNamespaceProps =
-      CatalogTable.catalogAndNamespaceToProps(self.name(), Seq(t.getSchemaName))
+      if (base.contains(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)) Map.empty[String, String]
+      else CatalogTable.catalogAndNamespaceToProps(self.name(), Seq(t.getSchemaName))
     val viewTable = CatalogTable(
       identifier = identifier,
       tableType = CatalogTableType.VIEW,

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -143,16 +143,20 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       .viewDefinition(view.queryText())
 
     Option(properties.get(TableCatalog.PROP_COMMENT)).foreach(ct.setComment)
-    // Spark only fills `viewDependencies()` for metric views; for a plain view derive them from the
-    // query text (the server requires a non-null list).
+    // Spark fills `viewDependencies()` only for metric views; for a plain view we derive them from
+    // the query text:
+    //  - derived (possibly empty, e.g. `SELECT 1`) -> send the list.
+    //  - derivation failed (`None`) -> leave unset (null) so the server can decide. An empty list
+    //    would wrongly persist "no dependencies", making the view unreadable where lineage is
+    //    validated at read time.
     val ucDeps = Option(view.viewDependencies()) match {
-      case Some(deps) => toUcDependencyList(deps)
+      case Some(deps) => Some(toUcDependencyList(deps))
       case None =>
-        ucDependencyListFromNames(
-          UCViewDependencies.derive(
-            view.queryText(), view.currentCatalog(), view.currentNamespace().toSeq))
+        UCViewDependencies
+          .derive(view.queryText(), view.currentCatalog(), view.currentNamespace().toSeq)
+          .map(ucDependencyListFromNames)
     }
-    ct.setViewDependencies(ucDeps)
+    ucDeps.foreach(ct.setViewDependencies)
     ct.setColumns(buildColumnInfos(view, convertDataTypeToTypeName).asJava)
 
     val propertiesToServer = new util.HashMap[String, String]()
@@ -169,9 +173,9 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
     Option(view.schemaMode())
       .filter(_ != SchemaUnsupported.toString)
       .foreach(m => propertiesToServer.put(CatalogTable.VIEW_SCHEMA_MODE, m))
-    UCViewTypes.addQueryColumnNames(propertiesToServer, view.queryColumnNames())
+    UCViewProperties.addQueryColumnNames(propertiesToServer, view.queryColumnNames())
     Option(view.currentCatalog()).foreach { catalog =>
-      UCViewTypes.addCreationContext(
+      UCViewProperties.addCreationContext(
         propertiesToServer,
         catalog,
         view.currentNamespace())
@@ -231,7 +235,7 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
 
     val props = new util.HashMap[String, String]()
     Option(t.getProperties).foreach(props.putAll)
-    val sqlConfigs = UCViewTypes.extractSqlConfigs(props)
+    val sqlConfigs = UCViewProperties.extractSqlConfigs(props)
     // Metric views have no persisted mode (createView omits Spark's UNSUPPORTED sentinel), so they
     // must reload as UNSUPPORTED; plain views use the persisted mode or default to compensation.
     val defaultSchemaMode =
@@ -239,13 +243,14 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
       else SchemaCompensation.toString
     val schemaMode = Option(props.get(CatalogTable.VIEW_SCHEMA_MODE)).getOrElse(defaultSchemaMode)
     val queryColumnNames =
-      UCViewTypes.extractQueryColumnNames(props).getOrElse(columns.map(_.name()))
+      UCViewProperties.extractQueryColumnNames(props).getOrElse(columns.map(_.name()))
     val (currentCatalog, currentNamespace) =
-      UCViewTypes.extractCreationContext(props).getOrElse((t.getCatalogName, Array(t.getSchemaName)))
+      UCViewProperties.extractCreationContext(props).getOrElse(
+        (t.getCatalogName, Array(t.getSchemaName)))
     // The VIEW_SQL_CONFIG_PREFIX / VIEW_SCHEMA_MODE keys are surfaced via `withSqlConfigs` /
     // `withSchemaMode`; drop them from `props` so they don't also leak into the user-visible
     // `properties()` map and get re-persisted (double-counted) on a createView/replace round-trip.
-    UCViewTypes.stripInternalViewProperties(props)
+    UCViewProperties.stripInternalViewProperties(props)
 
     val builder = new View.Builder()
       .withColumns(columns)

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDependencies.scala
@@ -14,23 +14,34 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnresolvedWith}
  *
  * Works on the *parsed* (unresolved) plan, not the analyzed one: analyzing would read each base
  * table's log / vend credentials and can rewrite away its catalog identity, dropping the dependency.
- * Best-effort -- any failure yields an empty list so view creation still succeeds.
+ * Best-effort -- derivation failure yields `None` (not an empty list), so the caller can leave the
+ * server's `view_dependencies` unset (null) rather than persisting a wrong "no dependencies" list;
+ * a successful derivation with no base tables (e.g. `SELECT 1`) yields `Some(Seq.empty)`.
  */
 private[spark] object UCViewDependencies extends Logging {
 
-  def derive(queryText: String, currentCatalog: String, currentNamespace: Seq[String]): Seq[String] = {
+  /**
+   * Returns `Some(deps)` when the query text parses and dependencies could be collected (the list
+   * may be empty for a view with no base tables), or `None` when parsing/derivation fails so the
+   * caller can send null instead of a misleading empty list.
+   */
+  def derive(
+      queryText: String,
+      currentCatalog: String,
+      currentNamespace: Seq[String]): Option[Seq[String]] = {
     try {
       val spark = SparkSession.active
       val parsed = spark.sessionState.sqlParser.parsePlan(queryText)
-      collectTableDependencies(
-        parsed, currentCatalog, currentNamespace, spark.sessionState.conf.caseSensitiveAnalysis)
+      Some(
+        collectTableDependencies(
+          parsed, currentCatalog, currentNamespace, spark.sessionState.conf.caseSensitiveAnalysis))
     } catch {
       case NonFatal(e) =>
         logWarning(
-          s"Failed to derive view dependencies from query text; persisting an empty list. " +
-            s"Query: $queryText",
+          s"Failed to derive view dependencies from query text; leaving them unset (null) so the " +
+            s"server can decide. Query: $queryText",
           e)
-        Seq.empty
+        None
     }
   }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewProperties.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewProperties.scala
@@ -1,0 +1,113 @@
+package io.unitycatalog.spark
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * (De)serialization of Spark's internal `view.*` metadata to/from a UC properties map.
+ *
+ * Spark's v2 `View` exposes the resolution-critical view metadata (SQL configs, query-output
+ * column names, creation catalog/namespace, ...) through typed accessors, but persists it as a flat
+ * bag of `view.*` string properties (`CatalogTable.VIEW_*`). UC has no first-class fields for these,
+ * so the connector round-trips them through the generic properties map. This object owns that
+ * encoding in one place, kept free of Spark-4.2-only types so it compiles on all supported Spark
+ * versions and is shared by the Spark 4.2 `createView` / `toView` load paths.
+ *
+ * Distinct from [[UCViewTypes]], which owns the UC-`TableType`-to-Spark-view-kind mapping.
+ */
+private[spark] object UCViewProperties {
+
+  /**
+   * Splits the `VIEW_SQL_CONFIG_PREFIX`-prefixed entries out of a UC properties map and returns
+   * them un-prefixed, as Spark's `View.sqlConfigs()` expects.
+   */
+  def extractSqlConfigs(properties: util.Map[String, String]): util.Map[String, String] = {
+    val configs = new util.HashMap[String, String]()
+    properties.asScala.foreach { case (k, v) =>
+      if (k.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX)) {
+        configs.put(k.substring(CatalogTable.VIEW_SQL_CONFIG_PREFIX.length), v)
+      }
+    }
+    configs
+  }
+
+  /** Persists Spark's query-output column names into UC view properties. */
+  def addQueryColumnNames(
+      properties: util.Map[String, String],
+      queryColumnNames: Array[String]): Unit = {
+    if (queryColumnNames.isEmpty) {
+      return
+    }
+    properties.put(
+      CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS,
+      queryColumnNames.length.toString)
+    queryColumnNames.zipWithIndex.foreach { case (name, index) =>
+      properties.put(s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index", name)
+    }
+  }
+
+  /** Persists the catalog/namespace active when the view was created. */
+  def addCreationContext(
+      properties: util.Map[String, String],
+      currentCatalog: String,
+      currentNamespace: Array[String]): Unit = {
+    CatalogTable.catalogAndNamespaceToProps(currentCatalog, currentNamespace.toSeq).foreach {
+      case (key, value) => properties.put(key, value)
+    }
+  }
+
+  /**
+   * Returns the persisted query-output column names when present. Absent keys mean the view was
+   * written by an older connector and the read path should fall back to the stored column names.
+   */
+  def extractQueryColumnNames(properties: util.Map[String, String]): Option[Array[String]] = {
+    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).flatMap { numCols =>
+      val count = numCols.toInt
+      if (count == 0) {
+        None
+      } else {
+        Some((0 until count).map { index =>
+          val key = s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index"
+          Option(properties.get(key)).getOrElse(
+            throw new IllegalStateException(
+              s"Corrupted view metadata: expected $count query-output columns but $key is missing"))
+        }.toArray)
+      }
+    }
+  }
+
+  /** Returns the persisted creation-time catalog and namespace when present. */
+  def extractCreationContext(
+      properties: util.Map[String, String]): Option[(String, Array[String])] = {
+    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).flatMap { numParts =>
+      val count = numParts.toInt
+      if (count == 0) {
+        None
+      } else {
+        val parts = (0 until count).map { index =>
+          val key = s"${CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX}$index"
+          Option(properties.get(key)).getOrElse(
+            throw new IllegalStateException(
+              s"Corrupted view metadata: expected $count catalog/namespace parts but $key is missing"))
+        }.toSeq
+        Some((parts.head, parts.tail.toArray))
+      }
+    }
+  }
+
+  /**
+   * Drops view metadata keys that Spark surfaces through typed {@code View} fields so they do not
+   * leak into user-visible {@code properties()} or get double-persisted on a round trip.
+   */
+  def stripInternalViewProperties(properties: util.Map[String, String]): Unit = {
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
+    properties.remove(CatalogTable.VIEW_SCHEMA_MODE)
+    properties.remove(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX))
+    properties.remove(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)
+    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX))
+  }
+}

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCViewTypes.scala
@@ -16,12 +16,7 @@
 
 package io.unitycatalog.spark
 
-import java.util
-
-import scala.collection.JavaConverters._
-
 import io.unitycatalog.client.model.TableType
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
  * View-type mapping for the connector, kept out of `UCSingleCatalog` so that catalog stays focused
@@ -127,98 +122,5 @@ private[spark] object UCViewTypes {
     case TableType.STREAMING_TABLE => "MANAGED"
     case TableType.EXTERNAL => "EXTERNAL"
     case _ => "FOREIGN"
-  }
-
-  /**
-   * Splits the `VIEW_SQL_CONFIG_PREFIX`-prefixed entries out of a UC properties map and returns
-   * them un-prefixed, as Spark's `View.sqlConfigs()` expects. Shared by the view-load path
-   * (`UCProxyViewSupport.toView` on Spark 4.2); kept here so it stays free of any
-   * Spark-4.2-only types and compiles on all three Spark versions.
-   */
-  def extractSqlConfigs(properties: util.Map[String, String]): util.Map[String, String] = {
-    val configs = new util.HashMap[String, String]()
-    properties.asScala.foreach { case (k, v) =>
-      if (k.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX)) {
-        configs.put(k.substring(CatalogTable.VIEW_SQL_CONFIG_PREFIX.length), v)
-      }
-    }
-    configs
-  }
-
-  /** Persists Spark's query-output column names into UC view properties. */
-  def addQueryColumnNames(
-      properties: util.Map[String, String],
-      queryColumnNames: Array[String]): Unit = {
-    if (queryColumnNames.isEmpty) {
-      return
-    }
-    properties.put(
-      CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS,
-      queryColumnNames.length.toString)
-    queryColumnNames.zipWithIndex.foreach { case (name, index) =>
-      properties.put(s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index", name)
-    }
-  }
-
-  /** Persists the catalog/namespace active when the view was created. */
-  def addCreationContext(
-      properties: util.Map[String, String],
-      currentCatalog: String,
-      currentNamespace: Array[String]): Unit = {
-    CatalogTable.catalogAndNamespaceToProps(currentCatalog, currentNamespace.toSeq).foreach {
-      case (key, value) => properties.put(key, value)
-    }
-  }
-
-  /**
-   * Returns the persisted query-output column names when present. Absent keys mean the view was
-   * written by an older connector and the read path should fall back to the stored column names.
-   */
-  def extractQueryColumnNames(properties: util.Map[String, String]): Option[Array[String]] = {
-    Option(properties.get(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)).flatMap { numCols =>
-      val count = numCols.toInt
-      if (count == 0) {
-        None
-      } else {
-        Some((0 until count).map { index =>
-          val key = s"${CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX}$index"
-          Option(properties.get(key)).getOrElse(
-            throw new IllegalStateException(
-              s"Corrupted view metadata: expected $count query-output columns but $key is missing"))
-        }.toArray)
-      }
-    }
-  }
-
-  /** Returns the persisted creation-time catalog and namespace when present. */
-  def extractCreationContext(
-      properties: util.Map[String, String]): Option[(String, Array[String])] = {
-    Option(properties.get(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)).flatMap { numParts =>
-      val count = numParts.toInt
-      if (count == 0) {
-        None
-      } else {
-        val parts = (0 until count).map { index =>
-          val key = s"${CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX}$index"
-          Option(properties.get(key)).getOrElse(
-            throw new IllegalStateException(
-              s"Corrupted view metadata: expected $count catalog/namespace parts but $key is missing"))
-        }.toSeq
-        Some((parts.head, parts.tail.toArray))
-      }
-    }
-  }
-
-  /**
-   * Drops view metadata keys that Spark surfaces through typed {@code View} fields so they do not
-   * leak into user-visible {@code properties()} or get double-persisted on a round trip.
-   */
-  def stripInternalViewProperties(properties: util.Map[String, String]): Unit = {
-    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_SQL_CONFIG_PREFIX))
-    properties.remove(CatalogTable.VIEW_SCHEMA_MODE)
-    properties.remove(CatalogTable.VIEW_QUERY_OUTPUT_NUM_COLUMNS)
-    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_QUERY_OUTPUT_COLUMN_NAME_PREFIX))
-    properties.remove(CatalogTable.VIEW_CATALOG_AND_NAMESPACE)
-    properties.keySet().removeIf(_.startsWith(CatalogTable.VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX))
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/AbstractViewReadIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/AbstractViewReadIntegrationTest.java
@@ -1,36 +1,197 @@
 package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME2;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME2;
+import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * End-to-end guarantee that a Unity Catalog view is resolvable and readable through a real Spark
- * session on every supported Spark version (the mock-based {@code UCViewProxySuite} / {@code
- * UCViewReadOnlySuite} don't drive Spark's analyzer, so they miss view-resolution bugs such as the
- * view schema mode). Subclasses supply the version-appropriate way to create the view.
+ * End-to-end check that a UC view is resolvable and readable through a real Spark session on every
+ * supported version (the mock suites don't drive Spark's analyzer, so they miss resolution bugs).
+ * All tests live here; subclasses supply only {@link #createView()} / {@link #dropView()} (SQL on
+ * Spark 4.2, the SDK on 4.0/4.1, which lack the v2 ViewCatalog).
+ *
+ * <p>The fixture ({@link #VIEW_QUERY}) is deliberately demanding: a literal plus a join of tables
+ * in two catalogs (one UNQUALIFIED, one FULLY-QUALIFIED), projecting int / string / array / struct
+ * columns, declared with names ({@link #DECLARED_COLUMNS}) that differ from its query output
+ * ({@link #QUERY_OUTPUT_COLUMNS}). Created under {@code CATALOG_NAME.SCHEMA_NAME} but read back
+ * with a different current catalog, it exercises both creation-context round-trips: the unqualified
+ * {@code employees} resolves only via the persisted {@code view.catalogAndNamespace.*}, and the
+ * declared columns read only via the persisted {@code view.query.out.*}. Getting either wrong fails
+ * with {@code TABLE_OR_VIEW_NOT_FOUND} / {@code INCOMPATIBLE_VIEW_SCHEMA_CHANGE}.
  */
 public abstract class AbstractViewReadIntegrationTest extends BaseSparkIntegrationTest {
 
+  protected SdkTableOperations tableOperations;
+
+  @BeforeEach
+  public void setUpTableOperations() {
+    tableOperations = new SdkTableOperations(createApiClient(serverConfig));
+  }
+
   protected static final String VIEW_NAME = "spark_test_view";
-  protected static final String VIEW_QUERY = "SELECT 1 AS c";
   protected static final String VIEW_FULL_NAME = CATALOG_NAME + "." + SCHEMA_NAME + "." + VIEW_NAME;
 
-  /** Creates VIEW_NAME (as VIEW_QUERY) the way the Spark version under test allows. */
+  /** MANAGED Delta table (in CATALOG_NAME.SCHEMA_NAME), referenced UNQUALIFIED in the view. */
+  protected static final String EMPLOYEES_TABLE_NAME = "employees";
+
+  protected static final String EMPLOYEES_TABLE_FULL_NAME =
+      CATALOG_NAME + "." + SCHEMA_NAME + "." + EMPLOYEES_TABLE_NAME;
+  /** EXTERNAL Delta table in a different catalog AND schema, referenced FULLY-QUALIFIED. */
+  protected static final String DEPARTMENTS_TABLE_NAME = "departments";
+
+  protected static final String DEPARTMENTS_TABLE_FULL_NAME =
+      CATALOG_NAME2 + "." + SCHEMA_NAME2 + "." + DEPARTMENTS_TABLE_NAME;
+
+  /**
+   * Names the SELECT list produces (a literal, aliases, passthroughs), spanning an int, a string,
+   * an array, and a struct -- all differ from {@link #DECLARED_COLUMNS} below.
+   */
+  protected static final String[] QUERY_OUTPUT_COLUMNS = {
+    "123", "e_id", "emp_name", "budget", "tags", "emp_info"
+  };
+  /** Declared view column names -- intentionally different from {@link #QUERY_OUTPUT_COLUMNS}. */
+  protected static final String[] DECLARED_COLUMNS = {
+    "num", "emp", "person", "dept_budget", "dept_tags", "person_info"
+  };
+
+  protected static final String VIEW_QUERY =
+      "SELECT 123, e.id AS e_id, e.name AS emp_name, d.budget, d.tags, "
+          + "named_struct('id', e.id, 'name', e.name) AS emp_info "
+          + "FROM "
+          + EMPLOYEES_TABLE_NAME
+          + " e JOIN "
+          + DEPARTMENTS_TABLE_FULL_NAME
+          + " d ON e.dept_id = d.dept_id WHERE d.budget > 100";
+
+  /** Creates VIEW_NAME (declaring {@link #DECLARED_COLUMNS} over {@link #VIEW_QUERY}). */
   protected abstract void createView();
 
+  /** Drops VIEW_NAME. */
+  protected abstract void dropView();
+
+  /**
+   * Asserts whether {@code SHOW VIEWS} lists the view. Default no-op: {@code SHOW VIEWS} only works
+   * on Spark 4.2 (4.0/4.1 throw {@code missingCatalogViewsAbilityError}); the 4.2 subclass
+   * overrides.
+   */
+  protected void verifyShowViews(boolean expectPresent) {}
+
+  /**
+   * Asserts the view's server-persisted dependencies. Default no-op: only the Spark 4.2 create path
+   * derives them from the query text (4.0/4.1 create via the SDK with no derivation); the 4.2
+   * subclass overrides to check the two source tables were captured.
+   */
+  protected void verifyViewDependencies() {}
+
+  /** Creates the MANAGED {@code employees} and EXTERNAL {@code departments} Delta source tables. */
+  protected void createSourceTables() {
+    sql(
+        "CREATE TABLE %s (id INT, name STRING, dept_id INT) USING delta",
+        EMPLOYEES_TABLE_FULL_NAME);
+    sql(
+        "INSERT INTO %s VALUES (1, 'Ann', 10), (2, 'Bob', 20), (3, 'Cy', 10), (4, 'Di', 99)",
+        EMPLOYEES_TABLE_FULL_NAME);
+    sql("CREATE SCHEMA IF NOT EXISTS %s.%s", CATALOG_NAME2, SCHEMA_NAME2);
+    sql(
+        "CREATE TABLE %s (dept_id INT, budget INT, tags ARRAY<STRING>) USING delta LOCATION '%s'",
+        DEPARTMENTS_TABLE_FULL_NAME, testDirectoryRoot.resolve(DEPARTMENTS_TABLE_NAME).toUri());
+    sql(
+        "INSERT INTO %s VALUES (10, 500, array('eng', 'core')), (20, 50, array('ops')), "
+            + "(30, 700, array('sales'))",
+        DEPARTMENTS_TABLE_FULL_NAME);
+  }
+
   protected void createSessionAndView() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+    session = createSparkSessionWithCatalogs(SPARK_CATALOG, CATALOG_NAME, CATALOG_NAME2);
+    createSourceTables();
+    // Create under CATALOG_NAME.SCHEMA_NAME so unqualified `employees` binds there -- that becomes
+    // the view's captured creation context.
+    sql("USE %s.%s", CATALOG_NAME, SCHEMA_NAME);
     createView();
   }
 
+  /**
+   * Asserts VIEW_NAME's presence in {@code SHOW TABLES} (which lists views on every version) via
+   * the {@code IN catalog.schema} form; when {@code currentIsViewNamespace}, also the unqualified
+   * form.
+   */
+  protected void verifyShowTables(boolean expectPresent, boolean currentIsViewNamespace) {
+    assertThat(viewListedBy(sql("SHOW TABLES IN %s.%s", CATALOG_NAME, SCHEMA_NAME)))
+        .isEqualTo(expectPresent);
+    if (currentIsViewNamespace) {
+      assertThat(viewListedBy(sql("SHOW TABLES"))).isEqualTo(expectPresent);
+    }
+  }
+
+  private static boolean viewListedBy(List<Row> showResult) {
+    return showResult.stream().anyMatch(r -> VIEW_NAME.equals(r.getString(1)));
+  }
+
+  /**
+   * SELECT / DESCRIBE the view (by {@code viewRef}) under its DECLARED column names. The result is
+   * catalog-independent, since resolution uses the persisted creation context. Expected rows
+   * reflect the filter (budget > 100 drops dept 20) and inner join (drops employee 4, dept 99
+   * unmatched).
+   */
+  private void verifyViewReadable(String viewRef) {
+    // Columns: num(int literal), emp(int), person(string), dept_budget(int), dept_tags(array),
+    // person_info(struct). getList/getStruct exercise the complex-type round-trip.
+    assertThat(
+            sql("SELECT * FROM %s ORDER BY %s", viewRef, DECLARED_COLUMNS[1]).stream()
+                .map(
+                    r ->
+                        r.getInt(0)
+                            + ":"
+                            + r.getInt(1)
+                            + ":"
+                            + r.getString(2)
+                            + ":"
+                            + r.getInt(3)
+                            + ":"
+                            + r.getList(4)
+                            + ":"
+                            + r.getStruct(5))
+                .collect(Collectors.toList()))
+        .containsExactly("123:1:Ann:500:[eng, core]:[1,Ann]", "123:3:Cy:500:[eng, core]:[3,Cy]");
+
+    assertThat(sql("DESCRIBE %s", viewRef).stream().map(r -> r.getString(0)))
+        .contains(DECLARED_COLUMNS);
+  }
+
+  /**
+   * All assertions share one session + fixture (expensive to build), running as ordered stages.
+   * SHOW / SELECT / DESCRIBE run twice -- view's own namespace current, then a different one -- to
+   * prove resolution is catalog-independent. Drop runs last since it destroys the view.
+   */
   @Test
-  public void testViewIsReadableThroughSpark() {
+  public void testViewLifecycleThroughSpark() {
     createSessionAndView();
-    assertThat(sql("SELECT * FROM %s", VIEW_FULL_NAME))
-        .extracting(row -> row.getInt(0))
-        .containsExactly(1);
+
+    // View's own namespace current: reference it by BARE name to prove unqualified resolution.
+    sql("USE %s.%s", CATALOG_NAME, SCHEMA_NAME);
+    verifyShowTables(true, /* currentIsViewNamespace= */ true);
+    verifyShowViews(true);
+    verifyViewDependencies();
+    verifyViewReadable(VIEW_NAME);
+
+    // A different catalog AND schema current: owns `departments` but not `employees` or the view.
+    sql("USE %s.%s", CATALOG_NAME2, SCHEMA_NAME2);
+    verifyShowTables(true, /* currentIsViewNamespace= */ false);
+    verifyShowViews(true);
+    verifyViewReadable(VIEW_FULL_NAME);
+
+    dropView();
+    verifyShowTables(false, /* currentIsViewNamespace= */ false);
+    verifyShowViews(false);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -73,6 +73,14 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
         createTestCatalog(catalog);
       }
     }
+    // Delta requires spark.sql.catalog.spark_catalog to be set for ANY Delta operation
+    // (DeltaLog.checkRequiredConfigurations); otherwise a Delta table -- even in a named UC catalog
+    // -- fails with DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG. When the caller did
+    // not configure spark_catalog above, point it at Delta's own catalog to satisfy that check.
+    if (!List.of(catalogs).contains(SPARK_CATALOG)) {
+      builder.config(
+          "spark.sql.catalog." + SPARK_CATALOG, "org.apache.spark.sql.delta.catalog.DeltaCatalog");
+    }
     // Use fake file system for cloud storage so that we can test credentials.
     builder.config("spark.hadoop.fs.s3.impl", S3CredentialTestFileSystem.class.getName());
     builder.config("spark.hadoop.fs.gs.impl", GCSCredentialTestFileSystem.class.getName());

--- a/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewReadOnlyIntegrationTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewReadOnlyIntegrationTest.java
@@ -2,54 +2,104 @@ package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
-import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
 import io.unitycatalog.client.model.CreateTable;
-import io.unitycatalog.client.model.DependencyList;
 import io.unitycatalog.client.model.TableType;
-import io.unitycatalog.server.sdk.tables.SdkTableOperations;
 import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Test;
 
 /**
- * Spark 4.0/4.1 lack the v2 {@code ViewCatalog}, so views can't be created via SQL. A view created
- * server-side must still be readable (shared base) and surface on the table listing.
+ * Spark 4.0/4.1 lack the v2 {@code ViewCatalog}, so views can't be created via SQL DDL. All
+ * assertions live in {@link AbstractViewReadIntegrationTest}; this subclass only supplies the
+ * server-side (SDK) create/drop. The created view carries the same declared-vs-query-output column
+ * difference and creation catalog/namespace as the SQL path, so the shared tests exercise the
+ * {@code view.query.out.*} and {@code view.catalogAndNamespace.*} round-trips on the read-only
+ * {@code buildV1ViewTable} path too.
  */
 public class UCViewReadOnlyIntegrationTest extends AbstractViewReadIntegrationTest {
 
   @Override
   @SneakyThrows
   protected void createView() {
-    new SdkTableOperations(createApiClient(serverConfig))
-        .createTable(
-            new CreateTable()
-                .name(VIEW_NAME)
-                .catalogName(CATALOG_NAME)
-                .schemaName(SCHEMA_NAME)
-                .tableType(TableType.VIEW)
-                .viewDefinition(VIEW_QUERY)
-                .viewDependencies(new DependencyList().dependencies(List.of()))
-                .columns(
-                    List.of(
-                        new ColumnInfo()
-                            .name("c")
-                            .typeName(ColumnTypeName.INT)
-                            .typeText("int")
-                            .typeJson(
-                                "{\"name\":\"c\",\"type\":\"integer\",\"nullable\":true,"
-                                    + "\"metadata\":{}}")
-                            .nullable(true)
-                            .position(0))));
+    // The view.query.out.* properties and the declared columns below are spelled out one entry per
+    // index, so they don't stay in sync with the fixture arrays automatically. Guard the expected
+    // size (6): if QUERY_OUTPUT_COLUMNS / DECLARED_COLUMNS change, this fails loudly here -- update
+    // both blocks -- rather than silently persisting a view that no longer matches VIEW_QUERY.
+    assertThat(QUERY_OUTPUT_COLUMNS).hasSize(6);
+    assertThat(DECLARED_COLUMNS).hasSize(6);
+
+    tableOperations.createTable(
+        new CreateTable()
+            .name(VIEW_NAME)
+            .catalogName(CATALOG_NAME)
+            .schemaName(SCHEMA_NAME)
+            .tableType(TableType.VIEW)
+            .viewDefinition(VIEW_QUERY)
+            // Omit view_dependencies (like the connector does for a plain view); the server accepts
+            // an absent list.
+            .properties(
+                Map.of(
+                    // Query-output names (differ from the declared columns below).
+                    "view.query.out.numCols", Integer.toString(6),
+                    "view.query.out.col.0", QUERY_OUTPUT_COLUMNS[0],
+                    "view.query.out.col.1", QUERY_OUTPUT_COLUMNS[1],
+                    "view.query.out.col.2", QUERY_OUTPUT_COLUMNS[2],
+                    "view.query.out.col.3", QUERY_OUTPUT_COLUMNS[3],
+                    "view.query.out.col.4", QUERY_OUTPUT_COLUMNS[4],
+                    "view.query.out.col.5", QUERY_OUTPUT_COLUMNS[5],
+                    // Creation catalog/namespace, so the unqualified `employees` resolves.
+                    "view.catalogAndNamespace.numParts", "2",
+                    "view.catalogAndNamespace.part.0", CATALOG_NAME,
+                    "view.catalogAndNamespace.part.1", SCHEMA_NAME))
+            // Declared columns matching VIEW_QUERY's projection: int, int, string, int,
+            // array<string>, struct<id:int,name:string>.
+            .columns(
+                List.of(
+                    column(DECLARED_COLUMNS[0], ColumnTypeName.INT, "int", "\"integer\"", 0),
+                    column(DECLARED_COLUMNS[1], ColumnTypeName.INT, "int", "\"integer\"", 1),
+                    column(DECLARED_COLUMNS[2], ColumnTypeName.STRING, "string", "\"string\"", 2),
+                    column(DECLARED_COLUMNS[3], ColumnTypeName.INT, "int", "\"integer\"", 3),
+                    column(
+                        DECLARED_COLUMNS[4],
+                        ColumnTypeName.ARRAY,
+                        "array<string>",
+                        "{\"type\":\"array\",\"elementType\":\"string\",\"containsNull\":true}",
+                        4),
+                    column(
+                        DECLARED_COLUMNS[5],
+                        ColumnTypeName.STRUCT,
+                        "struct<id:int,name:string>",
+                        "{\"type\":\"struct\",\"fields\":["
+                            + "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,"
+                            + "\"metadata\":{}},"
+                            + "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,"
+                            + "\"metadata\":{}}]}",
+                        5))));
   }
 
-  @Test
-  public void testViewAppearsUnderShowTables() {
-    createSessionAndView();
-    assertThat(sql("SHOW TABLES IN %s.%s", CATALOG_NAME, SCHEMA_NAME))
-        .anyMatch(row -> VIEW_NAME.equals(row.getString(1)));
+  @Override
+  @SneakyThrows
+  protected void dropView() {
+    tableOperations.deleteTable(VIEW_FULL_NAME);
+  }
+
+  private static ColumnInfo column(
+      String name, ColumnTypeName typeName, String typeText, String dataTypeJson, int position) {
+    return new ColumnInfo()
+        .name(name)
+        .typeName(typeName)
+        .typeText(typeText)
+        .typeJson(
+            "{\"name\":\""
+                + name
+                + "\",\"type\":"
+                + dataTypeJson
+                + ",\"nullable\":true,\"metadata\":{}}")
+        .nullable(true)
+        .position(position);
   }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewDDLIntegrationTest.java
@@ -2,122 +2,83 @@ package io.unitycatalog.spark;
 
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
-import static io.unitycatalog.server.utils.TestUtils.createApiClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.model.TableInfo;
-import io.unitycatalog.server.sdk.tables.SdkTableOperations;
-import java.io.File;
+import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Spark 4.2 exposes the v2 {@code ViewCatalog}, so CREATE / SHOW / DROP VIEW all route to Unity
- * Catalog. Complements the shared read guarantee with the full DDL round-trip.
+ * Spark 4.2 exposes the v2 {@code ViewCatalog}, so view create/drop route to Unity Catalog through
+ * SQL DDL. The shared read guarantees (query-output-column and creation-context round-trips) live
+ * in {@link AbstractViewReadIntegrationTest}; this subclass supplies the SQL create/drop and the
+ * {@code SHOW VIEWS} check, and adds the 4.2-only dependency-derivation assertions (the 4.0/4.1
+ * read-only path creates views via the SDK and never derives dependencies).
  */
 public class UCViewDDLIntegrationTest extends AbstractViewReadIntegrationTest {
 
-  @TempDir private File sourceTableDir;
-
-  private static final String STAGING_SCHEMA = "staging";
-  private static final String NEUTRAL_SCHEMA = "neutral";
-
   @Override
   protected void createView() {
-    sql("CREATE VIEW %s AS %s", VIEW_FULL_NAME, VIEW_QUERY);
+    // Declare DECLARED_COLUMNS over VIEW_QUERY's output (QUERY_OUTPUT_COLUMNS); the names differ,
+    // so this exercises the query-output-column round-trip.
+    sql(
+        "CREATE VIEW %s (%s) AS %s",
+        VIEW_FULL_NAME, String.join(", ", DECLARED_COLUMNS), VIEW_QUERY);
   }
 
-  @Test
-  public void testShowViewsListsViewAndDropRemovesIt() {
-    createSessionAndView();
-    assertThat(sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME))
-        .anyMatch(row -> VIEW_NAME.equals(row.getString(1)));
-
+  @Override
+  protected void dropView() {
     sql("DROP VIEW %s", VIEW_FULL_NAME);
-    assertThat(sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME))
-        .noneMatch(row -> VIEW_NAME.equals(row.getString(1)));
   }
 
-  /** A plain view's dependencies, derived from the query text, are persisted on the server. */
-  @Test
-  public void testCreateViewPersistsDerivedDependencies() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
-    String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
-    createSourceTable(srcFullName);
-    sql("CREATE VIEW %s AS SELECT * FROM %s", VIEW_FULL_NAME, srcFullName);
+  @Override
+  protected void verifyShowViews(boolean expectPresent) {
+    List<String> views =
+        sql("SHOW VIEWS IN %s.%s", CATALOG_NAME, SCHEMA_NAME).stream()
+            .map(r -> r.getString(1))
+            .toList();
+    if (expectPresent) {
+      // SHOW VIEWS lists views only -- the view is present, the source Delta tables are not.
+      assertThat(views).contains(VIEW_NAME).doesNotContain(EMPLOYEES_TABLE_NAME);
+    } else {
+      assertThat(views).doesNotContain(VIEW_NAME);
+    }
+  }
 
-    TableInfo view = getServerTable(VIEW_FULL_NAME);
-    assertThat(view.getViewDependencies().getDependencies())
+  /**
+   * On the 4.2 create path the connector derives view dependencies from the query text; assert the
+   * lifecycle view's two joined base tables were persisted (the unqualified {@code employees}
+   * qualified via the creation context, and the cross-catalog {@code departments}).
+   */
+  @Override
+  protected void verifyViewDependencies() {
+    assertThat(getServerTable(VIEW_FULL_NAME).getViewDependencies().getDependencies())
         .extracting(dependency -> dependency.getTable().getTableFullName())
-        .contains(srcFullName);
+        .containsExactlyInAnyOrder(EMPLOYEES_TABLE_FULL_NAME, DEPARTMENTS_TABLE_FULL_NAME);
   }
 
   /** A case-differing CTE reference is not leaked as a dependency; only the base table is kept. */
   @Test
   public void testCreateViewDerivesDependenciesWithCaseInsensitiveCte() {
+    final String DEP_SRC_TABLE_NAME = "dep_src";
+    final String DEP_SRC_TABLE_FULL_NAME =
+        CATALOG_NAME + "." + SCHEMA_NAME + "." + DEP_SRC_TABLE_NAME;
+
     session = createSparkSessionWithCatalogs(CATALOG_NAME);
-    String srcFullName = CATALOG_NAME + "." + SCHEMA_NAME + ".dep_src";
-    createSourceTable(srcFullName);
+    sql(
+        "CREATE TABLE %s (c INT) USING delta LOCATION '%s'",
+        DEP_SRC_TABLE_FULL_NAME, testDirectoryRoot.resolve(DEP_SRC_TABLE_NAME).toUri());
     sql(
         "CREATE VIEW %s AS WITH v_cte AS (SELECT * FROM %s) SELECT * FROM V_CTE",
-        VIEW_FULL_NAME, srcFullName);
-
+        VIEW_FULL_NAME, DEP_SRC_TABLE_FULL_NAME);
     assertThat(getServerTable(VIEW_FULL_NAME).getViewDependencies().getDependencies())
         .extracting(dependency -> dependency.getTable().getTableFullName())
-        .containsExactly(srcFullName);
-  }
-
-  /**
-   * A view created with an explicit column list stores the view's output names separately from the
-   * query's output names. Spark resolves the view using the persisted query-output names, not the
-   * declared column names.
-   */
-  @Test
-  public void testViewWithExplicitColumnListIsReadable() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
-    String view = CATALOG_NAME + "." + SCHEMA_NAME + ".v_renamed";
-    sql("CREATE VIEW %s (total) AS SELECT 42 AS my_count", view);
-
-    assertThat(sql("SELECT * FROM %s", view))
-        .extracting(row -> row.getInt(0))
-        .containsExactly(42);
-  }
-
-  /**
-   * Unqualified table references in a view body are resolved using the catalog/namespace active at
-   * creation time, not the view's own schema. Read from a third schema so the result cannot be
-   * explained by the reader's current namespace.
-   */
-  @Test
-  public void testViewResolvesUnqualifiedReferencesUsingCreationContext() {
-    session = createSparkSessionWithCatalogs(CATALOG_NAME);
-    sql("CREATE SCHEMA IF NOT EXISTS %s.%s", CATALOG_NAME, STAGING_SCHEMA);
-    sql("CREATE SCHEMA IF NOT EXISTS %s.%s", CATALOG_NAME, NEUTRAL_SCHEMA);
-    sql("CREATE VIEW %s.%s.source AS SELECT 'FROM_STAGING' AS src", CATALOG_NAME, STAGING_SCHEMA);
-    sql(
-        "CREATE VIEW %s.%s.source AS SELECT 'FROM_DEFAULT' AS src",
-        CATALOG_NAME,
-        SCHEMA_NAME);
-
-    sql("USE %s.%s", CATALOG_NAME, STAGING_SCHEMA);
-    sql(
-        "CREATE VIEW %s.%s.v_ctx AS SELECT src FROM source",
-        CATALOG_NAME,
-        SCHEMA_NAME);
-
-    sql("USE %s.%s", CATALOG_NAME, NEUTRAL_SCHEMA);
-    assertThat(sql("SELECT src FROM %s.%s.v_ctx", CATALOG_NAME, SCHEMA_NAME))
-        .extracting(row -> row.getString(0))
-        .containsExactly("FROM_STAGING");
-  }
-
-  private void createSourceTable(String fullName) {
-    sql("CREATE TABLE %s (c INT) USING parquet LOCATION '%s'", fullName, sourceTableDir.toURI());
+        .containsExactly(DEP_SRC_TABLE_FULL_NAME);
   }
 
   @SneakyThrows
   private TableInfo getServerTable(String fullName) {
-    return new SdkTableOperations(createApiClient(serverConfig)).getTable(fullName);
+    return tableOperations.getTable(fullName);
   }
 }

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -693,13 +693,15 @@ public class UCViewProxySuite {
   }
 
   @Test
-  public void testCreatePlainViewSendsViewPayloadWithNonNullDependencies() throws Exception {
-    // A plain CREATE VIEW carries no dependencies; the connector must still send a non-null
-    // (empty) dependency list so the server's view validation accepts it.
+  public void testCreatePlainViewOmitsDependenciesWhenDerivationFails() throws Exception {
+    // Spark leaves `viewDependencies()` null for a plain view. The connector then derives lineage
+    // from the query text; on failure it must send NO dependency list (null), not an empty one --
+    // an empty list would persist "no dependencies", wrong for a view that reads tables. This
+    // pure-mock suite has no active SparkSession, so derivation always fails here, exercising that
+    // fallback. (Successful derivation is covered end-to-end by UCViewDDLIntegrationTest.)
     View view = plainViewBuilder().build();
 
-    TableInfo ucView =
-        stubPlainView().viewDependencies(new DependencyList().dependencies(List.of()));
+    TableInfo ucView = stubPlainView();
     when(mockTablesApi.createTable(any(CreateTable.class))).thenReturn(ucView);
 
     View loaded = proxyViews.createView(Identifier.of(NAMESPACE, "v1"), view);
@@ -709,8 +711,7 @@ public class UCViewProxySuite {
     CreateTable request = captor.getValue();
     assertThat(request.getTableType()).isEqualTo(TableType.VIEW);
     assertThat(request.getViewDefinition()).isEqualTo(PLAIN_VIEW_QUERY);
-    assertThat(request.getViewDependencies()).isNotNull();
-    assertThat(request.getViewDependencies().getDependencies()).isEmpty();
+    assertThat(request.getViewDependencies()).isNull();
     assertThat(loaded.queryText()).isEqualTo(PLAIN_VIEW_QUERY);
     assertThat(loaded.properties().get(TableCatalog.PROP_TABLE_TYPE))
         .isEqualTo(TableSummary.VIEW_TABLE_TYPE);

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -745,10 +745,12 @@ public class TableRepository {
           session.persist(tableInfoDAO);
           if (RepositoryUtils.isViewLike(tableType.getValue())) {
             DependencyDAO.DependentType dependentType = DependencyDAO.DependentType.TABLE;
+            // view_dependencies is optional (see validateViewLike); treat an absent list as empty.
             List<DependencyDAO> depDAOs =
-                createTable.getViewDependencies().getDependencies().stream()
+                Optional.ofNullable(createTable.getViewDependencies())
+                    .map(DependencyList::getDependencies).orElse(List.of()).stream()
                     .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
-                    .collect(Collectors.toList());
+                    .toList();
             repositories
                 .getDependencyRepository()
                 .createDependencies(session, tableUUID, dependentType, depDAOs);
@@ -768,7 +770,11 @@ public class TableRepository {
 
   private void validateMetricView(Session session, CreateTable createTable) {
     validateViewLike(session, createTable, "metric view");
-    if (createTable.getViewDependencies().getDependencies().isEmpty()) {
+    // A metric view's dependencies are always client-supplied; require at least one.
+    if (Optional.ofNullable(createTable.getViewDependencies())
+        .map(DependencyList::getDependencies)
+        .orElse(List.of())
+        .isEmpty()) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT,
           "view_dependencies must contain at least one entry for metric view");
@@ -784,10 +790,14 @@ public class TableRepository {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT, "view_definition is required for " + entityLabel);
     }
+    // view_dependencies is optional here (shared by view + metric view):
+    //  - a plain view may omit it (e.g. the Spark connector sends null when it cannot derive
+    //    lineage from the view text).
+    //  - metric views DO require it, enforced by the validateMetricView caller, not here.
+    // When present, every listed dependency must resolve to an existing table/function.
     DependencyList viewDeps = createTable.getViewDependencies();
     if (viewDeps == null || viewDeps.getDependencies() == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "view_dependencies is required for " + entityLabel);
+      return;
     }
     List<DependencyDAO> depDAOs =
         viewDeps.getDependencies().stream()

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -191,7 +191,7 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
             "missing view_dependencies",
             (UnaryOperator<CreateTable>) request -> request.viewDependencies(null),
             ErrorCode.INVALID_ARGUMENT,
-            "view_dependencies is required for metric view"),
+            "view_dependencies must contain at least one entry for metric view"),
         Arguments.of(
             "empty dependency list",
             (UnaryOperator<CreateTable>)

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
@@ -107,6 +107,15 @@ public abstract class BaseViewCRUDTest extends BaseTableCRUDTestEnv {
     tableOperations.deleteTable(VIEW_FULL_NAME);
     assertApiException(
         () -> tableOperations.getTable(VIEW_FULL_NAME), ErrorCode.TABLE_NOT_FOUND, VIEW_FULL_NAME);
+
+    // view_dependencies is optional for a plain view: a client that does not compute base-table
+    // lineage (e.g. Spark for a plain view) may omit it. The view is still created and readable.
+    TableInfo createdWithoutDeps =
+        tableOperations.createTable(validViewRequest().viewDependencies(null));
+    assertThat(createdWithoutDeps.getName()).isEqualTo(VIEW_NAME);
+    assertThat(createdWithoutDeps.getTableType()).isEqualTo(TableType.VIEW);
+    assertThat(tableOperations.getTable(VIEW_FULL_NAME).getName()).isEqualTo(VIEW_NAME);
+    tableOperations.deleteTable(VIEW_FULL_NAME);
   }
 
   private static Stream<Arguments> negativeCreateCases() {
@@ -116,11 +125,6 @@ public abstract class BaseViewCRUDTest extends BaseTableCRUDTestEnv {
             (UnaryOperator<CreateTable>) request -> request.viewDefinition(null),
             ErrorCode.INVALID_ARGUMENT,
             "view_definition is required for view"),
-        Arguments.of(
-            "missing view_dependencies",
-            (UnaryOperator<CreateTable>) request -> request.viewDependencies(null),
-            ErrorCode.INVALID_ARGUMENT,
-            "view_dependencies is required for view"),
         Arguments.of(
             "non-existent dependency",
             (UnaryOperator<CreateTable>)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Connector (Spark 4.2): `UCViewDependencies.derive` now returns `Option`; on a failed derivation `createView` leaves `view_dependencies` unset (null) instead of sending an empty list, so a lineage-validating server can derive them itself.
- Server: `TableRepository` accepts null/absent `view_dependencies` for a plain view (metric views still require at least one entry).
- Connector (Spark 4.0/4.1): `buildV1ViewTable` prefers the persisted `view.query.out.*` / `view.catalogAndNamespace.*` over regenerating them, so a view created on 4.2 reads back correctly.
- Moved the view-property (de)serialization helpers into `UCViewProperties`, leaving `UCViewTypes` as pure type mapping.
- Tests: broadened the shared view integration fixture (cross-catalog join; int/string/array/struct columns; declared-vs-query-output names; creation-context round-trip) and always bind `spark.sql.catalog.spark_catalog` to a Delta-capable catalog so Delta operations work in every test session.
