### PR TITLE
Update public roadmap through v1.0

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -7,16 +7,16 @@ features may move in/out of milestones pending available resources, priorities, 
 
 ### Managed Delta table support
 
-Delta's [Catalog managed commits](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#catalog-managed-tables) are the basis for many new and powerful client (Delta) and server side features and 
-were introduced as `experimental` in the 0.4 release. 
+Delta's [Catalog managed commits](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#catalog-managed-tables) are the basis for many new and powerful client (Delta) and server side features and
+were introduced as `experimental` in the 0.4 release.
 * This release will introduce new Delta Catalog APIs as well as
-moving to non-experimental. 
+moving to non-experimental.
 * In addition, we'll be providing Uniform support with this release.
 
 ### Metric Views
 
-Metric views provide a centralized way to define and manage consistent, reusable, and governed core business metrics. 
-This will enable Unity Catalog to abstract your complex business logic into centralized definitions, enabling 
+Metric views provide a centralized way to define and manage consistent, reusable, and governed core business metrics.
+This will enable Unity Catalog to abstract your complex business logic into centralized definitions, enabling
 you to have a single source of metric truth for your key performance indicators.
 
 * This release will provide an experimental preview of this new capability.
@@ -35,18 +35,27 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td><b>v0.2</b></td>
     <td><b>v0.3</b></td>
     <td><b>v0.4</b></td>
-    <td><b>v0.5+</b></td>
+    <td><b>v0.5</b></td>
+    <td><b>v0.6</b></td>
+    <td><b>v0.7</b></td>
+    <td><b>v0.8</b></td>
+    <td><b>v1.0+</b></td>
   </tr>
-  
+
   <!-- Core Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Core</td>
+    <td colspan="11" bgcolor="grey" align="center">Core</td>
   </tr>
 
   <tr>
     <td>Catalog</td>
     <td>API + Server</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -60,6 +69,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Managed location in catalog</td>
@@ -68,6 +82,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -78,28 +97,21 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  <tr>
-    <td>Credential</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td align="center">🛠️</td>
-    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
-    <td>External Location</td>
+
+
+    <tr>
+    <td rowspan="1">Multi-tenancy</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
-    <td align="center">🛠️</td>
-    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  <tr>
-    <td>Multi-tenancy</td>
-    <td>API + Server</td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -107,9 +119,23 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
 
+<tr>
+    <td>S3-compatible storage</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+
   <!-- Identity & Authentication Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Identity & Authentication</td>
+    <td colspan="11" bgcolor="grey" align="center">Identity & Authentication</td>
   </tr>
 
   <tr>
@@ -120,29 +146,47 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Group management</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Support for Machine identities (SPs)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>SCIM to support identity sync from IdP  (users and groups)</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -156,14 +200,23 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>OAuth/OIDC for Services</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -174,6 +227,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>SAML authentication support</td>
@@ -182,54 +240,68 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
 
   <!-- Access Control & Governance Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Access Control & Governance</td>
+    <td colspan="11" bgcolor="grey" align="center">Access Control & Governance</td>
   </tr>
 
-  <tr>
+    <tr>
     <td>Support for change of ownership</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Add permission/privilege support for MODIFY, CREATE_X, BROWSE</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Add remaining permissions/privileges (MANAGE etc)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  <tr>
-    <td>Permission parity with Databricks UC</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
+
   <tr>
     <td>Temporary credential vending for tables</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -243,11 +315,21 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Temporary credential vending for models</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -261,19 +343,19 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
-    <td>Auditing</td>
+    <tr>
+    <td rowspan="1">Auditing</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  <tr>
-    <td>SQL DCL changes</td>
-    <td>Spark Integration</td>
     <td></td>
     <td></td>
     <td></td>
@@ -287,12 +369,22 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
   <tr>
     <td>Row level filters</td>
     <td>API + Server</td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+
     <td></td>
     <td></td>
     <td></td>
@@ -305,12 +397,22 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
   <tr>
     <td>ABAC</td>
     <td>API + Server</td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+
     <td></td>
     <td></td>
     <td></td>
@@ -323,31 +425,42 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
-  </tr>
-  
-  <!-- Server production-readiness (support running as a HMS replacement) Section -->
-  <tr>
-    <td colspan="7" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
   </tr>
 
+  <!-- Server production-readiness (support running as a HMS replacement) Section -->
   <tr>
-    <td>Monitoring and Telemetry</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center">❓</td>
+    <td colspan="11" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
   </tr>
-  <tr>
-    <td>Database schema upgrades</td>
+
+    <tr><td>Monitoring and Telemetry</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+    <tr><td>Database schema upgrades</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Change events</td>
@@ -356,18 +469,54 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+  <tr>
+    <td>Server-side storage credential and FileIO caching</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+  <tr>
+    <td>Managed tables and volumes lifecycle</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+
   <!-- Tables Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Tables</td>
+    <td colspan="11" bgcolor="grey" align="center">Tables</td>
   </tr>
-  
+
   <tr>
     <td rowspan="3">External table reads & writes</td>
     <td>API + Server</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -380,6 +529,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Delta integration</td>
@@ -388,12 +542,22 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="2">Managed Delta table reads</td>
     <td>API + Server</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -406,21 +570,34 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
+
+    <tr><td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Delta-Spark integration</td>
     <td></td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -432,8 +609,13 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="2">Delta Uniform tables with read as Iceberg via Iceberg REST API</td>
     <td>API + Server</td>
@@ -441,6 +623,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -450,18 +637,26 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Iceberg tables with create+read+write</td>
+
+    <tr><td rowspan="1">Iceberg tables with create+read+write</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Multi-engine data types for column definitions</td>
     <td>API + Server</td>
@@ -470,92 +665,129 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <!-- Views Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Views</td>
+    <td colspan="11" bgcolor="grey" align="center">Views</td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Basic Spark SQL flavor views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Multi-dialect views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Iceberg view support</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Materialized views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">🛠️</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
   </tr>
 
-  <tr>
-    <td rowspan="1">Metric views</td>
+    <tr><td rowspan="1">Metric views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">🛠️</td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Streaming tables</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">🛠️</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Shallow clones</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <!-- Non-tabular and AI assets Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Non-tabular and AI assets</td>
+    <td colspan="11" bgcolor="grey" align="center">Non-tabular and AI assets</td>
   </tr>
-  
+
   <tr>
     <td rowspan="3">Functions (SQL UDFs, Python UDFs)</td>
     <td>API + Server</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -568,16 +800,25 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Multi-engine functions (SQL)</td>
     <td>API + Server</td>
@@ -585,9 +826,14 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Remote functions</td>
     <td>API + Server</td>
@@ -595,9 +841,14 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+
   <tr>
     <td rowspan="2">External volumes</td>
     <td>API + Server</td>
@@ -606,16 +857,25 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="2">Managed volumes</td>
     <td>API + Server</td>
@@ -624,20 +884,34 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="3">Models and model versions</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -650,16 +924,25 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Features tables</td>
     <td>API + Server</td>
@@ -667,9 +950,14 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Data monitors</td>
     <td>API + Server</td>
@@ -677,59 +965,79 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+
   <!-- Sharing Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Sharing</td>
+    <td colspan="11" bgcolor="grey" align="center">Sharing</td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Delta Sharing integration</td>
+
+    <tr><td rowspan="1">Open Sharing</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+      <tr>
     <td rowspan="1">Shares</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+      <tr>
     <td rowspan="1">Recipients</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
+
+      <tr>
     <td rowspan="1">Providers</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+
   <!-- Federation Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Federation</td>
+    <td colspan="11" bgcolor="grey" align="center">Federation</td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Connections</td>
     <td>API + Server</td>
@@ -737,9 +1045,14 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+
   <tr>
     <td rowspan="1">Foreign objects (catalogs, schemas, tables)</td>
     <td>API + Server</td>
@@ -747,21 +1060,25 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
-  <tr>
+
+    <tr>
     <td rowspan="1">Support for different data sources: JDBC, Iceberg REST, HMS</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
-  </tr>
-  
-  <!-- UI Section -->
-  <tr>
-    <td colspan="7" bgcolor="grey" align="center">UI (needs to be completed)</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
 </table>

--- a/roadmap.md
+++ b/roadmap.md
@@ -3,26 +3,25 @@
 This document outlines the roadmap for the Unity Catalog open source project. As always,
 features may move in/out of milestones pending available resources, priorities, and community discussions.
 
-## 0.5 Release priorities
+## 0.6+
 
-### Managed Delta table support
+### View support
 
-Delta's [Catalog managed commits](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#catalog-managed-tables) are the basis for many new and powerful client (Delta) and server side features and
-were introduced as `experimental` in the 0.4 release.
-* This release will introduce new Delta Catalog APIs as well as
-moving to non-experimental.
-* In addition, we'll be providing Uniform support with this release.
+Views provide governed, reusable definitions over tables.
+We will start with supporting basic Spark SQL views and then progress toward broader engine interoperability.
 
-### Metric Views
+### Full Iceberg REST Catalog support
 
-Metric views provide a centralized way to define and manage consistent, reusable, and governed core business metrics.
-This will enable Unity Catalog to abstract your complex business logic into centralized definitions, enabling
-you to have a single source of metric truth for your key performance indicators.
+The Iceberg REST Catalog provides an open interface for engines and tools to discover and access Iceberg tables. We will continue to strengthen interoperability through this interface, including Delta Uniform table access and Iceberg table lifecycle support, so more engines can access data registered in Unity Catalog through open standards.
 
-* This release will provide an experimental preview of this new capability.
+### S3-compatible storage
 
-### Authentication
-Modular authentication will allow you to reuse your existing auth to secure Unity Catalog.
+S3-compatible storage support will allow Unity Catalog deployments to use object stores that expose an S3-compatible API. This allows Unity Catalog to be deployed across a broader range of on-prem and cloud environments.
+
+### Production hardening
+
+Production hardening focuses on the reliability and operational maturity needed for broader production deployments.
+The roadmap includes monitoring and telemetry, database schema upgrades, server-side storage credential and FileIO caching, and managed table and volume lifecycle support.
 
 
 ## Full roadmap
@@ -104,9 +103,35 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
 
+  <tr>
+    <td>Credential</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td align="center">🛠️</td>
+    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+  <tr>
+    <td>External Location</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td align="center">🛠️</td>
+    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
 
     <tr>
-    <td rowspan="1">Multi-tenancy</td>
+    <td>Multi-tenancy</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -350,7 +375,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
     <tr>
-    <td rowspan="1">Auditing</td>
+    <td>Auditing</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -361,6 +386,19 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+  <tr>
+    <td>SQL DCL changes</td>
+    <td>Spark Integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
   </tr>
   <tr>
     <td>RBAC</td>
@@ -582,7 +620,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
+    <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -644,7 +682,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
 
-    <tr><td rowspan="1">Iceberg tables with create+read+write</td>
+    <tr><td>Iceberg tables with create+read+write</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -658,7 +696,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Multi-engine data types for column definitions</td>
+    <td>Multi-engine data types for column definitions</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -678,7 +716,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Basic Spark SQL flavor views</td>
+    <td>Basic Spark SQL flavor views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -692,7 +730,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Multi-dialect views</td>
+    <td>Multi-dialect views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -706,7 +744,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Iceberg view support</td>
+    <td>Iceberg view support</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -720,7 +758,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Materialized views</td>
+    <td>Materialized views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -733,7 +771,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center">❓</td>
   </tr>
 
-    <tr><td rowspan="1">Metric views</td>
+    <tr><td>Metric views</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -747,7 +785,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Streaming tables</td>
+    <td>Streaming tables</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -761,7 +799,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Shallow clones</td>
+    <td>Shallow clones</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -820,7 +858,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Multi-engine functions (SQL)</td>
+    <td>Multi-engine functions (SQL)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -835,7 +873,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Remote functions</td>
+    <td>Remote functions</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -944,7 +982,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Features tables</td>
+    <td>Features tables</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -959,7 +997,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Data monitors</td>
+    <td>Data monitors</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -978,7 +1016,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td colspan="11" bgcolor="grey" align="center">Sharing</td>
   </tr>
 
-    <tr><td rowspan="1">Open Sharing</td>
+    <tr><td>Open Sharing</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -992,7 +1030,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
       <tr>
-    <td rowspan="1">Shares</td>
+    <td>Shares</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -1006,7 +1044,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
       <tr>
-    <td rowspan="1">Recipients</td>
+    <td>Recipients</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -1020,7 +1058,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
       <tr>
-    <td rowspan="1">Providers</td>
+    <td>Providers</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -1039,7 +1077,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Connections</td>
+    <td>Connections</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -1054,7 +1092,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
   <tr>
-    <td rowspan="1">Foreign objects (catalogs, schemas, tables)</td>
+    <td>Foreign objects (catalogs, schemas, tables)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
@@ -1069,7 +1107,7 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
   </tr>
 
     <tr>
-    <td rowspan="1">Support for different data sources: JDBC, Iceberg REST, HMS</td>
+    <td>Support for different data sources: JDBC, Iceberg REST, HMS</td>
     <td>API + Server</td>
     <td></td>
     <td></td>


### PR DESCRIPTION
## Summary

- Add cumulative v0.6, v0.7, v0.8, and v1.0+ roadmap columns.
- Update release timing for supported capabilities and planned work.
- Rename Delta Sharing integration to Open Sharing.
- Remove deprecated, unsupported, and UI roadmap entries.

## Validation

- Verified each feature row has 11 logical table columns.
- Kept retained existing roadmap items in their original order.
- Added new items only at the end of their assigned sections.