### PR TITLE
[Server] Implement Iceberg reportMetrics endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
@@ -45,9 +46,13 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ExceptionHandler(IcebergRestExceptionHandler.class)
 public class IcebergRestCatalogService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IcebergRestCatalogService.class);
 
   private static final String PREFIX_BASE = "catalogs/";
 
@@ -214,12 +219,32 @@ public class IcebergRestCatalogService {
     throw new NoSuchViewException("View does not exist: %s", namespace + "." + view);
   }
 
+  /**
+   * Accept a scan or commit report from an Iceberg client. Clients report after every scan and
+   * commit as long as the server advertises {@code V1_REPORT_METRICS}, which this service does. The
+   * report is acknowledged and discarded -- UC does not persist client telemetry today -- but the
+   * table is still resolved so that a report naming a table UC doesn't serve is answered with a
+   * 404, as the REST spec requires.
+   */
   @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}/metrics")
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse reportMetrics(
-      @Param("namespace") String namespace, @Param("table") String table) {
-    return HttpResponse.of(HttpStatus.OK);
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      @Param("table") String table,
+      ReportMetricsRequest request) {
+    try (Session session = sessionFactory.openSession()) {
+      tableRepository.getTable(catalog + "." + namespace + "." + table);
+      String metadataLocation =
+          tableRepository.getTableUniformMetadataLocation(session, catalog, namespace, table);
+      if (metadataLocation == null) {
+        throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
+      }
+    }
+
+    LOGGER.debug("Received {} for table {}.{}.{}", request.reportType(), catalog, namespace, table);
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/tables")

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.auth.AuthToken;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.CatalogInfo;
@@ -32,6 +36,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,6 +44,15 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.CommitMetrics;
+import org.apache.iceberg.metrics.CommitMetricsResult;
+import org.apache.iceberg.metrics.ImmutableCommitReport;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ScanMetrics;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
@@ -353,6 +367,140 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(resp.status().code()).isEqualTo(400);
     assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).message())
         .contains("must match the registered table location");
+  }
+
+  @Test
+  public void testReportMetrics() throws Exception {
+    createUniformIcebergTable();
+    String metricsPath =
+        TEST_BASE_PREFIX
+            + "/namespaces/"
+            + TestUtils.SCHEMA_NAME
+            + "/tables/"
+            + TestUtils.TABLE_NAME
+            + "/metrics";
+
+    // Per the REST spec, a report is acknowledged with 204 No Content.
+    assertThat(postJson(metricsPath, scanReportJson()).status().code()).isEqualTo(204);
+    assertThat(postJson(metricsPath, commitReportJson()).status().code()).isEqualTo(204);
+
+    // A body that isn't a metrics report is rejected rather than silently accepted.
+    assertThat(postJson(metricsPath, "{\"foo\":\"bar\"}").status().code()).isEqualTo(400);
+
+    // A table UC knows about but doesn't serve as an Iceberg table is a 404, like loadTable.
+    createTable("plainTable");
+    AggregatedHttpResponse resp =
+        postJson(
+            TEST_BASE_PREFIX
+                + "/namespaces/"
+                + TestUtils.SCHEMA_NAME
+                + "/tables/plainTable/metrics",
+            scanReportJson());
+    assertThat(resp.status().code()).isEqualTo(404);
+    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+        .isEqualTo(NoSuchTableException.class.getSimpleName());
+
+    // A table that doesn't exist at all is a 404 too.
+    resp =
+        postJson(
+            TEST_BASE_PREFIX
+                + "/namespaces/"
+                + TestUtils.SCHEMA_NAME
+                + "/tables/missingTable/metrics",
+            scanReportJson());
+    assertThat(resp.status().code()).isEqualTo(404);
+
+    // The non-prefixed URL isn't routed, matching the other Iceberg endpoints.
+    resp =
+        postJson(
+            TEST_BASE_NON_PREFIX
+                + "/namespaces/"
+                + TestUtils.SCHEMA_NAME
+                + "/tables/"
+                + TestUtils.TABLE_NAME
+                + "/metrics",
+            scanReportJson());
+    assertThat(resp.status().code()).isEqualTo(404);
+  }
+
+  private AggregatedHttpResponse postJson(String path, String json) {
+    return client
+        .execute(
+            RequestHeaders.of(HttpMethod.POST, path, HttpHeaderNames.CONTENT_TYPE, MediaType.JSON),
+            json)
+        .aggregate()
+        .join();
+  }
+
+  private static String scanReportJson() {
+    return ReportMetricsRequestParser.toJson(
+        ReportMetricsRequest.of(
+            ImmutableScanReport.builder()
+                .tableName(TestUtils.TABLE_NAME)
+                .schemaId(0)
+                .addProjectedFieldIds(1)
+                .addProjectedFieldNames("as_int")
+                .snapshotId(23L)
+                .filter(Expressions.alwaysTrue())
+                .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+                .build()));
+  }
+
+  private static String commitReportJson() {
+    return ReportMetricsRequestParser.toJson(
+        ReportMetricsRequest.of(
+            ImmutableCommitReport.builder()
+                .tableName(TestUtils.TABLE_NAME)
+                .snapshotId(23L)
+                .sequenceNumber(4L)
+                .operation("append")
+                .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
+                .build()));
+  }
+
+  /** Creates a table that the Iceberg endpoints see, i.e. one with uniform Iceberg metadata. */
+  private void createUniformIcebergTable() throws IOException, URISyntaxException, ApiException {
+    Path metadataFile = writeIcebergMetadata();
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+    TableInfo tableInfo = createTable(TestUtils.TABLE_NAME);
+
+    try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
+      Transaction tx = session.beginTransaction();
+      UUID tableId = UUID.fromString(Objects.requireNonNull(tableInfo.getTableId()));
+      TableInfoDAO tableInfoDAO = session.get(TableInfoDAO.class, tableId);
+      assertThat(tableInfoDAO).isNotNull();
+      tableInfoDAO.setUniformIcebergMetadataLocation(metadataFile.toUri().toString());
+      session.merge(tableInfoDAO);
+      tx.commit();
+    }
+  }
+
+  /** Creates a plain UC table, i.e. one without uniform Iceberg metadata. */
+  private TableInfo createTable(String tableName) throws ApiException, IOException {
+    return tableOperations.createTable(
+        new CreateTable()
+            .name(tableName)
+            .catalogName(TestUtils.CATALOG_NAME)
+            .schemaName(TestUtils.SCHEMA_NAME)
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("as_int")
+                        .typeText("INTEGER")
+                        .typeJson(
+                            "{\"name\":\"as_int\",\"type\":\"integer\","
+                                + "\"nullable\":true,\"metadata\":{}}")
+                        .typeName(ColumnTypeName.INT)
+                        .typePrecision(10)
+                        .typeScale(0)
+                        .position(0)
+                        .nullable(true)))
+            .storageLocation(icebergTableLocation.toString())
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.DELTA));
   }
 
   private Path writeIcebergMetadata() throws IOException, URISyntaxException {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`reportMetrics` in `IcebergRestCatalogService` took no request body and returned 200 unconditionally:

```java
@Post("/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}/metrics")
public HttpResponse reportMetrics(
    @Param("namespace") String namespace, @Param("table") String table) {
  return HttpResponse.of(HttpStatus.OK);
}
```

This endpoint is reached in normal operation. The service advertises `V1_REPORT_METRICS` in its config response, and `RESTSessionCatalog` installs a `RESTMetricsReporter` whenever the server does so:

```java
// RESTSessionCatalog.java
if (reportingViaRestEnabled && endpoints.contains(Endpoint.V1_REPORT_METRICS)) {
```

`rest-metrics-reporting-enabled` defaults to `true`, so clients report after every scan and commit. Those reports were discarded without being parsed, and a report naming a table the server does not serve was answered as though it had been accepted.

**Change**

- The body is bound to Iceberg's `ReportMetricsRequest`. No converter work was needed: the Iceberg protocol's request converter already uses an `ObjectMapper` with `RESTSerializers.registerAll` applied, so a malformed body is rejected with 400 instead of being ignored.
- The table is resolved the same way `tableExists` and `loadTable` resolve it, so a report for a table without uniform Iceberg metadata gets 404 rather than a silent 200.
- The response is 204 No Content, as `rest-catalog-open-api.yaml` specifies for `reportMetrics`.
- The report is logged at debug and discarded. This follows `DeltaApiService.reportMetrics`, added in #1681, which documents that UC does not persist client telemetry today. Storing or aggregating reports would need its own design discussion, so it is deliberately left out here.

**Testing**

`testReportMetrics` added to `IcebergRestCatalogTest`, confirmed to fail before the change (`expected: 204 but was: 200`) and pass after it. It covers a scan report, a commit report, a body that is not a metrics report, a table without uniform Iceberg metadata, a table that does not exist, and the non-prefixed URL. The reports are built with Iceberg's own `ImmutableScanReport` / `ImmutableCommitReport` and serialized with `ReportMetricsRequestParser`, so the test exercises exactly what a client sends rather than hand-written JSON.

`server/testOnly io.unitycatalog.server.service.* io.unitycatalog.server.sdk.delta.*` is 135 passed / 1 failed, the failure being `CloudCredentialVendorTest.testGenerateGcpTemporaryCredentials`, which also fails on an unmodified checkout in my environment.

**One thing I left alone**

When the table is absent from UC entirely, the 404 body carries `"type": "BaseException"` rather than `"NoSuchTableException"`, because `TableRepository` raises UC's own exception and `IcebergRestExceptionHandler` reports the original class name. The status code is correct and Iceberg's client builds a `NoSuchTableException` from the 404 regardless, and every other Iceberg endpoint behaves the same way, so mapping UC's `TABLE_NOT_FOUND` onto Iceberg's exception felt like a separate change. Happy to do it here if you'd prefer.
