### PR TITLE
[Server] Grant KMS permissions in vended AWS session policy

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -49,15 +49,25 @@ public class AwsPolicyGenerator {
       Resource: []
       """;
 
+  // The condition key S3 populates when it calls KMS on the caller's behalf. Its value is the ARN
+  // of the object being encrypted or decrypted, or the ARN of the bucket when the bucket has S3
+  // Bucket Keys enabled, in which case the data key is shared across the objects in the bucket.
+  static final String KMS_ENCRYPTION_CONTEXT_KEY = "kms:EncryptionContext:aws:s3:arn";
+
   // Unity Catalog doesn't know which KMS key a bucket is configured with, so the resource stays
-  // open. This grants nothing extra in practice: a session policy can only narrow what the
+  // open and the statement is narrowed by condition instead: to KMS calls made through S3, and to
+  // the S3 ARNs this policy already grants access to. A session policy can only narrow what the
   // assumed role is already allowed to do, so a role without KMS access still gets none.
   static final String KMS_STATEMENT = """
       Effect: Allow
       Action: []
       Resource:
         - "*"
-      """;
+      Condition:
+        StringLike:
+          "kms:ViaService": "s3.*.amazonaws.com"
+          "%s": []
+      """.formatted(KMS_ENCRYPTION_CONTEXT_KEY);
 
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
@@ -89,6 +99,8 @@ public class AwsPolicyGenerator {
               privileges, locations));
     }
 
+    ArrayNode kmsEncryptionContexts = (ArrayNode) kmsStatement.findPath(KMS_ENCRYPTION_CONTEXT_KEY);
+
     // Group each location by s3 bucket it's located in, then for each
     // bucket, add the bucket arn for the listBucket and operations statements,
     // then add each path as a conditional prefix
@@ -100,6 +112,11 @@ public class AwsPolicyGenerator {
       ArrayNode operationsResource = (ArrayNode) operationsStatement.findPath("Resource");
       bucketResource.add(String.format("arn:aws:s3:::%s", bucketName));
 
+      // A bucket with S3 Bucket Keys enabled encrypts under the bucket arn rather than the object
+      // arn, so the bucket has to be allowed as an encryption context on its own. That case can't
+      // be scoped to a path: the same data key covers every object in the bucket.
+      kmsEncryptionContexts.add(String.format("arn:aws:s3:::%s", bucketName));
+
       ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
       paths.forEach(path -> {
         // remove any preceding forward slashes
@@ -107,14 +124,17 @@ public class AwsPolicyGenerator {
 
         if (sanitizedPath.isEmpty()) {
           conditionalPrefixes.add("*");
-          operationsResource.add(String.format("arn:aws:s3:::%s/*", bucketName));
+          addObjectArn(String.format("arn:aws:s3:::%s/*", bucketName),
+              operationsResource, kmsEncryptionContexts);
         } else {
           conditionalPrefixes.add(sanitizedPath);
           conditionalPrefixes.add(sanitizedPath + "/");
           conditionalPrefixes.add(sanitizedPath + "/*");
 
-          operationsResource.add(String.format("arn:aws:s3:::%s/%s/*", bucketName, sanitizedPath));
-          operationsResource.add(String.format("arn:aws:s3:::%s/%s", bucketName, sanitizedPath));
+          addObjectArn(String.format("arn:aws:s3:::%s/%s/*", bucketName, sanitizedPath),
+              operationsResource, kmsEncryptionContexts);
+          addObjectArn(String.format("arn:aws:s3:::%s/%s", bucketName, sanitizedPath),
+              operationsResource, kmsEncryptionContexts);
         }
       });
     });
@@ -124,6 +144,17 @@ public class AwsPolicyGenerator {
     policyStatement.add(kmsStatement);
 
     return JSON_MAPPER.writeValueAsString(policyRoot);
+  }
+
+  /**
+   * Allows an object arn in the S3 operations statement, and allows the same arn as a KMS
+   * encryption context so that the KMS permissions cover exactly the objects the policy grants
+   * access to.
+   */
+  private static void addObjectArn(
+      String objectArn, ArrayNode operationsResource, ArrayNode kmsEncryptionContexts) {
+    operationsResource.add(objectArn);
+    kmsEncryptionContexts.add(objectArn);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -22,6 +22,12 @@ public class AwsPolicyGenerator {
   static final List<String> UPDATE_ACTIONS = List.of(
       "s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
 
+  // Reading an object encrypted with SSE-KMS requires kms:Decrypt, and writing one additionally
+  // requires kms:GenerateDataKey*. Without these the vended session credentials can't touch a
+  // table stored in a bucket with SSE-KMS, even when the assumed role itself is allowed to.
+  static final List<String> SELECT_KMS_ACTIONS = List.of("kms:Decrypt");
+  static final List<String> UPDATE_KMS_ACTIONS = List.of("kms:Decrypt", "kms:GenerateDataKey*");
+
   static final String POLICY_STATEMENT = """
       Version: 2012-10-17
       Statement: []
@@ -43,6 +49,16 @@ public class AwsPolicyGenerator {
       Resource: []
       """;
 
+  // Unity Catalog doesn't know which KMS key a bucket is configured with, so the resource stays
+  // open. This grants nothing extra in practice: a session policy can only narrow what the
+  // assumed role is already allowed to do, so a role without KMS access still gets none.
+  static final String KMS_STATEMENT = """
+      Effect: Allow
+      Action: []
+      Resource:
+        - "*"
+      """;
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
@@ -56,13 +72,17 @@ public class AwsPolicyGenerator {
     ArrayNode policyStatement = (ArrayNode) policyRoot.findPath("Statement");
     JsonNode operationsStatement = loadYaml(OPERATION_STATEMENT);
     policyStatement.add(operationsStatement);
+    JsonNode kmsStatement = loadYaml(KMS_STATEMENT);
 
-    // Add the appropriate S3 operations for the privileges requested
+    // Add the appropriate S3 and KMS operations for the privileges requested
     ArrayNode actions = (ArrayNode) operationsStatement.findPath("Action");
+    ArrayNode kmsActions = (ArrayNode) kmsStatement.findPath("Action");
     if (privileges.contains(CredentialContext.Privilege.UPDATE)) {
       UPDATE_ACTIONS.forEach(actions::add);
+      UPDATE_KMS_ACTIONS.forEach(kmsActions::add);
     } else if (privileges.contains(CredentialContext.Privilege.SELECT)) {
       SELECT_ACTIONS.forEach(actions::add);
+      SELECT_KMS_ACTIONS.forEach(kmsActions::add);
     } else {
       throw new NotAuthorizedException(
           String.format("Can't generate policy for unknown privileges '%s' for locations: '%s'",
@@ -98,6 +118,10 @@ public class AwsPolicyGenerator {
         }
       });
     });
+
+    // Appended after the per-bucket statements so that the position of the S3 statements
+    // within the policy doesn't change
+    policyStatement.add(kmsStatement);
 
     return JSON_MAPPER.writeValueAsString(policyRoot);
   }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -164,4 +164,59 @@ public class AwsPolicyGeneratorTest {
         .doesNotContain("s3:DeleteO*")
         .contains("s3:GetO*");
   }
+
+  @Test
+  public void testSelectPolicyGrantsKmsDecrypt() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement).isNotNull();
+    assertThat(statement.path("Action")).map(JsonNode::asText).containsExactly("kms:Decrypt");
+    assertThat(statement.path("Resource")).map(JsonNode::asText).containsExactly("*");
+  }
+
+  @Test
+  public void testUpdatePolicyGrantsKmsDecryptAndGenerateDataKey() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement).isNotNull();
+    assertThat(statement.path("Action"))
+        .map(JsonNode::asText)
+        .containsExactlyInAnyOrder("kms:Decrypt", "kms:GenerateDataKey*");
+    assertThat(statement.path("Resource")).map(JsonNode::asText).containsExactly("*");
+  }
+
+  @Test
+  public void testKmsStatementDoesNotShiftS3Statements() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode statements = JSON_MAPPER.readTree(policy).get("Statement");
+    assertThat(statements.get(0).path("Action")).map(JsonNode::asText).containsExactly("s3:GetO*");
+    assertThat(statements.get(1).path("Action"))
+        .map(JsonNode::asText)
+        .containsExactly("s3:ListBucket");
+  }
+
+  /**
+   * Returns the statement that carries the KMS actions, or {@code null} when the policy has none.
+   * Located by action prefix rather than by index so that the S3 statements the other tests assert
+   * on by index stay where they are.
+   */
+  private static JsonNode findKmsStatement(JsonNode policyRoot) {
+    for (JsonNode statement : policyRoot.path("Statement")) {
+      for (JsonNode action : statement.path("Action")) {
+        if (action.asText().startsWith("kms:")) {
+          return statement;
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -3,6 +3,8 @@ package io.unitycatalog.server.service.credential.aws;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.BUCKET_STATEMENT;
+import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.KMS_ENCRYPTION_CONTEXT_KEY;
+import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.KMS_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.OPERATION_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.POLICY_STATEMENT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +35,8 @@ public class AwsPolicyGeneratorTest {
     assertThatNoException().isThrownBy(() -> YAML_MAPPER.readTree(BUCKET_STATEMENT));
 
     assertThatNoException().isThrownBy(() -> YAML_MAPPER.readTree(OPERATION_STATEMENT));
+
+    assertThatNoException().isThrownBy(() -> YAML_MAPPER.readTree(KMS_STATEMENT));
   }
 
   @SneakyThrows
@@ -175,6 +179,7 @@ public class AwsPolicyGeneratorTest {
     assertThat(statement).isNotNull();
     assertThat(statement.path("Action")).map(JsonNode::asText).containsExactly("kms:Decrypt");
     assertThat(statement.path("Resource")).map(JsonNode::asText).containsExactly("*");
+    assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com");
   }
 
   @Test
@@ -189,6 +194,58 @@ public class AwsPolicyGeneratorTest {
         .map(JsonNode::asText)
         .containsExactlyInAnyOrder("kms:Decrypt", "kms:GenerateDataKey*");
     assertThat(statement.path("Resource")).map(JsonNode::asText).containsExactly("*");
+    assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com");
+  }
+
+  @Test
+  public void testKmsStatementIsScopedToGrantedS3Arns() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::my-bucket",
+            "arn:aws:s3:::my-bucket/path1/table1/*",
+            "arn:aws:s3:::my-bucket/path1/table1");
+  }
+
+  @Test
+  public void testKmsStatementCoversEveryBucket() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE),
+            Stream.of("s3://my-bucket1/path1/table1", "s3://my-bucket2")
+                .map(NormalizedURL::from)
+                .toList());
+
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
+        .map(JsonNode::asText)
+        .containsExactlyInAnyOrder(
+            "arn:aws:s3:::my-bucket1",
+            "arn:aws:s3:::my-bucket1/path1/table1/*",
+            "arn:aws:s3:::my-bucket1/path1/table1",
+            "arn:aws:s3:::my-bucket2",
+            "arn:aws:s3:::my-bucket2/*");
+  }
+
+  @Test
+  public void testKmsEncryptionContextEscapesIamSpecialCharacters() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE), List.of(NormalizedURL.from("s3://victim-bucket/*")));
+
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
+        .map(JsonNode::asText)
+        .containsExactly(
+            "arn:aws:s3:::victim-bucket",
+            "arn:aws:s3:::victim-bucket/${*}/*",
+            "arn:aws:s3:::victim-bucket/${*}")
+        .doesNotContain("arn:aws:s3:::victim-bucket/*", "arn:aws:s3:::victim-bucket/*/*");
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #917.

Tables stored in an S3 bucket with SSE-KMS encryption cannot be accessed through vended credentials. `AwsPolicyGenerator` grants only S3 actions, so the session policy attached to the vended credentials has no KMS permissions:

```java
static final List<String> SELECT_ACTIONS = List.of("s3:GetO*");
static final List<String> UPDATE_ACTIONS = List.of(
    "s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
```

Since a session policy can only narrow what the assumed role is allowed to do, the missing `kms:Decrypt` makes the request fail even when the role itself has access to the key. (The issue references `AwsCredentialVendor.java:46`, which moved to `AwsPolicyGenerator` in #1339. The behaviour is unchanged on `main`.)

**Change**

A KMS statement is added to the generated policy:

- `SELECT`: `kms:Decrypt`
- `UPDATE`: `kms:Decrypt`, `kms:GenerateDataKey*`

It is appended after the per-bucket statements, so the index of the existing S3 statements within the policy does not change. For `s3://my-bucket/path1/table1` it generates as:

```json
{
  "Effect": "Allow",
  "Action": ["kms:Decrypt"],
  "Resource": ["*"],
  "Condition": {
    "StringLike": {
      "kms:ViaService": "s3.*.amazonaws.com",
      "kms:EncryptionContext:aws:s3:arn": [
        "arn:aws:s3:::my-bucket",
        "arn:aws:s3:::my-bucket/path1/table1/*",
        "arn:aws:s3:::my-bucket/path1/table1"
      ]
    }
  }
}
```

**On the resource being `*`**

Unity Catalog does not know which KMS key a bucket is configured with, so the statement cannot name one. It is narrowed by condition instead:

- `kms:ViaService` limits the permissions to KMS calls S3 makes on the caller's behalf, so the credentials cannot use the key for anything else.
- `kms:EncryptionContext:aws:s3:arn` limits them to the S3 ARNs this policy already grants access to. The encryption context reuses the same ARN strings the S3 statement's `Resource` is built from, added through one helper so the two lists cannot drift apart, IAM escaping included.

The bucket ARN is listed alongside the object ARNs because a bucket with S3 Bucket Keys enabled encrypts under the bucket ARN rather than the object ARN. That case cannot be narrowed to a path, since a single data key covers every object in the bucket.

A session policy is also intersected with the role's own permissions, so a role without KMS access still receives none. Both properties are verified against real AWS below.

**Testing**

Unit tests added to `AwsPolicyGeneratorTest`, confirmed to fail before the change and pass after it, covering both conditions, the escaping of IAM special characters in the encryption context, multiple buckets, and one test pinning the position of the S3 statements so a future reordering does not silently break the existing index-based assertions.

Verified against real AWS with an SSE-KMS bucket and a role allowed to use the key, passing the generated policy to `sts:AssumeRole --policy`:

| case | before | after |
|---|---|---|
| SELECT / GetObject | AccessDenied | success |
| UPDATE / PutObject | AccessDenied | success |
| GetObject on an object encrypted with bucket keys | AccessDenied | success |

The denial before the change names KMS, not S3:

```
is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:...
because no session policy allows the kms:Decrypt action
```

Two negative cases confirm the statement grants nothing beyond the objects the policy already covers:

| case | result |
|---|---|
| role with S3 but no KMS permissions | denied, `no identity-based policy allows the kms:Decrypt action` |
| encryption context scoped to another path, S3 access unchanged | denied, `no session policy allows the kms:Decrypt action` |

The first shows the open resource adds nothing to what the role itself may do; the second shows the encryption context condition is actually enforced.
