### PR TITLE
Authorize PAYLOAD-source keys against the bound request body

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -26,6 +26,7 @@ import io.unitycatalog.server.service.UnityCatalogRestService;
 import io.unitycatalog.server.service.delta.DeltaApiMappers;
 import io.unitycatalog.server.service.delta.DeltaApiService;
 import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import io.unitycatalog.server.utils.ServerProperties;
 import java.util.List;
 import java.util.Objects;
 
@@ -51,9 +52,16 @@ public class ArmeriaServerBuilder {
   private final String basePath;
   private final String controlPath;
 
-  // Body mappers and response converters, created once and reused across registrations. The
-  // request converter is always the gated wrapper (see gatedJackson); only the wrapped mapper and
-  // the response converter vary by protocol.
+  /**
+   * Whether to install the PAYLOAD-source authorization gate in front of body binding. Tied to the
+   * same flag that installs the access decorator the gate depends on, so the gate is never left
+   * waiting on an authorizer that nothing will produce.
+   */
+  private final boolean authorizationEnabled;
+
+  // Body mappers and response converters, created once and reused across registrations. Only the
+  // body mapper and the (optional) response converter vary by protocol; see bodyConverter for how
+  // the request converter is chosen.
   private final ObjectMapper ucMapper;
   private final JacksonResponseConverterFunction scimResponseConverter;
   private final ObjectMapper icebergMapper;
@@ -61,7 +69,8 @@ public class ArmeriaServerBuilder {
   private final ObjectMapper deltaMapper;
   private final JacksonResponseConverterFunction deltaResponseConverter;
 
-  ArmeriaServerBuilder(int port, String basePath, String controlPath) {
+  ArmeriaServerBuilder(
+      int port, String basePath, String controlPath, ServerProperties serverProperties) {
     this.armeriaServerBuilder =
         Server.builder()
             .localPort(port, SessionProtocol.HTTP)
@@ -70,6 +79,7 @@ public class ArmeriaServerBuilder {
         "/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
     this.basePath = basePath;
     this.controlPath = controlPath;
+    this.authorizationEnabled = serverProperties.isAuthorizationEnabled();
     this.ucMapper =
         JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
     this.scimResponseConverter =
@@ -181,7 +191,7 @@ public class ArmeriaServerBuilder {
    * class calls {@code annotatedService}. It selects the protocol-specific body and response
    * converters and registers the service at {@code basePath + relativePath} ({@code ""} mounts at
    * the base path root). Because this is the sole registration path and every arm gets its body
-   * converter from {@link #gatedJackson}, no annotated service can reach the server ungated while
+   * converter from {@link #bodyConverter}, no annotated service can reach the server ungated while
    * authorization is enabled.
    *
    * <p>The per-protocol converter selection is a switch expression with no default, so it is
@@ -191,9 +201,9 @@ public class ArmeriaServerBuilder {
    */
   private void register(ServiceProtocol protocol, String relativePath, RegisteredService service) {
     RequestConverterFunction requestConverter = switch (protocol) {
-      case AUTH, UC, SCIM -> gatedJackson(ucMapper);
-      case ICEBERG -> gatedJackson(icebergMapper);
-      case DELTA -> gatedJackson(deltaMapper);
+      case AUTH, UC, SCIM -> bodyConverter(ucMapper);
+      case ICEBERG -> bodyConverter(icebergMapper);
+      case DELTA -> bodyConverter(deltaMapper);
     };
     // Auth and UC services have no response converter; they return HttpResponse.ofJson directly.
     List<JacksonResponseConverterFunction> responseConverters = switch (protocol) {
@@ -217,11 +227,12 @@ public class ArmeriaServerBuilder {
   }
 
   /**
-   * Wraps a Jackson body converter with {@link AuthorizationGateConverter}. Every annotated
-   * service's request converter goes through this (via {@link #register}) so the PAYLOAD-source
-   * auth check fires before body binding.
+   * The request converter for a service's body parameters: the authorization gate wrapping Jackson
+   * when authorization is enabled, plain Jackson when it is not. With authorization disabled
+   * nothing produces a {@code PayloadAuthorizer}, so a gate would wait on a value never produced.
    */
-  private static RequestConverterFunction gatedJackson(ObjectMapper mapper) {
-    return new AuthorizationGateConverter(new JacksonRequestConverterFunction(mapper));
+  private RequestConverterFunction bodyConverter(ObjectMapper mapper) {
+    JacksonRequestConverterFunction jackson = new JacksonRequestConverterFunction(mapper);
+    return authorizationEnabled ? new AuthorizationGateConverter(jackson, mapper) : jackson;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -119,7 +119,11 @@ public class UnityCatalogServer implements AutoCloseable {
 
   private Server initializeServer(UnityCatalogServer.Builder unityCatalogServerBuilder) {
     ArmeriaServerBuilder armeriaServerBuilder =
-        new ArmeriaServerBuilder(unityCatalogServerBuilder.port, BASE_PATH, CONTROL_PATH);
+        new ArmeriaServerBuilder(
+            unityCatalogServerBuilder.port,
+            BASE_PATH,
+            CONTROL_PATH,
+            unityCatalogServerBuilder.serverProperties);
 
     // Init all repositories
     Repositories repositories =

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/AuthorizationGateConverter.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.auth.decorator;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
@@ -7,29 +8,53 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import java.lang.reflect.ParameterizedType;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Fail-closed wrapper that enforces {@link UnityAccessDecorator}'s PAYLOAD-source authorization
- * before delegating to an inner body converter (e.g. Jackson). The decorator sets {@link
- * UnityAccessDecorator#AUTH_PENDING} on entry to the PAYLOAD path and clears it only after the
- * authorization evaluation succeeds; if the flag is still {@code true} when a parameter is being
- * bound, {@code peekData}'s callback never fired (no body, non-JSON content-type, malformed JSON,
- * trailing whitespace) and the request must be denied.
+ * Request-converter wrapper that runs {@link UnityAccessDecorator}'s PAYLOAD-source authorization
+ * during body binding, before the handler runs. When a request method reads authorization keys from
+ * the body, the decorator stashes a {@link UnityAccessDecorator#PAYLOAD_AUTHORIZER} callback in the
+ * request context; this converter delegates to the inner body converter (e.g. Jackson) first and
+ * then invokes the callback on the <em>bound object</em>, so authorization sees the exact value the
+ * handler will receive rather than a separate parse of the bytes.
+ *
+ * <p>Failure modes map to distinct statuses, and in neither does the handler run:
+ *
+ * <ul>
+ *   <li>A malformed / missing / non-JSON body fails in the delegate binding (a client error), which
+ *       surfaces as {@code 400} before authorization is even attempted.
+ *   <li>A well-formed but unauthorized body is denied by the callback, which throws {@code
+ *       PERMISSION_DENIED} ({@code 403}).
+ * </ul>
  *
  * <p>Wrapping Jackson (rather than sitting in front of it as a separate chain element) means
  * services register a single converter and the gate is impossible to forget when a new annotated
  * service is added.
  *
- * <p>Scope: gates only parameters bound via the converter chain. Endpoints with no body-bound
- * parameter (pure {@code @Param}/path) don't trigger this converter, but those endpoints also don't
- * use PAYLOAD locators, so the decorator never sets the flag and no gate is needed.
+ * <p>Registered only when authorization is enabled, since it depends on {@link
+ * UnityAccessDecorator} to supply the callback; otherwise a plain Jackson converter is used. That
+ * pairing is what lets a missing callback be treated as a fault and denied.
+ *
+ * <p>Scope: runs only for parameters bound via the converter chain. Endpoints with no body-bound
+ * parameter (pure {@code @Param}/path) don't trigger this converter at all.
  */
 public final class AuthorizationGateConverter implements RequestConverterFunction {
 
-  private final RequestConverterFunction delegate;
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationGateConverter.class);
 
-  public AuthorizationGateConverter(RequestConverterFunction delegate) {
+  private final RequestConverterFunction delegate;
+  private final ObjectMapper mapper;
+
+  /**
+   * @param delegate the Jackson converter this gate stands in for, which it calls to bind the body
+   * @param mapper the mapper {@code delegate} was built from. Passed separately because Jackson's
+   *     converter does not expose its own mapper, and it must be the same one so the keys read for
+   *     authorization resolve exactly as the handler's binding did.
+   */
+  public AuthorizationGateConverter(RequestConverterFunction delegate, ObjectMapper mapper) {
     this.delegate = Objects.requireNonNull(delegate);
+    this.mapper = Objects.requireNonNull(mapper);
   }
 
   @Override
@@ -39,11 +64,26 @@ public final class AuthorizationGateConverter implements RequestConverterFunctio
       Class<?> expectedResultType,
       ParameterizedType expectedParameterizedResultType)
       throws Exception {
-    if (Boolean.TRUE.equals(ctx.attr(UnityAccessDecorator.AUTH_PENDING))) {
+    // Bind first, authorize second: a malformed body fails here as a 400, an unauthorized one is
+    // denied below as a 403, and the handler runs in neither case. Authorizing the bound object
+    // rather than a separate parse means we authorize exactly what the handler receives.
+    Object bound =
+        delegate.convertRequest(ctx, request, expectedResultType, expectedParameterizedResultType);
+
+    // The access decorator always leaves an authorizer behind, and this gate only exists when that
+    // decorator does. A missing one is a broken assumption, not a request needing no check.
+    PayloadAuthorizer payloadAuthorizer = ctx.attr(UnityAccessDecorator.PAYLOAD_AUTHORIZER);
+    if (payloadAuthorizer == null) {
+      LOGGER.error(
+          "SECURITY VIOLATION: no payload authorizer was set for {}; the access decorator did not "
+              + "run before body binding. Denying the request.",
+          ctx.config().route());
       throw new BaseException(
-          ErrorCode.PERMISSION_DENIED, "Authorization could not be verified for this request");
+          ErrorCode.PERMISSION_DENIED, UnityAccessDecorator.ERR_AUTH_NOT_EXECUTED);
     }
-    return delegate.convertRequest(
-        ctx, request, expectedResultType, expectedParameterizedResultType);
+    // Throws BaseException(PERMISSION_DENIED) to deny; propagates to the exception handler as a
+    // 403.
+    payloadAuthorizer.authorize(bound, mapper);
+    return bound;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/PayloadAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/PayloadAuthorizer.java
@@ -1,0 +1,34 @@
+package io.unitycatalog.server.auth.decorator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+
+/**
+ * Per-request PAYLOAD-source authorization callback. {@link UnityAccessDecorator} stashes one in
+ * the request context under {@link UnityAccessDecorator#PAYLOAD_AUTHORIZER} for every request it
+ * handles; {@link AuthorizationGateConverter} invokes it on the bound body object right after
+ * binding and before the handler runs, so authorization sees the exact value the handler will
+ * receive.
+ */
+@FunctionalInterface
+public interface PayloadAuthorizer {
+
+  /**
+   * No body-derived check is required: the method declares no PAYLOAD key and was authorized
+   * inline. Set explicitly so the gate receives that as a value instead of inferring it from a
+   * missing one.
+   */
+  PayloadAuthorizer NO_BODY_CHECK_REQUIRED = (body, mapper) -> {};
+
+  /**
+   * Authorizes the request against the already-bound body.
+   *
+   * @param body the object the delegate converter bound the request body to (may be {@code null},
+   *     e.g. a JSON literal {@code null} body)
+   * @param mapper the same mapper used to bind {@code body}, used to re-serialize it to a
+   *     wire-name-keyed map so locator keys resolve the way the handler's binding did
+   * @throws BaseException with {@link ErrorCode#PERMISSION_DENIED} if the request is not authorized
+   */
+  void authorize(Object body, ObjectMapper mapper);
+}

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -2,10 +2,8 @@ package io.unitycatalog.server.auth.decorator;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.SplitHttpResponse;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
@@ -26,8 +24,6 @@ import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -36,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PARAM;
 import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PAYLOAD;
@@ -62,27 +59,34 @@ import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.S
  * for non-resource request values (operation mode, table type, flag, etc.) exposed directly as a
  * SpEL variable instead of being mapped to a resource identifier.
  *
- * <p>For PAYLOAD-source locators (body-read), {@code peekData} only observes complete JSON chunks;
- * anything else (no body, non-JSON content-type, malformed JSON, trailing whitespace) silently
- * skips the authorization evaluation. The {@link #AUTH_PENDING} flag and {@link
- * AuthorizationGateConverter} close that gap: the decorator marks the request auth-pending on
- * entry to the PAYLOAD path, clears it only after authorization succeeds, and the gate converter
- * denies any body-binding where the flag is still set.
+ * <p>PARAM- and SYSTEM-source locators are read from the request context and authorized inline.
+ * PAYLOAD-source locators need a field from the request body, which is not available yet, so the
+ * decorator stashes a {@link #PAYLOAD_AUTHORIZER} callback that {@link AuthorizationGateConverter}
+ * invokes on the bound body just before the handler runs.
  */
 public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnityAccessDecorator.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
-   * Per-request flag: {@code true} once the decorator enters the PAYLOAD path, flipped to
-   * {@code false} when the authorization evaluation completes inside the peekData callback. Read by
-   * {@link AuthorizationGateConverter} at body-binding time: if still {@code true}, authorization
-   * never ran (no body chunk arrived, content-type wasn't JSON, or JSON didn't complete) and the
-   * request must be denied.
+   * Client-facing message for every "an authorization check did not run" denial: the gate found no
+   * authorizer, a body carried no keys to evaluate, or a success response was produced without the
+   * check having run. Deliberately uniform and non-specific; the distinguishing detail belongs in
+   * the SECURITY VIOLATION log line, not the response. Public so tests can assert on it without
+   * copying the string.
    */
-  public static final AttributeKey<Boolean> AUTH_PENDING =
-      AttributeKey.valueOf(UnityAccessDecorator.class, "AUTH_PENDING");
+  public static final String ERR_AUTH_NOT_EXECUTED =
+      "Authorization could not be verified for this request";
+
+  /**
+   * Per-request {@link PayloadAuthorizer}, which {@link AuthorizationGateConverter} invokes on the
+   * bound body before the handler runs. Set on every request this decorator handles: the real
+   * authorizer when the method reads keys from the body, {@link
+   * PayloadAuthorizer#NO_BODY_CHECK_REQUIRED} when it does not. Always setting one means the gate
+   * never reads a missing value as "already authorized".
+   */
+  public static final AttributeKey<PayloadAuthorizer> PAYLOAD_AUTHORIZER =
+      AttributeKey.valueOf(UnityAccessDecorator.class, "PAYLOAD_AUTHORIZER");
   private final KeyMapper keyMapper;
   private final UserRepository userRepository;
 
@@ -177,43 +181,36 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     EvaluationAction evaluateAction =
         filterAnnotation
             .<EvaluationAction>map(x -> new ResultFilterAction(ctx, method))
-            .orElseGet(RequestEvaluationAction::new);
+            .orElseGet(() -> new RequestEvaluationAction(method));
 
     if (payloadLocators.isEmpty()) {
+      // All keys are already available, so authorize now.
       Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
-      evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
+      evaluateAction.runBeforeRequest(principal, expression, resourceIds, nonResourceValues);
+      // The method may still bind a body (e.g. updateCatalog authorizes on the "name" path param),
+      // so the gate converter still runs and needs to be told the check is done.
+      ctx.setAttr(PAYLOAD_AUTHORIZER, PayloadAuthorizer.NO_BODY_CHECK_REQUIRED);
     } else {
-      // Since we have PAYLOAD locators, we can only interrogate the payload while the request
-      // is being evaluated, via peekData()
-      LOGGER.debug("Checking authorization before in peekData.");
-
-      PeekDataHandler peekDataHandler = new PeekDataHandler(
-          req.contentType(),
-          payloadLocators,
-          resourceKeys,
-          nonResourceValues);
-
-      // peekData's lambda only fires when a body chunk arrives AND processPeekData returns true
-      // (JSON content-type + chunk ending in '}'). Any other path (no body, non-JSON, malformed
-      // JSON, trailing whitespace) silently skips authorization. Mark the request auth-pending
-      // here and clear it only after the authorization evaluation runs; AuthorizationGateConverter
-      // denies any body-binding attempt where this flag is still set.
-      ctx.setAttr(AUTH_PENDING, true);
-
-      req = req.peekData(data -> {
-        // This code block is not called immediately. It is called later as part of delegate.serve()
-        LOGGER.debug("Authorization peekData invoked.");
-
-        if (peekDataHandler.processPeekData(data)) {
-          Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
-          evaluateAction.beforeRequest(principal, expression, resourceIds, nonResourceValues);
-          ctx.setAttr(AUTH_PENDING, false);
-        }
-      });
+      // Some keys live in the body, so defer: the gate converter runs this on the bound object,
+      // which is what the handler will use. beforeRequest is called at the end of authorizePayload,
+      // once those keys are populated.
+      LOGGER.debug("Deferring PAYLOAD authorization to the request converter.");
+      ctx.setAttr(
+          PAYLOAD_AUTHORIZER,
+          (body, mapper) ->
+              authorizePayload(
+                  body,
+                  mapper,
+                  payloadLocators,
+                  resourceKeys,
+                  nonResourceValues,
+                  principal,
+                  expression,
+                  evaluateAction));
     }
 
-    HttpResponse response = delegate.serve(ctx, req);
-    return evaluateAction.afterRequest(response);
+    // runAfterRequest confirms at response time that beforeRequest actually ran.
+    return evaluateAction.runAfterRequest(delegate.serve(ctx, req));
   }
 
   private static Object findPayloadValue(String key, Map<String, Object> payload) {
@@ -232,20 +229,114 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
   }
 
-  private interface EvaluationAction {
-    void beforeRequest(
+  /**
+   * How a request is authorized. Subclasses implement {@link #beforeRequest}; {@link
+   * #runAfterRequest} is final because it must be the only place a response is split, so an action
+   * is never double-wrapped. It waits for headers only, to avoid buffering large LIST responses.
+   *
+   * <p>On success it confirms {@code beforeRequest} actually ran, catching a PAYLOAD method whose
+   * deferred callback never fired. This is a backstop only: the handler has already run, so its
+   * side effects are not rolled back. Prevention is the gate converter authorizing before the
+   * handler; see {@link #PAYLOAD_AUTHORIZER}.
+   *
+   * <p>When authorization already ran inline and no subclass needs {@link #successCheck}, there is
+   * nothing to verify and the response is returned unsplit.
+   */
+  private abstract class EvaluationAction {
+    private final Method method;
+    private final AtomicBoolean beforeRequestRan = new AtomicBoolean(false);
+
+    EvaluationAction(Method method) {
+      this.method = method;
+    }
+
+    /**
+     * Authorizes this request. Call this rather than {@link #beforeRequest}: it records that the
+     * check ran, which {@link #runAfterRequest} verifies. The flag is set only once {@code
+     * beforeRequest} returns, so a denial leaves it unset.
+     */
+    final void runBeforeRequest(
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues) {
+      beforeRequest(principal, expression, resourceIds, nonResourceValues);
+      beforeRequestRan.set(true);
+    }
+
+    /**
+     * Evaluates access, throwing a {@link BaseException} to deny. Implemented by subclasses;
+     * callers use {@link #runBeforeRequest} instead so the check is recorded.
+     */
+    protected abstract void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
         Map<String, Object> nonResourceValues);
 
-    HttpResponse afterRequest(HttpResponse response);
+    /** The annotated method being guarded, for use in subclass log messages. */
+    protected final Method method() {
+      return method;
+    }
+
+    /**
+     * Whether {@link #successCheck} has anything to check. Return false when it is a no-op, so the
+     * fast path can skip splitting the response.
+     */
+    protected abstract boolean needsSuccessCheck();
+
+    /**
+     * Subclass-specific success check, run only after {@code beforeRequest} is confirmed to have
+     * run, and only when {@link #needsSuccessCheck} is true. Throw a {@link BaseException} to deny.
+     */
+    protected abstract void successCheck();
+
+    final HttpResponse runAfterRequest(HttpResponse response) {
+      // Fast path: authorization already ran synchronously (PARAM/SYSTEM keys), and no subclass
+      // wants a success-time check, so there is nothing left to verify. Return the response as-is
+      // rather than splitting it, which would add a stream hop for a check whose answer is known.
+      if (beforeRequestRan.get() && !needsSuccessCheck()) {
+        return response;
+      }
+      SplitHttpResponse split = response.split();
+      return HttpResponse.of(
+          split
+              .headers()
+              .thenApply(
+                  headers -> {
+                    if (headers.status().isSuccess()) {
+                      try {
+                        if (!beforeRequestRan.get()) {
+                          LOGGER.error(
+                              "SECURITY VIOLATION: Method {} produced a success response without "
+                                  + "running authorization; denying the request.",
+                              method.getName());
+                          throw new BaseException(
+                              ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+                        }
+                        if (needsSuccessCheck()) {
+                          successCheck();
+                        }
+                      } catch (RuntimeException e) {
+                        // Abort the not-yet-consumed body before failing closed so the handler's
+                        // response payload is never streamed to the client.
+                        split.body().abort();
+                        throw e;
+                      }
+                    }
+                    return HttpResponse.of(headers, split.body());
+                  }));
+    }
   }
 
-  private class RequestEvaluationAction implements EvaluationAction {
+  private class RequestEvaluationAction extends EvaluationAction {
+
+    RequestEvaluationAction(Method method) {
+      super(method);
+    }
 
     @Override
-    public void beforeRequest(
+    protected void beforeRequest(
         UUID principal,
         String expression,
         Map<SecurableType, UUID> resourceIds,
@@ -256,25 +347,25 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    public HttpResponse afterRequest(HttpResponse response) {
-      return response;
-    }
-  }
-
-  private class ResultFilterAction implements EvaluationAction {
-    protected static final String ERR_AUTH_NOT_EXECUTED =
-        "Authorization required but failed to execute";
-    private final ServiceRequestContext ctx;
-    private final Method method;
-    private volatile ResultFilter resultFilter = null;
-
-    ResultFilterAction(ServiceRequestContext ctx, Method method) {
-      this.ctx = ctx;
-      this.method = method;
+    protected boolean needsSuccessCheck() {
+      return false;
     }
 
     @Override
-    public void beforeRequest(
+    protected void successCheck() {}
+  }
+
+  private class ResultFilterAction extends EvaluationAction {
+    private final ServiceRequestContext ctx;
+    private volatile ResultFilter resultFilter = null;
+
+    ResultFilterAction(ServiceRequestContext ctx, Method method) {
+      super(method);
+      this.ctx = ctx;
+    }
+
+    @Override
+    protected void beforeRequest(
       UUID principal,
       String expression,
       Map<SecurableType, UUID> resourceIds,
@@ -286,32 +377,23 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     }
 
     @Override
-    public HttpResponse afterRequest(HttpResponse response) {
-      // Wait only for response headers (not the full body) to run the enforcement check,
-      // then stream the body through. This avoids buffering large LIST responses just to
-      // check a flag that would allocate O(response size) per concurrent request.
-      SplitHttpResponse split = response.split();
-      return HttpResponse.of(split.headers().thenApply(
-        headers -> {
-          if (headers.status().isSuccess()) {
-            if (resultFilter == null) {
-              split.body().abort();
-              LOGGER.error(
-                  "SECURITY VIOLATION: Method {} did not execute evaluateAction",
-                  method.getName());
-              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
-            }
-            if (!resultFilter.wasCalled()) {
-              split.body().abort();
-              LOGGER.error(
-                  "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
-                      + "applyResponseFilter(). This is a security vulnerability!",
-                  method.getName());
-              throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
-            }
-          }
-          return HttpResponse.of(headers, split.body());
-        }));
+    protected boolean needsSuccessCheck() {
+      // The handler is trusted to call applyResponseFilter(); nothing upstream can confirm it did,
+      // so this action always needs the response-time check.
+      return true;
+    }
+
+    @Override
+    protected void successCheck() {
+      // beforeRequestRan is already confirmed by the base class, so resultFilter is non-null here.
+      // Additionally require the handler to have actually applied the response filter.
+      if (!resultFilter.wasCalled()) {
+        LOGGER.error(
+            "SECURITY VIOLATION: Method {} with @ResponseAuthorizeFilter did not call "
+                + "applyResponseFilter(). This is a security vulnerability!",
+            method().getName());
+        throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
+      }
     }
   }
 
@@ -413,77 +495,48 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     return matchingMethods;
   }
 
-  private static class PeekDataHandler {
-    // This is a little ugly - peekData provides only a block of data at a time, so lets
-    // buffer it up until we think its complete. A better long term solution would be to
-    // abandon this method and either integrate with Spring Boot to get full AOP support
-    // with aspect weaving, or build implement custom aspect weaving so we can intercept
-    // the method call directly and extract the payload data from the method arguments.
-
-    private final MediaType contentType;
-    private final List<AuthorizeKeyLocator> payloadLocators;
-    private final Map<SecurableType, Object> resourceKeys;
-    private final Map<String, Object> nonResourceValues;
-    private final ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
-
-    private PeekDataHandler(
-        MediaType contentType,
-        List<AuthorizeKeyLocator> payloadLocators,
-        Map<SecurableType, Object> resourceKeys,
-        Map<String, Object> nonResourceValues) {
-      this.contentType = contentType;
-      this.payloadLocators = payloadLocators;
-      this.resourceKeys = resourceKeys;
-      this.nonResourceValues = nonResourceValues;
+  /**
+   * Authorizes against the already-bound body, invoked by {@link AuthorizationGateConverter} after
+   * binding and before the handler. Reads locator keys off the exact object the handler will use,
+   * so there is no differential between what is authorized and what executes. A malformed body
+   * never reaches here; it fails binding as a 400. Throws {@link BaseException} with {@link
+   * ErrorCode#PERMISSION_DENIED} to deny.
+   */
+  private void authorizePayload(
+      Object body,
+      ObjectMapper mapper,
+      List<AuthorizeKeyLocator> payloadLocators,
+      Map<SecurableType, Object> resourceKeys,
+      Map<String, Object> nonResourceValues,
+      UUID principal,
+      String expression,
+      EvaluationAction evaluateAction) {
+    // A null body (e.g. the JSON literal "null") carries no authorization keys, so fail closed
+    // rather than NPE below.
+    if (body == null) {
+      throw new BaseException(ErrorCode.PERMISSION_DENIED, ERR_AUTH_NOT_EXECUTED);
     }
 
-    private boolean processPeekData(HttpData data) {
-      // TODO: For now, we're going to assume JSON data, but might need to support other
-      // content types.
-      if (contentType.equals(MediaType.JSON)) {
-        try {
-          dataStream.write(data.array());
-          LOGGER.debug("Payload: {}", dataStream.toString());
-        } catch (IOException e) {
-          // IGNORE
-        }
+    // Locators hold JSON wire names (e.g. "table_id"), so go back through the same mapper rather
+    // than reflection: the wire names come from its naming strategy / @JsonProperty, not the Java
+    // field names.
+    Map<String, Object> payload = mapper.convertValue(body, new TypeReference<>() {});
 
-        // Unfortunately we don't appear to get a signal that we've got all the data, so we have to
-        // resort to attempting to parse the data whenever it _looks_ complete.
-        // TODO: try to optimize this using Jackson streaming or something else.
-        if (data.array()[data.array().length - 1] == '}') {
-          try {
-            Map<String, Object> payload = MAPPER.readValue(
-                dataStream.toByteArray(),
-                new TypeReference<>() {
-                });
-
-            payloadLocators.forEach(
-                l -> {
-                  Object value = findPayloadValue(l.getKey(), payload);
-                  if (l.getType().isPresent()) {
-                    resourceKeys.put(l.getType().get(), value);
-                  } else {
-                    if (value != null && value.getClass().isEnum()) {
-                      // Convert enums to their string representation
-                      value = value.toString();
-                    }
-                    nonResourceValues.put(l.getVariableName(), value);
-                  }
-                });
-
-            return true;
-          } catch (IOException e) {
-            // This is probably because we read partial data.
-            LOGGER.warn("Error parsing payload: {}", e.getMessage());
+    payloadLocators.forEach(
+        l -> {
+          Object value = findPayloadValue(l.getKey(), payload);
+          if (l.getType().isPresent()) {
+            resourceKeys.put(l.getType().get(), value);
+          } else {
+            if (value != null && value.getClass().isEnum()) {
+              // Convert enums to their string representation
+              value = value.toString();
+            }
+            nonResourceValues.put(l.getVariableName(), value);
           }
-        }
+        });
 
-      } else {
-        LOGGER.warn("Skipping content-type: {}", contentType);
-      }
-
-      return false;
-    }
+    Map<SecurableType, UUID> resourceIds = mapResourceKeys(resourceKeys, nonResourceValues);
+    evaluateAction.runBeforeRequest(principal, expression, resourceIds, nonResourceValues);
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/ArmeriaServerBuilderTest.java
+++ b/server/src/test/java/io/unitycatalog/server/ArmeriaServerBuilderTest.java
@@ -3,13 +3,17 @@ package io.unitycatalog.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.server.Server;
+import io.unitycatalog.server.utils.ServerProperties;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 public class ArmeriaServerBuilderTest {
 
   @Test
   public void bindsToLoopbackInterfaces() {
-    try (Server server = new ArmeriaServerBuilder(0, "/api/", "/control/").build()) {
+    try (Server server =
+        new ArmeriaServerBuilder(0, "/api/", "/control/", new ServerProperties(new Properties()))
+            .build()) {
       assertThat(server.config().ports())
           .isNotEmpty()
           .allSatisfy(

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkCatalogAccessControlCRUDTest.java
@@ -14,10 +14,12 @@ import io.unitycatalog.client.model.SchemaInfo;
 import io.unitycatalog.client.model.SecurableType;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.UpdateCatalog;
+import io.unitycatalog.server.auth.decorator.UnityAccessDecorator;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.utils.TestUtils;
+import java.net.http.HttpResponse;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -210,19 +212,71 @@ public class SdkCatalogAccessControlCRUDTest extends SdkAccessControlBaseCRUDTes
     assertPermissionDenied(() -> principal1CatalogsApi.createCatalog(catalogWithLoc2));
   }
 
+  private static final String CATALOGS_PATH = "/api/2.1/unity-catalog/catalogs";
+
   /**
-   * POST /catalogs has a PAYLOAD-source authorization locator (@AuthorizeResourceKey on the
-   * CreateCatalog body). A body-less request never triggers UnityAccessDecorator's peekData
-   * callback, so checkAuthorization is silently skipped. AuthorizationGateConverter catches this at
-   * body-binding time and denies the request before the handler sees it.
+   * Body shapes the generated SDK cannot produce, exercised against POST /catalogs -- which reads
+   * its authorization key from the CreateCatalog body, so every case here goes through the
+   * PAYLOAD-source gate.
+   *
+   * <p>The cases share one setup because each is a single request with no state of its own. They
+   * cover the two failure modes the gate must keep distinct -- a body that cannot bind is a client
+   * error (400) raised before authorization, while a bound body that carries no usable key is a
+   * denial (403) -- plus the valid shapes that must not be mistaken for either.
    */
   @Test
   @SneakyThrows
-  public void bodylessPostDeniedByAuthorizationGate() {
+  public void rawBodyShapesAtThePayloadAuthorizationGate() {
+    // Body-less: fails in binding before authorization runs, so 400 rather than 403.
     assertHttpApiException(
-        TestUtils.sendRawEmptyPost(adminConfig, "/api/2.1/unity-catalog/catalogs"),
+        TestUtils.sendRawEmptyPost(adminConfig, CATALOGS_PATH), ErrorCode.INVALID_ARGUMENT);
+
+    // Non-JSON content-type: also cannot bind, so also 400 before authorization.
+    assertHttpApiException(
+        TestUtils.sendRawJsonPost(
+            adminConfig, CATALOGS_PATH, "{\"name\":\"cat_text\"}", "text/plain"),
+        ErrorCode.INVALID_ARGUMENT);
+
+    // JSON literal null: binds to null, so it carries no authorization keys. The gate must fail
+    // closed with 403 rather than NPE.
+    assertHttpApiException(
+        TestUtils.sendRawJsonPost(adminConfig, CATALOGS_PATH, "null", "application/json"),
         ErrorCode.PERMISSION_DENIED,
-        "Authorization could not be verified for this request");
+        UnityAccessDecorator.ERR_AUTH_NOT_EXECUTED);
+
+    // Malformed JSON: parsing fails during binding, so this is a client error before authorization
+    // rather than a denial.
+    assertHttpApiException(
+        TestUtils.sendRawJsonPost(adminConfig, CATALOGS_PATH, "{\"name\":", "application/json"),
+        ErrorCode.INVALID_ARGUMENT);
+
+    // Trailing whitespace after the JSON object must not be rejected by the gate.
+    HttpResponse<String> trailingNewline =
+        TestUtils.sendRawJsonPost(
+            adminConfig,
+            CATALOGS_PATH,
+            "{\"name\":\"cat_trailing_newline\"}\n",
+            "application/json");
+    assertThat(trailingNewline.statusCode()).isEqualTo(200);
+    assertThat(trailingNewline.body()).contains("cat_trailing_newline");
+
+    // A charset-qualified JSON content-type must not be rejected by the gate either.
+    HttpResponse<String> charset =
+        TestUtils.sendRawJsonPost(
+            adminConfig,
+            CATALOGS_PATH,
+            "{\"name\":\"cat_charset\"}",
+            "application/json; charset=utf-8");
+    assertThat(charset.statusCode()).isEqualTo(200);
+    assertThat(charset.body()).contains("cat_charset");
+
+    // Body split across two chunks, mid-token: the gate authorizes the reassembled body, so this
+    // must succeed exactly like the fixed-length case above.
+    HttpResponse<String> chunked =
+        TestUtils.sendTwoChunkJsonPost(
+            adminConfig, CATALOGS_PATH, "{\"name\":\"cat_chunked\"}", "application/json");
+    assertThat(chunked.statusCode()).isEqualTo(200);
+    assertThat(chunked.body()).contains("cat_chunked");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -155,6 +155,11 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     return client.execute(headers, HttpData.ofUtf8(formBody)).aggregate().join();
   }
 
+  /**
+   * Also covers the token endpoint's interaction with the authorization gate: it is excluded from
+   * the access decorators, so nothing sets a PayloadAuthorizer, and it binds its body with its own
+   * {@code @RequestConverter} rather than the gate. Both together are why it still succeeds.
+   */
   @Test
   public void testTokenExchangeWithCorrectIssuerAndAudience() throws IOException {
     String token =

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -305,8 +305,8 @@ public class TestUtils {
 
   /**
    * Sends a body-less POST to the given path. The SDK always attaches a serialized body, so raw
-   * HTTP is the only way to reach the body-less code path (used to exercise {@link
-   * io.unitycatalog.server.auth.decorator.AuthorizationGateConverter}'s silent-skip denial).
+   * HTTP is the only way to reach the body-less code path -- where the body cannot bind and the
+   * request fails as a 400 during binding, before authorization runs.
    */
   public static HttpResponse<String> sendRawEmptyPost(ServerConfig config, String path)
       throws Exception {

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -18,9 +18,13 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Flow;
 import org.junit.jupiter.api.function.Executable;
 
 public class TestUtils {
@@ -291,16 +295,96 @@ public class TestUtils {
   }
 
   /**
+   * As {@link #assertHttpApiException(HttpResponse, ErrorCode, String)}, but asserts only the code
+   * and envelope shape. Use when the message is framework-generated and not part of the contract
+   * (e.g. Armeria's own body-binding errors), so pinning its wording would be brittle.
+   */
+  public static void assertHttpApiException(HttpResponse<String> response, ErrorCode errorCode) {
+    assertUcErrorEnvelope(response.statusCode(), response.body(), errorCode, Optional.empty());
+  }
+
+  /**
    * Sends a body-less POST to the given path. The SDK always attaches a serialized body, so raw
    * HTTP is the only way to reach the body-less code path (used to exercise {@link
    * io.unitycatalog.server.auth.decorator.AuthorizationGateConverter}'s silent-skip denial).
    */
   public static HttpResponse<String> sendRawEmptyPost(ServerConfig config, String path)
       throws Exception {
+    return sendRawPost(config, path, HttpRequest.BodyPublishers.noBody(), null);
+  }
+
+  /**
+   * Sends a raw POST with the given JSON body and {@code Content-Type}. Use to exercise body and
+   * content-type shapes the generated SDK can't produce (e.g. a trailing newline, or a
+   * charset-qualified content-type) against authorization paths that read the request body.
+   */
+  public static HttpResponse<String> sendRawJsonPost(
+      ServerConfig config, String path, String body, String contentType) throws Exception {
+    return sendRawPost(config, path, HttpRequest.BodyPublishers.ofString(body), contentType);
+  }
+
+  /**
+   * Sends a raw POST whose body arrives as two {@code Transfer-Encoding: chunked} chunks, split at
+   * the halfway byte so the break falls mid-token. Authorization reads the reassembled body, so
+   * this must behave exactly like the equivalent fixed-length request.
+   */
+  public static HttpResponse<String> sendTwoChunkJsonPost(
+      ServerConfig config, String path, String body, String contentType) throws Exception {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    int mid = bytes.length / 2;
+    HttpRequest.BodyPublisher twoChunks =
+        HttpRequest.BodyPublishers.fromPublisher(
+            new BufferSequencePublisher(
+                ByteBuffer.wrap(Arrays.copyOfRange(bytes, 0, mid)),
+                ByteBuffer.wrap(Arrays.copyOfRange(bytes, mid, bytes.length))));
+    return sendRawPost(config, path, twoChunks, contentType);
+  }
+
+  /**
+   * Publishes a fixed sequence of buffers, one per unit of requested demand, reporting unknown
+   * length so {@code HttpRequest.BodyPublishers.fromPublisher} chunks the request.
+   *
+   * <p>Both properties are needed and neither comes for free. A publisher of known length (e.g.
+   * {@code concat}) sends {@code Content-Length} and is not chunked at all; one of unknown length
+   * but a single buffer (e.g. {@code ofInputStream}) is chunked but emits the body as one chunk.
+   * Honouring demand rather than pushing every buffer at once matters too: the JDK client corrupts
+   * the body if a publisher emits more than it asked for.
+   */
+  private record BufferSequencePublisher(ByteBuffer... buffers)
+      implements Flow.Publisher<ByteBuffer> {
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+      subscriber.onSubscribe(
+          new Flow.Subscription() {
+            private int next = 0;
+            private boolean completed = false;
+
+            @Override
+            public void request(long n) {
+              while (n-- > 0 && next < buffers.length) {
+                subscriber.onNext(buffers[next++]);
+              }
+              if (next == buffers.length && !completed) {
+                completed = true;
+                subscriber.onComplete();
+              }
+            }
+
+            @Override
+            public void cancel() {}
+          });
+    }
+  }
+
+  private static HttpResponse<String> sendRawPost(
+      ServerConfig config, String path, HttpRequest.BodyPublisher body, String contentType)
+      throws Exception {
     HttpRequest.Builder reqBuilder =
-        HttpRequest.newBuilder()
-            .uri(URI.create(config.getServerUrl() + path))
-            .POST(HttpRequest.BodyPublishers.noBody());
+        HttpRequest.newBuilder().uri(URI.create(config.getServerUrl() + path)).POST(body);
+    if (contentType != null) {
+      reqBuilder.header("Content-Type", contentType);
+    }
     if (config.getAuthToken() != null && !config.getAuthToken().isEmpty()) {
       reqBuilder.header("Authorization", "Bearer " + config.getAuthToken());
     }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

PAYLOAD-source authorization read the body through Armeria's `peekData`, which only sees chunks and has to guess when the body is complete. Anything it did not recognise -- no body, a non-JSON content-type, malformed JSON, trailing whitespace -- skipped the check and trigger a failure.

- `AuthorizationGateConverter` binds the body first, then authorizes the bound object, so authorization reads exactly what the handler receives. A body that cannot bind is a client error (400) before authorization; a bound body with no usable key is a denial (403). The handler runs in neither case.
- `UnityAccessDecorator` stashes a `PayloadAuthorizer` for the gate to invoke, replacing `peekData`, `PeekDataHandler` and `AUTH_PENDING`. Both branches set one, so a missing value is never read as "already authorized".
- `EvaluationAction` becomes an abstract class owning the single response-splitting path, skipping the split when authorization already ran inline.
- The gate is installed only when authorization is enabled, since nothing produces a `PayloadAuthorizer` otherwise.

One test covers the body shapes the SDK cannot produce: body-less, non-JSON content-type, malformed JSON, JSON literal `null`, trailing newline, charset-qualified content-type, and a body split across two chunks mid-token.
