### PR TITLE
[Server] Refresh Casbin policy across server instances

### DIFF
--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -101,6 +101,29 @@ values under that pattern can steer JWKS fetches (an SSRF-style surface).
 Use wildcard issuers only where necessary, only for domains you control, and avoid patterns that
 cover internal or sensitive hosts. Prefer exact issuer URLs and `https://` issuers when possible.
 
+### Multiple server instances
+
+Authorization decisions use an in-memory Casbin policy loaded from the shared `casbin_rule` table.
+A grant or revoke written on one server process is not visible to other processes until they reload
+that table.
+
+Refresh is **off by default**. For any multi-instance deployment that shares one database (HA,
+rolling updates, horizontal scale), set:
+
+```properties
+server.authorization.policy-refresh=true
+```
+
+Optional tuning:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `server.authorization.policy-refresh-interval` | `PT1M` | How often each instance polls `casbin_rule` |
+| `server.authorization.policy-refresh-debounce-interval` | `PT1S` | Minimum gap between deny-triggered reloads |
+
+Revocations propagate on the poll interval. A stale deny (a grant not yet seen) can trigger one
+debounced reload before returning 403.
+
 ### Restart the UC Server
 
 Now that the Google Authentication is configured, restart the UC Server with the following command.

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -34,6 +34,29 @@ server.audiences=
 server.cookie-timeout=P5D
 server.access-token-timeout=PT24H
 
+# Authorization policy refresh.
+# Each server instance keeps the Casbin policy set in memory, so an instance must poll the shared
+# database to see grants and revocations made through another instance. Leave this enabled whenever
+# more than one instance runs against one database: with it disabled, a revocation made through one
+# instance is never honoured by the others, which keep allowing access with no error.
+# Disabling this turns off both the periodic poll and the refresh on a denied request, restoring the
+# behaviour from before either existed. It is a full kill switch, not just a way to stop polling.
+# Default: enable
+# server.authorization.policy-refresh=enable
+#
+# How often to check for changes. The check is a single aggregate over the casbin_rule table, whose
+# cost grows with the number of policy rows; deployments with very large policy sets may want to
+# raise this. Revocations take effect within roughly this interval.
+# Default: PT1S
+# server.authorization.policy-refresh-interval=PT1S
+#
+# Shortest interval between two refreshes triggered by a denied request. A denied request refreshes
+# once and retries before returning 403, so a privilege granted through another instance moments
+# earlier is honoured immediately rather than after the next poll. This bounds the work an
+# unauthorized caller can force by repeatedly hitting a denied endpoint.
+# Default: PT1S
+# server.authorization.policy-refresh-debounce=PT1S
+
 # Enable MANAGED table
 # Default: true (enabled)
 # server.managed-table.enabled=true

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -34,27 +34,9 @@ server.audiences=
 server.cookie-timeout=P5D
 server.access-token-timeout=PT24H
 
-# Authorization policy refresh.
-# Each server instance keeps the Casbin policy set in memory, so an instance must poll the shared
-# database to see grants and revocations made through another instance. Leave this enabled whenever
-# more than one instance runs against one database: with it disabled, a revocation made through one
-# instance is never honoured by the others, which keep allowing access with no error.
-# Disabling this turns off both the periodic poll and the refresh on a denied request, restoring the
-# behaviour from before either existed. It is a full kill switch, not just a way to stop polling.
-# Default: enable
+# Authorization policy refresh (required for multiple instances on one database).
 # server.authorization.policy-refresh=enable
-#
-# How often to check for changes. The check is a single aggregate over the casbin_rule table, whose
-# cost grows with the number of policy rows; deployments with very large policy sets may want to
-# raise this. Revocations take effect within roughly this interval.
-# Default: PT1S
 # server.authorization.policy-refresh-interval=PT1S
-#
-# Shortest interval between two refreshes triggered by a denied request. A denied request refreshes
-# once and retries before returning 403, so a privilege granted through another instance moments
-# earlier is honoured immediately rather than after the next poll. This bounds the work an
-# unauthorized caller can force by repeatedly hitting a denied endpoint.
-# Default: PT1S
 # server.authorization.policy-refresh-debounce=PT1S
 
 # Enable MANAGED table

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -35,19 +35,20 @@ server.cookie-timeout=P5D
 server.access-token-timeout=PT24H
 
 # Authorization policy refresh across server instances that share one database.
-# Each instance keeps Casbin policy in memory; without refresh, grants/revokes made
-# through another instance are invisible until restart.
+# Required for any multi-instance / HA deployment: each instance keeps Casbin
+# policy in memory, and without refresh, grants/revokes made through another
+# instance are invisible until restart. See docs/server/auth.md.
 #
 # server.authorization.policy-refresh=false
-#   Kill switch. "false" (default) turns off background polling and deny-path reload
-#   (single-instance deployments). Set to "true" for multi-instance shared-DB setups.
+#   Kill switch. "false" (default) is for single-instance deployments. Set to
+#   "true" whenever more than one UC server process shares this database.
 #
 # server.authorization.policy-refresh-interval=PT1M
 #   How often this instance polls casbin_rule for changes and reloads if needed.
 #   Lower this for faster revoke propagation across replicas; raise it for very large
 #   policy tables to reduce count(*)/max(id) load.
 #
-# server.authorization.policy-refresh-debounce=PT1S
+# server.authorization.policy-refresh-debounce-interval=PT1S
 #   Minimum time between deny-triggered reloads. On 403, we may reload once and
 #   re-check (covers stale denies across instances); debounce avoids a reload stampede
 #   under many legitimate denials.

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -38,9 +38,9 @@ server.access-token-timeout=PT24H
 # Each instance keeps Casbin policy in memory; without refresh, grants/revokes made
 # through another instance are invisible until restart.
 #
-# server.authorization.policy-refresh=disable
-#   Kill switch. "disable" (default) turns off background polling and deny-path reload
-#   (single-instance deployments). Set to "enable" for multi-instance shared-DB setups.
+# server.authorization.policy-refresh=false
+#   Kill switch. "false" (default) turns off background polling and deny-path reload
+#   (single-instance deployments). Set to "true" for multi-instance shared-DB setups.
 #
 # server.authorization.policy-refresh-interval=PT1M
 #   How often this instance polls casbin_rule for changes and reloads if needed.

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -34,10 +34,22 @@ server.audiences=
 server.cookie-timeout=P5D
 server.access-token-timeout=PT24H
 
-# Authorization policy refresh (required for multiple instances on one database).
+# Authorization policy refresh across server instances that share one database.
+# Each instance keeps Casbin policy in memory; without refresh, grants/revokes made
+# through another instance are invisible until restart.
+#
 # server.authorization.policy-refresh=enable
+#   Kill switch. "enable" (default) turns on background polling and deny-path reload.
+#   Set to "disable" to turn both off (single-instance only; multi-instance is unsafe).
+#
 # server.authorization.policy-refresh-interval=PT1S
+#   How often this instance polls casbin_rule for changes and reloads if needed.
+#   Raise this for very large policy tables to reduce count(*)/max(id) load.
+#
 # server.authorization.policy-refresh-debounce=PT1S
+#   Minimum time between deny-triggered reloads. On 403, we may reload once and
+#   re-check (covers stale denies across instances); debounce avoids a reload stampede
+#   under many legitimate denials.
 
 # Enable MANAGED table
 # Default: true (enabled)

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -38,13 +38,14 @@ server.access-token-timeout=PT24H
 # Each instance keeps Casbin policy in memory; without refresh, grants/revokes made
 # through another instance are invisible until restart.
 #
-# server.authorization.policy-refresh=enable
-#   Kill switch. "enable" (default) turns on background polling and deny-path reload.
-#   Set to "disable" to turn both off (single-instance only; multi-instance is unsafe).
+# server.authorization.policy-refresh=disable
+#   Kill switch. "disable" (default) turns off background polling and deny-path reload
+#   (single-instance deployments). Set to "enable" for multi-instance shared-DB setups.
 #
-# server.authorization.policy-refresh-interval=PT1S
+# server.authorization.policy-refresh-interval=PT1M
 #   How often this instance polls casbin_rule for changes and reloads if needed.
-#   Raise this for very large policy tables to reduce count(*)/max(id) load.
+#   Lower this for faster revoke propagation across replicas; raise it for very large
+#   policy tables to reduce count(*)/max(id) load.
 #
 # server.authorization.policy-refresh-debounce=PT1S
 #   Minimum time between deny-triggered reloads. On 403, we may reload once and

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -64,10 +64,7 @@ public class UnityCatalogServer implements AutoCloseable {
   /** True when this server built the configurator itself and must therefore close it. */
   private final boolean ownsHibernateConfigurator;
 
-  /**
-   * Retained so {@link #close()} can stop the authorizer's background policy refresh. Assigned
-   * during {@link #initializeServer}, so it may still be null if construction fails early.
-   */
+  /** Set during {@link #initializeServer}; may be null if construction fails early. */
   private UnityCatalogAuthorizer authorizer;
 
   static {
@@ -93,8 +90,7 @@ public class UnityCatalogServer implements AutoCloseable {
     } catch (Throwable t) {
       // Construction failed after the SessionFactory was built; close it so a failed boot does
       // not leak its connection pool. Errors matter as much as RuntimeExceptions here: a
-      // NoClassDefFoundError out of initializeServer() would leak the pool just the same. The
-      // authorizer goes first because its policy refresh polls through the SessionFactory.
+      // NoClassDefFoundError out of initializeServer() would leak the pool just the same.
       closeAuthorizer(t);
       closeOwnedSessionFactory(t);
       throw t;
@@ -116,10 +112,7 @@ public class UnityCatalogServer implements AutoCloseable {
     }
   }
 
-  /**
-   * Stops the authorizer's background work if it has any. A failure to close is attached to {@code
-   * primaryFailure} so it cannot mask the original error; pass null when there is none.
-   */
+  /** Stops the authorizer if closeable; failures are suppressed onto {@code primaryFailure}. */
   private void closeAuthorizer(Throwable primaryFailure) {
     if (!(authorizer instanceof AutoCloseable closeable)) {
       return;
@@ -177,10 +170,15 @@ public class UnityCatalogServer implements AutoCloseable {
     if (serverProperties.isAuthorizationEnabled()) {
       try {
         LOGGER.info("Initializing JCasbinAuthorizer...");
-        UnityCatalogAuthorizer authorizer =
+        JCasbinAuthorizer authorizer =
             new JCasbinAuthorizer(hibernateConfigurator, serverProperties);
-        new UnityAccessUtil(repositories).initializeAdmin(authorizer);
-        return authorizer;
+        try {
+          new UnityAccessUtil(repositories).initializeAdmin(authorizer);
+          return authorizer;
+        } catch (Exception e) {
+          authorizer.close();
+          throw e;
+        }
       } catch (Exception e) {
         throw new BaseException(ErrorCode.INTERNAL, "Problem initializing authorizer.", e);
       }
@@ -321,10 +319,9 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   /**
-   * Stops the server, stops the authorizer's background policy refresh, and closes the Hibernate
-   * SessionFactory it created, releasing its pooled database connections, which the Armeria
-   * shutdown does not touch and which would otherwise stay open until the JVM exits. A
-   * configurator supplied via {@link Builder#hibernateConfigurator} is
+   * Stops the server and closes the Hibernate SessionFactory it created, releasing its pooled
+   * database connections, which the Armeria shutdown does not touch and which would otherwise stay
+   * open until the JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is
    * left open — the caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its
    * SessionFactory must not be restarted after this call: the factory is closed, so all persistence
    * operations would fail. Safe to call more than once and safe to call before {@link #start()}.
@@ -334,8 +331,6 @@ public class UnityCatalogServer implements AutoCloseable {
     try {
       stop();
     } finally {
-      // Before the SessionFactory: the authorizer's policy refresh polls through it, so closing
-      // the factory first would leave the refresher querying a closed factory.
       closeAuthorizer(null);
       if (ownsHibernateConfigurator) {
         hibernateConfigurator.getSessionFactory().close();

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -64,6 +64,12 @@ public class UnityCatalogServer implements AutoCloseable {
   /** True when this server built the configurator itself and must therefore close it. */
   private final boolean ownsHibernateConfigurator;
 
+  /**
+   * Retained so {@link #close()} can stop the authorizer's background policy refresh. Assigned
+   * during {@link #initializeServer}, so it may still be null if construction fails early.
+   */
+  private UnityCatalogAuthorizer authorizer;
+
   static {
     System.setProperty("log4j.configurationFile", "etc/conf/server.log4j2.properties");
     Configurator.initialize(null, "etc/conf/server.log4j2.properties");
@@ -87,7 +93,9 @@ public class UnityCatalogServer implements AutoCloseable {
     } catch (Throwable t) {
       // Construction failed after the SessionFactory was built; close it so a failed boot does
       // not leak its connection pool. Errors matter as much as RuntimeExceptions here: a
-      // NoClassDefFoundError out of initializeServer() would leak the pool just the same.
+      // NoClassDefFoundError out of initializeServer() would leak the pool just the same. The
+      // authorizer goes first because its policy refresh polls through the SessionFactory.
+      closeAuthorizer(t);
       closeOwnedSessionFactory(t);
       throw t;
     }
@@ -105,6 +113,25 @@ public class UnityCatalogServer implements AutoCloseable {
       hibernateConfigurator.getSessionFactory().close();
     } catch (Throwable closeFailure) {
       primaryFailure.addSuppressed(closeFailure);
+    }
+  }
+
+  /**
+   * Stops the authorizer's background work if it has any. A failure to close is attached to {@code
+   * primaryFailure} so it cannot mask the original error; pass null when there is none.
+   */
+  private void closeAuthorizer(Throwable primaryFailure) {
+    if (!(authorizer instanceof AutoCloseable closeable)) {
+      return;
+    }
+    try {
+      closeable.close();
+    } catch (Exception closeFailure) {
+      if (primaryFailure != null) {
+        primaryFailure.addSuppressed(closeFailure);
+      } else {
+        LOGGER.warn("Failed to close the authorizer", closeFailure);
+      }
     }
   }
 
@@ -128,7 +155,7 @@ public class UnityCatalogServer implements AutoCloseable {
     // Init metastore
     repositories.getMetastoreRepository().initMetastoreIfNeeded();
     // Init authorizer
-    UnityCatalogAuthorizer authorizer =
+    authorizer =
         initializeAuthorizer(
             unityCatalogServerBuilder.serverProperties, hibernateConfigurator, repositories);
     // Configure error response stack traces
@@ -150,7 +177,8 @@ public class UnityCatalogServer implements AutoCloseable {
     if (serverProperties.isAuthorizationEnabled()) {
       try {
         LOGGER.info("Initializing JCasbinAuthorizer...");
-        UnityCatalogAuthorizer authorizer = new JCasbinAuthorizer(hibernateConfigurator);
+        UnityCatalogAuthorizer authorizer =
+            new JCasbinAuthorizer(hibernateConfigurator, serverProperties);
         new UnityAccessUtil(repositories).initializeAdmin(authorizer);
         return authorizer;
       } catch (Exception e) {
@@ -293,9 +321,10 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   /**
-   * Stops the server and closes the Hibernate SessionFactory it created, releasing its pooled
-   * database connections, which the Armeria shutdown does not touch and which would otherwise stay
-   * open until the JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is
+   * Stops the server, stops the authorizer's background policy refresh, and closes the Hibernate
+   * SessionFactory it created, releasing its pooled database connections, which the Armeria
+   * shutdown does not touch and which would otherwise stay open until the JVM exits. A
+   * configurator supplied via {@link Builder#hibernateConfigurator} is
    * left open — the caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its
    * SessionFactory must not be restarted after this call: the factory is closed, so all persistence
    * operations would fail. Safe to call more than once and safe to call before {@link #start()}.
@@ -305,6 +334,9 @@ public class UnityCatalogServer implements AutoCloseable {
     try {
       stop();
     } finally {
+      // Before the SessionFactory: the authorizer's policy refresh polls through it, so closing
+      // the factory first would leave the refresher querying a closed factory.
+      closeAuthorizer(null);
       if (ownsHibernateConfigurator) {
         hibernateConfigurator.getSessionFactory().close();
       }

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -1,0 +1,206 @@
+package io.unitycatalog.server.auth;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.casbin.jcasbin.main.SyncedEnforcer;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.NativeQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keeps one server instance's in-memory Casbin policy set in step with the shared database.
+ *
+ * <p>jCasbin evaluates every decision against an in-memory copy of the policy set that {@link
+ * org.casbin.jcasbin.main.CoreEnforcer} loads once, in its constructor. Writes go to the writing
+ * instance's memory and to {@code casbin_rule}, but no other instance ever learns about them. With
+ * more than one replica and no session affinity that means a grant made through one replica is
+ * invisible to the others, and — more seriously — a revocation made through one replica is not
+ * honoured by the others, which keep allowing access and vending credentials with no error and
+ * nothing in the log. This class closes that gap by reloading when the table changes.
+ *
+ * <h2>Change detection</h2>
+ *
+ * <p>Detection is {@code select count(*), coalesce(max(id), 0) from casbin_rule}: when either value
+ * differs from the previously observed pair, the policy set is reloaded. That pair cannot miss a
+ * change, given two properties of the casbin JDBC adapter:
+ *
+ * <ul>
+ *   <li>{@code casbin_rule.id} is an auto-incrementing primary key in every dialect the adapter
+ *       supports, so an insert always moves {@code max(id)}.
+ *   <li>The adapter only ever inserts and deletes — it issues no {@code UPDATE} against the table,
+ *       and even {@code updatePolicy} is a delete followed by an insert.
+ * </ul>
+ *
+ * <p>So an insert moves {@code max(id)}, a delete moves {@code count(*)}, and a delete paired with
+ * an insert leaves the count unchanged but still moves {@code max(id)}. No in-place update exists
+ * that could alter a row's contents without moving one of the two. The comparison is for inequality
+ * rather than for growth, so even a sequence reset triggers a reload.
+ *
+ * <p>Deliberately plain standard SQL: it works on every backend the adapter supports and needs no
+ * schema change, no extra table, and no database-specific notification mechanism.
+ *
+ * <h2>Concurrency</h2>
+ *
+ * <p>Reloading is safe to do while requests are being served, but only because the enforcer is a
+ * {@link SyncedEnforcer}: it overrides {@code loadPolicy()} to hold a write lock for the whole
+ * clear-then-repopulate cycle, while {@code enforce()} holds the matching read lock. A plain {@code
+ * Enforcer} would let concurrent {@code enforce()} calls observe the momentarily empty model that
+ * {@code loadPolicy()} passes through, denying valid requests.
+ */
+public class CasbinPolicyRefresher implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CasbinPolicyRefresher.class);
+
+  /**
+   * Reuses Hibernate's connection pool rather than opening a second one. {@code casbin_rule} is not
+   * a Hibernate-managed entity, so this has to be a native query.
+   */
+  private static final String VERSION_QUERY =
+      "select count(*), coalesce(max(id), 0) from casbin_rule";
+
+  private final SyncedEnforcer enforcer;
+  private final SessionFactory sessionFactory;
+
+  /**
+   * Last observed {@code (count, maxId)}. Guarded by {@code this} along with every reload, so the
+   * scheduled poll and a deny-triggered refresh can never interleave.
+   *
+   * <p>Deliberately left at a value the table can never report, so the first check always reloads.
+   * Seeding this from the table in the constructor would be a race: the enforcer loads the policy
+   * set before the refresher is built, so a write landing between the two would already be included
+   * in the seeded version while never having reached the enforcer — and would then never be picked
+   * up. One redundant reload at startup is a cheap price for closing that.
+   */
+  private long lastCount = -1;
+
+  private long lastMaxId = -1;
+
+  private ScheduledExecutorService executor;
+
+  public CasbinPolicyRefresher(SyncedEnforcer enforcer, SessionFactory sessionFactory) {
+    this.enforcer = enforcer;
+    this.sessionFactory = sessionFactory;
+  }
+
+  /**
+   * Starts polling for changes made by other instances.
+   *
+   * @param interval delay between the end of one check and the start of the next
+   */
+  public synchronized void start(Duration interval) {
+    if (executor != null) {
+      return;
+    }
+    executor =
+        Executors.newSingleThreadScheduledExecutor(
+            runnable -> {
+              Thread thread = new Thread(runnable, "casbin-policy-refresher");
+              // Daemon so a forgotten refresher can never hold the JVM open.
+              thread.setDaemon(true);
+              return thread;
+            });
+    long millis = Math.max(1, interval.toMillis());
+    // Fixed delay rather than fixed rate: a reload slower than the interval must not cause runs to
+    // queue up back to back.
+    executor.scheduleWithFixedDelay(this::pollQuietly, millis, millis, TimeUnit.MILLISECONDS);
+    LOGGER.info("Casbin policy refresh enabled, checking every {}ms", millis);
+  }
+
+  /** Never lets a failure escape into the executor, which would silently cancel the schedule. */
+  private void pollQuietly() {
+    try {
+      checkAndReload();
+    } catch (Throwable t) {
+      LOGGER.warn("Casbin policy refresh check failed; will retry on the next interval", t);
+    }
+  }
+
+  /**
+   * Reloads the policy set if the table has changed since the last observation.
+   *
+   * @return true if a reload happened
+   */
+  public synchronized boolean checkAndReload() {
+    long[] version = readVersion().orElse(null);
+    if (version == null) {
+      // Could not read the table. Leave the last observed values alone so the next check compares
+      // against a real observation rather than treating the failure as a change.
+      return false;
+    }
+    if (version[0] == lastCount && version[1] == lastMaxId) {
+      return false;
+    }
+    LOGGER.debug(
+        "Casbin policy changed (count {} -> {}, maxId {} -> {}); reloading",
+        lastCount,
+        version[0],
+        lastMaxId,
+        version[1]);
+    enforcer.loadPolicy();
+    recordVersion(version[0], version[1]);
+    return true;
+  }
+
+  /**
+   * Reloads unconditionally, for callers that cannot wait for the next poll — a request about to be
+   * denied, where the grant may have been made through another replica moments ago.
+   */
+  public synchronized void forceReload() {
+    enforcer.loadPolicy();
+    readVersion().ifPresent(version -> recordVersion(version[0], version[1]));
+  }
+
+  private void recordVersion(long count, long maxId) {
+    lastCount = count;
+    lastMaxId = maxId;
+  }
+
+  /**
+   * Reads {@code (count, maxId)}, or empty when the table cannot be read — expected before the
+   * adapter has created it, and possible during a transient database failure.
+   */
+  private Optional<long[]> readVersion() {
+    try {
+      return sessionFactory.fromSession(
+          session -> {
+            NativeQuery<?> query = session.createNativeQuery(VERSION_QUERY);
+            Object[] row = (Object[]) query.getSingleResult();
+            return Optional.of(
+                new long[] {((Number) row[0]).longValue(), ((Number) row[1]).longValue()});
+          });
+    } catch (Exception e) {
+      LOGGER.debug("Could not read the Casbin policy version", e);
+      return Optional.empty();
+    }
+  }
+
+  /** Stops polling. Idempotent, and safe to call whether or not {@link #start} ever ran. */
+  @Override
+  public void close() {
+    ScheduledExecutorService toShutDown;
+    synchronized (this) {
+      toShutDown = executor;
+      executor = null;
+    }
+    if (toShutDown == null) {
+      return;
+    }
+    toShutDown.shutdownNow();
+    try {
+      if (!toShutDown.awaitTermination(5, TimeUnit.SECONDS)) {
+        LOGGER.warn("Casbin policy refresher did not stop within 5s");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Visible for testing: whether the polling thread is currently scheduled. */
+  synchronized boolean isRunning() {
+    return executor != null && !executor.isShutdown();
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -12,71 +12,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Keeps one server instance's in-memory Casbin policy set in step with the shared database.
+ * Reloads the in-memory Casbin policy when {@code casbin_rule} changes in the shared database.
  *
- * <p>jCasbin evaluates every decision against an in-memory copy of the policy set that {@link
- * org.casbin.jcasbin.main.CoreEnforcer} loads once, in its constructor. Writes go to the writing
- * instance's memory and to {@code casbin_rule}, but no other instance ever learns about them. With
- * more than one replica and no session affinity that means a grant made through one replica is
- * invisible to the others, and — more seriously — a revocation made through one replica is not
- * honoured by the others, which keep allowing access and vending credentials with no error and
- * nothing in the log. This class closes that gap by reloading when the table changes.
- *
- * <h2>Change detection</h2>
- *
- * <p>Detection is {@code select count(*), coalesce(max(id), 0) from casbin_rule}: when either value
- * differs from the previously observed pair, the policy set is reloaded. That pair cannot miss a
- * change, given two properties of the casbin JDBC adapter:
- *
- * <ul>
- *   <li>{@code casbin_rule.id} is an auto-incrementing primary key in every dialect the adapter
- *       supports, so an insert always moves {@code max(id)}.
- *   <li>The adapter only ever inserts and deletes — it issues no {@code UPDATE} against the table,
- *       and even {@code updatePolicy} is a delete followed by an insert.
- * </ul>
- *
- * <p>So an insert moves {@code max(id)}, a delete moves {@code count(*)}, and a delete paired with
- * an insert leaves the count unchanged but still moves {@code max(id)}. No in-place update exists
- * that could alter a row's contents without moving one of the two. The comparison is for inequality
- * rather than for growth, so even a sequence reset triggers a reload.
- *
- * <p>Deliberately plain standard SQL: it works on every backend the adapter supports and needs no
- * schema change, no extra table, and no database-specific notification mechanism.
- *
- * <h2>Concurrency</h2>
- *
- * <p>Reloading is safe to do while requests are being served, but only because the enforcer is a
- * {@link SyncedEnforcer}: it overrides {@code loadPolicy()} to hold a write lock for the whole
- * clear-then-repopulate cycle, while {@code enforce()} holds the matching read lock. A plain {@code
- * Enforcer} would let concurrent {@code enforce()} calls observe the momentarily empty model that
- * {@code loadPolicy()} passes through, denying valid requests.
+ * <p>Change detection uses {@code select count(*), coalesce(max(id), 0) from casbin_rule}. The JDBC
+ * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least one
+ * of the two values. Requires a {@link SyncedEnforcer} so {@code loadPolicy()} is safe under concurrent
+ * {@code enforce()} calls.
  */
 public class CasbinPolicyRefresher implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CasbinPolicyRefresher.class);
 
-  /**
-   * Reuses Hibernate's connection pool rather than opening a second one. {@code casbin_rule} is not
-   * a Hibernate-managed entity, so this has to be a native query.
-   */
   private static final String VERSION_QUERY =
       "select count(*), coalesce(max(id), 0) from casbin_rule";
 
   private final SyncedEnforcer enforcer;
   private final SessionFactory sessionFactory;
 
-  /**
-   * Last observed {@code (count, maxId)}. Guarded by {@code this} along with every reload, so the
-   * scheduled poll and a deny-triggered refresh can never interleave.
-   *
-   * <p>Deliberately left at a value the table can never report, so the first check always reloads.
-   * Seeding this from the table in the constructor would be a race: the enforcer loads the policy
-   * set before the refresher is built, so a write landing between the two would already be included
-   * in the seeded version while never having reached the enforcer — and would then never be picked
-   * up. One redundant reload at startup is a cheap price for closing that.
-   */
+  // Initial -1 forces a reload on first check (see recordVersion).
   private long lastCount = -1;
-
   private long lastMaxId = -1;
 
   private ScheduledExecutorService executor;
@@ -86,11 +40,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     this.sessionFactory = sessionFactory;
   }
 
-  /**
-   * Starts polling for changes made by other instances.
-   *
-   * @param interval delay between the end of one check and the start of the next
-   */
   public synchronized void start(Duration interval) {
     if (executor != null) {
       return;
@@ -99,18 +48,14 @@ public class CasbinPolicyRefresher implements AutoCloseable {
         Executors.newSingleThreadScheduledExecutor(
             runnable -> {
               Thread thread = new Thread(runnable, "casbin-policy-refresher");
-              // Daemon so a forgotten refresher can never hold the JVM open.
               thread.setDaemon(true);
               return thread;
             });
     long millis = Math.max(1, interval.toMillis());
-    // Fixed delay rather than fixed rate: a reload slower than the interval must not cause runs to
-    // queue up back to back.
     executor.scheduleWithFixedDelay(this::pollQuietly, millis, millis, TimeUnit.MILLISECONDS);
     LOGGER.info("Casbin policy refresh enabled, checking every {}ms", millis);
   }
 
-  /** Never lets a failure escape into the executor, which would silently cancel the schedule. */
   private void pollQuietly() {
     try {
       checkAndReload();
@@ -119,16 +64,10 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  /**
-   * Reloads the policy set if the table has changed since the last observation.
-   *
-   * @return true if a reload happened
-   */
+  /** @return true if a reload happened */
   public synchronized boolean checkAndReload() {
     long[] version = readVersion().orElse(null);
     if (version == null) {
-      // Could not read the table. Leave the last observed values alone so the next check compares
-      // against a real observation rather than treating the failure as a change.
       return false;
     }
     if (version[0] == lastCount && version[1] == lastMaxId) {
@@ -145,10 +84,7 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     return true;
   }
 
-  /**
-   * Reloads unconditionally, for callers that cannot wait for the next poll — a request about to be
-   * denied, where the grant may have been made through another replica moments ago.
-   */
+  /** Unconditional reload for callers that cannot wait for the next poll. */
   public synchronized void forceReload() {
     enforcer.loadPolicy();
     readVersion().ifPresent(version -> recordVersion(version[0], version[1]));
@@ -159,10 +95,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     lastMaxId = maxId;
   }
 
-  /**
-   * Reads {@code (count, maxId)}, or empty when the table cannot be read — expected before the
-   * adapter has created it, and possible during a transient database failure.
-   */
   private Optional<long[]> readVersion() {
     try {
       return sessionFactory.fromSession(
@@ -178,7 +110,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  /** Stops polling. Idempotent, and safe to call whether or not {@link #start} ever ran. */
   @Override
   public void close() {
     ScheduledExecutorService toShutDown;
@@ -199,7 +130,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  /** Visible for testing: whether the polling thread is currently scheduled. */
   synchronized boolean isRunning() {
     return executor != null && !executor.isShutdown();
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -101,19 +101,20 @@ public class CasbinPolicyRefresher implements AutoCloseable {
         return false;
       }
 
-      LOGGER.debug(
-          "Casbin policy changed (count {} -> {}, maxId {} -> {}); reloading",
-          lastCount,
-          db[0],
-          lastMaxId,
-          db[1]);
-
+      long previousCount = lastCount;
+      long previousMaxId = lastMaxId;
       // May throw: leave checkSeq alone so waiters retry.
       reloader.run();
       // Stamp the probed version, not a post-reload re-read: a fresher DB stamp would claim we
       // loaded state the new enforcer may not contain.
       recordVersion(db[0], db[1]);
       checkSeq.incrementAndGet();
+      LOGGER.info(
+          "Reloaded Casbin policy from casbin_rule (count {} -> {}, maxId {} -> {})",
+          previousCount,
+          db[0],
+          previousMaxId,
+          db[1]);
       return true;
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -15,9 +15,9 @@ import org.slf4j.LoggerFactory;
  * Reloads the in-memory Casbin policy when {@code casbin_rule} changes in the shared database.
  *
  * <p>Change detection uses {@code select count(*), coalesce(max(id), 0) from casbin_rule}. The JDBC
- * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least one
- * of the two values. Requires a {@link SyncedEnforcer} so {@code loadPolicy()} is safe under concurrent
- * {@code enforce()} calls.
+ * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least
+ * one of the two values. Requires a {@link SyncedEnforcer} so {@code loadPolicy()} is safe under
+ * concurrent {@code enforce()} calls.
  */
 public class CasbinPolicyRefresher implements AutoCloseable {
 

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -116,23 +116,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  /**
-   * Unconditional reload for callers that cannot wait for the next poll. Takes the same monitor as
-   * {@link #checkAndReload()} before rebuilding so it cannot deadlock with a concurrent check
-   * (monitor then {@code reloadLock.writeLock()}).
-   */
-  public void forceReload() {
-    synchronized (this) {
-      reloader.run();
-      recordLatestVersion();
-    }
-  }
-
-  /** Must be called while holding {@code this}'s monitor. */
-  private void recordLatestVersion() {
-    readVersion().ifPresent(latest -> recordVersion(latest[0], latest[1]));
-  }
-
   private void recordVersion(long count, long maxId) {
     lastCount = count;
     lastMaxId = maxId;

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -110,6 +110,8 @@ public class CasbinPolicyRefresher implements AutoCloseable {
 
       // May throw: leave checkSeq alone so waiters retry.
       reloader.run();
+      // Stamp the probed version, not a post-reload re-read: a fresher DB stamp would claim we
+      // loaded state the new enforcer may not contain.
       recordVersion(db[0], db[1]);
       checkSeq.incrementAndGet();
       return true;

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -14,6 +14,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Reloads the in-memory Casbin policy when {@code casbin_rule} changes in the shared database.
  *
+ * <p>{@code casbin_rule} is the JDBC adapter table that persists Casbin policy and grouping rows
+ * (grants, revokes, and hierarchy). {@link JCasbinAuthorizer} writes through the adapter with
+ * auto-save enabled, but each server process only loads that table into its enforcer at startup
+ * unless this refresher reloads it.
+ *
  * <p>Change detection uses {@code select count(*), coalesce(max(id), 0) from casbin_rule}. The JDBC
  * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least
  * one of the two values. Requires a {@link SyncedEnforcer} so {@code loadPolicy()} is safe under

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
@@ -37,6 +38,12 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   private long lastCount = -1;
   private long lastMaxId = -1;
 
+  /**
+   * Advanced only after a consistent check (no-op or successful reload). Callers that wait on the
+   * monitor while another thread finishes can skip by comparing against a pre-lock snapshot.
+   */
+  private final AtomicLong checkSeq = new AtomicLong();
+
   private ScheduledExecutorService executor;
 
   public CasbinPolicyRefresher(Runnable reloader, SessionFactory sessionFactory) {
@@ -68,42 +75,62 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  /** @return true if a reload happened */
+  /**
+   * Probes {@code casbin_rule} and reloads when the version changed.
+   *
+   * <p>Probe, reload, and version stamp run under one lock so concurrent callers coalesce: a waiter
+   * that blocked while another thread completed a consistent check skips. The stamped version is
+   * the one probed before reload, so the cache matches what was loaded.
+   *
+   * @return true if a reload happened
+   */
   public boolean checkAndReload() {
-    long[] version = readVersion().orElse(null);
-    if (version == null) {
-      return false;
-    }
+    long seenCheck = checkSeq.get();
     synchronized (this) {
-      if (version[0] == lastCount && version[1] == lastMaxId) {
+      if (checkSeq.get() != seenCheck) {
         return false;
       }
+
+      long[] db = readVersion().orElse(null);
+      if (db == null) {
+        // Probe failed: do not advance checkSeq so waiters retry.
+        return false;
+      }
+      if (db[0] == lastCount && db[1] == lastMaxId) {
+        checkSeq.incrementAndGet();
+        return false;
+      }
+
       LOGGER.debug(
           "Casbin policy changed (count {} -> {}, maxId {} -> {}); reloading",
           lastCount,
-          version[0],
+          db[0],
           lastMaxId,
-          version[1]);
+          db[1]);
+
+      // May throw: leave checkSeq alone so waiters retry.
+      reloader.run();
+      recordVersion(db[0], db[1]);
+      checkSeq.incrementAndGet();
+      return true;
     }
-    reloader.run();
-    recordLatestVersion();
-    return true;
   }
 
-  /** Unconditional reload for callers that cannot wait for the next poll. */
+  /**
+   * Unconditional reload for callers that cannot wait for the next poll. Takes the same monitor as
+   * {@link #checkAndReload()} before rebuilding so it cannot deadlock with a concurrent check
+   * (monitor then {@code reloadLock.writeLock()}).
+   */
   public void forceReload() {
-    reloader.run();
-    recordLatestVersion();
+    synchronized (this) {
+      reloader.run();
+      recordLatestVersion();
+    }
   }
 
+  /** Must be called while holding {@code this}'s monitor. */
   private void recordLatestVersion() {
-    readVersion()
-        .ifPresent(
-            latest -> {
-              synchronized (this) {
-                recordVersion(latest[0], latest[1]);
-              }
-            });
+    readVersion().ifPresent(latest -> recordVersion(latest[0], latest[1]));
   }
 
   private void recordVersion(long count, long maxId) {

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.casbin.jcasbin.main.SyncedEnforcer;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
@@ -21,8 +20,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Change detection uses {@code select count(*), coalesce(max(id), 0) from casbin_rule}. The JDBC
  * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least
- * one of the two values. Requires a {@link SyncedEnforcer} so {@code loadPolicy()} is safe under
- * concurrent {@code enforce()} calls.
+ * one of the two values. Reload is delegated to {@link JCasbinAuthorizer} so a fresh enforcer can
+ * be built and swapped without blocking {@code enforce()} on the live instance.
  */
 public class CasbinPolicyRefresher implements AutoCloseable {
 
@@ -31,7 +30,7 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   private static final String VERSION_QUERY =
       "select count(*), coalesce(max(id), 0) from casbin_rule";
 
-  private final SyncedEnforcer enforcer;
+  private final Runnable reloader;
   private final SessionFactory sessionFactory;
 
   // Initial -1 forces a reload on first check (see recordVersion).
@@ -40,8 +39,8 @@ public class CasbinPolicyRefresher implements AutoCloseable {
 
   private ScheduledExecutorService executor;
 
-  public CasbinPolicyRefresher(SyncedEnforcer enforcer, SessionFactory sessionFactory) {
-    this.enforcer = enforcer;
+  public CasbinPolicyRefresher(Runnable reloader, SessionFactory sessionFactory) {
+    this.reloader = reloader;
     this.sessionFactory = sessionFactory;
   }
 
@@ -71,8 +70,6 @@ public class CasbinPolicyRefresher implements AutoCloseable {
 
   /** @return true if a reload happened */
   public boolean checkAndReload() {
-    // Read the DB version outside the monitor so poller/deny-path callers do not contend on
-    // JDBC latency. Only the compare / loadPolicy / cached-version update need the lock.
     long[] version = readVersion().orElse(null);
     if (version == null) {
       return false;
@@ -87,15 +84,17 @@ public class CasbinPolicyRefresher implements AutoCloseable {
           version[0],
           lastMaxId,
           version[1]);
-      enforcer.loadPolicy();
-      recordVersion(version[0], version[1]);
-      return true;
     }
+    reloader.run();
+    synchronized (this) {
+      recordVersion(version[0], version[1]);
+    }
+    return true;
   }
 
   /** Unconditional reload for callers that cannot wait for the next poll. */
   public void forceReload() {
-    enforcer.loadPolicy();
+    reloader.run();
     readVersion()
         .ifPresent(
             version -> {

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -86,20 +86,22 @@ public class CasbinPolicyRefresher implements AutoCloseable {
           version[1]);
     }
     reloader.run();
-    synchronized (this) {
-      recordVersion(version[0], version[1]);
-    }
+    recordLatestVersion();
     return true;
   }
 
   /** Unconditional reload for callers that cannot wait for the next poll. */
   public void forceReload() {
     reloader.run();
+    recordLatestVersion();
+  }
+
+  private void recordLatestVersion() {
     readVersion()
         .ifPresent(
-            version -> {
+            latest -> {
               synchronized (this) {
-                recordVersion(version[0], version[1]);
+                recordVersion(latest[0], latest[1]);
               }
             });
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -70,29 +70,39 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   }
 
   /** @return true if a reload happened */
-  public synchronized boolean checkAndReload() {
+  public boolean checkAndReload() {
+    // Read the DB version outside the monitor so poller/deny-path callers do not contend on
+    // JDBC latency. Only the compare / loadPolicy / cached-version update need the lock.
     long[] version = readVersion().orElse(null);
     if (version == null) {
       return false;
     }
-    if (version[0] == lastCount && version[1] == lastMaxId) {
-      return false;
+    synchronized (this) {
+      if (version[0] == lastCount && version[1] == lastMaxId) {
+        return false;
+      }
+      LOGGER.debug(
+          "Casbin policy changed (count {} -> {}, maxId {} -> {}); reloading",
+          lastCount,
+          version[0],
+          lastMaxId,
+          version[1]);
+      enforcer.loadPolicy();
+      recordVersion(version[0], version[1]);
+      return true;
     }
-    LOGGER.debug(
-        "Casbin policy changed (count {} -> {}, maxId {} -> {}); reloading",
-        lastCount,
-        version[0],
-        lastMaxId,
-        version[1]);
-    enforcer.loadPolicy();
-    recordVersion(version[0], version[1]);
-    return true;
   }
 
   /** Unconditional reload for callers that cannot wait for the next poll. */
-  public synchronized void forceReload() {
+  public void forceReload() {
     enforcer.loadPolicy();
-    readVersion().ifPresent(version -> recordVersion(version[0], version[1]));
+    readVersion()
+        .ifPresent(
+            version -> {
+              synchronized (this) {
+                recordVersion(version[0], version[1]);
+              }
+            });
   }
 
   private void recordVersion(long count, long maxId) {

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -2,6 +2,7 @@ package io.unitycatalog.server.auth;
 
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import io.unitycatalog.server.utils.ServerProperties;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -9,12 +10,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.casbin.adapter.JDBCAdapter;
 import org.casbin.jcasbin.main.Enforcer;
 import org.casbin.jcasbin.main.SyncedEnforcer;
 import org.casbin.jcasbin.model.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An authorizer that uses the JCasbin library to enforce access control policies.
@@ -26,9 +30,32 @@ import org.casbin.jcasbin.model.Model;
  * SyncedEnforcer} is used because the UC server shares one authorizer across concurrent REST
  * requests; jCasbin's plain {@link Enforcer} is not thread-safe for concurrent {@code enforce()}
  * and policy mutations.
+ *
+ * <p>The policy set lives in memory and is loaded once by the enforcer's constructor, so an
+ * instance would otherwise never see a grant or revocation made through another instance. A {@link
+ * CasbinPolicyRefresher} polls the shared table and reloads on change, which is what makes running
+ * more than one server instance against one database safe.
  */
-public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
+public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JCasbinAuthorizer.class);
+
   private final SyncedEnforcer enforcer;
+  private final CasbinPolicyRefresher refresher;
+  private final long refreshDebounceNanos;
+
+  /**
+   * Gates every part of cross-instance policy refresh — both the background poll and the
+   * deny-triggered reload — so that disabling it restores exactly the behaviour from before refresh
+   * existed. A flag that only turned off the poll would not be a usable kill switch.
+   */
+  private final boolean refreshEnabled;
+
+  /**
+   * When the last deny-triggered refresh was claimed. Seeded so the very first deny is allowed to
+   * refresh rather than being treated as inside a window that never happened.
+   */
+  private final AtomicLong lastRefreshNanos = new AtomicLong(Long.MIN_VALUE / 2);
 
   private static final int PRINCIPAL_INDEX = 0;
   private static final int RESOURCE_INDEX = 1;
@@ -38,7 +65,9 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
   private static final int HIERARCHY_PARENT_INDEX = 0;
   private static final int HIERARCHY_CHILD_INDEX = 1;
 
-  public JCasbinAuthorizer(HibernateConfigurator hibernateConfigurator) throws Exception {
+  public JCasbinAuthorizer(
+      HibernateConfigurator hibernateConfigurator, ServerProperties serverProperties)
+      throws Exception {
     Properties properties = hibernateConfigurator.getHibernateProperties();
     String driver = properties.getProperty("hibernate.connection.driver_class");
     String url = properties.getProperty("hibernate.connection.url");
@@ -53,6 +82,18 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
 
     enforcer = new SyncedEnforcer(model, adapter);
     enforcer.enableAutoSave(true);
+
+    this.refreshDebounceNanos = serverProperties.getPolicyRefreshDebounce().toNanos();
+    this.refreshEnabled = serverProperties.isPolicyRefreshEnabled();
+    this.refresher = new CasbinPolicyRefresher(enforcer, hibernateConfigurator.getSessionFactory());
+    if (refreshEnabled) {
+      refresher.start(serverProperties.getPolicyRefreshInterval());
+    } else {
+      LOGGER.warn(
+          "Casbin policy refresh is disabled. Authorization changes made through another server"
+              + " instance will not be seen by this one, so running more than one instance against"
+              + " this database is unsafe.");
+    }
   }
 
   /**
@@ -160,5 +201,43 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer {
                 l -> UUID.fromString(l.get(PRINCIPAL_INDEX)),
                 Collectors.mapping(
                     l -> Privileges.fromValue(l.get(PRIVILEGE_INDEX)), Collectors.toList())));
+  }
+
+  /**
+   * Reloads the policy set so a request denied against a stale view can be re-evaluated, at most
+   * once per configured debounce interval.
+   *
+   * <p>The timestamp is claimed <em>before</em> reloading, and losing the compare-and-set means
+   * returning false rather than waiting. Both matter: this runs on a path reachable by
+   * unauthenticated callers, so without them a client repeatedly hitting a denied endpoint could
+   * force continuous full-table reloads, each taking the enforcer's write lock and stalling every
+   * concurrent authorization check.
+   */
+  @Override
+  public boolean refreshAuthorizations() {
+    if (!refreshEnabled) {
+      return false;
+    }
+    long now = System.nanoTime();
+    long last = lastRefreshNanos.get();
+    if (now - last < refreshDebounceNanos) {
+      return false;
+    }
+    if (!lastRefreshNanos.compareAndSet(last, now)) {
+      return false;
+    }
+    refresher.forceReload();
+    return true;
+  }
+
+  /** Stops the background policy refresh. The enforcer and its adapter need no explicit cleanup. */
+  @Override
+  public void close() {
+    refresher.close();
+  }
+
+  /** Visible for testing. */
+  CasbinPolicyRefresher getRefresher() {
+    return refresher;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -31,10 +31,8 @@ import org.slf4j.LoggerFactory;
  * requests; jCasbin's plain {@link Enforcer} is not thread-safe for concurrent {@code enforce()}
  * and policy mutations.
  *
- * <p>The policy set lives in memory and is loaded once by the enforcer's constructor, so an
- * instance would otherwise never see a grant or revocation made through another instance. A {@link
- * CasbinPolicyRefresher} polls the shared table and reloads on change, which is what makes running
- * more than one server instance against one database safe.
+ * <p>{@link CasbinPolicyRefresher} polls the shared {@code casbin_rule} table so grants and
+ * revocations made through other instances are picked up.
  */
 public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable {
 
@@ -44,17 +42,8 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   private final CasbinPolicyRefresher refresher;
   private final long refreshDebounceNanos;
 
-  /**
-   * Gates every part of cross-instance policy refresh — both the background poll and the
-   * deny-triggered reload — so that disabling it restores exactly the behaviour from before refresh
-   * existed. A flag that only turned off the poll would not be a usable kill switch.
-   */
   private final boolean refreshEnabled;
 
-  /**
-   * When the last deny-triggered refresh was claimed. Seeded so the very first deny is allowed to
-   * refresh rather than being treated as inside a window that never happened.
-   */
   private final AtomicLong lastRefreshNanos = new AtomicLong(Long.MIN_VALUE / 2);
 
   private static final int PRINCIPAL_INDEX = 0;
@@ -203,16 +192,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
                     l -> Privileges.fromValue(l.get(PRIVILEGE_INDEX)), Collectors.toList())));
   }
 
-  /**
-   * Reloads the policy set so a request denied against a stale view can be re-evaluated, at most
-   * once per configured debounce interval.
-   *
-   * <p>The timestamp is claimed <em>before</em> reloading, and losing the compare-and-set means
-   * returning false rather than waiting. Both matter: this runs on a path reachable by
-   * unauthenticated callers, so without them a client repeatedly hitting a denied endpoint could
-   * force continuous full-table reloads, each taking the enforcer's write lock and stalling every
-   * concurrent authorization check.
-   */
+  /** Rate-limited reload before returning 403, for cross-instance create-then-read. */
   @Override
   public boolean refreshAuthorizations() {
     if (!refreshEnabled) {
@@ -230,13 +210,11 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     return true;
   }
 
-  /** Stops the background policy refresh. The enforcer and its adapter need no explicit cleanup. */
   @Override
   public void close() {
     refresher.close();
   }
 
-  /** Visible for testing. */
   CasbinPolicyRefresher getRefresher() {
     return refresher;
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -45,7 +45,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JCasbinAuthorizer.class);
 
-  private final AtomicReference<SyncedEnforcer> current = new AtomicReference<>();
+  private final AtomicReference<SyncedEnforcer> currentEnforcer = new AtomicReference<>();
   final ReadWriteLock reloadLock = new ReentrantReadWriteLock();
   private final JDBCAdapter adapter;
   private final String modelText;
@@ -76,9 +76,9 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
     InputStream modelStream = this.getClass().getResourceAsStream("/jcasbin_auth_model.conf");
     this.modelText = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
-    current.set(newEnforcer());
+    currentEnforcer.set(newEnforcer());
 
-    this.refreshDebounceNanos = serverProperties.getPolicyRefreshDebounce().toNanos();
+    this.refreshDebounceNanos = serverProperties.getPolicyRefreshDebounceInterval().toNanos();
     this.refreshEnabled = serverProperties.isPolicyRefreshEnabled();
     this.refresher =
         new CasbinPolicyRefresher(this::reloadFromStore, hibernateConfigurator.getSessionFactory());
@@ -110,10 +110,6 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     return username;
   }
 
-  private SyncedEnforcer live() {
-    return current.get();
-  }
-
   private SyncedEnforcer newEnforcer() {
     Model model = new Model();
     model.loadModelFromText(modelText);
@@ -129,7 +125,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   void reloadFromStore() {
     reloadLock.writeLock().lock();
     try {
-      current.set(newEnforcer());
+      currentEnforcer.set(newEnforcer());
     } finally {
       reloadLock.writeLock().unlock();
     }
@@ -146,7 +142,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   private <T> T mutate(Function<SyncedEnforcer, T> action) {
     reloadLock.readLock().lock();
     try {
-      return action.apply(live());
+      return action.apply(currentEnforcer.get());
     } finally {
       reloadLock.readLock().unlock();
     }
@@ -196,7 +192,8 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   @Override
   public UUID getHierarchyParent(UUID resource) {
     List<List<String>> policy =
-        live()
+        currentEnforcer
+            .get()
             .getFilteredNamedGroupingPolicy(
                 HIERARCHY_POLICY, HIERARCHY_CHILD_INDEX, resource.toString());
     if (policy.isEmpty() || policy.get(0).isEmpty()) {
@@ -207,12 +204,14 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public boolean authorize(UUID principal, UUID resource, Privileges action) {
-    return live().enforce(principal.toString(), resource.toString(), action.toString());
+    return currentEnforcer
+        .get()
+        .enforce(principal.toString(), resource.toString(), action.toString());
   }
 
   @Override
   public boolean authorizeAny(UUID principal, UUID resource, Privileges... actions) {
-    SyncedEnforcer enforcer = live();
+    SyncedEnforcer enforcer = currentEnforcer.get();
     return Arrays.stream(actions)
         .anyMatch(
             action ->
@@ -221,7 +220,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public boolean authorizeAll(UUID principal, UUID resource, Privileges... actions) {
-    SyncedEnforcer enforcer = live();
+    SyncedEnforcer enforcer = currentEnforcer.get();
     return Arrays.stream(actions)
         .allMatch(
             action ->
@@ -231,7 +230,9 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   @Override
   public List<Privileges> listAuthorizations(UUID principal, UUID resource) {
     List<List<String>> list =
-        live().getPermissionsForUserInDomain(principal.toString(), resource.toString());
+        currentEnforcer
+            .get()
+            .getPermissionsForUserInDomain(principal.toString(), resource.toString());
     return list.stream()
         .map(l -> l.get(PRIVILEGE_INDEX))
         .map(Privileges::fromValue)
@@ -240,7 +241,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public Map<UUID, List<Privileges>> listAuthorizations(UUID resource) {
-    return live().getFilteredPolicy(RESOURCE_INDEX, resource.toString()).stream()
+    return currentEnforcer.get().getFilteredPolicy(RESOURCE_INDEX, resource.toString()).stream()
         .collect(
             Collectors.groupingBy(
                 l -> UUID.fromString(l.get(PRINCIPAL_INDEX)),
@@ -251,7 +252,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   /**
    * Rate-limited policy check before returning 403, for cross-instance create-then-read.
    *
-   * @return true if the live enforcer was replaced (by this call or a coalesced concurrent check)
+   * @return true if the current enforcer was replaced (this call or a coalesced concurrent check)
    */
   @Override
   public boolean refreshAuthorizations() {
@@ -266,9 +267,9 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     if (!lastRefreshNanos.compareAndSet(last, now)) {
       return false;
     }
-    SyncedEnforcer before = live();
+    SyncedEnforcer before = currentEnforcer.get();
     refresher.checkAndReload();
-    return live() != before;
+    return currentEnforcer.get() != before;
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -12,6 +12,9 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.casbin.adapter.JDBCAdapter;
@@ -34,15 +37,16 @@ import org.slf4j.LoggerFactory;
  *
  * <p>{@link CasbinPolicyRefresher} polls the shared {@code casbin_rule} table so grants and
  * revocations made through other instances are picked up. Reload builds a fresh enforcer and swaps
- * it under {@code writeLock} so {@code enforce()} keeps using the previous instance. Local writes
- * take the same lock so they are not lost across the swap.
+ * it under the exclusive side of {@code reloadLock} so {@code enforce()} keeps using the previous
+ * instance. Local writes take the shared side so they are not lost across the swap, but do not wait
+ * for each other.
  */
 public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JCasbinAuthorizer.class);
 
   private final AtomicReference<SyncedEnforcer> current = new AtomicReference<>();
-  private final Object writeLock = new Object();
+  final ReadWriteLock reloadLock = new ReentrantReadWriteLock();
   private final JDBCAdapter adapter;
   private final String modelText;
   private final CasbinPolicyRefresher refresher;
@@ -119,65 +123,66 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   }
 
   /**
-   * Rebuilds policy from {@code casbin_rule} on a new enforcer and swaps it in. Holds {@code
-   * writeLock} for the whole load so local grants are not applied to the outgoing instance.
+   * Rebuilds policy from {@code casbin_rule} on a new enforcer and swaps it in. Holds the exclusive
+   * lock for the whole load so local grants are not applied to the outgoing instance.
    */
   void reloadFromStore() {
-    synchronized (writeLock) {
+    reloadLock.writeLock().lock();
+    try {
       current.set(newEnforcer());
+    } finally {
+      reloadLock.writeLock().unlock();
+    }
+  }
+
+  private <T> T mutate(Function<SyncedEnforcer, T> action) {
+    reloadLock.readLock().lock();
+    try {
+      return action.apply(live());
+    } finally {
+      reloadLock.readLock().unlock();
     }
   }
 
   @Override
   public boolean grantAuthorization(UUID principal, UUID resource, Privileges action) {
-    synchronized (writeLock) {
-      return live().addPolicy(principal.toString(), resource.toString(), action.toString());
-    }
+    return mutate(e -> e.addPolicy(principal.toString(), resource.toString(), action.toString()));
   }
 
   @Override
   public boolean revokeAuthorization(UUID principal, UUID resource, Privileges action) {
-    synchronized (writeLock) {
-      return live().removePolicy(principal.toString(), resource.toString(), action.toString());
-    }
+    return mutate(
+        e -> e.removePolicy(principal.toString(), resource.toString(), action.toString()));
   }
 
   @Override
   public boolean clearAuthorizationsForPrincipal(UUID principal) {
-    synchronized (writeLock) {
-      return live().removeFilteredPolicy(PRINCIPAL_INDEX, principal.toString());
-    }
+    return mutate(e -> e.removeFilteredPolicy(PRINCIPAL_INDEX, principal.toString()));
   }
 
   @Override
   public boolean clearAuthorizationsForResource(UUID resource) {
-    synchronized (writeLock) {
-      return live().removeFilteredPolicy(RESOURCE_INDEX, resource.toString());
-    }
+    return mutate(e -> e.removeFilteredPolicy(RESOURCE_INDEX, resource.toString()));
   }
 
   @Override
   public boolean addHierarchyChild(UUID parent, UUID child) {
-    synchronized (writeLock) {
-      return live().addNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString());
-    }
+    return mutate(
+        e -> e.addNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString()));
   }
 
   @Override
   public boolean removeHierarchyChild(UUID parent, UUID child) {
-    synchronized (writeLock) {
-      return live()
-          .removeNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString());
-    }
+    return mutate(
+        e -> e.removeNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString()));
   }
 
   @Override
   public boolean removeHierarchyChildren(UUID resource) {
-    synchronized (writeLock) {
-      return live()
-          .removeFilteredNamedGroupingPolicy(
-              HIERARCHY_POLICY, HIERARCHY_PARENT_INDEX, resource.toString());
-    }
+    return mutate(
+        e ->
+            e.removeFilteredNamedGroupingPolicy(
+                HIERARCHY_POLICY, HIERARCHY_PARENT_INDEX, resource.toString()));
   }
 
   @Override
@@ -260,12 +265,5 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   CasbinPolicyRefresher getRefresher() {
     return refresher;
-  }
-
-  /** Runs {@code action} while holding the write lock. Used to test that reads do not take it. */
-  void withWriteLock(Runnable action) {
-    synchronized (writeLock) {
-      action.run();
-    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -240,7 +240,11 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
                     l -> Privileges.fromValue(l.get(PRIVILEGE_INDEX)), Collectors.toList())));
   }
 
-  /** Rate-limited reload before returning 403, for cross-instance create-then-read. */
+  /**
+   * Rate-limited policy check before returning 403, for cross-instance create-then-read.
+   *
+   * @return true if the live enforcer was replaced (by this call or a coalesced concurrent check)
+   */
   @Override
   public boolean refreshAuthorizations() {
     if (!refreshEnabled) {
@@ -254,8 +258,9 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     if (!lastRefreshNanos.compareAndSet(last, now)) {
       return false;
     }
-    refresher.forceReload();
-    return true;
+    SyncedEnforcer before = live();
+    refresher.checkAndReload();
+    return live() != before;
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -81,7 +81,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     if (refreshEnabled) {
       refresher.start(serverProperties.getPolicyRefreshInterval());
     } else {
-      LOGGER.warn(
+      LOGGER.info(
           "Casbin policy refresh is disabled. Authorization changes made through another server"
               + " instance will not be seen by this one, so running more than one instance against"
               + " this database is unsafe.");
@@ -260,5 +260,12 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   CasbinPolicyRefresher getRefresher() {
     return refresher;
+  }
+
+  /** Runs {@code action} while holding the write lock. Used to test that reads do not take it. */
+  void withWriteLock(Runnable action) {
+    synchronized (writeLock) {
+      action.run();
+    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.casbin.adapter.JDBCAdapter;
@@ -32,13 +33,18 @@ import org.slf4j.LoggerFactory;
  * and policy mutations.
  *
  * <p>{@link CasbinPolicyRefresher} polls the shared {@code casbin_rule} table so grants and
- * revocations made through other instances are picked up.
+ * revocations made through other instances are picked up. Reload builds a fresh enforcer and swaps
+ * it under {@code writeLock} so {@code enforce()} keeps using the previous instance. Local writes
+ * take the same lock so they are not lost across the swap.
  */
 public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JCasbinAuthorizer.class);
 
-  private final SyncedEnforcer enforcer;
+  private final AtomicReference<SyncedEnforcer> current = new AtomicReference<>();
+  private final Object writeLock = new Object();
+  private final JDBCAdapter adapter;
+  private final String modelText;
   private final CasbinPolicyRefresher refresher;
   private final long refreshDebounceNanos;
 
@@ -62,19 +68,16 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     String url = properties.getProperty("hibernate.connection.url");
     String user = resolveConnectionUsername(properties);
     String password = properties.getProperty("hibernate.connection.password");
-    JDBCAdapter adapter = new JDBCAdapter(driver, url, user, password);
+    this.adapter = new JDBCAdapter(driver, url, user, password);
 
     InputStream modelStream = this.getClass().getResourceAsStream("/jcasbin_auth_model.conf");
-    String string = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
-    Model model = new Model();
-    model.loadModelFromText(string);
-
-    enforcer = new SyncedEnforcer(model, adapter);
-    enforcer.enableAutoSave(true);
+    this.modelText = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
+    current.set(newEnforcer());
 
     this.refreshDebounceNanos = serverProperties.getPolicyRefreshDebounce().toNanos();
     this.refreshEnabled = serverProperties.isPolicyRefreshEnabled();
-    this.refresher = new CasbinPolicyRefresher(enforcer, hibernateConfigurator.getSessionFactory());
+    this.refresher =
+        new CasbinPolicyRefresher(this::reloadFromStore, hibernateConfigurator.getSessionFactory());
     if (refreshEnabled) {
       refresher.start(serverProperties.getPolicyRefreshInterval());
     } else {
@@ -103,48 +106,86 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     return username;
   }
 
+  private SyncedEnforcer live() {
+    return current.get();
+  }
+
+  private SyncedEnforcer newEnforcer() {
+    Model model = new Model();
+    model.loadModelFromText(modelText);
+    SyncedEnforcer enforcer = new SyncedEnforcer(model, adapter);
+    enforcer.enableAutoSave(true);
+    return enforcer;
+  }
+
+  /**
+   * Rebuilds policy from {@code casbin_rule} on a new enforcer and swaps it in. Holds {@code
+   * writeLock} for the whole load so local grants are not applied to the outgoing instance.
+   */
+  void reloadFromStore() {
+    synchronized (writeLock) {
+      current.set(newEnforcer());
+    }
+  }
+
   @Override
   public boolean grantAuthorization(UUID principal, UUID resource, Privileges action) {
-    return enforcer.addPolicy(principal.toString(), resource.toString(), action.toString());
+    synchronized (writeLock) {
+      return live().addPolicy(principal.toString(), resource.toString(), action.toString());
+    }
   }
 
   @Override
   public boolean revokeAuthorization(UUID principal, UUID resource, Privileges action) {
-    return enforcer.removePolicy(principal.toString(), resource.toString(), action.toString());
+    synchronized (writeLock) {
+      return live().removePolicy(principal.toString(), resource.toString(), action.toString());
+    }
   }
 
   @Override
   public boolean clearAuthorizationsForPrincipal(UUID principal) {
-    return enforcer.removeFilteredPolicy(PRINCIPAL_INDEX, principal.toString());
+    synchronized (writeLock) {
+      return live().removeFilteredPolicy(PRINCIPAL_INDEX, principal.toString());
+    }
   }
 
   @Override
   public boolean clearAuthorizationsForResource(UUID resource) {
-    return enforcer.removeFilteredPolicy(RESOURCE_INDEX, resource.toString());
+    synchronized (writeLock) {
+      return live().removeFilteredPolicy(RESOURCE_INDEX, resource.toString());
+    }
   }
 
   @Override
   public boolean addHierarchyChild(UUID parent, UUID child) {
-    return enforcer.addNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString());
+    synchronized (writeLock) {
+      return live().addNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString());
+    }
   }
 
   @Override
   public boolean removeHierarchyChild(UUID parent, UUID child) {
-    return enforcer.removeNamedGroupingPolicy(
-        HIERARCHY_POLICY, parent.toString(), child.toString());
+    synchronized (writeLock) {
+      return live()
+          .removeNamedGroupingPolicy(HIERARCHY_POLICY, parent.toString(), child.toString());
+    }
   }
 
   @Override
   public boolean removeHierarchyChildren(UUID resource) {
-    return enforcer.removeFilteredNamedGroupingPolicy(
-        HIERARCHY_POLICY, HIERARCHY_PARENT_INDEX, resource.toString());
+    synchronized (writeLock) {
+      return live()
+          .removeFilteredNamedGroupingPolicy(
+              HIERARCHY_POLICY, HIERARCHY_PARENT_INDEX, resource.toString());
+    }
   }
 
   @Override
   public UUID getHierarchyParent(UUID resource) {
     List<List<String>> policy =
-        enforcer.getFilteredNamedGroupingPolicy(
-            HIERARCHY_POLICY, HIERARCHY_CHILD_INDEX, resource.toString());
+        live()
+            .getFilteredNamedGroupingPolicy(
+                HIERARCHY_POLICY, HIERARCHY_CHILD_INDEX, resource.toString());
     if (policy.isEmpty() || policy.get(0).isEmpty()) {
       return null;
     }
@@ -153,11 +194,12 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public boolean authorize(UUID principal, UUID resource, Privileges action) {
-    return enforcer.enforce(principal.toString(), resource.toString(), action.toString());
+    return live().enforce(principal.toString(), resource.toString(), action.toString());
   }
 
   @Override
   public boolean authorizeAny(UUID principal, UUID resource, Privileges... actions) {
+    SyncedEnforcer enforcer = live();
     return Arrays.stream(actions)
         .anyMatch(
             action ->
@@ -166,6 +208,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public boolean authorizeAll(UUID principal, UUID resource, Privileges... actions) {
+    SyncedEnforcer enforcer = live();
     return Arrays.stream(actions)
         .allMatch(
             action ->
@@ -175,7 +218,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   @Override
   public List<Privileges> listAuthorizations(UUID principal, UUID resource) {
     List<List<String>> list =
-        enforcer.getPermissionsForUserInDomain(principal.toString(), resource.toString());
+        live().getPermissionsForUserInDomain(principal.toString(), resource.toString());
     return list.stream()
         .map(l -> l.get(PRIVILEGE_INDEX))
         .map(Privileges::fromValue)
@@ -184,7 +227,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
 
   @Override
   public Map<UUID, List<Privileges>> listAuthorizations(UUID resource) {
-    return enforcer.getFilteredPolicy(RESOURCE_INDEX, resource.toString()).stream()
+    return live().getFilteredPolicy(RESOURCE_INDEX, resource.toString()).stream()
         .collect(
             Collectors.groupingBy(
                 l -> UUID.fromString(l.get(PRINCIPAL_INDEX)),

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -135,6 +135,14 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     }
   }
 
+  /**
+   * Runs a policy mutation on the live enforcer.
+   *
+   * <p>Takes the <em>read</em> side of {@code reloadLock} on purpose: many grants may proceed
+   * together (SyncedEnforcer still serializes mutations on one instance), while reload takes the
+   * write side so a mutation cannot land on an enforcer that is about to be discarded. The lock
+   * names refer to the live-enforcer pointer, not to Casbin read vs write.
+   */
   private <T> T mutate(Function<SyncedEnforcer, T> action) {
     reloadLock.readLock().lock();
     try {

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -43,18 +43,10 @@ public interface UnityCatalogAuthorizer {
   Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
 
   /**
-   * Forces this instance to pick up authorization changes made through another instance, if it has
-   * not already done so recently.
+   * Reload cached authorization state from the shared store, if supported. Called on the deny path
+   * before returning 403. Implementations should rate-limit; default is a no-op.
    *
-   * <p>Called on the deny path so that a request denied against a stale view can be re-evaluated
-   * before returning {@code 403}: without session affinity, the request that grants a privilege and
-   * the request that next relies on it may land on different instances. Implementations are
-   * expected to rate-limit, since the deny path is reachable by unauthenticated callers.
-   *
-   * <p>The default does nothing, which is correct for any implementation that does not cache
-   * authorization state.
-   *
-   * @return true if a refresh actually happened, meaning a re-evaluation may now succeed
+   * @return true if a refresh ran and re-evaluation may succeed
    */
   default boolean refreshAuthorizations() {
     return false;

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -43,8 +43,9 @@ public interface UnityCatalogAuthorizer {
   Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
 
   /**
-   * Reload cached authorization state from the shared store, if supported. Called on the deny path
-   * before returning 403. Implementations should rate-limit; default is a no-op.
+   * Reload cached authorization state from the shared store, if supported. Called from
+   * authorization evaluation after a deny (request checks and list filters). Implementations should
+   * rate-limit; default is a no-op.
    *
    * @return true if a refresh ran and re-evaluation may succeed
    */

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -41,4 +41,22 @@ public interface UnityCatalogAuthorizer {
   List<Privileges> listAuthorizations(UUID principal, UUID resource);
 
   Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
+
+  /**
+   * Forces this instance to pick up authorization changes made through another instance, if it has
+   * not already done so recently.
+   *
+   * <p>Called on the deny path so that a request denied against a stale view can be re-evaluated
+   * before returning {@code 403}: without session affinity, the request that grants a privilege and
+   * the request that next relies on it may land on different instances. Implementations are
+   * expected to rate-limit, since the deny path is reachable by unauthenticated callers.
+   *
+   * <p>The default does nothing, which is correct for any implementation that does not cache
+   * authorization state.
+   *
+   * @return true if a refresh actually happened, meaning a re-evaluation may now succeed
+   */
+  default boolean refreshAuthorizations() {
+    return false;
+  }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -89,10 +89,6 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private final UnityAccessEvaluator evaluator;
 
-  /**
-   * Retained so a denied request can ask the authorizer to pick up changes made through another
-   * server instance before the denial is final. See {@link RequestEvaluationAction#beforeRequest}.
-   */
   private final UnityCatalogAuthorizer authorizer;
 
   // Context attribute key for passing ResultFilter to service methods
@@ -252,17 +248,6 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private class RequestEvaluationAction implements EvaluationAction {
 
-    /**
-     * Evaluates the authorization expression, and on failure gives the authorizer one chance to
-     * pick up changes made through another server instance before denying.
-     *
-     * <p>Without this retry, a client that creates a resource through one instance and immediately
-     * reads it through another gets a spurious {@code 403} until the reading instance next
-     * refreshes its policy set. The refresh is rate-limited by the authorizer, so a genuinely
-     * unauthorized caller cannot turn repeated denials into repeated reloads. Only the
-     * request-level gate does this; response filtering deliberately does not, since there a false
-     * result is an ordinary "omit this row" decision rather than a denial.
-     */
     @Override
     public void beforeRequest(
         UUID principal,

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -89,8 +89,6 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private final UnityAccessEvaluator evaluator;
 
-  private final UnityCatalogAuthorizer authorizer;
-
   // Context attribute key for passing ResultFilter to service methods
   public static final AttributeKey<ResultFilter> RESULT_FILTER_ATTR =
       AttributeKey.valueOf(ResultFilter.class, "RESULT_FILTER");
@@ -102,7 +100,6 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new BaseException(ErrorCode.INTERNAL, "Error initializing access evaluator.", e);
     }
-    this.authorizer = authorizer;
     keyMapper = repositories.getKeyMapper();
     userRepository = repositories.getUserRepository();
   }
@@ -255,11 +252,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
         Map<SecurableType, UUID> resourceIds,
         Map<String, Object> nonResourceValues) {
       if (!evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
-        if (!authorizer.refreshAuthorizations()
-            || !evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
-          throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
-        }
-        LOGGER.debug("Access allowed after refreshing authorizations for principal {}", principal);
+        throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
       }
     }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -89,6 +89,12 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private final UnityAccessEvaluator evaluator;
 
+  /**
+   * Retained so a denied request can ask the authorizer to pick up changes made through another
+   * server instance before the denial is final. See {@link RequestEvaluationAction#beforeRequest}.
+   */
+  private final UnityCatalogAuthorizer authorizer;
+
   // Context attribute key for passing ResultFilter to service methods
   public static final AttributeKey<ResultFilter> RESULT_FILTER_ATTR =
       AttributeKey.valueOf(ResultFilter.class, "RESULT_FILTER");
@@ -100,6 +106,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new BaseException(ErrorCode.INTERNAL, "Error initializing access evaluator.", e);
     }
+    this.authorizer = authorizer;
     keyMapper = repositories.getKeyMapper();
     userRepository = repositories.getUserRepository();
   }
@@ -245,6 +252,17 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private class RequestEvaluationAction implements EvaluationAction {
 
+    /**
+     * Evaluates the authorization expression, and on failure gives the authorizer one chance to
+     * pick up changes made through another server instance before denying.
+     *
+     * <p>Without this retry, a client that creates a resource through one instance and immediately
+     * reads it through another gets a spurious {@code 403} until the reading instance next
+     * refreshes its policy set. The refresh is rate-limited by the authorizer, so a genuinely
+     * unauthorized caller cannot turn repeated denials into repeated reloads. Only the
+     * request-level gate does this; response filtering deliberately does not, since there a false
+     * result is an ordinary "omit this row" decision rather than a denial.
+     */
     @Override
     public void beforeRequest(
         UUID principal,
@@ -252,7 +270,11 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
         Map<SecurableType, UUID> resourceIds,
         Map<String, Object> nonResourceValues) {
       if (!evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
-        throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
+        if (!authorizer.refreshAuthorizations()
+            || !evaluator.evaluate(principal, expression, resourceIds, nonResourceValues)) {
+          throw new BaseException(ErrorCode.PERMISSION_DENIED, "Access denied.");
+        }
+        LOGGER.debug("Access allowed after refreshing authorizations for principal {}", principal);
       }
     }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
@@ -76,6 +76,9 @@ public class UnityAccessEvaluator {
   /**
    * Evaluate authorization expression with resource IDs and parameter values.
    *
+   * <p>On deny, attempts one debounced policy refresh and re-evaluates the SpEL expression (context
+   * is reused). If refresh is disabled, debounced, or throws, the original deny is kept.
+   *
    * @param principal The principal UUID
    * @param expression The SpEL authorization expression
    * @param resourceIds Map of resource types to their UUIDs
@@ -100,8 +103,29 @@ public class UnityAccessEvaluator {
     resourceIds.forEach((k, v) -> context.setVariable(k.name().toLowerCase(), v));
     nonResourceValues.forEach(context::setVariable);
 
-    Boolean result = parser.parseExpression(expression).getValue(context, Boolean.class);
+    if (eval(expression, context)) {
+      return true;
+    }
 
-    return result != null ? result : false;
+    try {
+      if (!authorizer.refreshAuthorizations()) {
+        return false;
+      }
+    } catch (RuntimeException e) {
+      LOGGER.warn(
+          "Authorization refresh failed for principal {}; keeping original deny", principal, e);
+      return false;
+    }
+
+    boolean allowedAfterRefresh = eval(expression, context);
+    if (allowedAfterRefresh) {
+      LOGGER.debug("Access allowed after refreshing authorizations for principal {}", principal);
+    }
+    return allowedAfterRefresh;
+  }
+
+  private boolean eval(String expression, StandardEvaluationContext context) {
+    Boolean result = parser.parseExpression(expression).getValue(context, Boolean.class);
+    return result != null && result;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -471,27 +471,15 @@ public class ServerProperties {
     return isTrueOrEnable(get(Property.AUTHORIZATION_ENABLED));
   }
 
-  /**
-   * Whether this instance picks up authorization changes made through other instances. Must stay
-   * enabled whenever more than one instance runs against one database, or a grant or revocation
-   * made through one instance will never reach the others.
-   *
-   * <p>Gates both the periodic poll and the refresh performed when a request is about to be denied,
-   * so that disabling it is a complete kill switch rather than only stopping the poll.
-   */
+  /** Whether cross-instance policy refresh is enabled (poll and deny-path reload). */
   public boolean isPolicyRefreshEnabled() {
     return isTrueOrEnable(get(Property.POLICY_REFRESH_ENABLED));
   }
 
-  /** How long to wait between checks for authorization changes. Defaults to 1 second. */
   public Duration getPolicyRefreshInterval() {
     return Duration.parse(get(Property.POLICY_REFRESH_INTERVAL));
   }
 
-  /**
-   * Shortest interval between two refreshes triggered by a denied request. Bounds the work an
-   * unauthorized caller can force by repeatedly hitting a denied endpoint. Defaults to 1 second.
-   */
   public Duration getPolicyRefreshDebounce() {
     return Duration.parse(get(Property.POLICY_REFRESH_DEBOUNCE));
   }

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -191,8 +191,7 @@ public class ServerProperties {
     SERVER_ENV("server.env", "dev", new EnumValidator(true, "dev", "prod", "test")),
     AUTHORIZATION_ENABLED(
         "server.authorization", "disable", new EnumValidator(true, "enable", "disable")),
-    POLICY_REFRESH_ENABLED(
-        "server.authorization.policy-refresh", "false", BOOLEAN_VALIDATOR),
+    POLICY_REFRESH_ENABLED("server.authorization.policy-refresh", "false", BOOLEAN_VALIDATOR),
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
     POLICY_REFRESH_DEBOUNCE(

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -191,6 +191,14 @@ public class ServerProperties {
     SERVER_ENV("server.env", "dev", new EnumValidator(true, "dev", "prod", "test")),
     AUTHORIZATION_ENABLED(
         "server.authorization", "disable", new EnumValidator(true, "enable", "disable")),
+    POLICY_REFRESH_ENABLED(
+        "server.authorization.policy-refresh",
+        "enable",
+        new EnumValidator(true, "enable", "disable")),
+    POLICY_REFRESH_INTERVAL(
+        "server.authorization.policy-refresh-interval", "PT1S", DURATION_VALIDATOR),
+    POLICY_REFRESH_DEBOUNCE(
+        "server.authorization.policy-refresh-debounce", "PT1S", DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),
@@ -461,6 +469,31 @@ public class ServerProperties {
 
   public boolean isAuthorizationEnabled() {
     return isTrueOrEnable(get(Property.AUTHORIZATION_ENABLED));
+  }
+
+  /**
+   * Whether this instance picks up authorization changes made through other instances. Must stay
+   * enabled whenever more than one instance runs against one database, or a grant or revocation
+   * made through one instance will never reach the others.
+   *
+   * <p>Gates both the periodic poll and the refresh performed when a request is about to be denied,
+   * so that disabling it is a complete kill switch rather than only stopping the poll.
+   */
+  public boolean isPolicyRefreshEnabled() {
+    return isTrueOrEnable(get(Property.POLICY_REFRESH_ENABLED));
+  }
+
+  /** How long to wait between checks for authorization changes. Defaults to 1 second. */
+  public Duration getPolicyRefreshInterval() {
+    return Duration.parse(get(Property.POLICY_REFRESH_INTERVAL));
+  }
+
+  /**
+   * Shortest interval between two refreshes triggered by a denied request. Bounds the work an
+   * unauthorized caller can force by repeatedly hitting a denied endpoint. Defaults to 1 second.
+   */
+  public Duration getPolicyRefreshDebounce() {
+    return Duration.parse(get(Property.POLICY_REFRESH_DEBOUNCE));
   }
 
   public boolean isIncludeStackTraceInError() {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -194,8 +194,8 @@ public class ServerProperties {
     POLICY_REFRESH_ENABLED("server.authorization.policy-refresh", "false", BOOLEAN_VALIDATOR),
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
-    POLICY_REFRESH_DEBOUNCE(
-        "server.authorization.policy-refresh-debounce", "PT1S", DURATION_VALIDATOR),
+    POLICY_REFRESH_DEBOUNCE_INTERVAL(
+        "server.authorization.policy-refresh-debounce-interval", "PT1S", DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),
@@ -477,8 +477,8 @@ public class ServerProperties {
     return Duration.parse(get(Property.POLICY_REFRESH_INTERVAL));
   }
 
-  public Duration getPolicyRefreshDebounce() {
-    return Duration.parse(get(Property.POLICY_REFRESH_DEBOUNCE));
+  public Duration getPolicyRefreshDebounceInterval() {
+    return Duration.parse(get(Property.POLICY_REFRESH_DEBOUNCE_INTERVAL));
   }
 
   public boolean isIncludeStackTraceInError() {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -193,10 +193,10 @@ public class ServerProperties {
         "server.authorization", "disable", new EnumValidator(true, "enable", "disable")),
     POLICY_REFRESH_ENABLED(
         "server.authorization.policy-refresh",
-        "enable",
+        "disable",
         new EnumValidator(true, "enable", "disable")),
     POLICY_REFRESH_INTERVAL(
-        "server.authorization.policy-refresh-interval", "PT1S", DURATION_VALIDATOR),
+        "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
     POLICY_REFRESH_DEBOUNCE(
         "server.authorization.policy-refresh-debounce", "PT1S", DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -192,9 +192,7 @@ public class ServerProperties {
     AUTHORIZATION_ENABLED(
         "server.authorization", "disable", new EnumValidator(true, "enable", "disable")),
     POLICY_REFRESH_ENABLED(
-        "server.authorization.policy-refresh",
-        "disable",
-        new EnumValidator(true, "enable", "disable")),
+        "server.authorization.policy-refresh", "false", BOOLEAN_VALIDATOR),
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
     POLICY_REFRESH_DEBOUNCE(

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -18,28 +18,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for running the UC server as multiple instances against one shared database.
- *
- * <p>Every other authorizer test uses a single {@link JCasbinAuthorizer}, and jCasbin evaluates
- * every decision against an in-memory copy of the policy set that is loaded once in the
- * constructor. A single instance therefore always reads back its own writes, and the cross-instance
- * staleness bug is invisible by construction. These tests exist to close that gap.
- *
- * <p>Each {@code JCasbinAuthorizer} here stands in for one replica: they share the {@link
- * HibernateConfigurator} (and so the database), but each constructs its own {@code JDBCAdapter} and
- * its own {@code SyncedEnforcer}, exactly as separate pods would. {@code SyncedEnforcer} makes a
- * single instance thread-safe; it does not share policy state between instances, and its lock —
- * though static — cannot help here because the two instances hold two distinct {@code Model}s.
- *
- * <p>Propagation is eventually consistent, so the cross-instance assertions poll with a bounded
- * timeout rather than asserting immediately. Asserting immediately would be flaky by construction.
+ * Cross-replica Casbin policy propagation. Each {@link JCasbinAuthorizer} is a separate in-memory
+ * enforcer against one shared database; assertions poll because propagation is asynchronous.
  */
 public class JCasbinAuthorizerMultiInstanceTest {
 
-  /** Generous enough to absorb a slow CI machine, short enough to fail fast when broken. */
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(5);
-
-  /** Far shorter than production's default so the tests are not dominated by waiting. */
   private static final String TEST_REFRESH_INTERVAL = "PT0.05S";
 
   private HibernateConfigurator hibernateConfigurator;
@@ -54,8 +38,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
 
   @AfterEach
   void tearDown() {
-    // Close the replicas before the SessionFactory they poll through, and close them at all so the
-    // refresh threads do not accumulate across the suite.
     replicas.forEach(JCasbinAuthorizer::close);
     replicas.clear();
     hibernateConfigurator.getSessionFactory().close();
@@ -70,17 +52,11 @@ public class JCasbinAuthorizerMultiInstanceTest {
     return new ServerProperties(properties);
   }
 
-  /** Starts a replica that polls for changes, as a production instance does. */
   private JCasbinAuthorizer startReplica() throws Exception {
     return register(
         new JCasbinAuthorizer(hibernateConfigurator, properties(true, TEST_REFRESH_INTERVAL)));
   }
 
-  /**
-   * Starts a replica that does not poll, so a test can drive {@link
-   * CasbinPolicyRefresher#checkAndReload()} itself and observe its return value rather than racing
-   * the background thread.
-   */
   private JCasbinAuthorizer startReplicaWithoutRefresh() throws Exception {
     return register(
         new JCasbinAuthorizer(hibernateConfigurator, properties(false, TEST_REFRESH_INTERVAL)));
@@ -91,11 +67,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     return authorizer;
   }
 
-  /**
-   * Performs the one unconditional reload every refresher does on its first check, so that
-   * subsequent assertions are about genuine changes. That first reload is deliberate — see {@link
-   * CasbinPolicyRefresher} on why the version is not seeded in the constructor.
-   */
   private static void settle(JCasbinAuthorizer replica) {
     assertThat(replica.getRefresher().checkAndReload())
         .as("the first check always reloads")
@@ -121,13 +92,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     fail("%s did not happen within %s", description, AWAIT_TIMEOUT);
   }
 
-  /**
-   * A grant issued through one replica must be honoured by every other replica.
-   *
-   * <p>Without session affinity the request that creates a resource and the request that next reads
-   * it land on different pods, so the reader would otherwise deny access to a resource the writer
-   * just created — a spurious {@code 403 PERMISSION_DENIED} that succeeds on retry.
-   */
   @Test
   void grantOnOneReplicaIsVisibleToAnother() throws Exception {
     UnityCatalogAuthorizer replicaA = startReplica();
@@ -144,16 +108,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
         () -> replicaB.authorize(principal, resource, Privileges.CREATE_CATALOG));
   }
 
-  /**
-   * A revocation issued through one replica must be honoured by every other replica.
-   *
-   * <p>This is the security-relevant direction: a stale replica keeps <em>allowing</em> access, so
-   * the request returns {@code 200 OK} and credentials are vended for a privilege that has already
-   * been revoked. There is no error, and nothing in the server logs — only an audit surfaces it.
-   *
-   * <p>Replica B is started after the grant so that it begins with the privilege in its cache; the
-   * assertion is specifically about the revocation propagating, not the grant.
-   */
   @Test
   void revokeOnOneReplicaIsHonouredByAnother() throws Exception {
     UnityCatalogAuthorizer replicaA = startReplica();
@@ -173,16 +127,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
         () -> !replicaB.authorize(principal, resource, Privileges.SELECT));
   }
 
-  /**
-   * A hierarchy edge added through one replica must be visible to every other replica.
-   *
-   * <p>Nested resources inherit non-OWNER privileges by walking the {@code g2} ancestor chain, so a
-   * missing edge breaks inherited access on the child even when the grant on the parent is known.
-   * The missing edge also makes {@code getHierarchyParent} return {@code null}, which {@code
-   * PermissionService} treats as "no parent" rather than as an error — the parent and grandparent
-   * owner checks are skipped and a permission listing silently degrades from every assignment to
-   * only the caller's own.
-   */
   @Test
   void hierarchyEdgeAddedOnOneReplicaIsVisibleToAnother() throws Exception {
     UnityCatalogAuthorizer replicaA = startReplica();
@@ -203,14 +147,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
         () -> replicaB.authorize(principal, schema, Privileges.SELECT));
   }
 
-  /**
-   * Control test: the write itself reaches the shared database.
-   *
-   * <p>A replica started after the grant sees it immediately, which localises any propagation
-   * failure to the in-memory cache of already-running replicas rather than to the persistence path.
-   * This is also why a pod restart appeared to "fix" the problem in production while nothing had
-   * actually been repaired — the restart only reloaded the cache.
-   */
   @Test
   void grantIsPersistedAndVisibleToAReplicaStartedAfterwards() throws Exception {
     UnityCatalogAuthorizer replicaA = startReplica();
@@ -225,13 +161,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
         .isTrue();
   }
 
-  /**
-   * Change detection must notice an insert.
-   *
-   * <p>Detection compares {@code (count(*), max(id))} on {@code casbin_rule}. An insert always
-   * moves {@code max(id)}, because the adapter declares {@code id} as auto-incrementing on every
-   * dialect.
-   */
   @Test
   void detectsAnInsert() throws Exception {
     UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
@@ -243,12 +172,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     assertThat(reader.getRefresher().checkAndReload()).isTrue();
   }
 
-  /**
-   * Change detection must notice a delete.
-   *
-   * <p>A delete leaves {@code max(id)} alone but lowers {@code count(*)}, which is the only reason
-   * the count is part of the pair at all.
-   */
   @Test
   void detectsADelete() throws Exception {
     UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
@@ -264,10 +187,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     assertThat(reader.getRefresher().checkAndReload()).isTrue();
   }
 
-  /**
-   * Change detection must notice a delete paired with an insert, the case that defeats a count on
-   * its own: the count returns to where it started, and only {@code max(id)} reveals the change.
-   */
   @Test
   void detectsADeleteAndInsertThatLeavesTheCountUnchanged() throws Exception {
     UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
@@ -288,25 +207,14 @@ public class JCasbinAuthorizerMultiInstanceTest {
     assertThat(reader.authorize(principal, revoked, Privileges.SELECT)).isFalse();
   }
 
-  /**
-   * The deny-triggered refresh must be rate-limited. It runs on a path reachable by unauthenticated
-   * callers, so without a debounce a client hammering a denied endpoint would force continuous
-   * full-table reloads, each holding the enforcer's write lock.
-   */
   @Test
   void denyTriggeredRefreshIsDebounced() throws Exception {
     JCasbinAuthorizer replica = startReplica();
 
-    // Default debounce is 1s, so only the first of two immediate calls may do any work. The
-    // background poll uses checkAndReload rather than this path, so it cannot perturb the window.
     assertThat(replica.refreshAuthorizations()).isTrue();
     assertThat(replica.refreshAuthorizations()).isFalse();
   }
 
-  /**
-   * Disabling refresh must disable all of it, including the deny-triggered reload — otherwise the
-   * setting is not a kill switch and an operator cannot fully roll back to the previous behaviour.
-   */
   @Test
   void disablingRefreshAlsoDisablesTheDenyTriggeredReload() throws Exception {
     JCasbinAuthorizer replica = startReplicaWithoutRefresh();
@@ -315,11 +223,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     assertThat(replica.refreshAuthorizations()).isFalse();
   }
 
-  /**
-   * With refresh disabled, a replica must exhibit the original stale behaviour. This is what makes
-   * the enabled cases above meaningful: it shows the polling is what fixes them, rather than
-   * something incidental to the test setup.
-   */
   @Test
   void withRefreshDisabledAGrantNeverReachesAnotherReplica() throws Exception {
     UnityCatalogAuthorizer replicaA = startReplicaWithoutRefresh();
@@ -334,7 +237,6 @@ public class JCasbinAuthorizerMultiInstanceTest {
     assertThat(replicaB.authorize(principal, resource, Privileges.CREATE_CATALOG)).isFalse();
   }
 
-  /** A closed authorizer must not leave its refresh thread behind. */
   @Test
   void closeStopsTheRefreshThread() throws Exception {
     JCasbinAuthorizer replica = startReplica();

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -47,11 +47,18 @@ public class JCasbinAuthorizerMultiInstanceTest {
   }
 
   private ServerProperties properties(boolean refreshEnabled, String interval) {
+    return properties(refreshEnabled, interval, null);
+  }
+
+  private ServerProperties properties(boolean refreshEnabled, String interval, String debounce) {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
     properties.setProperty(
         Property.POLICY_REFRESH_ENABLED.getKey(), Boolean.toString(refreshEnabled));
     properties.setProperty(Property.POLICY_REFRESH_INTERVAL.getKey(), interval);
+    if (debounce != null) {
+      properties.setProperty(Property.POLICY_REFRESH_DEBOUNCE_INTERVAL.getKey(), debounce);
+    }
     return new ServerProperties(properties);
   }
 
@@ -212,10 +219,23 @@ public class JCasbinAuthorizerMultiInstanceTest {
 
   @Test
   void denyTriggeredRefreshIsDebounced() throws Exception {
-    JCasbinAuthorizer replica = startReplica();
+    JCasbinAuthorizer replica =
+        register(
+            new JCasbinAuthorizer(
+                hibernateConfigurator, properties(true, "PT1H", TEST_REFRESH_INTERVAL)));
+    JCasbinAuthorizer writer = startReplicaWithoutRefresh();
 
     replica.refreshAuthorizations();
-    assertThat(replica.refreshAuthorizations()).isFalse();
+    assertThat(replica.refreshAuthorizations())
+        .as("a second check inside the debounce window is skipped")
+        .isFalse();
+
+    writer.grantAuthorization(UUID.randomUUID(), UUID.randomUUID(), Privileges.SELECT);
+    Thread.sleep(Duration.parse(TEST_REFRESH_INTERVAL).toMillis() + 50);
+
+    assertThat(replica.refreshAuthorizations())
+        .as("after the debounce window a changed policy is reloaded")
+        .isTrue();
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -1,0 +1,347 @@
+package io.unitycatalog.server.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.unitycatalog.server.persist.model.Privileges;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.ServerProperties.Property;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for running the UC server as multiple instances against one shared database.
+ *
+ * <p>Every other authorizer test uses a single {@link JCasbinAuthorizer}, and jCasbin evaluates
+ * every decision against an in-memory copy of the policy set that is loaded once in the
+ * constructor. A single instance therefore always reads back its own writes, and the cross-instance
+ * staleness bug is invisible by construction. These tests exist to close that gap.
+ *
+ * <p>Each {@code JCasbinAuthorizer} here stands in for one replica: they share the {@link
+ * HibernateConfigurator} (and so the database), but each constructs its own {@code JDBCAdapter} and
+ * its own {@code SyncedEnforcer}, exactly as separate pods would. {@code SyncedEnforcer} makes a
+ * single instance thread-safe; it does not share policy state between instances, and its lock —
+ * though static — cannot help here because the two instances hold two distinct {@code Model}s.
+ *
+ * <p>Propagation is eventually consistent, so the cross-instance assertions poll with a bounded
+ * timeout rather than asserting immediately. Asserting immediately would be flaky by construction.
+ */
+public class JCasbinAuthorizerMultiInstanceTest {
+
+  /** Generous enough to absorb a slow CI machine, short enough to fail fast when broken. */
+  private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(5);
+
+  /** Far shorter than production's default so the tests are not dominated by waiting. */
+  private static final String TEST_REFRESH_INTERVAL = "PT0.05S";
+
+  private HibernateConfigurator hibernateConfigurator;
+  private final List<JCasbinAuthorizer> replicas = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    Properties properties = new Properties();
+    properties.setProperty(Property.SERVER_ENV.getKey(), "test");
+    hibernateConfigurator = new HibernateConfigurator(new ServerProperties(properties));
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Close the replicas before the SessionFactory they poll through, and close them at all so the
+    // refresh threads do not accumulate across the suite.
+    replicas.forEach(JCasbinAuthorizer::close);
+    replicas.clear();
+    hibernateConfigurator.getSessionFactory().close();
+  }
+
+  private ServerProperties properties(boolean refreshEnabled, String interval) {
+    Properties properties = new Properties();
+    properties.setProperty(Property.SERVER_ENV.getKey(), "test");
+    properties.setProperty(
+        Property.POLICY_REFRESH_ENABLED.getKey(), refreshEnabled ? "enable" : "disable");
+    properties.setProperty(Property.POLICY_REFRESH_INTERVAL.getKey(), interval);
+    return new ServerProperties(properties);
+  }
+
+  /** Starts a replica that polls for changes, as a production instance does. */
+  private JCasbinAuthorizer startReplica() throws Exception {
+    return register(
+        new JCasbinAuthorizer(hibernateConfigurator, properties(true, TEST_REFRESH_INTERVAL)));
+  }
+
+  /**
+   * Starts a replica that does not poll, so a test can drive {@link
+   * CasbinPolicyRefresher#checkAndReload()} itself and observe its return value rather than racing
+   * the background thread.
+   */
+  private JCasbinAuthorizer startReplicaWithoutRefresh() throws Exception {
+    return register(
+        new JCasbinAuthorizer(hibernateConfigurator, properties(false, TEST_REFRESH_INTERVAL)));
+  }
+
+  private JCasbinAuthorizer register(JCasbinAuthorizer authorizer) {
+    replicas.add(authorizer);
+    return authorizer;
+  }
+
+  /**
+   * Performs the one unconditional reload every refresher does on its first check, so that
+   * subsequent assertions are about genuine changes. That first reload is deliberate — see {@link
+   * CasbinPolicyRefresher} on why the version is not seeded in the constructor.
+   */
+  private static void settle(JCasbinAuthorizer replica) {
+    assertThat(replica.getRefresher().checkAndReload())
+        .as("the first check always reloads")
+        .isTrue();
+    assertThat(replica.getRefresher().checkAndReload())
+        .as("nothing changed since the first check")
+        .isFalse();
+  }
+
+  private static void await(String description, BooleanSupplier condition) {
+    long deadline = System.nanoTime() + AWAIT_TIMEOUT.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      try {
+        Thread.sleep(20);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        fail("Interrupted while waiting for " + description);
+      }
+    }
+    fail("%s did not happen within %s", description, AWAIT_TIMEOUT);
+  }
+
+  /**
+   * A grant issued through one replica must be honoured by every other replica.
+   *
+   * <p>Without session affinity the request that creates a resource and the request that next reads
+   * it land on different pods, so the reader would otherwise deny access to a resource the writer
+   * just created — a spurious {@code 403 PERMISSION_DENIED} that succeeds on retry.
+   */
+  @Test
+  void grantOnOneReplicaIsVisibleToAnother() throws Exception {
+    UnityCatalogAuthorizer replicaA = startReplica();
+    UnityCatalogAuthorizer replicaB = startReplica();
+
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+
+    replicaA.grantAuthorization(principal, resource, Privileges.CREATE_CATALOG);
+
+    assertThat(replicaA.authorize(principal, resource, Privileges.CREATE_CATALOG)).isTrue();
+    await(
+        "the grant to reach replica B",
+        () -> replicaB.authorize(principal, resource, Privileges.CREATE_CATALOG));
+  }
+
+  /**
+   * A revocation issued through one replica must be honoured by every other replica.
+   *
+   * <p>This is the security-relevant direction: a stale replica keeps <em>allowing</em> access, so
+   * the request returns {@code 200 OK} and credentials are vended for a privilege that has already
+   * been revoked. There is no error, and nothing in the server logs — only an audit surfaces it.
+   *
+   * <p>Replica B is started after the grant so that it begins with the privilege in its cache; the
+   * assertion is specifically about the revocation propagating, not the grant.
+   */
+  @Test
+  void revokeOnOneReplicaIsHonouredByAnother() throws Exception {
+    UnityCatalogAuthorizer replicaA = startReplica();
+
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    replicaA.grantAuthorization(principal, resource, Privileges.SELECT);
+
+    UnityCatalogAuthorizer replicaB = startReplica();
+    assertThat(replicaB.authorize(principal, resource, Privileges.SELECT)).isTrue();
+
+    replicaA.revokeAuthorization(principal, resource, Privileges.SELECT);
+
+    assertThat(replicaA.authorize(principal, resource, Privileges.SELECT)).isFalse();
+    await(
+        "the revocation to reach replica B",
+        () -> !replicaB.authorize(principal, resource, Privileges.SELECT));
+  }
+
+  /**
+   * A hierarchy edge added through one replica must be visible to every other replica.
+   *
+   * <p>Nested resources inherit non-OWNER privileges by walking the {@code g2} ancestor chain, so a
+   * missing edge breaks inherited access on the child even when the grant on the parent is known.
+   * The missing edge also makes {@code getHierarchyParent} return {@code null}, which {@code
+   * PermissionService} treats as "no parent" rather than as an error — the parent and grandparent
+   * owner checks are skipped and a permission listing silently degrades from every assignment to
+   * only the caller's own.
+   */
+  @Test
+  void hierarchyEdgeAddedOnOneReplicaIsVisibleToAnother() throws Exception {
+    UnityCatalogAuthorizer replicaA = startReplica();
+    UnityCatalogAuthorizer replicaB = startReplica();
+
+    UUID principal = UUID.randomUUID();
+    UUID catalog = UUID.randomUUID();
+    UUID schema = UUID.randomUUID();
+
+    replicaA.addHierarchyChild(catalog, schema);
+    replicaA.grantAuthorization(principal, catalog, Privileges.SELECT);
+
+    await(
+        "the hierarchy edge to reach replica B",
+        () -> catalog.equals(replicaB.getHierarchyParent(schema)));
+    await(
+        "the inherited privilege to reach replica B",
+        () -> replicaB.authorize(principal, schema, Privileges.SELECT));
+  }
+
+  /**
+   * Control test: the write itself reaches the shared database.
+   *
+   * <p>A replica started after the grant sees it immediately, which localises any propagation
+   * failure to the in-memory cache of already-running replicas rather than to the persistence path.
+   * This is also why a pod restart appeared to "fix" the problem in production while nothing had
+   * actually been repaired — the restart only reloaded the cache.
+   */
+  @Test
+  void grantIsPersistedAndVisibleToAReplicaStartedAfterwards() throws Exception {
+    UnityCatalogAuthorizer replicaA = startReplica();
+
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    replicaA.grantAuthorization(principal, resource, Privileges.CREATE_CATALOG);
+
+    UnityCatalogAuthorizer replicaStartedLater = startReplica();
+
+    assertThat(replicaStartedLater.authorize(principal, resource, Privileges.CREATE_CATALOG))
+        .isTrue();
+  }
+
+  /**
+   * Change detection must notice an insert.
+   *
+   * <p>Detection compares {@code (count(*), max(id))} on {@code casbin_rule}. An insert always
+   * moves {@code max(id)}, because the adapter declares {@code id} as auto-incrementing on every
+   * dialect.
+   */
+  @Test
+  void detectsAnInsert() throws Exception {
+    UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
+    JCasbinAuthorizer reader = startReplicaWithoutRefresh();
+    settle(reader);
+
+    writer.grantAuthorization(UUID.randomUUID(), UUID.randomUUID(), Privileges.SELECT);
+
+    assertThat(reader.getRefresher().checkAndReload()).isTrue();
+  }
+
+  /**
+   * Change detection must notice a delete.
+   *
+   * <p>A delete leaves {@code max(id)} alone but lowers {@code count(*)}, which is the only reason
+   * the count is part of the pair at all.
+   */
+  @Test
+  void detectsADelete() throws Exception {
+    UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    writer.grantAuthorization(principal, resource, Privileges.SELECT);
+
+    JCasbinAuthorizer reader = startReplicaWithoutRefresh();
+    settle(reader);
+
+    writer.revokeAuthorization(principal, resource, Privileges.SELECT);
+
+    assertThat(reader.getRefresher().checkAndReload()).isTrue();
+  }
+
+  /**
+   * Change detection must notice a delete paired with an insert, the case that defeats a count on
+   * its own: the count returns to where it started, and only {@code max(id)} reveals the change.
+   */
+  @Test
+  void detectsADeleteAndInsertThatLeavesTheCountUnchanged() throws Exception {
+    UnityCatalogAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID revoked = UUID.randomUUID();
+    writer.grantAuthorization(principal, revoked, Privileges.SELECT);
+
+    JCasbinAuthorizer reader = startReplicaWithoutRefresh();
+    settle(reader);
+
+    // One row out, one row in: same count, higher max id.
+    writer.revokeAuthorization(principal, revoked, Privileges.SELECT);
+    UUID granted = UUID.randomUUID();
+    writer.grantAuthorization(principal, granted, Privileges.SELECT);
+
+    assertThat(reader.getRefresher().checkAndReload()).isTrue();
+    assertThat(reader.authorize(principal, granted, Privileges.SELECT)).isTrue();
+    assertThat(reader.authorize(principal, revoked, Privileges.SELECT)).isFalse();
+  }
+
+  /**
+   * The deny-triggered refresh must be rate-limited. It runs on a path reachable by unauthenticated
+   * callers, so without a debounce a client hammering a denied endpoint would force continuous
+   * full-table reloads, each holding the enforcer's write lock.
+   */
+  @Test
+  void denyTriggeredRefreshIsDebounced() throws Exception {
+    JCasbinAuthorizer replica = startReplica();
+
+    // Default debounce is 1s, so only the first of two immediate calls may do any work. The
+    // background poll uses checkAndReload rather than this path, so it cannot perturb the window.
+    assertThat(replica.refreshAuthorizations()).isTrue();
+    assertThat(replica.refreshAuthorizations()).isFalse();
+  }
+
+  /**
+   * Disabling refresh must disable all of it, including the deny-triggered reload — otherwise the
+   * setting is not a kill switch and an operator cannot fully roll back to the previous behaviour.
+   */
+  @Test
+  void disablingRefreshAlsoDisablesTheDenyTriggeredReload() throws Exception {
+    JCasbinAuthorizer replica = startReplicaWithoutRefresh();
+
+    assertThat(replica.getRefresher().isRunning()).isFalse();
+    assertThat(replica.refreshAuthorizations()).isFalse();
+  }
+
+  /**
+   * With refresh disabled, a replica must exhibit the original stale behaviour. This is what makes
+   * the enabled cases above meaningful: it shows the polling is what fixes them, rather than
+   * something incidental to the test setup.
+   */
+  @Test
+  void withRefreshDisabledAGrantNeverReachesAnotherReplica() throws Exception {
+    UnityCatalogAuthorizer replicaA = startReplicaWithoutRefresh();
+    UnityCatalogAuthorizer replicaB = startReplicaWithoutRefresh();
+
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+
+    replicaA.grantAuthorization(principal, resource, Privileges.CREATE_CATALOG);
+
+    assertThat(replicaA.authorize(principal, resource, Privileges.CREATE_CATALOG)).isTrue();
+    assertThat(replicaB.authorize(principal, resource, Privileges.CREATE_CATALOG)).isFalse();
+  }
+
+  /** A closed authorizer must not leave its refresh thread behind. */
+  @Test
+  void closeStopsTheRefreshThread() throws Exception {
+    JCasbinAuthorizer replica = startReplica();
+    assertThat(replica.getRefresher().isRunning()).isTrue();
+
+    replica.close();
+
+    assertThat(replica.getRefresher().isRunning()).isFalse();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -214,7 +214,7 @@ public class JCasbinAuthorizerMultiInstanceTest {
   void denyTriggeredRefreshIsDebounced() throws Exception {
     JCasbinAuthorizer replica = startReplica();
 
-    assertThat(replica.refreshAuthorizations()).isTrue();
+    replica.refreshAuthorizations();
     assertThat(replica.refreshAuthorizations()).isFalse();
   }
 

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -251,12 +251,15 @@ public class JCasbinAuthorizerMultiInstanceTest {
     CountDownLatch releaseWriteLock = new CountDownLatch(1);
     Thread holder =
         new Thread(
-            () ->
-                replica.withWriteLock(
-                    () -> {
-                      holdingWriteLock.countDown();
-                      awaitLatch(releaseWriteLock, "the write lock to be released");
-                    }),
+            () -> {
+              replica.reloadLock.writeLock().lock();
+              try {
+                holdingWriteLock.countDown();
+                awaitLatch(releaseWriteLock, "the write lock to be released");
+              } finally {
+                replica.reloadLock.writeLock().unlock();
+              }
+            },
             "write-lock-holder");
     holder.start();
     assertThat(holdingWriteLock.await(2, TimeUnit.SECONDS))

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -47,7 +47,7 @@ public class JCasbinAuthorizerMultiInstanceTest {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
     properties.setProperty(
-        Property.POLICY_REFRESH_ENABLED.getKey(), refreshEnabled ? "enable" : "disable");
+        Property.POLICY_REFRESH_ENABLED.getKey(), Boolean.toString(refreshEnabled));
     properties.setProperty(Property.POLICY_REFRESH_INTERVAL.getKey(), interval);
     return new ServerProperties(properties);
   }

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -235,6 +238,71 @@ public class JCasbinAuthorizerMultiInstanceTest {
 
     assertThat(replicaA.authorize(principal, resource, Privileges.CREATE_CATALOG)).isTrue();
     assertThat(replicaB.authorize(principal, resource, Privileges.CREATE_CATALOG)).isFalse();
+  }
+
+  @Test
+  void authorizeDoesNotWaitForTheWriteLock() throws Exception {
+    JCasbinAuthorizer replica = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    replica.grantAuthorization(principal, resource, Privileges.SELECT);
+
+    CountDownLatch holdingWriteLock = new CountDownLatch(1);
+    CountDownLatch releaseWriteLock = new CountDownLatch(1);
+    Thread holder =
+        new Thread(
+            () ->
+                replica.withWriteLock(
+                    () -> {
+                      holdingWriteLock.countDown();
+                      awaitLatch(releaseWriteLock, "the write lock to be released");
+                    }),
+            "write-lock-holder");
+    holder.start();
+    assertThat(holdingWriteLock.await(2, TimeUnit.SECONDS))
+        .as("the write lock should be held")
+        .isTrue();
+
+    AtomicBoolean grantFinished = new AtomicBoolean(false);
+    Thread writer =
+        new Thread(
+            () -> {
+              try {
+                replica.grantAuthorization(
+                    UUID.randomUUID(), UUID.randomUUID(), Privileges.CREATE_CATALOG);
+              } catch (Exception e) {
+                fail("grantAuthorization failed", e);
+              }
+              grantFinished.set(true);
+            },
+            "blocked-writer");
+    writer.start();
+    await(
+        "the writer to block on the write lock",
+        () -> {
+          Thread.State state = writer.getState();
+          return state == Thread.State.BLOCKED || state == Thread.State.WAITING;
+        });
+    assertThat(grantFinished.get()).as("a write should wait for the write lock").isFalse();
+
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isTrue();
+
+    releaseWriteLock.countDown();
+    writer.join(2000);
+    holder.join(2000);
+    assertThat(grantFinished.get()).isTrue();
+    assertThat(holder.isAlive()).isFalse();
+  }
+
+  private static void awaitLatch(CountDownLatch latch, String description) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        fail(description + " did not happen within 5s");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail("Interrupted while waiting for " + description);
+    }
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -22,8 +22,7 @@ public class JCasbinAuthorizerTest {
   void setUp() throws Exception {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
-    // These tests only ever use one authorizer, so there is nothing to pick up from another
-    // instance; polling would just add a background thread per test.
+    // Single-instance tests do not need background polling.
     properties.setProperty(Property.POLICY_REFRESH_ENABLED.getKey(), "disable");
     ServerProperties serverProperties = new ServerProperties(properties);
     HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,9 +22,23 @@ public class JCasbinAuthorizerTest {
   void setUp() throws Exception {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
+    // These tests only ever use one authorizer, so there is nothing to pick up from another
+    // instance; polling would just add a background thread per test.
+    properties.setProperty(Property.POLICY_REFRESH_ENABLED.getKey(), "disable");
     ServerProperties serverProperties = new ServerProperties(properties);
     HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);
-    authenticator = new JCasbinAuthorizer(hibernateConfigurator);
+    authenticator = new JCasbinAuthorizer(hibernateConfigurator, serverProperties);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (authenticator instanceof AutoCloseable closeable) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -23,7 +23,7 @@ public class JCasbinAuthorizerTest {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
     // Single-instance tests do not need background polling.
-    properties.setProperty(Property.POLICY_REFRESH_ENABLED.getKey(), "disable");
+    properties.setProperty(Property.POLICY_REFRESH_ENABLED.getKey(), "false");
     ServerProperties serverProperties = new ServerProperties(properties);
     HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);
     authenticator = new JCasbinAuthorizer(hibernateConfigurator, serverProperties);

--- a/server/src/test/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluatorTest.java
@@ -1,0 +1,81 @@
+package io.unitycatalog.server.auth.decorator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
+import io.unitycatalog.server.model.SecurableType;
+import io.unitycatalog.server.persist.model.Privileges;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UnityAccessEvaluatorTest {
+
+  @Test
+  void evaluateSkipsRefreshWhenExpressionAllows() throws Exception {
+    UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
+    UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
+
+    assertThat(
+            evaluator.evaluate(
+                UUID.randomUUID(), "#permit", Collections.emptyMap(), Collections.emptyMap()))
+        .isTrue();
+    verify(authorizer, never()).refreshAuthorizations();
+  }
+
+  @Test
+  void evaluateKeepsDenyWhenRefreshReturnsFalse() throws Exception {
+    UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
+    when(authorizer.refreshAuthorizations()).thenReturn(false);
+    UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
+
+    assertThat(
+            evaluator.evaluate(
+                UUID.randomUUID(), "#deny", Collections.emptyMap(), Collections.emptyMap()))
+        .isFalse();
+    verify(authorizer, times(1)).refreshAuthorizations();
+  }
+
+  @Test
+  void evaluateKeepsDenyWhenRefreshThrows() throws Exception {
+    UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
+    when(authorizer.refreshAuthorizations()).thenThrow(new RuntimeException("reload failed"));
+    UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
+
+    assertThat(
+            evaluator.evaluate(
+                UUID.randomUUID(), "#deny", Collections.emptyMap(), Collections.emptyMap()))
+        .isFalse();
+    verify(authorizer, times(1)).refreshAuthorizations();
+  }
+
+  @Test
+  void evaluateAllowsAfterSuccessfulRefresh() throws Exception {
+    UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
+    UUID principal = UUID.randomUUID();
+    UUID catalog = UUID.randomUUID();
+
+    when(authorizer.authorize(eq(principal), eq(catalog), eq(Privileges.OWNER)))
+        .thenReturn(false, true);
+    when(authorizer.refreshAuthorizations()).thenReturn(true);
+
+    UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
+
+    assertThat(
+            evaluator.evaluate(
+                principal,
+                "#authorize(#principal, #catalog, OWNER)",
+                Map.of(SecurableType.CATALOG, catalog),
+                Collections.emptyMap()))
+        .isTrue();
+    verify(authorizer, times(1)).refreshAuthorizations();
+    verify(authorizer, times(2)).authorize(eq(principal), eq(catalog), eq(Privileges.OWNER));
+  }
+}


### PR DESCRIPTION
## Motivation / Problem

Unity Catalog's `JCasbinAuthorizer` uses jCasbin with a JDBC adapter: every grant/revoke is **persisted** to the shared `casbin_rule` table, but authorization decisions are made against an **in-memory** policy loaded into the enforcer.

Today that in-memory policy is loaded **once at process start**. There is no watcher, no pub/sub, and no periodic reload across instances. `SyncedEnforcer` only makes a single process safe under concurrent `enforce()` / policy mutations on *that* JVM — it does not synchronize memory across processes.

So when multiple UC server replicas share one database:

- A grant/revoke written through replica A is visible in the DB immediately.
- Replica B keeps serving from its stale in-memory copy until restart.
- Result: spurious `403 Permission Denied` after a grant, and — worse — continued access after a revocation.

This is unsafe for any multi-replica deployment (HA, rolling updates, horizontal scale).

### Concrete example

1. Deploy two UC servers (`uc-1`, `uc-2`) against the same Postgres/MySQL database, behind a load balancer.
2. An admin calls `GRANT SELECT ON catalog.schema.table TO user@example.com` and the request lands on **`uc-1`**.
   - `uc-1` writes the policy row to `casbin_rule` and updates its local enforcer.
3. Moments later, `user@example.com` reads that table; the request lands on **`uc-2`**.
   - `uc-2`'s enforcer still lacks the grant → **403**, even though the grant is already in the DB.
4. The inverse is worse: revoke on `uc-1`, then a request on `uc-2` can still **succeed** until `uc-2` restarts — stale allow.

A related path is create-then-read across instances (e.g. create a securable / grant ownership on one replica, immediately access it via another): the deny path looks like a false negative until policy is reloaded.

### Why jCasbin / the current authorizer does not handle this

| What exists today | What it covers | What it does *not* cover |
|---|---|---|
| `JDBCAdapter` + `enableAutoSave(true)` | Persist local grant/revoke to `casbin_rule` | Notify other processes that policy changed |
| `SyncedEnforcer` | Thread-safe enforce/mutate **within one JVM** | Cross-process / cross-replica consistency |
| Startup `SyncedEnforcer(model, adapter)` | Initial `loadPolicy()` from DB | Subsequent reloads when another instance writes |

jCasbin does not ship a built-in multi-node policy invalidation for the JDBC adapter. Without an external refresh mechanism, each UC replica is effectively a permanently stale cache of authorization state.

## Solution

This PR adds `CasbinPolicyRefresher`, which:

1. **Polls** `casbin_rule` with `select count(*), coalesce(max(id), 0)` and reloads when either value changes (inserts/deletes with auto-increment ids change at least one). Probe, reload, and version stamp run under one lock with a `checkSeq` so concurrent callers coalesce; waiters skip after a consistent check. The stamped version is the one **probed before** reload, so the cache matches what was loaded (not a fresher post-reload re-read).
2. On a **denied** evaluation in `UnityAccessEvaluator.evaluate`, triggers one **debounced** `checkAndReload` (same version-aware path as the poller) and re-evaluates before returning 403. `refreshAuthorizations` returns true only if the current enforcer instance changed, including when a coalesced concurrent check performed the swap.

Reload does **not** call `loadPolicy()` on the current enforcer. It builds a fresh enforcer from the store and swaps it in under the exclusive side of a `ReadWriteLock`:

- `authorize` / `enforce` keep using the previous instance (no lock).
- Local grants/revokes take the shared side so they cannot land on the outgoing instance, but do not wait for each other (`SyncedEnforcer` still serializes mutations on one instance). The read lock is on the current-enforcer pointer, not Casbin read vs write.
- Reload takes the exclusive side for the whole `newEnforcer()` so the swap is not a stop-the-world for reads.

Refresh is **off by default**. Single-instance deployments are unchanged; multi-instance shared-DB setups must set `server.authorization.policy-refresh=true`. See [docs/server/auth.md](https://github.com/unitycatalog/unitycatalog/blob/fix/casbin-cross-replica-policy-refresh/docs/server/auth.md#multiple-server-instances).

## Alternatives considered

More efficient push-based options exist; we deliberately did not take them:

- **Redis (or similar) pub/sub** — lower latency invalidation, but would add another third-party runtime dependency and operational surface for every multi-replica deployment.
- **Native DB notify** (e.g. Postgres `LISTEN`/`NOTIFY`) — event-driven and cheap, but ties the server to Postgres-specific APIs and would introduce compile-time / dialect-specific database dependencies. UC supports more than one DB backend via JDBC/Hibernate, so policy refresh should stay portable.

Polling the shared `casbin_rule` table keeps the solution DB-agnostic and dependency-free, at the cost of up-to-interval propagation delay (tunable) and a cheap version query per interval.

## Configuration

| Property | Default | Purpose |
|---|---|---|
| `server.authorization.policy-refresh` | `false` | Kill switch (`true`/`false`). Off disables poll and deny-path reload. |
| `server.authorization.policy-refresh-interval` | `PT1M` | How often to poll `casbin_rule` for changes |
| `server.authorization.policy-refresh-debounce-interval` | `PT1S` | Min gap between deny-triggered checks (avoids stampede on legitimate 403s) |

No Helm change needed — defaults apply via existing `extraProperties`. Set `server.authorization.policy-refresh=true` for multi-instance shared-DB deployments. Documented in `docs/server/auth.md`.

## Test plan

- [x] `JCasbinAuthorizerMultiInstanceTest` — grant/revoke/hierarchy propagation, change detection, debounce (including after the window), kill switch, `close()`, authorize stays live during exclusive reload lock
- [x] `JCasbinAuthorizerTest` — existing grant/revoke/hierarchy/list behavior
- [x] `UnityAccessEvaluatorTest` — deny-path refresh + retry in `evaluate`
- [ ] `server/test` passes in CI

## Limitations

- Refresh is opt-in. Multi-instance deployments must enable it.
- Revocations propagate asynchronously (up to poll interval); deny-path refresh only helps stale *denies*.
- A write that lands during `newEnforcer()` may wait until the next check (version stamp is the pre-reload probe).
- `count(*)` cost grows with policy size; raise interval for very large policy sets.
