### PR TITLE
[Hadoop] Support Iceberg scan-plan credential renewal

### DIFF
--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/UCCredentialHadoopConfs.java
@@ -71,7 +71,8 @@ public final class UCCredentialHadoopConfs {
 
   /**
    * Collects credential settings and produces Hadoop configuration properties via {@link
-   * #buildForTable}, {@link #buildForStagingTable}, or {@link #buildForPath}.
+   * #buildForTable}, {@link #buildForStagingTable}, {@link #buildForIcebergPlan}, or {@link
+   * #buildForPath}.
    */
   public static final class Builder {
 
@@ -244,6 +245,40 @@ public final class UCCredentialHadoopConfs {
           tokenProvider,
           stagingTableId,
           location,
+          appVersions);
+    }
+
+    /**
+     * Builds Hadoop properties for credentials scoped to an Iceberg REST server-side scan plan.
+     *
+     * <p>Credential renewal calls {@code credentialsEndpoint} with the standard {@code planId}
+     * query parameter. The returned Iceberg {@code storage-credentials} are converted to the same
+     * renewable Hadoop credential providers used by the other builder modes.
+     *
+     * @param credentialsEndpoint the absolute Iceberg REST credentials endpoint from the scan-plan
+     *     catalog, excluding the {@code planId} query parameter
+     * @param planId the opaque plan ID returned by the server-side scan planning response
+     * @return unmodifiable map; empty if the scheme is unrecognized
+     * @throws IllegalArgumentException if an endpoint, plan ID, or {@code tokenProvider} is missing
+     * @throws ApiException if the credential fetch from the Iceberg REST API fails
+     */
+    public Map<String, String> buildForIcebergPlan(String credentialsEndpoint, String planId)
+        throws ApiException {
+      Preconditions.checkArgument(
+          credentialsEndpoint != null && !credentialsEndpoint.isEmpty(),
+          "credentialsEndpoint is required");
+      Preconditions.checkArgument(planId != null && !planId.isEmpty(), "planId is required");
+      Preconditions.checkArgument(tokenProvider != null, "tokenProvider is required");
+      return CredPropsUtil.createIcebergPlanCredProps(
+          credentialRenewalEnabled,
+          credentialScopedFsEnabled,
+          hadoopConf,
+          scheme,
+          apiClient,
+          catalogUri,
+          tokenProvider,
+          credentialsEndpoint,
+          planId,
           appVersions);
     }
 

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/CredPropsUtil.java
@@ -5,14 +5,19 @@ import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.internal.ApiClientUtils;
 import io.unitycatalog.client.internal.Clock;
+import io.unitycatalog.client.internal.Preconditions;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.AzureCredential;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache.RenewableCredential;
+import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+import io.unitycatalog.hadoop.internal.id.IcebergPlanCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import io.unitycatalog.hadoop.internal.props.CredPropsBuilder;
@@ -25,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -145,6 +151,32 @@ public class CredPropsUtil {
             credContextId(catalogUri, scheme, tokenProvider), stagingTableId, location));
   }
 
+  /** Fetches credentials scoped to an Iceberg REST server-side scan plan. */
+  public static Map<String, String> createIcebergPlanCredProps(
+      boolean renewCredEnabled,
+      boolean credScopedFsEnabled,
+      Configuration hadoopConf,
+      String scheme,
+      ApiClient apiClient,
+      String catalogUri,
+      TokenProvider tokenProvider,
+      String credentialsEndpoint,
+      String planId,
+      Map<String, String> appVersions)
+      throws ApiException {
+    return createCredProps(
+        renewCredEnabled,
+        credScopedFsEnabled,
+        hadoopConf,
+        scheme,
+        apiClient,
+        catalogUri,
+        tokenProvider,
+        appVersions,
+        new IcebergPlanCredId(
+            credContextId(catalogUri, scheme, tokenProvider), credentialsEndpoint, planId));
+  }
+
   /** Fetches path credentials from the UC REST API and builds Hadoop configuration properties. */
   public static Map<String, String> createPathCredProps(
       boolean renewCredEnabled,
@@ -191,9 +223,15 @@ public class CredPropsUtil {
       // Unsupported scheme: skip the credential fetch entirely and return no props.
       return Collections.emptyMap();
     }
-    List<GenericCredential> credentials =
+    List<GenericCredential> fetchedCredentials =
         fetchGenericCredentials(
             hadoopConf, apiClient, catalogUri, tokenProvider, appVersions, credId);
+    List<GenericCredential> credentials =
+        fetchedCredentials.stream()
+            .filter(credential -> matchesCloud(cloudType.get(), credential))
+            .collect(Collectors.toList());
+    Preconditions.checkState(
+        !credentials.isEmpty(), "No vended credential matched storage scheme '%s'.", scheme);
     CredPropsBuilder builder =
         CredPropsBuilder.forCloud(cloudType.get(), hadoopConf)
             .credScopedFsEnabled(credScopedFsEnabled)
@@ -204,6 +242,18 @@ public class CredPropsUtil {
     }
 
     return builder.build();
+  }
+
+  private static boolean matchesCloud(CloudType cloudType, GenericCredential credential) {
+    switch (cloudType) {
+      case S3:
+        return credential instanceof AwsCredential;
+      case ABFS:
+        return credential instanceof AzureCredential;
+      case GCS:
+        return credential instanceof GcsCredential;
+    }
+    throw new IllegalStateException("Unhandled cloud type: " + cloudType);
   }
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -95,6 +95,11 @@ public class UCHadoopConfConstants {
   public static final String UC_DELTA_STAGING_TABLE_LOCATION_KEY =
       "fs.unitycatalog.delta.staging.table.location";
 
+  // Keys for Iceberg REST scan-plan credential requests.
+  public static final String UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY =
+      "fs.unitycatalog.iceberg.credentials.endpoint";
+  public static final String UC_ICEBERG_PLAN_ID_KEY = "fs.unitycatalog.iceberg.plan.id";
+
   // Keys for path based temporary credential requests.
   public static final String UC_PATH_KEY = "fs.unitycatalog.path";
   public static final String UC_PATH_OPERATION_KEY = "fs.unitycatalog.path.operation";
@@ -103,6 +108,7 @@ public class UCHadoopConfConstants {
   public static final String UC_CREDENTIALS_TYPE_KEY = "fs.unitycatalog.credentials.type";
   public static final String UC_CREDENTIALS_TYPE_TABLE_VALUE = "table";
   public static final String UC_CREDENTIALS_TYPE_PATH_VALUE = "path";
+  public static final String UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE = "iceberg-plan";
 
   // Key to enable the credential cache.
   public static final String UC_CREDENTIAL_CACHE_ENABLED_KEY =

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/GenericCredentialFetcher.java
@@ -11,6 +11,7 @@ import io.unitycatalog.hadoop.internal.UCHadoopConfConstants;
 import io.unitycatalog.hadoop.internal.id.CredId;
 import io.unitycatalog.hadoop.internal.id.DeltaStagingTableCredId;
 import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
+import io.unitycatalog.hadoop.internal.id.IcebergPlanCredId;
 import io.unitycatalog.hadoop.internal.id.PathCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import java.net.URI;
@@ -49,6 +50,11 @@ public interface GenericCredentialFetcher {
     return new UCDeltaStagingTableCredentialFetcher(credId, api);
   }
 
+  /** Creates a fetcher backed by an Iceberg REST scan-plan credentials endpoint. */
+  static GenericCredentialFetcher forIcebergPlan(IcebergPlanCredId credId, ApiClient apiClient) {
+    return new IcebergPlanCredentialFetcher(credId, apiClient);
+  }
+
   /**
    * Creates a {@link GenericCredentialFetcher} from an already-built {@link ApiClient} and the
    * {@link CredId} identifying the credential scope. The fetcher subtype is selected from the
@@ -65,6 +71,8 @@ public interface GenericCredentialFetcher {
     } else if (credId instanceof DeltaStagingTableCredId) {
       return forUcDeltaStagingTable(
           (DeltaStagingTableCredId) credId, new DeltaTemporaryCredentialsApi(apiClient));
+    } else if (credId instanceof IcebergPlanCredId) {
+      return forIcebergPlan((IcebergPlanCredId) credId, apiClient);
     } else {
       throw new IllegalArgumentException("Unsupported CredId type: " + credId);
     }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/IcebergPlanCredentialFetcher.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/auth/IcebergPlanCredentialFetcher.java
@@ -1,0 +1,230 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.internal.Preconditions;
+import io.unitycatalog.hadoop.internal.id.IcebergPlanCredId;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/** Fetches and converts standard Iceberg REST scan-plan credentials. */
+final class IcebergPlanCredentialFetcher implements GenericCredentialFetcher {
+  private static final String STORAGE_CREDENTIALS = "storage-credentials";
+  private static final String PREFIX = "prefix";
+  private static final String CONFIG = "config";
+
+  private static final String S3_ACCESS_KEY_ID = "s3.access-key-id";
+  private static final String S3_SECRET_ACCESS_KEY = "s3.secret-access-key";
+  private static final String S3_SESSION_TOKEN = "s3.session-token";
+  private static final String S3_SESSION_TOKEN_EXPIRES_AT_MS = "s3.session-token-expires-at-ms";
+
+  private static final String ADLS_SAS_TOKEN_PREFIX = "adls.sas-token.";
+  private static final String ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX = "adls.sas-token-expires-at-ms.";
+
+  private static final String GCS_OAUTH2_TOKEN = "gcs.oauth2.token";
+  private static final String GCS_OAUTH2_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
+
+  private final IcebergPlanCredId credId;
+  private final ApiClient apiClient;
+
+  IcebergPlanCredentialFetcher(IcebergPlanCredId credId, ApiClient apiClient) {
+    Preconditions.checkNotNull(credId, "credId is required");
+    Preconditions.checkNotNull(apiClient, "apiClient is required");
+    this.credId = credId;
+    this.apiClient = apiClient;
+  }
+
+  @Override
+  public List<GenericCredential> createCredentials() throws ApiException {
+    HttpRequest.Builder requestBuilder =
+        HttpRequest.newBuilder(requestUri()).header("Accept", "application/json").GET();
+    if (apiClient.getReadTimeout() != null) {
+      requestBuilder.timeout(apiClient.getReadTimeout());
+    }
+    Consumer<HttpRequest.Builder> requestInterceptor = apiClient.getRequestInterceptor();
+    if (requestInterceptor != null) {
+      requestInterceptor.accept(requestBuilder);
+    }
+
+    HttpResponse<String> response;
+    try {
+      response =
+          apiClient
+              .getHttpClient()
+              .send(
+                  requestBuilder.build(),
+                  HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw new ApiException(response.statusCode(), response.headers(), response.body());
+    }
+
+    return parseResponse(
+        apiClient.getObjectMapper(), response.body(), response.statusCode(), response.headers());
+  }
+
+  private URI requestUri() {
+    String endpoint = credId.credentialsEndpoint();
+    Preconditions.checkArgument(
+        !endpoint.contains("#"), "credentialsEndpoint cannot contain a fragment");
+    String separator = endpoint.contains("?") ? "&" : "?";
+    URI uri = URI.create(endpoint + separator + "planId=" + ApiClient.urlEncode(credId.planId()));
+    Preconditions.checkArgument(uri.isAbsolute(), "credentialsEndpoint must be an absolute URI");
+    return uri;
+  }
+
+  private static List<GenericCredential> parseResponse(
+      ObjectMapper mapper,
+      String responseBody,
+      int responseCode,
+      java.net.http.HttpHeaders responseHeaders)
+      throws ApiException {
+    JsonNode root;
+    try {
+      root = mapper.readTree(responseBody);
+    } catch (IOException e) {
+      throw new ApiException(
+          "Failed to parse Iceberg plan credentials response",
+          e,
+          responseCode,
+          responseHeaders,
+          responseBody);
+    }
+
+    JsonNode credentials = root == null ? null : root.get(STORAGE_CREDENTIALS);
+    Preconditions.checkArgument(
+        credentials != null && credentials.isArray() && !credentials.isEmpty(),
+        "Iceberg credentials response contained no storage credentials");
+
+    List<GenericCredential> result = new ArrayList<>();
+    for (JsonNode credential : credentials) {
+      result.add(toGenericCredential(credential));
+    }
+    return result;
+  }
+
+  private static GenericCredential toGenericCredential(JsonNode credential) {
+    Preconditions.checkArgument(
+        credential != null && credential.isObject(), "Invalid Iceberg storage credential");
+    String prefix = requiredText(credential, PREFIX, "storage credential");
+    JsonNode configNode = credential.get(CONFIG);
+    Preconditions.checkArgument(
+        configNode != null && configNode.isObject(),
+        "Iceberg credential for '%s' is missing config",
+        prefix);
+    Map<String, String> config = stringMap(configNode, prefix);
+
+    boolean isS3 =
+        config.containsKey(S3_ACCESS_KEY_ID)
+            || config.containsKey(S3_SECRET_ACCESS_KEY)
+            || config.containsKey(S3_SESSION_TOKEN)
+            || config.containsKey(S3_SESSION_TOKEN_EXPIRES_AT_MS);
+    List<String> adlsAccounts = adlsAccounts(config);
+    boolean isAzure = !adlsAccounts.isEmpty();
+    boolean isGcs =
+        config.containsKey(GCS_OAUTH2_TOKEN) || config.containsKey(GCS_OAUTH2_TOKEN_EXPIRES_AT);
+    int cloudCount = (isS3 ? 1 : 0) + (isAzure ? 1 : 0) + (isGcs ? 1 : 0);
+    Preconditions.checkArgument(
+        cloudCount == 1,
+        "Iceberg credential for '%s' must contain exactly one cloud credential config",
+        prefix);
+
+    if (isS3) {
+      return new AwsCredential(
+          requiredConfig(config, S3_ACCESS_KEY_ID, prefix),
+          requiredConfig(config, S3_SECRET_ACCESS_KEY, prefix),
+          requiredConfig(config, S3_SESSION_TOKEN, prefix),
+          requiredExpiration(config, S3_SESSION_TOKEN_EXPIRES_AT_MS, prefix),
+          prefix);
+    } else if (isAzure) {
+      Preconditions.checkArgument(
+          adlsAccounts.size() == 1,
+          "Iceberg credential for '%s' contains SAS tokens for multiple ADLS accounts",
+          prefix);
+      String account = adlsAccounts.get(0);
+      return new AzureCredential(
+          requiredConfig(config, ADLS_SAS_TOKEN_PREFIX + account, prefix),
+          requiredExpiration(config, ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + account, prefix),
+          prefix);
+    } else {
+      return new GcsCredential(
+          requiredConfig(config, GCS_OAUTH2_TOKEN, prefix),
+          requiredExpiration(config, GCS_OAUTH2_TOKEN_EXPIRES_AT, prefix),
+          prefix);
+    }
+  }
+
+  private static Map<String, String> stringMap(JsonNode config, String prefix) {
+    Map<String, String> result = new LinkedHashMap<>();
+    Iterator<Map.Entry<String, JsonNode>> fields = config.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> field = fields.next();
+      Preconditions.checkArgument(
+          field.getValue().isTextual(),
+          "Iceberg credential config '%s' for '%s' must be a string",
+          field.getKey(),
+          prefix);
+      result.put(field.getKey(), field.getValue().textValue());
+    }
+    return result;
+  }
+
+  private static List<String> adlsAccounts(Map<String, String> config) {
+    List<String> accounts = new ArrayList<>();
+    for (String key : config.keySet()) {
+      if (key.startsWith(ADLS_SAS_TOKEN_PREFIX) && key.length() > ADLS_SAS_TOKEN_PREFIX.length()) {
+        accounts.add(key.substring(ADLS_SAS_TOKEN_PREFIX.length()));
+      }
+    }
+    return accounts;
+  }
+
+  private static String requiredText(JsonNode node, String key, String description) {
+    JsonNode value = node.get(key);
+    Preconditions.checkArgument(
+        value != null && value.isTextual() && !value.textValue().isEmpty(),
+        "Iceberg %s is missing %s",
+        description,
+        key);
+    return value.textValue();
+  }
+
+  private static String requiredConfig(Map<String, String> config, String key, String prefix) {
+    String value = config.get(key);
+    Preconditions.checkArgument(
+        value != null && !value.isEmpty(),
+        "Iceberg credential for '%s' is missing config '%s'",
+        prefix,
+        key);
+    return value;
+  }
+
+  private static long requiredExpiration(Map<String, String> config, String key, String prefix) {
+    String value = requiredConfig(config, key, prefix);
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Iceberg credential config '%s' for '%s' must be epoch milliseconds", key, prefix),
+          e);
+    }
+  }
+}

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/CredId.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.hadoop.internal.id;
 
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_PATH_VALUE;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_TABLE_VALUE;
@@ -12,6 +13,8 @@ import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_SCH
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_STAGING_TABLE_LOCATION_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_DELTA_TABLE_NAME_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_ICEBERG_PLAN_ID_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_PATH_OPERATION_KEY;
 import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_TABLE_ID_KEY;
@@ -35,7 +38,7 @@ import org.apache.hadoop.conf.Configuration;
  * TokenProvider.configs()} a credential is vended from, hashed into a single id (see {@link
  * UCHadoopConfConstants#UC_CRED_CONTEXT_ID_KEY}).
  *
- * <p>There are five implementations:
+ * <p>There are six implementations:
  *
  * <ul>
  *   <li>{@link TableCredId} — keyed by credential context, table ID, and operation; used for
@@ -47,6 +50,8 @@ import org.apache.hadoop.conf.Configuration;
  *   <li>{@link DeltaStagingTableCredId} — keyed by credential context, staging table ID, and
  *       location; used for staging-table-level temporary credentials via the UC Delta credentials
  *       API.
+ *   <li>{@link IcebergPlanCredId} — keyed by credential context, credentials endpoint, and scan
+ *       plan ID; used for credentials scoped to an Iceberg REST server-side scan plan.
  *   <li>{@link DefaultCredId} — keyed by URI scheme and authority; used as a fallback when no Unity
  *       Catalog credential type is present in the configuration.
  * </ul>
@@ -77,8 +82,18 @@ public interface CredId {
     // stagingTableId is always from UC Delta API.
     boolean hasUcDeltaStagingTableId = stagingTableId != null && !stagingTableId.isEmpty();
 
-    if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type) && !isDeltaApi && !hasUcDeltaStagingTableId) {
-      // Case 1: UC table (legacy API) — keyed by cred context + table ID + operation.
+    if (UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE.equals(type)) {
+      // Case 1: Iceberg scan plan — keyed by context + endpoint + authorized scan plan ID.
+      String credContextId = readCredContextId(conf);
+      return new IcebergPlanCredId(
+          credContextId,
+          conf.get(UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY),
+          conf.get(UC_ICEBERG_PLAN_ID_KEY));
+
+    } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)
+        && !isDeltaApi
+        && !hasUcDeltaStagingTableId) {
+      // Case 2: UC table (legacy API) — keyed by cred context + table ID + operation.
       String credContextId = readCredContextId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       String tableId = conf.get(UC_TABLE_ID_KEY);
@@ -87,7 +102,7 @@ public interface CredId {
     } else if (UC_CREDENTIALS_TYPE_PATH_VALUE.equals(type)
         && !isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 2: Path-based credentials (legacy UC API) — keyed by cred context + path + operation.
+      // Case 3: Path-based credentials (legacy UC API) — keyed by cred context + path + operation.
       String credContextId = readCredContextId(conf);
       String path = conf.get(UC_PATH_KEY);
       String pathOp = conf.get(UC_PATH_OPERATION_KEY);
@@ -96,7 +111,7 @@ public interface CredId {
     } else if (UC_CREDENTIALS_TYPE_TABLE_VALUE.equals(type)
         && isDeltaApi
         && !hasUcDeltaStagingTableId) {
-      // Case 3: Delta table — keyed by cred context + catalog.schema.table + operation + location.
+      // Case 4: Delta table — keyed by cred context + catalog.schema.table + operation + location.
       String credContextId = readCredContextId(conf);
       String tableOp = conf.get(UC_TABLE_OPERATION_KEY);
       UCDeltaTableIdentifier identifier =
@@ -108,13 +123,13 @@ public interface CredId {
       return new DeltaTableCredId(credContextId, identifier, tableOp, location);
 
     } else if (hasUcDeltaStagingTableId) {
-      // Case 4: Delta staging table — keyed by cred context + staging table UUID + location.
+      // Case 5: Delta staging table — keyed by cred context + staging table UUID + location.
       String credContextId = readCredContextId(conf);
       String location = conf.get(UC_DELTA_STAGING_TABLE_LOCATION_KEY);
       return new DeltaStagingTableCredId(credContextId, stagingTableId, location);
 
     } else {
-      // Case 5: No recognized credential type — delegate to the caller-provided fallback.
+      // Case 6: No recognized credential type — delegate to the caller-provided fallback.
       return defaultCredId.get();
     }
   }

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/IcebergPlanCredId.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/id/IcebergPlanCredId.java
@@ -1,0 +1,82 @@
+package io.unitycatalog.hadoop.internal.id;
+
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY;
+import static io.unitycatalog.hadoop.internal.UCHadoopConfConstants.UC_ICEBERG_PLAN_ID_KEY;
+
+import io.unitycatalog.client.internal.Preconditions;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link CredId} keyed by credential context, Iceberg credentials endpoint, and scan plan ID.
+ *
+ * <p>The plan ID identifies the authorized server-side scan, rather than the source table. This
+ * keeps renewed credentials scoped to the same FGAC plan as the credentials returned with the
+ * original plan response.
+ */
+public final class IcebergPlanCredId implements CredId {
+  private final String credContextId;
+  private final String credentialsEndpoint;
+  private final String planId;
+
+  public IcebergPlanCredId(String credContextId, String credentialsEndpoint, String planId) {
+    Preconditions.checkNotNull(credContextId, "credContextId is required");
+    Preconditions.checkArgument(
+        credentialsEndpoint != null && !credentialsEndpoint.isEmpty(),
+        "credentialsEndpoint is required");
+    Preconditions.checkArgument(planId != null && !planId.isEmpty(), "planId is required");
+    this.credContextId = credContextId;
+    this.credentialsEndpoint = credentialsEndpoint;
+    this.planId = planId;
+  }
+
+  public String credentialsEndpoint() {
+    return credentialsEndpoint;
+  }
+
+  public String planId() {
+    return planId;
+  }
+
+  @Override
+  public Map<String, String> props() {
+    return Map.of(
+        UC_CRED_CONTEXT_ID_KEY,
+        credContextId,
+        UC_CREDENTIALS_TYPE_KEY,
+        UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE,
+        UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY,
+        credentialsEndpoint,
+        UC_ICEBERG_PLAN_ID_KEY,
+        planId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof IcebergPlanCredId)) return false;
+    IcebergPlanCredId that = (IcebergPlanCredId) o;
+    return Objects.equals(credContextId, that.credContextId)
+        && Objects.equals(credentialsEndpoint, that.credentialsEndpoint)
+        && Objects.equals(planId, that.planId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(credContextId, credentialsEndpoint, planId);
+  }
+
+  @Override
+  public String toString() {
+    return "IcebergPlanCredId{credContextId="
+        + credContextId
+        + ", credentialsEndpoint="
+        + credentialsEndpoint
+        + ", planId="
+        + planId
+        + "}";
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/UCCredentialHadoopConfsTest.java
@@ -119,6 +119,34 @@ class UCCredentialHadoopConfsTest {
   }
 
   @Test
+  void icebergPlanBuildRejectsMissingFields() {
+    TokenProvider tp = TokenProvider.create(Map.of("type", "static", "token", "tok"));
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForIcebergPlan(null, "plan-id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("credentialsEndpoint is required");
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .tokenProvider(tp)
+                    .buildForIcebergPlan("http://uc/v1/credentials", ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("planId is required");
+
+    assertThatThrownBy(
+            () ->
+                UCCredentialHadoopConfs.builder("http://uc", "s3")
+                    .buildForIcebergPlan("http://uc/v1/credentials", "plan-id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tokenProvider is required");
+  }
+
+  @Test
   void stagingTableBuildRejectsMissingFields() {
     TokenProvider tp = TokenProvider.create(Map.of("type", "static", "token", "tok"));
 

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/CredPropsUtilTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.GcsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -58,7 +60,77 @@ class CredPropsUtilTest {
                     UCCredentialHadoopConfs.TableOperation.READ,
                     Map.of()))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Initial credentials cannot be null or empty");
+        .hasMessageContaining("No vended credential matched storage scheme 's3'");
+  }
+
+  @Test
+  void icebergPlanPropsCarryRenewalIdentityToExecutors() throws Exception {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) ->
+            () ->
+                java.util.List.of(
+                    new AwsCredential("ak", "sk", "st", 4_102_444_800_000L, "s3://bucket/t"));
+
+    Map<String, String> props =
+        CredPropsUtil.createIcebergPlanCredProps(
+            true,
+            false,
+            new Configuration(false),
+            "s3",
+            null,
+            "http://uc",
+            tokenProvider(),
+            "http://uc/iceberg/v1/ns/t/credentials",
+            "plan-1",
+            Map.of("Delta", "4.2.0"));
+
+    assertThat(props)
+        .containsEntry(
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+            UCHadoopConfConstants.UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE)
+        .containsEntry(
+            UCHadoopConfConstants.UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY,
+            "http://uc/iceberg/v1/ns/t/credentials")
+        .containsEntry(UCHadoopConfConstants.UC_ICEBERG_PLAN_ID_KEY, "plan-1")
+        .containsEntry(UCHadoopConfConstants.UC_AUTH_TYPE, "static")
+        .containsEntry(UCHadoopConfConstants.UC_AUTH_TOKEN_KEY, "tok")
+        .containsEntry(UCHadoopConfConstants.UC_ENGINE_VERSION_PREFIX + "Delta", "4.2.0");
+
+    Configuration serialized = new Configuration(false);
+    props.forEach(serialized::set);
+    assertThat(io.unitycatalog.hadoop.internal.id.CredId.create(serialized))
+        .isInstanceOf(io.unitycatalog.hadoop.internal.id.IcebergPlanCredId.class);
+  }
+
+  @Test
+  void icebergPlanPropsKeepOnlyCredentialsForRequestedCloud() throws Exception {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) ->
+            () ->
+                java.util.List.of(
+                    new AwsCredential("ak", "sk", "st", 4_102_444_800_000L, "s3://bucket/t"),
+                    new GcsCredential("oauth", 4_102_444_800_000L, "gs://bucket/t"));
+
+    Map<String, String> props =
+        CredPropsUtil.createIcebergPlanCredProps(
+            false,
+            false,
+            new Configuration(false),
+            "s3",
+            null,
+            "http://uc",
+            tokenProvider(),
+            "http://uc/iceberg/v1/ns/t/credentials",
+            "plan-1",
+            Map.of());
+
+    assertThat(props)
+        .containsEntry("fs.s3a.access.key", "ak")
+        .doesNotContainKey("fs.gs.auth.access.token.credential");
+    assertThat(
+            CredentialUtil.decodeCredPrefixes(
+                props.get(UCHadoopConfConstants.UC_CREDENTIAL_PREFIXES_KEY).split(",")))
+        .containsExactly("s3://bucket/t");
   }
 
   private static TokenProvider tokenProvider() {

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/IcebergPlanCredentialFetcherTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/auth/IcebergPlanCredentialFetcherTest.java
@@ -1,0 +1,211 @@
+package io.unitycatalog.hadoop.internal.auth;
+
+import static io.unitycatalog.hadoop.internal.id.CredIdTest.EMPTY_CRED_CONTEXT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.hadoop.internal.id.IcebergPlanCredId;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class IcebergPlanCredentialFetcherTest {
+  private static final long EXPIRATION = 4_102_444_800_000L;
+
+  private HttpServer server;
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void fetchesAwsAzureAndGcsCredentialsWithPlanAndBearerToken() throws Exception {
+    List<String> queries = new ArrayList<>();
+    List<String> authorizationHeaders = new ArrayList<>();
+    AtomicReference<String> token = new AtomicReference<>("token-1");
+    String body =
+        "{\"storage-credentials\":["
+            + "{\"prefix\":\"s3://bucket/table\",\"config\":{"
+            + "\"s3.access-key-id\":\"ak\",\"s3.secret-access-key\":\"sk\","
+            + "\"s3.session-token\":\"st\",\"s3.session-token-expires-at-ms\":\""
+            + EXPIRATION
+            + "\"}},"
+            + "{\"prefix\":\"abfss://container@acct.dfs.core.windows.net/table\",\"config\":{"
+            + "\"adls.sas-token.acct\":\"sas\","
+            + "\"adls.sas-token-expires-at-ms.acct\":\""
+            + EXPIRATION
+            + "\"}},"
+            + "{\"prefix\":\"gs://bucket/table\",\"config\":{"
+            + "\"gcs.oauth2.token\":\"oauth\",\"gcs.oauth2.token-expires-at\":\""
+            + EXPIRATION
+            + "\"}}]}";
+    String endpoint =
+        startServer(
+            exchange -> {
+              queries.add(exchange.getRequestURI().getRawQuery());
+              authorizationHeaders.add(exchange.getRequestHeaders().getFirst("Authorization"));
+              respond(exchange, 200, body);
+            });
+
+    GenericCredentialFetcher fetcher = fetcher(endpoint, "plan id/1", tokenProvider(token));
+    List<GenericCredential> credentials = fetcher.createCredentials();
+
+    assertThat(credentials).hasSize(3);
+    assertThat(credentials.get(0))
+        .isEqualTo(new AwsCredential("ak", "sk", "st", EXPIRATION, "s3://bucket/table"));
+    assertThat(credentials.get(1))
+        .isEqualTo(
+            new AzureCredential(
+                "sas", EXPIRATION, "abfss://container@acct.dfs.core.windows.net/table"));
+    assertThat(credentials.get(2))
+        .isEqualTo(new GcsCredential("oauth", EXPIRATION, "gs://bucket/table"));
+    assertThat(queries).containsExactly("planId=plan%20id%2F1");
+    assertThat(authorizationHeaders).containsExactly("Bearer token-1");
+
+    token.set("token-2");
+    fetcher.createCredentials();
+    assertThat(authorizationHeaders).containsExactly("Bearer token-1", "Bearer token-2");
+  }
+
+  @Test
+  void preservesExistingEndpointQueryAndCredentialOrder() throws Exception {
+    String body =
+        "{\"storage-credentials\":["
+            + awsCredential("s3://bucket/table", Long.toString(EXPIRATION))
+            + ","
+            + awsCredential("s3://bucket/table/partition", Long.toString(EXPIRATION))
+            + "]}";
+    AtomicReference<String> query = new AtomicReference<>();
+    String endpoint =
+        startServer(
+                exchange -> {
+                  query.set(exchange.getRequestURI().getRawQuery());
+                  respond(exchange, 200, body);
+                })
+            + "?warehouse=w";
+
+    List<GenericCredential> credentials =
+        fetcher(endpoint, "plan-1", tokenProvider(new AtomicReference<>("tok")))
+            .createCredentials();
+
+    assertThat(credentials)
+        .extracting(GenericCredential::prefix)
+        .containsExactly("s3://bucket/table", "s3://bucket/table/partition");
+    assertThat(query.get()).isEqualTo("warehouse=w&planId=plan-1");
+  }
+
+  @Test
+  void propagatesHttpErrorsWithoutExposingResponseAsCredentials() throws Exception {
+    String endpoint = startServer(exchange -> respond(exchange, 403, "{\"error\":\"denied\"}"));
+
+    assertThatThrownBy(
+            () ->
+                fetcher(endpoint, "plan-1", tokenProvider(new AtomicReference<>("tok")))
+                    .createCredentials())
+        .isInstanceOf(ApiException.class)
+        .satisfies(error -> assertThat(((ApiException) error).getCode()).isEqualTo(403));
+  }
+
+  @Test
+  void rejectsMissingCredentialsAndMalformedExpiration() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    String endpoint =
+        startServer(
+            exchange -> {
+              if (requests.getAndIncrement() == 0) {
+                respond(exchange, 200, "{\"storage-credentials\":[]}");
+              } else {
+                respond(
+                    exchange,
+                    200,
+                    "{\"storage-credentials\":["
+                        + awsCredential("s3://bucket/table", "not-a-number")
+                        + "]}");
+              }
+            });
+    GenericCredentialFetcher fetcher =
+        fetcher(endpoint, "plan-1", tokenProvider(new AtomicReference<>("tok")));
+
+    assertThatThrownBy(fetcher::createCredentials)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("no storage credentials");
+    assertThatThrownBy(fetcher::createCredentials)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("epoch milliseconds");
+  }
+
+  private GenericCredentialFetcher fetcher(
+      String endpoint, String planId, TokenProvider tokenProvider) {
+    ApiClient apiClient =
+        ApiClientBuilder.create().uri(serverBaseUri()).tokenProvider(tokenProvider).build();
+    return GenericCredentialFetcher.forIcebergPlan(
+        new IcebergPlanCredId(EMPTY_CRED_CONTEXT_ID, endpoint, planId), apiClient);
+  }
+
+  private String startServer(ExchangeHandler handler) throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/iceberg/v1/ns/table/credentials", handler::handle);
+    server.start();
+    return serverBaseUri() + "/iceberg/v1/ns/table/credentials";
+  }
+
+  private String serverBaseUri() {
+    return "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  private static TokenProvider tokenProvider(AtomicReference<String> token) {
+    return new TokenProvider() {
+      @Override
+      public void initialize(Map<String, String> configs) {}
+
+      @Override
+      public String accessToken() {
+        return token.get();
+      }
+
+      @Override
+      public Map<String, String> configs() {
+        return Map.of("type", "test");
+      }
+    };
+  }
+
+  private static String awsCredential(String prefix, String expiration) {
+    return "{\"prefix\":\""
+        + prefix
+        + "\",\"config\":{\"s3.access-key-id\":\"ak\","
+        + "\"s3.secret-access-key\":\"sk\",\"s3.session-token\":\"st\","
+        + "\"s3.session-token-expires-at-ms\":\""
+        + expiration
+        + "\"}}";
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+
+  @FunctionalInterface
+  private interface ExchangeHandler {
+    void handle(HttpExchange exchange) throws IOException;
+  }
+}

--- a/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
+++ b/connectors/hadoop/src/test/java/io/unitycatalog/hadoop/internal/id/CredIdTest.java
@@ -337,6 +337,41 @@ public class CredIdTest {
   }
 
   @Test
+  void icebergPlanKeyPropsRoundTripAndIsolatePlans() {
+    String endpoint = "https://uc/iceberg/v1/ns/t/credentials";
+    CredId key = new IcebergPlanCredId(CONTEXT_A, endpoint, "plan-1");
+    assertThat(key.props())
+        .containsOnly(
+            entry(UCHadoopConfConstants.UC_CRED_CONTEXT_ID_KEY, CONTEXT_A),
+            entry(
+                UCHadoopConfConstants.UC_CREDENTIALS_TYPE_KEY,
+                UCHadoopConfConstants.UC_CREDENTIALS_TYPE_ICEBERG_PLAN_VALUE),
+            entry(UCHadoopConfConstants.UC_ICEBERG_CREDENTIALS_ENDPOINT_KEY, endpoint),
+            entry(UCHadoopConfConstants.UC_ICEBERG_PLAN_ID_KEY, "plan-1"));
+    assertPropsRoundTrip(key);
+
+    assertThat(key).isNotEqualTo(new IcebergPlanCredId(CONTEXT_A, endpoint, "plan-2"));
+    assertThat(key)
+        .isNotEqualTo(
+            new IcebergPlanCredId(
+                CONTEXT_A, "https://other/iceberg/v1/ns/t/credentials", "plan-1"));
+    assertThat(key).isNotEqualTo(new IcebergPlanCredId(CONTEXT_B, endpoint, "plan-1"));
+  }
+
+  @Test
+  void icebergPlanKeyRejectsMissingFields() {
+    assertThatThrownBy(() -> new IcebergPlanCredId(null, "https://uc/credentials", "plan"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("credContextId");
+    assertThatThrownBy(() -> new IcebergPlanCredId(CONTEXT_A, "", "plan"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("credentialsEndpoint");
+    assertThatThrownBy(() -> new IcebergPlanCredId(CONTEXT_A, "https://uc/credentials", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("planId");
+  }
+
+  @Test
   void defaultKeyPropsAreEmpty() {
     assertThat(new DefaultCredId(URI.create("s3://b"), new Configuration()).props()).isEmpty();
   }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR. (N/A)
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [x] If you have added or modified a feature, documentation in docs is updated. (Public API JavaDoc)

**Description of changes**

Adds renewable Hadoop credentials for Iceberg REST server-side scan plans.

- Adds `UCCredentialHadoopConfs.Builder.buildForIcebergPlan(credentialsEndpoint, planId)`.
- Refreshes through the standard table credentials endpoint using `planId`, preserving the FGAC authorization scope of the original plan.
- Re-evaluates the configured token provider on every credential request, so OAuth access-token refresh continues to work.
- Supports AWS, Azure, and GCS credentials, including multiple storage prefixes.
- Serializes the plan-scoped renewal identity and auth configuration into Hadoop properties for executor-side renewal.
- Filters mixed-cloud credential responses to the requested storage scheme while preserving cache isolation by catalog, auth context, scheme, endpoint, and plan ID.
- Propagates HTTP failures and preserves the configured request timeout and retrying HTTP client.

This deliberately does not refresh through the source table temporary-credentials API: using the opaque scan-plan ID keeps renewal tied to the same fine-grained authorization decision.

**Testing**

`build/sbt "hadoop / Test / test"`

1,470 tests passed.