### PR TITLE
[Hadoop] Use vended credentials in scoped filesystem tests

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/MultiCredentialScopedFsTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/MultiCredentialScopedFsTest.java
@@ -64,6 +64,7 @@ public class MultiCredentialScopedFsTest extends BaseSparkIntegrationTest {
       CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
       CredentialTestFileSystem.credentialCheckEnabled = true;
       PerPathCredentialTestFileSystem.clearExpectedCredentials();
+      PerPathCredentialTestFileSystem.clearVendedCredentials();
     }
   }
 
@@ -106,12 +107,14 @@ public class MultiCredentialScopedFsTest extends BaseSparkIntegrationTest {
   }
 
   private static void vend(GenericCredential... credentials) {
+    List<GenericCredential> vendedCredentials = List.of(credentials);
     GenericCredentialFetcher fetcher = mock(GenericCredentialFetcher.class);
     try {
-      when(fetcher.createCredentials()).thenReturn(List.of(credentials));
+      when(fetcher.createCredentials()).thenReturn(vendedCredentials);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
     CredPropsUtil.genericCredFetcherFactory = (apiClient, credId) -> fetcher;
+    PerPathCredentialTestFileSystem.setVendedCredentials(vendedCredentials);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PerPathCredentialTestFileSystem.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PerPathCredentialTestFileSystem.java
@@ -3,11 +3,13 @@ package io.unitycatalog.spark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 
+import io.unitycatalog.hadoop.internal.CredentialUtil;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.AwsVendedTokenProvider;
+import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.conf.Configuration;
@@ -23,6 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 public class PerPathCredentialTestFileSystem extends CredentialTestFileSystem {
 
   private static final Map<String, AwsCredential> EXPECTED_CREDENTIALS = new ConcurrentHashMap<>();
+  private static volatile List<GenericCredential> vendedCredentials = List.of();
 
   static void setRequiredCredential(String prefix, AwsCredential credential) {
     EXPECTED_CREDENTIALS.put(new Path(prefix).toString(), credential);
@@ -32,21 +35,30 @@ public class PerPathCredentialTestFileSystem extends CredentialTestFileSystem {
     EXPECTED_CREDENTIALS.clear();
   }
 
+  static void setVendedCredentials(List<GenericCredential> credentials) {
+    vendedCredentials = List.copyOf(credentials);
+  }
+
+  static void clearVendedCredentials() {
+    vendedCredentials = List.of();
+  }
+
   @Override
   protected void checkCredentials(Path f) {
     if (!credentialCheckEnabled) {
       return;
     }
     String uri = new Path(f.toUri()).toString();
-    String expectedPrefix =
-        EXPECTED_CREDENTIALS.keySet().stream()
-            .filter(prefix -> covers(uri, prefix))
-            .max(Comparator.comparingInt(String::length))
-            .orElseThrow(() -> new AssertionError("no expected credential registered for " + f));
+    List<String> prefixes = new ArrayList<>(EXPECTED_CREDENTIALS.keySet());
+    int expectedPrefixIndex = CredentialUtil.longestCoveringIndex(uri, prefixes);
+    assertThat(expectedPrefixIndex)
+        .as("expected a credential to be registered for %s", f)
+        .isNotNegative();
+    String expectedPrefix = prefixes.get(expectedPrefixIndex);
     String expectedAccessKey = EXPECTED_CREDENTIALS.get(expectedPrefix).accessKeyId();
     Configuration conf = getConf();
 
-    GenericCredentialFetcher fetcher = () -> new ArrayList<>(EXPECTED_CREDENTIALS.values());
+    GenericCredentialFetcher fetcher = () -> vendedCredentials;
     try (MockedStatic<GenericCredentialFetcher> mockedFetcher =
         mockStatic(GenericCredentialFetcher.class)) {
       mockedFetcher.when(() -> GenericCredentialFetcher.create(conf)).thenReturn(fetcher);
@@ -62,9 +74,5 @@ public class PerPathCredentialTestFileSystem extends CredentialTestFileSystem {
   @Override
   protected String scheme() {
     return "s3:";
-  }
-
-  private static boolean covers(String uri, String prefix) {
-    return (uri + "/").startsWith(prefix + "/");
   }
 }


### PR DESCRIPTION
## Summary

- Pass the credentials supplied to `vend(...)` into the test filesystem's runtime credential fetcher.
- Keep vended credentials separate from expected per-path credentials.
- Reuse `CredentialUtil.longestCoveringIndex` instead of duplicating prefix-matching logic.

## Why

Previously, the test filesystem reconstructed fetched credentials from its expected values. That could hide a mismatch between the credentials actually vended and those expected by the test.

## Testing

- `./build/sbt -J-Xmx4G \"spark/testOnly io.unitycatalog.spark.MultiCredentialScopedFsTest\"` (1 test passed)