### PR TITLE
Render errors in the dialect of the service that was called

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -10,15 +10,19 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.docs.DocService;
 import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
-import io.unitycatalog.server.exception.ExceptionHandlingDecorator;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
+import io.unitycatalog.server.exception.GlobalExceptionHandlingDecorator;
+import io.unitycatalog.server.exception.ServiceExceptionHandlingDecorator;
 import io.unitycatalog.server.service.AuthService;
 import io.unitycatalog.server.service.IcebergRestCatalogService;
+import io.unitycatalog.server.service.RegisteredService;
+import io.unitycatalog.server.service.ScimService;
+import io.unitycatalog.server.service.UnityCatalogRestService;
 import io.unitycatalog.server.service.delta.DeltaApiMappers;
 import io.unitycatalog.server.service.delta.DeltaApiService;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
@@ -27,13 +31,14 @@ import java.util.Objects;
 
 /**
  * Wraps Armeria's {@link ServerBuilder} with Unity-Catalog-aware registration. Callers register
- * each annotated service through a protocol-specific {@code annotate*} method ({@link
- * #annotateUc}, {@link #annotateAuth}, {@link #annotateScim}, {@link #annotateIceberg},
- * {@link #annotateDelta}). Those methods funnel through the single private {@link #register}, the
- * only place this class registers an annotated service, and it always installs the PAYLOAD-source
- * authorization gate in front of the body converter -- so no annotated service can reach the server
- * ungated. {@link #withSecurityDecorators} attaches caller-supplied access/auth decorators to the
- * API path prefixes, and {@link #build()} builds the server.
+ * each annotated service with {@code annotate}, overloaded per service type so the argument picks
+ * the {@link ServiceProtocol} and with it the base path, body mapper, and response converter. The
+ * error dialect is not chosen here: the service supplies its own via {@link
+ * RegisteredService#exceptionHandler()}. Those overloads funnel through the single private {@link
+ * #register}, the only place this class registers an annotated service, so every route is wired the
+ * same way, including the PAYLOAD-source gate in front of body binding. {@link
+ * #withSecurityDecorators} attaches caller-supplied access/auth decorators to the API path
+ * prefixes, and {@link #build()} builds the server.
  *
  * <p>{@link UnityCatalogServer} bootstraps the collaborators (Hibernate, authorizer, repositories),
  * constructs the service handlers, and decides whether authorization is enabled; this class turns
@@ -80,33 +85,31 @@ public class ArmeriaServerBuilder {
   }
 
   /** Registers a control-plane auth service at {@code controlPath + relativePath}. */
-  ArmeriaServerBuilder annotateAuth(String relativePath, AuthService service) {
+  ArmeriaServerBuilder annotate(String relativePath, AuthService service) {
     register(ServiceProtocol.AUTH, relativePath, service);
     return this;
   }
 
-  // TODO: introduce an interface for the two SCIM services and replace Object here with it.
   /** Registers a SCIM2 service (UC body + SCIM response converter) under the control path. */
-  ArmeriaServerBuilder annotateScim(String relativePath, Object service) {
+  ArmeriaServerBuilder annotate(String relativePath, ScimService service) {
     register(ServiceProtocol.SCIM, relativePath, service);
     return this;
   }
 
-  // TODO: introduce an interface for all UC REST services and replace Object here with it.
   /** Registers a standard Unity Catalog REST service at {@code basePath + relativePath}. */
-  ArmeriaServerBuilder annotateUc(String relativePath, Object service) {
+  ArmeriaServerBuilder annotate(String relativePath, UnityCatalogRestService service) {
     register(ServiceProtocol.UC, relativePath, service);
     return this;
   }
 
   /** Registers an Iceberg REST catalog service (Iceberg mapper) under the base path. */
-  ArmeriaServerBuilder annotateIceberg(String relativePath, IcebergRestCatalogService service) {
+  ArmeriaServerBuilder annotate(String relativePath, IcebergRestCatalogService service) {
     register(ServiceProtocol.ICEBERG, relativePath, service);
     return this;
   }
 
   /** Registers a UC Delta REST service (Delta mapper) under the base path. */
-  ArmeriaServerBuilder annotateDelta(String relativePath, DeltaApiService service) {
+  ArmeriaServerBuilder annotate(String relativePath, DeltaApiService service) {
     register(ServiceProtocol.DELTA, relativePath, service);
     return this;
   }
@@ -139,7 +142,9 @@ public class ArmeriaServerBuilder {
           .build(decorator);
     }
 
-    armeriaServerBuilder.decorator(new ExceptionHandlingDecorator(new GlobalExceptionHandler()));
+    // Also registered globally, where it is outermost and can catch what the route decorators above
+    // throw. This instance carries no dialect: it finds the per-service one for the matched route.
+    armeriaServerBuilder.decorator(GlobalExceptionHandlingDecorator::new);
     return this;
   }
 
@@ -172,30 +177,43 @@ public class ArmeriaServerBuilder {
   }
 
   /**
-   * The single registration point behind every {@code annotate*} method, and the only place this
-   * class calls {@code annotatedService}. It selects the protocol-specific body mapper and response
-   * converter, wraps the request converter with {@link AuthorizationGateConverter} (so the
-   * PAYLOAD-source authorization gate fires before body binding for every route without exception),
-   * and registers the service at {@code basePath + relativePath} ({@code ""} mounts at the base
-   * path root). Because this is the sole registration path and it always wraps with the gate, no
-   * annotated service can reach the server ungated.
+   * The single registration point behind every {@code annotate} overload, and the only place this
+   * class calls {@code annotatedService}. It selects the protocol-specific body and response
+   * converters and registers the service at {@code basePath + relativePath} ({@code ""} mounts at
+   * the base path root). Because this is the sole registration path and every arm gets its body
+   * converter from {@link #gatedJackson}, no annotated service can reach the server ungated while
+   * authorization is enabled.
    *
    * <p>The per-protocol converter selection is a switch expression with no default, so it is
    * checked for exhaustiveness: adding a {@link ServiceProtocol} constant without a corresponding
    * arm is a compile error, and a new service kind cannot be registered without also deciding its
-   * (still gated) converters.
+   * converters.
    */
-  private void register(ServiceProtocol protocol, String relativePath, Object service) {
-    List<Object> converters = switch (protocol) {
-      // Auth and UC services do not have response converter. They return HttpResponse.ofJson
-      // directly.
-      case AUTH, UC -> List.of(gatedJackson(ucMapper));
-      case SCIM -> List.of(gatedJackson(ucMapper), scimResponseConverter);
-      case ICEBERG -> List.of(gatedJackson(icebergMapper), icebergResponseConverter);
-      case DELTA -> List.of(gatedJackson(deltaMapper), deltaResponseConverter);
+  private void register(ServiceProtocol protocol, String relativePath, RegisteredService service) {
+    RequestConverterFunction requestConverter = switch (protocol) {
+      case AUTH, UC, SCIM -> gatedJackson(ucMapper);
+      case ICEBERG -> gatedJackson(icebergMapper);
+      case DELTA -> gatedJackson(deltaMapper);
     };
-    armeriaServerBuilder.annotatedService(
-        protocol.basePath(basePath, controlPath) + relativePath, service, converters.toArray());
+    // Auth and UC services have no response converter; they return HttpResponse.ofJson directly.
+    List<JacksonResponseConverterFunction> responseConverters = switch (protocol) {
+      case AUTH, UC -> List.of();
+      case SCIM -> List.of(scimResponseConverter);
+      case ICEBERG -> List.of(icebergResponseConverter);
+      case DELTA -> List.of(deltaResponseConverter);
+    };
+    // The service names its own dialect, so both paths use the same value: exceptionHandlers()
+    // covers exceptions thrown inside the handler, the per-service decorator covers those thrown by
+    // decorators sitting outside it.
+    ExceptionHandlerFunction handler = service.exceptionHandler();
+    armeriaServerBuilder
+        .annotatedService()
+        .pathPrefix(protocol.basePath(basePath, controlPath) + relativePath)
+        .requestConverters(requestConverter)
+        .responseConverters(responseConverters)
+        .exceptionHandlers(handler)
+        .decorator(delegate -> new ServiceExceptionHandlingDecorator(delegate, handler))
+        .build(service);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -179,42 +179,41 @@ public class UnityCatalogServer implements AutoCloseable {
 
     SchemaService schemaService = new SchemaService(authorizer, repositories, serverProperties);
 
-    // Each annotate* call registers one service. Order is not significant (Armeria routes by path
+    // Each annotate call registers one service. Order is not significant (Armeria routes by path
     // specificity); relative paths are resolved against the protocol's base path ("" mounts at the
     // base path root).
     armeriaServerBuilder
-        .annotateAuth("auth", new AuthService(securityContext, serverProperties, repositories))
-        .annotateScim("scim2/Users", new Scim2UserService(authorizer, repositories))
-        .annotateScim("scim2/Me", new Scim2SelfService(authorizer, repositories))
-        .annotateUc("permissions", new PermissionService(authorizer, repositories))
-        .annotateUc("catalogs", new CatalogService(authorizer, repositories, serverProperties))
-        .annotateUc("schemas", schemaService)
-        .annotateUc("volumes", new VolumeService(authorizer, repositories, serverProperties))
-        .annotateUc("tables", new TableService(authorizer, repositories, serverProperties))
-        .annotateUc(
+        .annotate("auth", new AuthService(securityContext, serverProperties, repositories))
+        .annotate("scim2/Users", new Scim2UserService(authorizer, repositories))
+        .annotate("scim2/Me", new Scim2SelfService(authorizer, repositories))
+        .annotate("permissions", new PermissionService(authorizer, repositories))
+        .annotate("catalogs", new CatalogService(authorizer, repositories, serverProperties))
+        .annotate("schemas", schemaService)
+        .annotate("volumes", new VolumeService(authorizer, repositories, serverProperties))
+        .annotate("tables", new TableService(authorizer, repositories, serverProperties))
+        .annotate(
             "staging-tables", new StagingTableService(authorizer, repositories, serverProperties))
-        .annotateUc("functions", new FunctionService(authorizer, repositories, serverProperties))
-        .annotateUc("models", new ModelService(authorizer, repositories, serverProperties))
-        .annotateUc("", new MetastoreService(repositories))
-        .annotateUc(
+        .annotate("functions", new FunctionService(authorizer, repositories, serverProperties))
+        .annotate("models", new ModelService(authorizer, repositories, serverProperties))
+        .annotate("", new MetastoreService(repositories))
+        .annotate(
             "temporary-table-credentials",
             new TemporaryTableCredentialsService(
                 storageCredentialVendor, repositories, serverProperties))
-        .annotateUc(
+        .annotate(
             "temporary-volume-credentials",
             new TemporaryVolumeCredentialsService(storageCredentialVendor, repositories))
-        .annotateUc(
+        .annotate(
             "temporary-model-version-credentials",
             new TemporaryModelVersionCredentialsService(storageCredentialVendor, repositories))
-        .annotateUc(
+        .annotate(
             "temporary-path-credentials",
             new TemporaryPathCredentialsService(storageCredentialVendor))
-        .annotateUc(
-            "credentials", new CredentialService(authorizer, repositories, serverProperties))
-        .annotateUc(
+        .annotate("credentials", new CredentialService(authorizer, repositories, serverProperties))
+        .annotate(
             "delta/preview/commits",
             new DeltaCommitsService(authorizer, repositories, serverProperties))
-        .annotateUc(
+        .annotate(
             "external-locations",
             new ExternalLocationService(authorizer, repositories, serverProperties));
     addIcebergApiServices(armeriaServerBuilder, schemaService, repositories, fileOperations);
@@ -233,7 +232,7 @@ public class UnityCatalogServer implements AutoCloseable {
     MetadataService metadataService = new MetadataService(fileOperations);
     TableConfigService tableConfigService = new TableConfigService(fileOperations);
 
-    armeriaServerBuilder.annotateIceberg(
+    armeriaServerBuilder.annotate(
         "iceberg",
         new IcebergRestCatalogService(
             schemaService, tableConfigService, metadataService, repositories));
@@ -248,7 +247,7 @@ public class UnityCatalogServer implements AutoCloseable {
     LOGGER.info("Adding UC Delta API services...");
     DeltaApiService deltaApiService =
         new DeltaApiService(authorizer, repositories, serverProperties, storageCredentialVendor);
-    armeriaServerBuilder.annotateDelta("", deltaApiService);
+    armeriaServerBuilder.annotate("", deltaApiService);
   }
 
   private void addSecurityDecorators(

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -11,7 +11,6 @@ import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import io.netty.util.AttributeKey;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
@@ -384,8 +383,10 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
   }
 
   private static Method findServiceMethod(HttpService httpService) throws ClassNotFoundException {
-    if (httpService.unwrap() instanceof SimpleDecoratingHttpService decoratingService
-        && decoratingService.unwrap() instanceof AnnotatedService service) {
+    // as() searches the whole decorator chain, so this does not depend on how many decorators sit
+    // between the route and the annotated service.
+    HttpService annotated = httpService.as(AnnotatedService.class);
+    if (annotated instanceof AnnotatedService service) {
 
       LOGGER.debug("serviceName = {}, methodName = {}",
           service.serviceName(),

--- a/server/src/main/java/io/unitycatalog/server/exception/DeltaApiExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/DeltaApiExceptionHandler.java
@@ -12,6 +12,11 @@ import java.util.Arrays;
  */
 public class DeltaApiExceptionHandler extends BaseExceptionHandler {
 
+  /** Shared instance; these handlers are stateless. */
+  public static final DeltaApiExceptionHandler INSTANCE = new DeltaApiExceptionHandler();
+
+  private DeltaApiExceptionHandler() {}
+
   @Override
   protected HttpResponse createErrorResponse(BaseException exception) {
     ErrorCode errorCode = exception.getErrorCode();

--- a/server/src/main/java/io/unitycatalog/server/exception/ExceptionHandlingDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ExceptionHandlingDecorator.java
@@ -32,8 +32,14 @@ public abstract class ExceptionHandlingDecorator extends SimpleDecoratingHttpSer
 
   @Override
   public final HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+    // An exception can surface two ways: thrown while serve() runs (the catch), or delivered later
+    // as an error signal on the returned response when the service completes asynchronously (the
+    // recover). recover can only substitute a response that has not started flushing yet; a failure
+    // after headers are on the wire is unrecoverable by anyone.
     try {
-      return unwrap().serve(ctx, req);
+      return unwrap()
+          .serve(ctx, req)
+          .recover(Throwable.class, cause -> resolveHandler(ctx).handleException(ctx, req, cause));
     } catch (Exception e) {
       return resolveHandler(ctx).handleException(ctx, req, e);
     }

--- a/server/src/main/java/io/unitycatalog/server/exception/ExceptionHandlingDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ExceptionHandlingDecorator.java
@@ -2,37 +2,40 @@ package io.unitycatalog.server.exception;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 
 /**
- * Catch exceptions and send response
+ * Turns an exception into a formatted error response, in the dialect of the service that was
+ * called.
  *
- * <p>The normal ExceptionHandler annotations do not catch exceptions from Decorators. This can be
- * used to catch those and return the desired response.
+ * <p>Armeria's own {@code @ExceptionHandler} support only wraps the annotated-service invocation,
+ * while authentication and PARAM/SYSTEM-source authorization run in route decorators outside it. An
+ * exception can therefore surface at two depths, so there are two subclasses registered at two
+ * depths: {@link ServiceExceptionHandlingDecorator} per service, and {@link
+ * GlobalExceptionHandlingDecorator} outermost. They differ only in how they answer {@link
+ * #resolveHandler}.
  *
- * <p>This should be set at the bottom of the decorator chain to ensure that it will catch
- * exceptions from upstream decorators.
- *
- * <p>.decorator(decorator1) .decorator(decorator2) .decorator(new ExceptionHandlingDecorator())
+ * <p>The global one must be registered last so it ends up at the bottom of the decorator chain,
+ * where it can catch exceptions from the decorators above it.
  */
-public class ExceptionHandlingDecorator implements DecoratingHttpServiceFunction {
+public abstract class ExceptionHandlingDecorator extends SimpleDecoratingHttpService {
 
-  private final ExceptionHandlerFunction exceptionHandlerFunction;
-
-  public ExceptionHandlingDecorator(ExceptionHandlerFunction exceptionHandlerFunction) {
-    this.exceptionHandlerFunction = exceptionHandlerFunction;
+  protected ExceptionHandlingDecorator(HttpService delegate) {
+    super(delegate);
   }
 
+  /** The dialect to render an exception from this request in. */
+  protected abstract ExceptionHandlerFunction resolveHandler(ServiceRequestContext ctx);
+
   @Override
-  public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
-      throws Exception {
+  public final HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
     try {
-      return delegate.serve(ctx, req);
+      return unwrap().serve(ctx, req);
     } catch (Exception e) {
-      return exceptionHandlerFunction.handleException(ctx, req, e);
+      return resolveHandler(ctx).handleException(ctx, req, e);
     }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler extends BaseExceptionHandler {
     }
 
     Map<String, Object> details = new HashMap<>();
-    details.put("@type", "google.rpc.ErrorInfo");
+    details.put("@type", "type.googleapis.com/google.rpc.ErrorInfo");
     details.put("reason", exception.getErrorCode().name());
     response.put("details", List.of(details));
 

--- a/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandler.java
@@ -16,6 +16,11 @@ import java.util.Map;
  */
 public class GlobalExceptionHandler extends BaseExceptionHandler {
 
+  /** Shared instance; these handlers are stateless. */
+  public static final GlobalExceptionHandler INSTANCE = new GlobalExceptionHandler();
+
+  private GlobalExceptionHandler() {}
+
   @Override
   public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
     // SCIM has its own error format, handle before normalization

--- a/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandlingDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandlingDecorator.java
@@ -1,0 +1,27 @@
+package io.unitycatalog.server.exception;
+
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+
+/**
+ * Registered globally, making it the outermost element of every chain and so the only thing that
+ * can catch a denial thrown by a route decorator, before the service is reached at all.
+ *
+ * <p>It tries to delegate to the {@link ServiceExceptionHandlingDecorator} of the calling service,
+ * or falls back to the default {@link GlobalExceptionHandler} it it finds none.
+ */
+public final class GlobalExceptionHandlingDecorator extends ExceptionHandlingDecorator {
+
+  public GlobalExceptionHandlingDecorator(HttpService delegate) {
+    super(delegate);
+  }
+
+  @Override
+  protected ExceptionHandlerFunction resolveHandler(ServiceRequestContext ctx) {
+    ServiceExceptionHandlingDecorator service =
+        ctx.config().service().as(ServiceExceptionHandlingDecorator.class);
+    // Absent for routes registered without a service dialect: the "/" greeting and the doc service.
+    return service != null ? service.handler() : GlobalExceptionHandler.INSTANCE;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandlingDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/GlobalExceptionHandlingDecorator.java
@@ -9,7 +9,7 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
  * can catch a denial thrown by a route decorator, before the service is reached at all.
  *
  * <p>It tries to delegate to the {@link ServiceExceptionHandlingDecorator} of the calling service,
- * or falls back to the default {@link GlobalExceptionHandler} it it finds none.
+ * or falls back to the default {@link GlobalExceptionHandler} if it finds none.
  */
 public final class GlobalExceptionHandlingDecorator extends ExceptionHandlingDecorator {
 

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -21,6 +21,11 @@ import org.apache.iceberg.rest.responses.ErrorResponse;
  */
 public class IcebergRestExceptionHandler extends BaseExceptionHandler {
 
+  /** Shared instance; these handlers are stateless. */
+  public static final IcebergRestExceptionHandler INSTANCE = new IcebergRestExceptionHandler();
+
+  private IcebergRestExceptionHandler() {}
+
   /**
    * Walks the cause chain past BaseException wrappers to find the original exception, so the
    * Iceberg error type reflects the actual exception (e.g., "NoSuchTableException") rather than

--- a/server/src/main/java/io/unitycatalog/server/exception/ServiceExceptionHandlingDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ServiceExceptionHandlingDecorator.java
@@ -1,0 +1,27 @@
+package io.unitycatalog.server.exception;
+
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import java.util.Objects;
+
+/** Registered around a single service, and the one place a service's error dialect is recorded. */
+public final class ServiceExceptionHandlingDecorator extends ExceptionHandlingDecorator {
+
+  private final ExceptionHandlerFunction handler;
+
+  public ServiceExceptionHandlingDecorator(HttpService delegate, ExceptionHandlerFunction handler) {
+    super(delegate);
+    this.handler = Objects.requireNonNull(handler, "handler");
+  }
+
+  /** The dialect of the service this wraps. */
+  public ExceptionHandlerFunction handler() {
+    return handler;
+  }
+
+  @Override
+  protected ExceptionHandlerFunction resolveHandler(ServiceRequestContext ctx) {
+    return handler;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -19,7 +19,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.RequestConverter;
@@ -50,8 +50,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class AuthService {
+public class AuthService implements RegisteredService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthService.class);
   private final UserRepository userRepository;
@@ -61,6 +60,11 @@ public class AuthService {
   private final ServerProperties serverProperties;
 
   private static final String EMPTY_RESPONSE = "{}";
+
+  @Override
+  public ExceptionHandlerFunction exceptionHandler() {
+    return GlobalExceptionHandler.INSTANCE;
+  }
 
   public AuthService(
       SecurityContext securityContext,

--- a/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
@@ -3,7 +3,6 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -13,7 +12,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CreateCatalog;
 import io.unitycatalog.server.model.ListCatalogsResponse;
@@ -33,8 +31,7 @@ import static io.unitycatalog.server.model.SecurableType.CATALOG;
 import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class CatalogService extends AuthorizedService {
+public class CatalogService extends AuthorizedService implements UnityCatalogRestService {
   private final CatalogRepository catalogRepository;
   private final MetastoreRepository metastoreRepository;
 

--- a/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
@@ -7,7 +7,6 @@ import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateCredentialRequest;
 import io.unitycatalog.server.model.CredentialInfo;
 import io.unitycatalog.server.model.ListCredentialsResponse;
@@ -21,7 +20,6 @@ import java.util.Optional;
 import java.util.UUID;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Get;
@@ -41,8 +39,7 @@ import lombok.SneakyThrows;
  *   <li><b>GCP</b> - Not implemented yet.
  * </ul>
  */
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class CredentialService extends AuthorizedService {
+public class CredentialService extends AuthorizedService implements UnityCatalogRestService {
   private final CredentialRepository credentialRepository;
   private final MetastoreRepository metastoreRepository;
 

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
@@ -2,14 +2,12 @@ package io.unitycatalog.server.service;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.DeltaCommit;
 import io.unitycatalog.server.model.DeltaGetCommits;
 import io.unitycatalog.server.persist.DeltaCommitRepository;
@@ -23,8 +21,7 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 /**
  * REST API service for Delta commits to Delta tables in Unity Catalog.
  */
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class DeltaCommitsService extends AuthorizedService {
+public class DeltaCommitsService extends AuthorizedService implements UnityCatalogRestService {
 
   private final DeltaCommitRepository deltaCommitRepository;
 

--- a/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
@@ -8,7 +8,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import io.unitycatalog.server.model.SecurableType;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -17,7 +16,6 @@ import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateExternalLocation;
 import io.unitycatalog.server.model.ExternalLocationInfo;
 import io.unitycatalog.server.model.ListExternalLocationsResponse;
@@ -30,8 +28,7 @@ import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
 import lombok.SneakyThrows;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class ExternalLocationService extends AuthorizedService {
+public class ExternalLocationService extends AuthorizedService implements UnityCatalogRestService {
   private final ExternalLocationRepository externalLocationRepository;
   private final MetastoreRepository metastoreRepository;
 

--- a/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
@@ -10,7 +10,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateFunctionRequest;
 import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.FunctionInfo;
@@ -26,14 +25,12 @@ import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class FunctionService extends AuthorizedService {
+public class FunctionService extends AuthorizedService implements UnityCatalogRestService {
 
   private final FunctionRepository functionRepository;
   private final SchemaRepository schemaRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -5,7 +5,7 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
@@ -49,8 +49,7 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ExceptionHandler(IcebergRestExceptionHandler.class)
-public class IcebergRestCatalogService {
+public class IcebergRestCatalogService implements RegisteredService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergRestCatalogService.class);
 
@@ -71,6 +70,11 @@ public class IcebergRestCatalogService {
   private final MetadataService metadataService;
   private final TableRepository tableRepository;
   private final SessionFactory sessionFactory;
+
+  @Override
+  public ExceptionHandlerFunction exceptionHandler() {
+    return IcebergRestExceptionHandler.INSTANCE;
+  }
 
   public IcebergRestCatalogService(
       SchemaService schemaService,

--- a/server/src/main/java/io/unitycatalog/server/service/MetastoreService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/MetastoreService.java
@@ -1,15 +1,12 @@
 package io.unitycatalog.server.service;
 
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.persist.MetastoreRepository;
 import io.unitycatalog.server.persist.Repositories;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class MetastoreService {
+public class MetastoreService implements UnityCatalogRestService {
   private final MetastoreRepository metastoreRepository;
 
   public MetastoreService(Repositories repositories) {

--- a/server/src/main/java/io/unitycatalog/server/service/ModelService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ModelService.java
@@ -3,7 +3,6 @@ package io.unitycatalog.server.service;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -13,7 +12,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateModelVersion;
 import io.unitycatalog.server.model.CreateRegisteredModel;
 import io.unitycatalog.server.model.FinalizeModelVersion;
@@ -40,8 +38,7 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class ModelService extends AuthorizedService {
+public class ModelService extends AuthorizedService implements UnityCatalogRestService {
 
   private final ModelRepository modelRepository;
   private final SchemaRepository schemaRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
@@ -17,7 +17,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.PermissionsChange;
 import io.unitycatalog.server.model.PermissionsList;
 import io.unitycatalog.server.model.Privilege;
@@ -45,13 +44,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class PermissionService {
+public class PermissionService implements UnityCatalogRestService {
 
   private final UnityCatalogAuthorizer authorizer;
   private final MetastoreRepository metastoreRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/RegisteredService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/RegisteredService.java
@@ -1,0 +1,27 @@
+package io.unitycatalog.server.service;
+
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+
+/**
+ * Implemented by every annotated service that can be registered with the server. Its one job is to
+ * name the error dialect the service speaks, so a failure is rendered the same way whether it was
+ * thrown in the handler or in a decorator ahead of it.
+ *
+ * <p>An interface rather than a base class, so a service's protocol and its choice of
+ * implementation base stay independent: it can extend {@link AuthorizedService} for the
+ * authorization helpers while declaring its protocol here.
+ *
+ * <p>Deliberately left without a default. Each protocol supplies the dialect its services share
+ * ({@link UnityCatalogRestService}, {@link ScimService}), so a new protocol has to decide what it
+ * speaks rather than silently inheriting the Unity Catalog envelope.
+ *
+ * <p>The dialect is declared in code rather than as an {@code @ExceptionHandler} annotation on each
+ * service: {@code ArmeriaServerBuilder} passes it to Armeria at registration time and the
+ * exception-handling decorators read it back, so both paths are driven by this one method and
+ * cannot disagree.
+ */
+public interface RegisteredService {
+
+  /** The dialect errors from this service are rendered in. */
+  ExceptionHandlerFunction exceptionHandler();
+}

--- a/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
@@ -11,7 +11,6 @@ import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CreateSchema;
 import io.unitycatalog.server.model.ListSchemasResponse;
@@ -29,15 +28,13 @@ import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class SchemaService extends AuthorizedService {
+public class SchemaService extends AuthorizedService implements UnityCatalogRestService {
   private final SchemaRepository schemaRepository;
   private final CatalogRepository catalogRepository;
   private final MetastoreRepository metastoreRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/Scim2SelfService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/Scim2SelfService.java
@@ -6,7 +6,6 @@ import static io.unitycatalog.server.utils.Scim2Utils.asUserResource;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Produces;
 import com.linecorp.armeria.server.annotation.StatusCode;
@@ -15,14 +14,12 @@ import com.unboundid.scim2.common.types.UserResource;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.Scim2RuntimeException;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.security.JwtClaim;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class Scim2SelfService {
+public class Scim2SelfService implements ScimService {
   private final UserRepository userRepository;
   private final UnityCatalogAuthorizer authorizer;
 

--- a/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/Scim2UserService.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -36,7 +35,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.Scim2RuntimeException;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
@@ -63,8 +61,7 @@ import java.util.UUID;
  *   <li>userName - maps to SCIM primary email
  * </ul>
  */
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class Scim2UserService {
+public class Scim2UserService implements ScimService {
   private final UserRepository userRepository;
   private final UnityCatalogAuthorizer authorizer;
 

--- a/server/src/main/java/io/unitycatalog/server/service/ScimService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ScimService.java
@@ -1,0 +1,21 @@
+package io.unitycatalog.server.service;
+
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import io.unitycatalog.server.exception.GlobalExceptionHandler;
+
+/**
+ * Implemented by the SCIM2 services mounted under the control path: {@code scim2/Users} and {@code
+ * scim2/Me}.
+ *
+ * <p>SCIM differs from the plain REST services in serialization, not in error format: those routes
+ * get a SCIM response converter, but errors still use the Unity Catalog envelope. This type is what
+ * {@code ArmeriaServerBuilder.annotate} matches, so a service is only mounted where its converter
+ * is applied.
+ */
+public interface ScimService extends RegisteredService {
+
+  @Override
+  default ExceptionHandlerFunction exceptionHandler() {
+    return GlobalExceptionHandler.INSTANCE;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
@@ -5,14 +5,12 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateStagingTable;
 import io.unitycatalog.server.model.StagingTableInfo;
 import io.unitycatalog.server.persist.Repositories;
@@ -20,8 +18,7 @@ import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.utils.ServerProperties;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class StagingTableService extends AuthorizedService {
+public class StagingTableService extends AuthorizedService implements UnityCatalogRestService {
 
   private final StagingTableRepository stagingTableRepository;
   private final SchemaRepository schemaRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -13,7 +13,6 @@ import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
@@ -28,14 +27,12 @@ import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class TableService extends AuthorizedService {
+public class TableService extends AuthorizedService implements UnityCatalogRestService {
 
   private final TableRepository tableRepository;
   private final SchemaRepository schemaRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
@@ -12,7 +12,6 @@ import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryModelVersionCredential;
 import io.unitycatalog.server.model.ModelVersionInfo;
 import io.unitycatalog.server.model.ModelVersionOperation;
@@ -25,11 +24,9 @@ import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Set;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class TemporaryModelVersionCredentialsService {
+public class TemporaryModelVersionCredentialsService implements UnityCatalogRestService {
   private final ModelRepository modelRepository;
   private final StorageCredentialVendor storageCredentialVendor;
 

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
@@ -1,12 +1,10 @@
 package io.unitycatalog.server.service;
 
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryPathCredential;
 import io.unitycatalog.server.model.PathOperation;
 import io.unitycatalog.server.service.credential.CredentialContext;
@@ -21,8 +19,7 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class TemporaryPathCredentialsService {
+public class TemporaryPathCredentialsService implements UnityCatalogRestService {
   private final StorageCredentialVendor storageCredentialVendor;
 
   public TemporaryPathCredentialsService(StorageCredentialVendor storageCredentialVendor) {

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
@@ -1,13 +1,11 @@
 package io.unitycatalog.server.service;
 
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryTableCredential;
 import io.unitycatalog.server.model.TableOperation;
 import io.unitycatalog.server.persist.Repositories;
@@ -25,8 +23,7 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class TemporaryTableCredentialsService {
+public class TemporaryTableCredentialsService implements UnityCatalogRestService {
   private final TableRepository tableRepository;
   private final StorageCredentialVendor storageCredentialVendor;
   private final ServerProperties serverProperties;

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
@@ -1,14 +1,12 @@
 package io.unitycatalog.server.service;
 
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.GenerateTemporaryVolumeCredential;
 import io.unitycatalog.server.model.VolumeInfo;
 import io.unitycatalog.server.model.VolumeOperation;
@@ -25,8 +23,7 @@ import static io.unitycatalog.server.model.SecurableType.VOLUME;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class TemporaryVolumeCredentialsService {
+public class TemporaryVolumeCredentialsService implements UnityCatalogRestService {
   private final VolumeRepository volumeRepository;
   private final StorageCredentialVendor storageCredentialVendor;
 

--- a/server/src/main/java/io/unitycatalog/server/service/UnityCatalogRestService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/UnityCatalogRestService.java
@@ -1,0 +1,20 @@
+package io.unitycatalog.server.service;
+
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import io.unitycatalog.server.exception.GlobalExceptionHandler;
+
+/**
+ * Implemented by the Unity Catalog REST services mounted under the main API base path: catalogs,
+ * schemas, tables, volumes, functions, models, credentials, and the rest.
+ *
+ * <p>Supplies the Unity Catalog error envelope for all of them, and names the group in the type
+ * system so {@code ArmeriaServerBuilder.annotate} selects the right protocol and cannot be handed a
+ * SCIM service by mistake.
+ */
+public interface UnityCatalogRestService extends RegisteredService {
+
+  @Override
+  default ExceptionHandlerFunction exceptionHandler() {
+    return GlobalExceptionHandler.INSTANCE;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
@@ -12,7 +12,6 @@ import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.model.CreateVolumeRequestContent;
 import io.unitycatalog.server.model.ListVolumesResponseContent;
 import io.unitycatalog.server.model.SchemaInfo;
@@ -29,15 +28,13 @@ import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
-@ExceptionHandler(GlobalExceptionHandler.class)
-public class VolumeService extends AuthorizedService {
+public class VolumeService extends AuthorizedService implements UnityCatalogRestService {
   private final VolumeRepository volumeRepository;
   private final SchemaRepository schemaRepository;
   private final CatalogRepository catalogRepository;

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -9,7 +9,6 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
@@ -32,6 +31,7 @@ import io.unitycatalog.server.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.server.delta.model.DeltaTableType;
 import io.unitycatalog.server.delta.model.DeltaUpdateTableRequest;
 import io.unitycatalog.server.exception.BaseException;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import io.unitycatalog.server.exception.DeltaApiExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.CreateStagingTable;
@@ -44,6 +44,7 @@ import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.service.AuthorizedService;
+import io.unitycatalog.server.service.RegisteredService;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.NormalizedURL;
@@ -57,9 +58,11 @@ import java.util.UUID;
  *
  * <p>Enables Delta clients (e.g., Delta Spark, Delta Kernel) to create, read, write, and manage
  * managed and external Delta tables.
+ *
+ * <p>Its own protocol, with its own body mapper and the error format Delta clients expect, so it
+ * implements {@link RegisteredService} directly rather than the unrelated UC REST interface.
  */
-@ExceptionHandler(DeltaApiExceptionHandler.class)
-public class DeltaApiService extends AuthorizedService {
+public class DeltaApiService extends AuthorizedService implements RegisteredService {
 
   private static final List<String> ENDPOINTS =
       List.of(
@@ -81,6 +84,12 @@ public class DeltaApiService extends AuthorizedService {
   private final TableRepository tableRepository;
   private final StagingTableRepository stagingTableRepository;
   private final StorageCredentialVendor storageCredentialVendor;
+
+
+  @Override
+  public ExceptionHandlerFunction exceptionHandler() {
+    return DeltaApiExceptionHandler.INSTANCE;
+  }
 
   public DeltaApiService(
       UnityCatalogAuthorizer authorizer,

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaCommitsAccessControlCRUDTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.sdk.access;
 
 import static io.unitycatalog.server.utils.TestUtils.assertApiException;
+import static io.unitycatalog.server.utils.TestUtils.assertDeltaPermissionDenied;
 import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -239,7 +240,7 @@ public class SdkDeltaCommitsAccessControlCRUDTest extends SdkAccessControlBaseCR
                                 .fileName("00000003.json")
                                 .fileSize(1024L)
                                 .fileModificationTimestamp(1700000003L))));
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () ->
             readUserDeltaApi.updateTable(
                 TestUtils.CATALOG_NAME,

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Runs the staging-table access-control suite against the Delta REST createStagingTable /
@@ -64,6 +65,11 @@ public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccess
                 TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, buildCreateRequest(staging, name));
     return new FinalizedTable(
         resp.getMetadata().getTableUuid().toString(), resp.getMetadata().getLocation());
+  }
+
+  @Override
+  protected void assertDeniedInSurfaceFormat(Executable executable) {
+    TestUtils.assertDeltaPermissionDenied(executable);
   }
 
   @Override

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkDeltaStagingTableAccessControlTest.java
@@ -73,6 +73,11 @@ public class SdkDeltaStagingTableAccessControlTest extends SdkStagingTableAccess
   }
 
   @Override
+  protected void assertDeniedInSurfaceFormat(Executable executable, String containsMessage) {
+    TestUtils.assertDeltaPermissionDenied(executable, containsMessage);
+  }
+
+  @Override
   protected void fetchTempCreds(ServerConfig config, String tableId) throws Exception {
     new DeltaTemporaryCredentialsApi(TestUtils.createApiClient(config))
         .getStagingTableCredentials(UUID.fromString(tableId));

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -37,12 +37,14 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
+import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCRUDTest {
 
@@ -331,7 +333,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
             new TablesApi(apiClient)
                 .createTable(createExternalTableRequest(name, location))
                 .getStorageLocation(),
-      "PERMISSION_DENIED");
+        TestUtils::assertPermissionDenied);
   }
 
   /**
@@ -349,7 +351,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                     deltaExternalTableRequest(name, location))
                 .getMetadata()
                 .getLocation(),
-      "PermissionDeniedException");
+        TestUtils::assertDeltaPermissionDenied);
   }
 
   @FunctionalInterface
@@ -359,7 +361,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
   }
 
   private void runExternalTableVolumePermissionsTest(
-      ExternalTableCreator tableCreator, String createTablePermissionDeniedMessage)
+      ExternalTableCreator tableCreator, Consumer<Executable> assertCreateTableDenied)
       throws Exception {
     // Create external location as userC
     String externalLocationName = "test_external_loc";
@@ -467,14 +469,12 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
 
         // Verify that we can not create another under the same path, or subdir, or parent
         for (String url : List.of(tableLocation, tableLocation + "/subdir", storageRoot)) {
-          TestUtils.assertPermissionDenied(
-              () -> tableCreator.create(apiClient, tableName + "_another", url),
-              createTablePermissionDeniedMessage);
+          assertCreateTableDenied.accept(
+              () -> tableCreator.create(apiClient, tableName + "_another", url));
         }
       } else {
-        TestUtils.assertPermissionDenied(
-            () -> tableCreator.create(apiClient, tableName, tableLocation),
-            createTablePermissionDeniedMessage);
+        assertCreateTableDenied.accept(
+            () -> tableCreator.create(apiClient, tableName, tableLocation));
       }
 
       // Verify that the Volume creation is as expected
@@ -506,9 +506,8 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
             () ->
                 volumesApi.createVolume(
                     createExternalVolumeRequest(volumeName + "_another", tableLocation)));
-        TestUtils.assertPermissionDenied(
-            () -> tableCreator.create(apiClient, tableName + "_another", volumeLocation),
-            createTablePermissionDeniedMessage);
+        assertCreateTableDenied.accept(
+            () -> tableCreator.create(apiClient, tableName + "_another", volumeLocation));
       }
     }
   }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
@@ -10,6 +10,7 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Access control tests for staging tables that require authorization to be enabled.
@@ -51,6 +52,13 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
    * surface; each subclass implements this against its own RPC.
    */
   protected abstract void fetchTempCreds(ServerConfig config, String tableId) throws Exception;
+
+  /**
+   * Asserts {@code executable} is denied in this surface's error dialect. UC and Delta endpoints
+   * render the same denial differently, so each subclass asserts its own envelope rather than the
+   * test body accepting either.
+   */
+  protected abstract void assertDeniedInSurfaceFormat(Executable executable);
 
   /**
    * Test that attempting to create a managed table from another user's staging table fails with
@@ -99,7 +107,7 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
     // getStagingTableCredentials).
     // Owner allowed; non-owner denied.
     fetchTempCreds(userAConfig, staging.id());
-    TestUtils.assertPermissionDenied(() -> fetchTempCreds(userBConfig, staging.id()));
+    assertDeniedInSurfaceFormat(() -> fetchTempCreds(userBConfig, staging.id()));
 
     // createStagingTable authz (catalog USE_CATALOG/OWNER + schema USE_SCHEMA+CREATE_TABLE OR
     // schema OWNER). Both surfaces share the same SpEL constant
@@ -145,7 +153,7 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
     grantPermissions(
         userCEmail, SecurableType.CATALOG, TestUtils.CATALOG_NAME, Privileges.USE_CATALOG);
     ServerConfig userCConfig = createTestUserServerConfig(userCEmail);
-    TestUtils.assertPermissionDenied(
+    assertDeniedInSurfaceFormat(
         () ->
             createStaging(
                 userCConfig, TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "staging_denied"));
@@ -168,6 +176,6 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
     // {@code generateTemporaryTableCredentials} reaches the same 403 via its own ownership check.
     // Either subclass's surface must exhibit the fail-closed 403; we don't pin which one wins for
     // an owner-with-regular-UUID call here.
-    TestUtils.assertPermissionDenied(() -> fetchTempCreds(userBConfig, finalized.tableId()));
+    assertDeniedInSurfaceFormat(() -> fetchTempCreds(userBConfig, finalized.tableId()));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkStagingTableAccessControlTest.java
@@ -61,6 +61,13 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
   protected abstract void assertDeniedInSurfaceFormat(Executable executable);
 
   /**
+   * As {@link #assertDeniedInSurfaceFormat(Executable)}, and additionally asserts the denial
+   * reason. Use when the test cares which authorization check rejected the request.
+   */
+  protected abstract void assertDeniedInSurfaceFormat(
+      Executable executable, String containsMessage);
+
+  /**
    * Test that attempting to create a managed table from another user's staging table fails with
    * PERMISSION_DENIED error.
    *
@@ -161,7 +168,7 @@ public abstract class SdkStagingTableAccessControlTest extends SdkAccessControlB
     // Steps 3+4: User B's createTable on User A's staging is rejected at commitStagingTable;
     // User A's same request succeeds and produces a regular table that reuses the staging UUID
     // and storage location.
-    TestUtils.assertPermissionDenied(
+    assertDeniedInSurfaceFormat(
         () -> finalizeManagedTable(userBConfig, staging, TestUtils.TABLE_NAME),
         "User attempts to create table on a staging location without ownership");
     FinalizedTable finalized = finalizeManagedTable(userAConfig, staging, TestUtils.TABLE_NAME);

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkTableAccessControlCRUDTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.sdk.access;
 
 import static io.unitycatalog.server.utils.TestUtils.assertApiExceptionStatusOnly;
+import static io.unitycatalog.server.utils.TestUtils.assertDeltaPermissionDenied;
 import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -171,7 +172,7 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
     assertThat(adminDeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1")).isNotNull();
 
     // loadTable (regular-1) -> use catalog, use schema, but no SELECT -> denied
-    assertPermissionDenied(() -> regular1DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1"));
+    assertDeltaPermissionDenied(() -> regular1DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1"));
 
     // loadTable (regular-2) -> use schema, use catalog, select -> allowed
     assertThat(regular2DeltaApi.loadTable("cat_pr1", "sch_pr1", "tbl_pr1")).isNotNull();
@@ -194,13 +195,13 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
 
     // Delta getTableCredentials authz: READ requires SELECT, READ_WRITE requires MODIFY
     // getTableCredentials READ (regular-1) -> use catalog, use schema, but no SELECT -> denied
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () ->
             regular1DeltaCredsApi.getTableCredentials(
                 DeltaCredentialOperation.READ, "cat_pr1", "sch_pr1", "tbl_pr1"));
 
     // getTableCredentials READ_WRITE (regular-2) -> has SELECT but not MODIFY -> denied
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () ->
             regular2DeltaCredsApi.getTableCredentials(
                 DeltaCredentialOperation.READ_WRITE, "cat_pr1", "sch_pr1", "tbl_pr1"));
@@ -288,7 +289,8 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
 
     // delete table (regular-1) -> -- -> denied via UC REST and Delta REST
     assertPermissionDenied(() -> regular1TablesApi.deleteTable("cat_pr1.sch_rg2.tab_rg2"));
-    assertPermissionDenied(() -> regular1DeltaApi.deleteTable("cat_pr1", "sch_rg2", "tab_rg2"));
+    assertDeltaPermissionDenied(
+        () -> regular1DeltaApi.deleteTable("cat_pr1", "sch_rg2", "tab_rg2"));
 
     // delete table (principal-1) -> owner [catalog] -> allowed (UC REST)
     principal1TablesApi.deleteTable("cat_pr1.sch_rg2.tab_rg2");
@@ -306,7 +308,7 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
     regular2TablesApi.createTable(createTableRg2Delta);
 
     // Delta delete (regular-1) -> -- -> denied
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () -> regular1DeltaApi.deleteTable("cat_pr1", "sch_rg2", "tab_rg2_delta"));
 
     // Delta delete (principal-1) -> owner [catalog] -> allowed
@@ -332,7 +334,7 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
     // source table (or its parent schema/catalog).
     grantPermissions(REGULAR_1, SecurableType.SCHEMA, "cat_pr1.sch_rg2", Privileges.USE_SCHEMA);
     grantPermissions(REGULAR_1, SecurableType.SCHEMA, "cat_pr1.sch_rg2", Privileges.CREATE_TABLE);
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () ->
             regular1DeltaApi.renameTable(
                 "cat_pr1",
@@ -342,7 +344,7 @@ public class SdkTableAccessControlCRUDTest extends SdkAccessControlBaseCRUDTest 
 
     // Missing create permission: principal-1 satisfies DELETE_TABLE through catalog ownership but
     // has neither schema ownership nor USE_SCHEMA + CREATE_TABLE for the new name.
-    assertPermissionDenied(
+    assertDeltaPermissionDenied(
         () ->
             principal1DeltaApi.renameTable(
                 "cat_pr1",

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
@@ -17,6 +17,7 @@ import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Runs the staging-table access-control suite against the UC REST createStagingTable / createTable.
@@ -61,6 +62,11 @@ public class SdkUCStagingTableAccessControlTest extends SdkStagingTableAccessCon
                     .storageLocation(staging.location())
                     .properties(Map.of(TableProperties.UC_TABLE_ID, staging.id())));
     return new FinalizedTable(info.getTableId(), info.getStorageLocation());
+  }
+
+  @Override
+  protected void assertDeniedInSurfaceFormat(Executable executable) {
+    TestUtils.assertPermissionDenied(executable);
   }
 
   @Override

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkUCStagingTableAccessControlTest.java
@@ -70,6 +70,11 @@ public class SdkUCStagingTableAccessControlTest extends SdkStagingTableAccessCon
   }
 
   @Override
+  protected void assertDeniedInSurfaceFormat(Executable executable, String containsMessage) {
+    TestUtils.assertPermissionDenied(executable, containsMessage);
+  }
+
+  @Override
   protected void fetchTempCreds(ServerConfig config, String tableId) throws Exception {
     new TemporaryCredentialsApi(TestUtils.createApiClient(config))
         .generateTemporaryTableCredentials(

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/TemporaryPathCredentialAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/TemporaryPathCredentialAccessControlTest.java
@@ -6,7 +6,7 @@ import static io.unitycatalog.client.model.PathOperation.PATH_READ_WRITE;
 import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
 import static io.unitycatalog.server.utils.TestUtils.SCHEMA_FULL_NAME;
 import static io.unitycatalog.server.utils.TestUtils.TEST_AWS_MASTER_ROLE_ARN;
-import static io.unitycatalog.server.utils.TestUtils.assertApiException;
+import static io.unitycatalog.server.utils.TestUtils.assertPermissionDenied;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -39,7 +39,6 @@ import io.unitycatalog.client.model.TemporaryCredentials;
 import io.unitycatalog.client.model.VolumeInfo;
 import io.unitycatalog.client.model.VolumeType;
 import io.unitycatalog.server.base.ServerConfig;
-import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.service.credential.CredentialContext;
@@ -365,10 +364,7 @@ public class TemporaryPathCredentialAccessControlTest extends SdkAccessControlBa
       TemporaryCredentialsApi api, String url, PathOperation operation) {
     GenerateTemporaryPathCredential request =
         new GenerateTemporaryPathCredential().url(url).operation(operation);
-    assertApiException(
-        () -> api.generateTemporaryPathCredentials(request),
-        ErrorCode.PERMISSION_DENIED,
-        "PERMISSION_DENIED");
+    assertPermissionDenied(() -> api.generateTemporaryPathCredentials(request));
   }
 
   private void assertValidTemporaryCredentials(TemporaryCredentials credentials) {

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaCredentialsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaCredentialsTest.java
@@ -116,7 +116,7 @@ public class SdkDeltaCredentialsTest extends BaseCRUDTestWithMockCredentials {
     // -------- getTableCredentials: missing `operation` param (SDK-side required check) --------
     // This ApiException is thrown locally by the generated client before the server is reached,
     // so there is no Delta-format response body to verify -- use the generic assertApiException.
-    TestUtils.assertApiException(
+    TestUtils.assertClientException(
         () ->
             deltaCredentialsApi.getTableCredentials(
                 /* operation= */ null,

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -268,7 +268,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     commit1_other_filename.getCommitInfo().setFileName("some_other_filename_" + UUID.randomUUID());
     assertApiException(
         () -> deltaCommitsApi.commit(commit1_other_filename),
-        ErrorCode.ALREADY_EXISTS,
+        ErrorCode.COMMIT_VERSION_CONFLICT,
         "Commit version already accepted.");
 
     DeltaCommit commit3 =
@@ -294,13 +294,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Replay old version 1 with a different file name -> genuine conflict.
     assertApiException(
         () -> deltaCommitsApi.commit(commit1_other_filename),
-        ErrorCode.ALREADY_EXISTS,
+        ErrorCode.COMMIT_VERSION_CONFLICT,
         "Commit version already accepted.");
 
     // Get commits with wrong table id
     assertApiException(
         () -> getAllCommits(ZERO_UUID, tableInfo.getStorageLocation(), 0L, Optional.empty()),
-        ErrorCode.NOT_FOUND,
+        ErrorCode.TABLE_NOT_FOUND,
         "Table not found");
 
     // Try to get the commits with different start and end version range
@@ -352,7 +352,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // the backfill above, so replaying the identical commit2 conflicts rather than no-op'ing.
     assertApiException(
         () -> deltaCommitsApi.commit(commit2),
-        ErrorCode.ALREADY_EXISTS,
+        ErrorCode.COMMIT_VERSION_CONFLICT,
         "Commit version already accepted.");
 
     // Commit one more version before deleting the table
@@ -370,7 +370,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         () ->
             getAllCommits(
                 tableInfo.getTableId(), tableInfo.getStorageLocation(), 0L, Optional.empty()),
-        ErrorCode.NOT_FOUND,
+        ErrorCode.TABLE_NOT_FOUND,
         "Table not found");
     List<DeltaCommitDAO> commitDAOs = getCommitDAOs(UUID.fromString(tableInfo.getTableId()));
     assertThat(commitDAOs.size()).isEqualTo(0);
@@ -424,7 +424,9 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaCommit commitWithWrongId =
         createCommitObject(ZERO_UUID, 1L, tableInfo.getStorageLocation());
     assertApiException(
-        () -> deltaCommitsApi.commit(commitWithWrongId), ErrorCode.NOT_FOUND, "Table not found");
+        () -> deltaCommitsApi.commit(commitWithWrongId),
+        ErrorCode.TABLE_NOT_FOUND,
+        "Table not found");
 
     checkCommitInvalidParameter(1L, c -> c.setTableUri(null), "table_uri");
     checkCommitInvalidParameter(1L, c -> c.setTableUri(""), "table_uri");

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -3,6 +3,8 @@ package io.unitycatalog.server.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
@@ -124,12 +126,79 @@ public class TestUtils {
   }
 
   /**
-   * Asserts the call fails with PERMISSION_DENIED (HTTP 403). Only checks the error code and the
-   * generic {@code "PERMISSION_DENIED"} marker in the message; use {@link
-   * #assertPermissionDenied(Executable, String)} when the specific cause matters.
+   * Asserts the call fails with permission-denied at HTTP 403 in the <em>Unity Catalog</em> error
+   * envelope, parsing the body to confirm its shape: {@code {"error_code": "PERMISSION_DENIED",
+   * "message": ..., "details": [{"reason": "PERMISSION_DENIED", "@type": ...}]}}.
+   *
+   * <p>Use for endpoints served by {@code GlobalExceptionHandler}. Delta API endpoints speak a
+   * different dialect and must be asserted with {@link #assertDeltaPermissionDenied} -- keeping the
+   * two apart is what makes these tests notice if an endpoint starts answering in the wrong format.
    */
   public static void assertPermissionDenied(Executable executable) {
-    assertPermissionDenied(executable, "PERMISSION_DENIED");
+    ApiException ex = assertThrows(ApiException.class, executable);
+    assertThat(ex.getCode()).isEqualTo(ErrorCode.PERMISSION_DENIED.getHttpStatus().code());
+    JsonNode body = parseErrorBody(ex);
+    assertThat(body.path("error_code").asText())
+        .as("UC envelope error_code in: %s", ex.getResponseBody())
+        .isEqualTo(ErrorCode.PERMISSION_DENIED.name());
+    assertThat(body.has("message"))
+        .as("UC envelope must carry a message: %s", ex.getResponseBody())
+        .isTrue();
+    assertThat(body.path("details").isArray())
+        .as("UC envelope must carry a details array: %s", ex.getResponseBody())
+        .isTrue();
+    assertThat(body.path("details").path(0).path("reason").asText())
+        .as("UC envelope details[0].reason in: %s", ex.getResponseBody())
+        .isEqualTo(ErrorCode.PERMISSION_DENIED.name());
+    // The Delta envelope nests under "error"; its absence is what distinguishes the two dialects.
+    assertThat(body.has("error"))
+        .as(
+            "expected the UC envelope, but the body is nested Delta-style: %s",
+            ex.getResponseBody())
+        .isFalse();
+  }
+
+  /**
+   * Asserts the call fails with permission-denied in the <em>Delta API</em> error envelope, parsing
+   * the body to confirm its shape: {@code {"error": {"type": "PermissionDeniedException", "code":
+   * 403, "message": ...}}}.
+   *
+   * <p>Delta clients parse this shape specifically, so a UC-style body here would be a regression
+   * even though the status code is the same. See {@link #assertPermissionDenied} for UC endpoints.
+   */
+  public static void assertDeltaPermissionDenied(Executable executable) {
+    int expectedCode =
+        ErrorCode.getDeltaHttpStatus(DeltaErrorType.PERMISSION_DENIED_EXCEPTION.getValue()).code();
+    ApiException ex = assertThrows(ApiException.class, executable);
+    assertThat(ex.getCode()).isEqualTo(expectedCode);
+    JsonNode body = parseErrorBody(ex);
+    assertThat(body.has("error"))
+        .as("expected the Delta envelope nested under \"error\": %s", ex.getResponseBody())
+        .isTrue();
+    JsonNode error = body.path("error");
+    assertThat(error.path("type").asText())
+        .as("Delta envelope error.type in: %s", ex.getResponseBody())
+        .isEqualTo(DeltaErrorType.PERMISSION_DENIED_EXCEPTION.getValue());
+    assertThat(error.path("code").asInt())
+        .as("Delta envelope error.code in: %s", ex.getResponseBody())
+        .isEqualTo(expectedCode);
+    assertThat(error.has("message"))
+        .as("Delta envelope must carry a message: %s", ex.getResponseBody())
+        .isTrue();
+    // The UC envelope puts error_code at the top level; its absence distinguishes the two dialects.
+    assertThat(body.has("error_code"))
+        .as("expected the Delta envelope, but the body is UC-style: %s", ex.getResponseBody())
+        .isFalse();
+  }
+
+  /** Parses an error response body as JSON, failing with the raw body if it is not valid JSON. */
+  private static JsonNode parseErrorBody(ApiException ex) {
+    try {
+      return new ObjectMapper().readTree(ex.getResponseBody());
+    } catch (Exception e) {
+      return org.assertj.core.api.Assertions.fail(
+          "Error response was not valid JSON: " + ex.getResponseBody(), e);
+    }
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -80,23 +80,74 @@ public class TestUtils {
         .build();
   }
 
+  /**
+   * Asserts the call fails with a Unity Catalog REST error: the HTTP status matches {@code
+   * errorCode}, the body is the UC envelope carrying that code, and its message contains {@code
+   * containsMessage}. For Delta API endpoints use {@link #assertDeltaApiException}; for a
+   * client-side SDK exception raised before the server is reached (no response body) use {@link
+   * #assertClientException}.
+   */
   public static void assertApiException(
       Executable executable, ErrorCode errorCode, String containsMessage) {
     ApiException ex = assertThrows(ApiException.class, executable);
-    // Check the message first. When tests fail due to mismatching error, the message can tell us
-    // more.
-    assertThat(ex.getMessage()).contains(containsMessage);
-    assertThat(ex.getCode()).isEqualTo(errorCode.getHttpStatus().code());
+    assertUcErrorEnvelope(
+        ex.getCode(), ex.getResponseBody(), errorCode, Optional.of(containsMessage));
   }
 
   /**
-   * Asserts the call fails by checking the HTTP status code is {@code expectedStatus}. Use for
-   * body-less responses; otherwise use {@link #assertApiException} / {@link
-   * #assertDeltaApiException}.
+   * Asserts {@code ex} carries the Unity Catalog error envelope for {@code errorCode} -- {@code
+   * {"error_code": <CODE>, "message": ..., "details": [{"reason": <CODE>, ...}]}}. When {@code
+   * containsMessage} is present, the message must contain it. The absence of a nested {@code
+   * "error"} object is what distinguishes this from the Delta envelope.
+   */
+  private static void assertUcErrorEnvelope(
+      int statusCode, String bodyText, ErrorCode errorCode, Optional<String> containsMessage) {
+    assertThat(statusCode).isEqualTo(errorCode.getHttpStatus().code());
+    JsonNode body = parseErrorBody(bodyText);
+    // A UC envelope carries error_code and message at the top level, plus a details array whose
+    // ErrorInfo entry repeats the code as its reason; the Delta envelope nests everything under
+    // "error". Assert both the code and that it is not the Delta shape.
+    assertThat(body.path("error_code").asText())
+        .as("UC envelope error_code in: %s", bodyText)
+        .isEqualTo(errorCode.name());
+    assertThat(body.path("details").path(0).path("reason").asText())
+        .as("UC envelope details[0].reason in: %s", bodyText)
+        .isEqualTo(errorCode.name());
+    assertThat(body.has("error"))
+        .as("expected the UC envelope, but the body is nested Delta-style: %s", bodyText)
+        .isFalse();
+    JsonNode message = body.path("message");
+    assertThat(message.isTextual()).as("UC envelope must carry a message: %s", bodyText).isTrue();
+    containsMessage.ifPresent(
+        m -> assertThat(message.asText()).as("error message in: %s", bodyText).contains(m));
+  }
+
+  /**
+   * Asserts a client-side SDK exception: the generated client rejected the call before reaching the
+   * server, so the status matches {@code errorCode} but there is no response body to parse. Use
+   * {@link #assertApiException} when the server produced the error.
+   */
+  public static void assertClientException(
+      Executable executable, ErrorCode errorCode, String containsMessage) {
+    ApiException ex = assertThrows(ApiException.class, executable);
+    assertThat(ex.getCode()).isEqualTo(errorCode.getHttpStatus().code());
+    assertThat(ex.getMessage()).contains(containsMessage);
+  }
+
+  /**
+   * Asserts the call fails with {@code expectedStatus} and a genuinely empty body. Use only for
+   * responses that carry no body by construction -- e.g. a HEAD request, which has none whatever
+   * the status. A normal error response always carries a body, so assert it with {@link
+   * #assertApiException} or {@link #assertDeltaApiException} instead; the empty-body check here
+   * fails fast if this is misused on one.
    */
   public static void assertApiExceptionStatusOnly(Executable executable, int expectedStatus) {
     ApiException ex = assertThrows(ApiException.class, executable);
     assertThat(ex.getCode()).isEqualTo(expectedStatus);
+    String bodyText = ex.getResponseBody();
+    assertThat(bodyText == null || bodyText.isBlank())
+        .as("expected a body-less response, but got: %s", bodyText)
+        .isTrue();
   }
 
   public static void assertDeltaApiException(
@@ -117,12 +168,14 @@ public class TestUtils {
   }
 
   /**
-   * Asserts the call fails with PERMISSION_DENIED (HTTP 403) and the exception message contains
-   * {@code containsMessage}. Use this when the test cares that a specific authz check fired -- e.g.
-   * a staging-table ownership check -- rather than just that something produced a 403.
+   * As {@link #assertPermissionDenied(Executable)}, and additionally asserts the error message
+   * states {@code containsMessage}.
+   *
+   * <p>Only for when the test cares <em>why</em> permission was denied, e.g. a staging-table
+   * ownership check. The envelope's own markers are asserted structurally.
    */
   public static void assertPermissionDenied(Executable executable, String containsMessage) {
-    assertApiException(executable, ErrorCode.PERMISSION_DENIED, containsMessage);
+    assertPermissionDeniedImpl(executable, Optional.of(containsMessage));
   }
 
   /**
@@ -135,27 +188,21 @@ public class TestUtils {
    * two apart is what makes these tests notice if an endpoint starts answering in the wrong format.
    */
   public static void assertPermissionDenied(Executable executable) {
+    assertPermissionDeniedImpl(executable, Optional.empty());
+  }
+
+  private static void assertPermissionDeniedImpl(
+      Executable executable, Optional<String> containsMessage) {
+    // The envelope's own PERMISSION_DENIED marker is asserted structurally below, so passing it as
+    // the reason would look like a check without being one; reject it. A real reason states why.
+    containsMessage.ifPresent(
+        r ->
+            assertThat(r)
+                .as("assert the reason for the denial, not the envelope marker")
+                .isNotEqualTo(ErrorCode.PERMISSION_DENIED.name()));
     ApiException ex = assertThrows(ApiException.class, executable);
-    assertThat(ex.getCode()).isEqualTo(ErrorCode.PERMISSION_DENIED.getHttpStatus().code());
-    JsonNode body = parseErrorBody(ex);
-    assertThat(body.path("error_code").asText())
-        .as("UC envelope error_code in: %s", ex.getResponseBody())
-        .isEqualTo(ErrorCode.PERMISSION_DENIED.name());
-    assertThat(body.has("message"))
-        .as("UC envelope must carry a message: %s", ex.getResponseBody())
-        .isTrue();
-    assertThat(body.path("details").isArray())
-        .as("UC envelope must carry a details array: %s", ex.getResponseBody())
-        .isTrue();
-    assertThat(body.path("details").path(0).path("reason").asText())
-        .as("UC envelope details[0].reason in: %s", ex.getResponseBody())
-        .isEqualTo(ErrorCode.PERMISSION_DENIED.name());
-    // The Delta envelope nests under "error"; its absence is what distinguishes the two dialects.
-    assertThat(body.has("error"))
-        .as(
-            "expected the UC envelope, but the body is nested Delta-style: %s",
-            ex.getResponseBody())
-        .isFalse();
+    assertUcErrorEnvelope(
+        ex.getCode(), ex.getResponseBody(), ErrorCode.PERMISSION_DENIED, containsMessage);
   }
 
   /**
@@ -167,11 +214,28 @@ public class TestUtils {
    * even though the status code is the same. See {@link #assertPermissionDenied} for UC endpoints.
    */
   public static void assertDeltaPermissionDenied(Executable executable) {
+    assertDeltaPermissionDeniedImpl(executable, Optional.empty());
+  }
+
+  /**
+   * As {@link #assertDeltaPermissionDenied(Executable)}, and additionally asserts the error message
+   * states {@code containsMessage}.
+   *
+   * <p>Only for when the test cares <em>why</em> permission was denied. The envelope's own markers
+   * are asserted structurally, so passing {@code "PermissionDeniedException"} here adds nothing and
+   * is rejected.
+   */
+  public static void assertDeltaPermissionDenied(Executable executable, String containsMessage) {
+    assertDeltaPermissionDeniedImpl(executable, Optional.of(containsMessage));
+  }
+
+  private static void assertDeltaPermissionDeniedImpl(
+      Executable executable, Optional<String> containsMessage) {
     int expectedCode =
         ErrorCode.getDeltaHttpStatus(DeltaErrorType.PERMISSION_DENIED_EXCEPTION.getValue()).code();
     ApiException ex = assertThrows(ApiException.class, executable);
     assertThat(ex.getCode()).isEqualTo(expectedCode);
-    JsonNode body = parseErrorBody(ex);
+    JsonNode body = parseErrorBody(ex.getResponseBody());
     assertThat(body.has("error"))
         .as("expected the Delta envelope nested under \"error\": %s", ex.getResponseBody())
         .isTrue();
@@ -182,22 +246,30 @@ public class TestUtils {
     assertThat(error.path("code").asInt())
         .as("Delta envelope error.code in: %s", ex.getResponseBody())
         .isEqualTo(expectedCode);
-    assertThat(error.has("message"))
-        .as("Delta envelope must carry a message: %s", ex.getResponseBody())
-        .isTrue();
     // The UC envelope puts error_code at the top level; its absence distinguishes the two dialects.
     assertThat(body.has("error_code"))
         .as("expected the Delta envelope, but the body is UC-style: %s", ex.getResponseBody())
         .isFalse();
+    JsonNode message = error.path("message");
+    assertThat(message.isTextual())
+        .as("error envelope must carry a message: %s", ex.getResponseBody())
+        .isTrue();
+    containsMessage.ifPresent(
+        r -> {
+          assertThat(r)
+              .as("assert the reason for the denial, not the envelope marker")
+              .isNotEqualTo(DeltaErrorType.PERMISSION_DENIED_EXCEPTION.getValue());
+          assertThat(message.asText()).as("denial reason in: %s", ex.getResponseBody()).contains(r);
+        });
   }
 
   /** Parses an error response body as JSON, failing with the raw body if it is not valid JSON. */
-  private static JsonNode parseErrorBody(ApiException ex) {
+  private static JsonNode parseErrorBody(String bodyText) {
     try {
-      return new ObjectMapper().readTree(ex.getResponseBody());
+      return new ObjectMapper().readTree(bodyText);
     } catch (Exception e) {
       return org.assertj.core.api.Assertions.fail(
-          "Error response was not valid JSON: " + ex.getResponseBody(), e);
+          "Error response was not valid JSON: " + bodyText, e);
     }
   }
 
@@ -208,9 +280,8 @@ public class TestUtils {
    */
   public static void assertHttpApiException(
       HttpResponse<String> response, ErrorCode errorCode, String containsMessage) {
-    // Check the body first. When tests fail due to mismatching error, the body can tell us more.
-    assertThat(response.body()).contains(containsMessage).contains(errorCode.name());
-    assertThat(response.statusCode()).isEqualTo(errorCode.getHttpStatus().code());
+    assertUcErrorEnvelope(
+        response.statusCode(), response.body(), errorCode, Optional.of(containsMessage));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -110,9 +110,15 @@ public class TestUtils {
     assertThat(body.path("error_code").asText())
         .as("UC envelope error_code in: %s", bodyText)
         .isEqualTo(errorCode.name());
-    assertThat(body.path("details").path(0).path("reason").asText())
+    JsonNode errorInfo = body.path("details").path(0);
+    assertThat(errorInfo.path("reason").asText())
         .as("UC envelope details[0].reason in: %s", bodyText)
         .isEqualTo(errorCode.name());
+    // The detail is a google.rpc.ErrorInfo packed as a protobuf Any, so its @type must be the full
+    // type URL (with the type.googleapis.com/ prefix), not a bare message name.
+    assertThat(errorInfo.path("@type").asText())
+        .as("UC envelope details[0].@type in: %s", bodyText)
+        .isEqualTo("type.googleapis.com/google.rpc.ErrorInfo");
     assertThat(body.has("error"))
         .as("expected the UC envelope, but the body is nested Delta-style: %s", bodyText)
         .isFalse();


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Armeria's `@ExceptionHandler` only wraps the annotated-service invocation, but authorization runs in route decorators outside it. A denial thrown there was always formatted with the UC envelope, so a 403 on a Delta or Iceberg route came back in a shape those clients do not expect.

- Each service names its dialect via `RegisteredService.exceptionHandler()`, replacing 21 per-service `@ExceptionHandler` annotations. `register` feeds that one value to both Armeria and the decorator, so they cannot disagree.
- `ExceptionHandlingDecorator` splits into `ServiceExceptionHandlingDecorator` (per service, records the dialect) and `GlobalExceptionHandlingDecorator` (outermost, the only one that can catch a route-decorator denial; reads the dialect off the route's chain).
- `RegisteredService` is an interface, so a service's protocol is independent of its base class. `annotate` is overloaded per service type, so the argument picks the protocol.
- `assertPermissionDenied` splits into UC and Delta variants that parse the body and reject the other dialect. This caught eight call sites asserting the UC shape against Delta endpoints.
- Also corrects the `ErrorInfo` detail's `@type` to the full protobuf Any type URL `type.googleapis.com/google.rpc.ErrorInfo` (the previous bare `google.rpc.ErrorInfo` was not a valid type URL)

Note: re-adding an `@ExceptionHandler` annotation will now fail at startup, since the handlers are singletons with private constructors. The dialect belongs in `exceptionHandler()`.
