### PR TITLE
Update Unity Catalog OSS roadmap through v1.0

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -3,7 +3,7 @@
 This document outlines the roadmap for the Unity Catalog open source project. As always,
 features may move in/out of milestones pending available resources, priorities, and community discussions.
 
-## 0.6+
+## 0.6+ Release priorities
 
 ### View support
 
@@ -24,14 +24,16 @@ Production hardening focuses on the reliability and operational maturity needed 
 The roadmap includes monitoring and telemetry, database schema upgrades, server-side storage credential and FileIO caching, and managed table and volume lifecycle support.
 
 
+> **Note:** The projected roadmap is tentative and may change. For details of what shipped in each release, see the [Unity Catalog release notes](https://github.com/unitycatalog/unitycatalog/releases).
+
 ## Full roadmap
 
 <table>
   <tr>
     <td><b>Feature</b></td>
     <td><b>Area</b></td>
-    <td><b>v0.1</b></td>
-    <td><b>v0.2</b></td>
+    
+    
     <td><b>v0.3</b></td>
     <td><b>v0.4</b></td>
     <td><b>v0.5</b></td>
@@ -41,13 +43,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Core Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Core</td>
+    <td colspan="8" bgcolor="grey" align="center">Core</td>
   </tr>
   <tr>
     <td>Catalog</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -59,8 +61,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Schema</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -72,8 +74,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Managed location in catalog</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -85,8 +87,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Managed location in schema</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -98,8 +100,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Credential</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -111,8 +113,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>External Location</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -124,8 +126,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Multi-tenancy</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -137,8 +139,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
 <tr>
     <td>S3-compatible storage</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -149,13 +151,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Identity & Authentication Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Identity & Authentication</td>
+    <td colspan="8" bgcolor="grey" align="center">Identity & Authentication</td>
   </tr>
   <tr>
     <td>Local identity management (user)</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -167,8 +169,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Group management</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -180,8 +182,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Support for Machine identities (SPs)</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -193,8 +195,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>SCIM to support identity sync from IdP  (users and groups)</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -206,8 +208,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>OAuth/OIDC for Users</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -219,8 +221,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>OAuth/OIDC for Services</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -232,8 +234,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>OAuth client-side support</td>
     <td>Spark integration</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -245,8 +247,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>SAML authentication support</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -257,13 +259,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Access Control & Governance Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Access Control & Governance</td>
+    <td colspan="8" bgcolor="grey" align="center">Access Control & Governance</td>
   </tr>
     <tr>
     <td>Support for change of ownership</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -275,8 +277,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Add permission/privilege support for MODIFY, CREATE_X, BROWSE</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -288,8 +290,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Add remaining permissions/privileges (MANAGE etc)</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -301,8 +303,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Temporary credential vending for tables</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -314,8 +316,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Temporary credential vending for volumes</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -327,8 +329,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Temporary credential vending for models</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -340,8 +342,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Basic grants</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -353,8 +355,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Auditing</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -366,8 +368,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>SQL DCL changes</td>
     <td>Spark Integration</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -379,8 +381,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>RBAC</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -392,8 +394,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Row level filters</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -405,8 +407,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Column level masks</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -418,8 +420,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>ABAC</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -431,8 +433,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Lineage</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -443,12 +445,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Server production-readiness (support running as a HMS replacement) Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
+    <td colspan="8" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
   </tr>
     <tr><td>Monitoring and Telemetry</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -459,8 +461,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td>Database schema upgrades</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -472,8 +474,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Change events</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -485,8 +487,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Server-side storage credential and FileIO caching</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -498,8 +500,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Managed tables and volumes lifecycle</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -510,13 +512,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Tables Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Tables</td>
+    <td colspan="8" bgcolor="grey" align="center">Tables</td>
   </tr>
   <tr>
     <td rowspan="3">External table reads & writes</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -528,8 +530,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Spark integration</td>
     <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -540,8 +542,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Delta integration</td>
     <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -552,8 +554,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="2">Managed Delta table reads</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -565,8 +567,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Delta+Spark integration</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -576,8 +578,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -589,8 +591,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Delta-Spark integration</td>
     <td></td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -601,8 +603,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Delta Kernel integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -613,8 +615,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="2">Delta Uniform tables with read as Iceberg via Iceberg REST API</td>
     <td>API + Server</td>
-    <td align="center">🛠️</td>
-    <td align="center">🛠️</td>
+    
+    
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -626,8 +628,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Delta integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -637,8 +639,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td>Iceberg tables with create+read+write</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -650,8 +652,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Multi-engine data types for column definitions</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -662,13 +664,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Views Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Views</td>
+    <td colspan="8" bgcolor="grey" align="center">Views</td>
   </tr>
     <tr>
     <td>Basic Spark SQL flavor views</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -680,8 +682,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Multi-dialect views</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -693,8 +695,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Iceberg view support</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -706,8 +708,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Materialized views</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -718,8 +720,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td>Metric views</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -731,8 +733,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Streaming tables</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -744,8 +746,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Shallow clones</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -756,13 +758,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Non-tabular and AI assets Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Non-tabular and AI assets</td>
+    <td colspan="8" bgcolor="grey" align="center">Non-tabular and AI assets</td>
   </tr>
   <tr>
     <td rowspan="3">Functions (SQL UDFs, Python UDFs)</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -774,8 +776,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>ML integrations with advanced python SDK</td>
     <td></td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -786,8 +788,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Spark integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -798,8 +800,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Multi-engine functions (SQL)</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -811,8 +813,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Remote functions</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -824,8 +826,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="2">External volumes</td>
     <td>API + Server</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -837,8 +839,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Spark integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -849,8 +851,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="2">Managed volumes</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -862,8 +864,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Spark integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -874,8 +876,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="3">Models and model versions</td>
     <td>API + Server</td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -887,8 +889,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>MLflow integration</td>
     <td></td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
+    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -899,8 +901,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Spark integration</td>
     <td></td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -911,8 +913,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Features tables</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -924,8 +926,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Data monitors</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -936,12 +938,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Sharing Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Sharing</td>
+    <td colspan="8" bgcolor="grey" align="center">Sharing</td>
   </tr>
     <tr><td>Open Sharing</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -953,8 +955,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
       <tr>
     <td>Shares</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -966,8 +968,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
       <tr>
     <td>Recipients</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -979,8 +981,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
       <tr>
     <td>Providers</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -991,13 +993,13 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
   <!-- Federation Section -->
   <tr>
-    <td colspan="10" bgcolor="grey" align="center">Federation</td>
+    <td colspan="8" bgcolor="grey" align="center">Federation</td>
   </tr>
   <tr>
     <td>Connections</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -1009,8 +1011,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Foreign objects (catalogs, schemas, tables)</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>
@@ -1022,8 +1024,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Support for different data sources: JDBC, Iceberg REST, HMS</td>
     <td>API + Server</td>
-    <td></td>
-    <td></td>
+    
+    
     <td></td>
     <td></td>
     <td></td>

--- a/roadmap.md
+++ b/roadmap.md
@@ -3,31 +3,29 @@
 This document outlines the roadmap for the Unity Catalog open source project. As always,
 features may move in/out of milestones pending available resources, priorities, and community discussions.
 
-## 0.5 Release priorities
+## 0.6+
 
-### Managed Delta table support
+### View support
 
-Delta's [Catalog managed commits](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#catalog-managed-tables) are the basis for many new and powerful client (Delta) and server side features and 
-were introduced as `experimental` in the 0.4 release. 
-* This release will introduce new Delta Catalog APIs as well as
-moving to non-experimental. 
-* In addition, we'll be providing Uniform support with this release.
+Views provide governed, reusable definitions over tables.
+We will start with supporting basic Spark SQL views and then progress toward broader engine interoperability.
 
-### Metric Views
+### Full Iceberg REST Catalog support
 
-Metric views provide a centralized way to define and manage consistent, reusable, and governed core business metrics. 
-This will enable Unity Catalog to abstract your complex business logic into centralized definitions, enabling 
-you to have a single source of metric truth for your key performance indicators.
+The Iceberg REST Catalog provides an open interface for engines and tools to discover and access Iceberg tables. We will continue to strengthen interoperability through this interface, including Delta Uniform table access and Iceberg table lifecycle support, so more engines can access data registered in Unity Catalog through open standards.
 
-* This release will provide an experimental preview of this new capability.
+### S3-compatible storage
 
-### Authentication
-Modular authentication will allow you to reuse your existing auth to secure Unity Catalog.
+S3-compatible storage support will allow Unity Catalog deployments to use object stores that expose an S3-compatible API. This allows Unity Catalog to be deployed across a broader range of on-prem and cloud environments.
+
+### Production hardening
+
+Production hardening focuses on the reliability and operational maturity needed for broader production deployments.
+The roadmap includes monitoring and telemetry, database schema upgrades, server-side storage credential and FileIO caching, and managed table and volume lifecycle support.
 
 
 ## Full roadmap
 
-<table>
   <tr>
     <td><b>Feature</b></td>
     <td><b>Area</b></td>
@@ -35,17 +33,23 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td><b>v0.2</b></td>
     <td><b>v0.3</b></td>
     <td><b>v0.4</b></td>
-    <td><b>v0.5+</b></td>
+    <td><b>v0.5</b></td>
+    <td><b>v0.6</b></td>
+    <td><b>v0.7</b></td>
+    <td><b>v0.8</b></td>
+    <td><b>v1.0+</b></td>
   </tr>
-  
   <!-- Core Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Core</td>
+    <td colspan="11" bgcolor="grey" align="center">Core</td>
   </tr>
-
   <tr>
     <td>Catalog</td>
     <td>API + Server</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -60,6 +64,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Managed location in catalog</td>
@@ -68,6 +76,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -78,6 +90,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Credential</td>
@@ -86,6 +102,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -96,22 +116,41 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Multi-tenancy</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-
+<tr>
+    <td>S3-compatible storage</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
   <!-- Identity & Authentication Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Identity & Authentication</td>
+    <td colspan="11" bgcolor="grey" align="center">Identity & Authentication</td>
   </tr>
-
   <tr>
     <td>Local identity management (user)</td>
     <td>API + Server</td>
@@ -120,29 +159,45 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Group management</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Support for Machine identities (SPs)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>SCIM to support identity sync from IdP  (users and groups)</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -156,14 +211,22 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>OAuth/OIDC for Services</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -174,6 +237,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>SAML authentication support</td>
@@ -182,54 +249,63 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-
   <!-- Access Control & Governance Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Access Control & Governance</td>
+    <td colspan="11" bgcolor="grey" align="center">Access Control & Governance</td>
   </tr>
-
-  <tr>
+    <tr>
     <td>Support for change of ownership</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Add permission/privilege support for MODIFY, CREATE_X, BROWSE</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Add remaining permissions/privileges (MANAGE etc)</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  <tr>
-    <td>Permission parity with Databricks UC</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Temporary credential vending for tables</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -243,11 +319,19 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Temporary credential vending for models</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -261,10 +345,18 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Auditing</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -278,11 +370,19 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
   </tr>
   <tr>
     <td>RBAC</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -296,11 +396,19 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
   <tr>
     <td>Column level masks</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -314,6 +422,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
   <tr>
@@ -323,31 +435,39 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <!-- Server production-readiness (support running as a HMS replacement) Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
+    <td colspan="11" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
   </tr>
-
-  <tr>
-    <td>Monitoring and Telemetry</td>
+    <tr><td>Monitoring and Telemetry</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
-    <td>Database schema upgrades</td>
+    <tr><td>Database schema upgrades</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Change events</td>
@@ -356,17 +476,49 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td align="center">❓</td>
   </tr>
-  
+  <tr>
+    <td>Server-side storage credential and FileIO caching</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+  <tr>
+    <td>Managed tables and volumes lifecycle</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
   <!-- Tables Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Tables</td>
+    <td colspan="11" bgcolor="grey" align="center">Tables</td>
   </tr>
-  
   <tr>
     <td rowspan="3">External table reads & writes</td>
     <td>API + Server</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -380,6 +532,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Delta integration</td>
@@ -388,11 +544,18 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
     <td rowspan="2">Managed Delta table reads</td>
     <td>API + Server</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -406,21 +569,31 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
+    <tr><td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
     <td>Delta-Spark integration</td>
     <td></td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -432,8 +605,11 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
     <td rowspan="2">Delta Uniform tables with read as Iceberg via Iceberg REST API</td>
     <td>API + Server</td>
@@ -441,6 +617,10 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
   <tr>
@@ -450,111 +630,141 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
+    <tr><td>Iceberg tables with create+read+write</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
   <tr>
-    <td rowspan="1">Iceberg tables with create+read+write</td>
+    <td>Multi-engine data types for column definitions</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  
-  <tr>
-    <td rowspan="1">Multi-engine data types for column definitions</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <!-- Views Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Views</td>
+    <td colspan="11" bgcolor="grey" align="center">Views</td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Basic Spark SQL flavor views</td>
+    <tr>
+    <td>Basic Spark SQL flavor views</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+    <tr>
+    <td>Multi-dialect views</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Multi-dialect views</td>
+    <tr>
+    <td>Iceberg view support</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+    <tr>
+    <td>Materialized views</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
+  </tr>
+    <tr><td>Metric views</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+  </tr>
+    <tr>
+    <td>Streaming tables</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center">❓</td>
+  </tr>
+    <tr>
+    <td>Shallow clones</td>
+    <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Iceberg view support</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  
-  <tr>
-    <td rowspan="1">Materialized views</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center">🛠️</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-
-  <tr>
-    <td rowspan="1">Metric views</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center">🛠️</td>
-  </tr>
-  
-  <tr>
-    <td rowspan="1">Streaming tables</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center">🛠️</td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  
-  <tr>
-    <td rowspan="1">Shallow clones</td>
-    <td>API + Server</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-  </tr>
-  
   <!-- Non-tabular and AI assets Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Non-tabular and AI assets</td>
+    <td colspan="11" bgcolor="grey" align="center">Non-tabular and AI assets</td>
   </tr>
-  
   <tr>
     <td rowspan="3">Functions (SQL UDFs, Python UDFs)</td>
     <td>API + Server</td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -568,36 +778,49 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Multi-engine functions (SQL)</td>
+    <td>Multi-engine functions (SQL)</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Remote functions</td>
+    <td>Remote functions</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <tr>
     <td rowspan="2">External volumes</td>
     <td>API + Server</td>
@@ -606,16 +829,23 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
     <td rowspan="2">Managed volumes</td>
     <td>API + Server</td>
@@ -624,20 +854,31 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
     <td rowspan="3">Models and model versions</td>
     <td>API + Server</td>
     <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
@@ -650,118 +891,144 @@ Modular authentication will allow you to reuse your existing auth to secure Unit
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  <tr>
+    <tr>
     <td>Spark integration</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Features tables</td>
+    <td>Features tables</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Data monitors</td>
+    <td>Data monitors</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <!-- Sharing Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Sharing</td>
+    <td colspan="11" bgcolor="grey" align="center">Sharing</td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Delta Sharing integration</td>
+    <tr><td>Open Sharing</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Shares</td>
+      <tr>
+    <td>Shares</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Recipients</td>
+      <tr>
+    <td>Recipients</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Providers</td>
+      <tr>
+    <td>Providers</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
   <!-- Federation Section -->
   <tr>
-    <td colspan="7" bgcolor="grey" align="center">Federation</td>
+    <td colspan="11" bgcolor="grey" align="center">Federation</td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Connections</td>
+    <td>Connections</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
   <tr>
-    <td rowspan="1">Foreign objects (catalogs, schemas, tables)</td>
+    <td>Foreign objects (catalogs, schemas, tables)</td>
     <td>API + Server</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
   </tr>
-  
-  <tr>
-    <td rowspan="1">Support for different data sources: JDBC, Iceberg REST, HMS</td>
+    <tr>
+    <td>Support for different data sources: JDBC, Iceberg REST, HMS</td>
     <td>API + Server</td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
-    <td align="center">❓</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
-  
-  <!-- UI Section -->
-  <tr>
-    <td colspan="7" bgcolor="grey" align="center">UI (needs to be completed)</td>
-  </tr>
-</table>

--- a/roadmap.md
+++ b/roadmap.md
@@ -36,8 +36,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td><b>v0.4</b></td>
     <td><b>v0.5</b></td>
     <td><b>v0.6</b></td>
+    <td><b>v0.7</b></td>
     <td><b>v0.8+</b></td>
-    
   </tr>
   <!-- Core Section -->
   <tr>

--- a/roadmap.md
+++ b/roadmap.md
@@ -26,6 +26,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
 
 ## Full roadmap
 
+<table>
   <tr>
     <td><b>Feature</b></td>
     <td><b>Area</b></td>
@@ -1032,3 +1033,4 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
   </tr>
+</table>

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,8 +32,6 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td><b>Feature</b></td>
     <td><b>Area</b></td>
-    
-    
     <td><b>v0.3</b></td>
     <td><b>v0.4</b></td>
     <td><b>v0.5</b></td>
@@ -48,106 +46,82 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Catalog</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Schema</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Managed location in catalog</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Managed location in schema</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Credential</td>
     <td>API + Server</td>
-    
-    
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>External Location</td>
     <td>API + Server</td>
-    
-    
     <td align="center">🛠️</td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Multi-tenancy</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
 <tr>
     <td>S3-compatible storage</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <!-- Identity & Authentication Section -->
   <tr>
@@ -156,106 +130,82 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Local identity management (user)</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Group management</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Support for Machine identities (SPs)</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>SCIM to support identity sync from IdP  (users and groups)</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>OAuth/OIDC for Users</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>OAuth/OIDC for Services</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>OAuth client-side support</td>
     <td>Spark integration</td>
-    
-    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>SAML authentication support</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <!-- Access Control & Governance Section -->
   <tr>
@@ -264,184 +214,142 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Support for change of ownership</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Add permission/privilege support for MODIFY, CREATE_X, BROWSE</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Add remaining permissions/privileges (MANAGE etc)</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Temporary credential vending for tables</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Temporary credential vending for volumes</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Temporary credential vending for models</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Basic grants</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Auditing</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>SQL DCL changes</td>
     <td>Spark Integration</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>RBAC</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Row level filters</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Column level masks</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>ABAC</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Lineage</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <!-- Server production-readiness (support running as a HMS replacement) Section -->
   <tr>
@@ -449,66 +357,51 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td>Monitoring and Telemetry</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr><td>Database schema upgrades</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Change events</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Server-side storage credential and FileIO caching</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Managed tables and volumes lifecycle</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <!-- Tables Section -->
   <tr>
@@ -517,150 +410,114 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="3">External table reads & writes</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Spark integration</td>
     <td></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Delta integration</td>
     <td></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td rowspan="2">Managed Delta table reads</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Delta+Spark integration</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr><td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Delta-Spark integration</td>
     <td></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Delta Kernel integration</td>
     <td></td>
-    
-    
     <td align="center" bgcolor="green"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td rowspan="2">Delta Uniform tables with read as Iceberg via Iceberg REST API</td>
     <td>API + Server</td>
-    
-    
     <td align="center">🛠️</td>
     <td align="center">🛠️</td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Delta integration</td>
     <td></td>
-    
-    
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr><td>Iceberg tables with create+read+write</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Multi-engine data types for column definitions</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <!-- Views Section -->
   <tr>
@@ -669,92 +526,71 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <tr>
     <td>Basic Spark SQL flavor views</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Multi-dialect views</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Iceberg view support</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Materialized views</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
     <tr><td>Metric views</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Streaming tables</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
     <tr>
     <td>Shallow clones</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <!-- Non-tabular and AI assets Section -->
   <tr>
@@ -763,178 +599,136 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td rowspan="3">Functions (SQL UDFs, Python UDFs)</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>ML integrations with advanced python SDK</td>
     <td></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Spark integration</td>
     <td></td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Multi-engine functions (SQL)</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Remote functions</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td rowspan="2">External volumes</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Spark integration</td>
     <td></td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td rowspan="2">Managed volumes</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Spark integration</td>
     <td></td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td rowspan="3">Models and model versions</td>
     <td>API + Server</td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>MLflow integration</td>
     <td></td>
-    
-    
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
     <tr>
     <td>Spark integration</td>
     <td></td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <tr>
     <td>Features tables</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Data monitors</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <!-- Sharing Section -->
   <tr>
@@ -942,54 +736,42 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   </tr>
     <tr><td>Open Sharing</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
       <tr>
     <td>Shares</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
       <tr>
     <td>Recipients</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
       <tr>
     <td>Providers</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
   <!-- Federation Section -->
   <tr>
@@ -998,40 +780,31 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
   <tr>
     <td>Connections</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
   <tr>
     <td>Foreign objects (catalogs, schemas, tables)</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center">❓</td>
-    
   </tr>
     <tr>
     <td>Support for different data sources: JDBC, Iceberg REST, HMS</td>
     <td>API + Server</td>
-    
-    
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    
   </tr>
 </table>

--- a/roadmap.md
+++ b/roadmap.md
@@ -36,13 +36,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td><b>v0.4</b></td>
     <td><b>v0.5</b></td>
     <td><b>v0.6</b></td>
-    <td><b>v0.7</b></td>
-    <td><b>v0.8</b></td>
-    <td><b>v1.0+</b></td>
+    <td><b>v0.8+</b></td>
+    
   </tr>
   <!-- Core Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Core</td>
+    <td colspan="10" bgcolor="grey" align="center">Core</td>
   </tr>
   <tr>
     <td>Catalog</td>
@@ -55,7 +54,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Schema</td>
@@ -68,7 +67,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Managed location in catalog</td>
@@ -81,7 +80,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Managed location in schema</td>
@@ -94,7 +93,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Credential</td>
@@ -107,7 +106,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>External Location</td>
@@ -120,7 +119,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Multi-tenancy</td>
@@ -132,8 +131,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
 <tr>
     <td>S3-compatible storage</td>
@@ -146,11 +145,11 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <!-- Identity & Authentication Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Identity & Authentication</td>
+    <td colspan="10" bgcolor="grey" align="center">Identity & Authentication</td>
   </tr>
   <tr>
     <td>Local identity management (user)</td>
@@ -163,7 +162,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Group management</td>
@@ -175,8 +174,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Support for Machine identities (SPs)</td>
@@ -189,7 +188,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>SCIM to support identity sync from IdP  (users and groups)</td>
@@ -202,7 +201,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>OAuth/OIDC for Users</td>
@@ -215,7 +214,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>OAuth/OIDC for Services</td>
@@ -228,7 +227,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>OAuth client-side support</td>
@@ -241,7 +240,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>SAML authentication support</td>
@@ -253,12 +252,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <!-- Access Control & Governance Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Access Control & Governance</td>
+    <td colspan="10" bgcolor="grey" align="center">Access Control & Governance</td>
   </tr>
     <tr>
     <td>Support for change of ownership</td>
@@ -270,8 +269,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Add permission/privilege support for MODIFY, CREATE_X, BROWSE</td>
@@ -284,7 +283,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Add remaining permissions/privileges (MANAGE etc)</td>
@@ -297,7 +296,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Temporary credential vending for tables</td>
@@ -310,7 +309,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Temporary credential vending for volumes</td>
@@ -323,7 +322,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Temporary credential vending for models</td>
@@ -336,7 +335,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Basic grants</td>
@@ -349,7 +348,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Auditing</td>
@@ -361,8 +360,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>SQL DCL changes</td>
@@ -374,8 +373,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>RBAC</td>
@@ -387,8 +386,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Row level filters</td>
@@ -400,8 +399,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Column level masks</td>
@@ -413,8 +412,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>ABAC</td>
@@ -426,8 +425,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Lineage</td>
@@ -439,12 +438,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <!-- Server production-readiness (support running as a HMS replacement) Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
+    <td colspan="10" bgcolor="grey" align="center">Server production-readiness (support running as a HMS replacement)</td>
   </tr>
     <tr><td>Monitoring and Telemetry</td>
     <td>API + Server</td>
@@ -456,7 +455,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr><td>Database schema upgrades</td>
     <td>API + Server</td>
@@ -468,7 +467,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Change events</td>
@@ -480,8 +479,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Server-side storage credential and FileIO caching</td>
@@ -494,7 +493,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Managed tables and volumes lifecycle</td>
@@ -507,11 +506,11 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <!-- Tables Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Tables</td>
+    <td colspan="10" bgcolor="grey" align="center">Tables</td>
   </tr>
   <tr>
     <td rowspan="3">External table reads & writes</td>
@@ -524,7 +523,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Spark integration</td>
@@ -536,7 +535,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Delta integration</td>
@@ -548,7 +547,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td rowspan="2">Managed Delta table reads</td>
@@ -561,7 +560,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Delta+Spark integration</td>
@@ -573,7 +572,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr><td rowspan="3">Managed Delta tables creates+writes with catalog-managed commits</td>
     <td>API + Server</td>
@@ -585,7 +584,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Delta-Spark integration</td>
@@ -597,7 +596,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Delta Kernel integration</td>
@@ -609,7 +608,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td rowspan="2">Delta Uniform tables with read as Iceberg via Iceberg REST API</td>
@@ -622,7 +621,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Delta integration</td>
@@ -634,7 +633,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr><td>Iceberg tables with create+read+write</td>
     <td>API + Server</td>
@@ -646,7 +645,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Multi-engine data types for column definitions</td>
@@ -659,11 +658,11 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <!-- Views Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Views</td>
+    <td colspan="10" bgcolor="grey" align="center">Views</td>
   </tr>
     <tr>
     <td>Basic Spark SQL flavor views</td>
@@ -676,7 +675,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Multi-dialect views</td>
@@ -688,8 +687,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Iceberg view support</td>
@@ -702,7 +701,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Materialized views</td>
@@ -714,8 +713,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
     <tr><td>Metric views</td>
     <td>API + Server</td>
@@ -727,7 +726,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Streaming tables</td>
@@ -739,8 +738,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
     <tr>
     <td>Shallow clones</td>
@@ -752,12 +751,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <!-- Non-tabular and AI assets Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Non-tabular and AI assets</td>
+    <td colspan="10" bgcolor="grey" align="center">Non-tabular and AI assets</td>
   </tr>
   <tr>
     <td rowspan="3">Functions (SQL UDFs, Python UDFs)</td>
@@ -770,7 +769,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>ML integrations with advanced python SDK</td>
@@ -782,7 +781,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Spark integration</td>
@@ -793,8 +792,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Multi-engine functions (SQL)</td>
@@ -806,8 +805,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Remote functions</td>
@@ -819,8 +818,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td rowspan="2">External volumes</td>
@@ -833,7 +832,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Spark integration</td>
@@ -844,8 +843,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td rowspan="2">Managed volumes</td>
@@ -858,7 +857,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Spark integration</td>
@@ -869,8 +868,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td rowspan="3">Models and model versions</td>
@@ -883,7 +882,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>MLflow integration</td>
@@ -895,7 +894,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
     <tr>
     <td>Spark integration</td>
@@ -906,8 +905,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <tr>
     <td>Features tables</td>
@@ -919,8 +918,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Data monitors</td>
@@ -932,12 +931,12 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <!-- Sharing Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Sharing</td>
+    <td colspan="10" bgcolor="grey" align="center">Sharing</td>
   </tr>
     <tr><td>Open Sharing</td>
     <td>API + Server</td>
@@ -949,7 +948,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
       <tr>
     <td>Shares</td>
@@ -962,7 +961,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
       <tr>
     <td>Recipients</td>
@@ -975,7 +974,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
       <tr>
     <td>Providers</td>
@@ -988,11 +987,11 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
   <!-- Federation Section -->
   <tr>
-    <td colspan="11" bgcolor="grey" align="center">Federation</td>
+    <td colspan="10" bgcolor="grey" align="center">Federation</td>
   </tr>
   <tr>
     <td>Connections</td>
@@ -1004,8 +1003,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
   <tr>
     <td>Foreign objects (catalogs, schemas, tables)</td>
@@ -1017,8 +1016,8 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center">❓</td>
+    
   </tr>
     <tr>
     <td>Support for different data sources: JDBC, Iceberg REST, HMS</td>
@@ -1030,7 +1029,7 @@ The roadmap includes monitoring and telemetry, database schema upgrades, server-
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg" alt="done"/></td>
+    
   </tr>
 </table>


### PR DESCRIPTION
Summary

Add v0.6, v0.7, v0.8, and v1.0+ roadmap columns.
Update release timing for supported capabilities and planned work.
Add the 0.6+ priorities introduction.