### PR TITLE
File content based commit idempotency for CCv2

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -128,7 +128,9 @@ public class UnityCatalogServer implements AutoCloseable {
     // Init all repositories
     Repositories repositories =
         new Repositories(
-            hibernateConfigurator.getSessionFactory(), unityCatalogServerBuilder.serverProperties);
+            hibernateConfigurator.getSessionFactory(),
+            unityCatalogServerBuilder.serverProperties,
+            unityCatalogServerBuilder.cloudCredentialVendor);
     // Init metastore
     repositories.getMetastoreRepository().initMetastoreIfNeeded();
     // Init authorizer
@@ -173,13 +175,10 @@ public class UnityCatalogServer implements AutoCloseable {
       Repositories repositories) {
     LOGGER.info("Adding Unity Catalog API services...");
     ServerProperties serverProperties = unityCatalogServerBuilder.serverProperties;
-    CloudCredentialVendor cloudCredentialVendor =
-        unityCatalogServerBuilder.cloudCredentialVendor != null
-            ? unityCatalogServerBuilder.cloudCredentialVendor
-            : new CloudCredentialVendor(serverProperties);
-    StorageCredentialVendor storageCredentialVendor =
-        new StorageCredentialVendor(cloudCredentialVendor, repositories.getExternalLocationUtils());
-    FileOperations fileOperations = new FileOperations(storageCredentialVendor, serverProperties);
+    // The credential/file-IO chain is built and owned by Repositories (so repositories can read
+    // table storage); reuse those instances here rather than rebuilding them.
+    StorageCredentialVendor storageCredentialVendor = repositories.getStorageCredentialVendor();
+    FileOperations fileOperations = repositories.getFileOperations();
 
     SchemaService schemaService = new SchemaService(authorizer, repositories, serverProperties);
 

--- a/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
@@ -48,9 +48,6 @@ public enum ErrorCode {
   UNIMPLEMENTED(12, 501, DeltaErrorType.NOT_IMPLEMENTED_EXCEPTION),
   INTERNAL(13, 500, DeltaErrorType.INTERNAL_SERVER_ERROR_EXCEPTION),
   DATA_LOSS(15, 500, DeltaErrorType.INTERNAL_SERVER_ERROR_EXCEPTION),
-  // CCv2 commit whose idempotency the server could not determine (e.g. the published or staged
-  // commit file could not be read for a content comparison). Retriable.
-  COMMIT_STATE_UNKNOWN(22, 500, DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION),
   // UC-specific "already exists" error codes for backwards compatibility (all HTTP 400). But new
   // Delta API returns 409 as it has no backwards compatibility concern.
   RESOURCE_ALREADY_EXISTS(16, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
@@ -58,7 +55,10 @@ public enum ErrorCode {
   SCHEMA_ALREADY_EXISTS(18, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
   TABLE_ALREADY_EXISTS(19, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
   STORAGE_CREDENTIAL_ALREADY_EXISTS(20, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
-  EXTERNAL_LOCATION_ALREADY_EXISTS(21, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409);
+  EXTERNAL_LOCATION_ALREADY_EXISTS(21, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
+  // CCv2 commit whose idempotency the server could not determine (e.g. the published or staged
+  // commit file could not be read for a content comparison). Retriable.
+  COMMIT_STATE_UNKNOWN(22, 500, DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION);
 
   // Canonical mapping from DeltaErrorType to HTTP status. Built at class-load time and validated
   // to ensure every ErrorCode that shares the same deltaErrorType also agrees on deltaHttpStatus.

--- a/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
   UNIMPLEMENTED(12, 501, DeltaErrorType.NOT_IMPLEMENTED_EXCEPTION),
   INTERNAL(13, 500, DeltaErrorType.INTERNAL_SERVER_ERROR_EXCEPTION),
   DATA_LOSS(15, 500, DeltaErrorType.INTERNAL_SERVER_ERROR_EXCEPTION),
+  // CCv2 commit whose idempotency the server could not determine (e.g. the published or staged
+  // commit file could not be read for a content comparison). Retriable.
+  COMMIT_STATE_UNKNOWN(22, 500, DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION),
   // UC-specific "already exists" error codes for backwards compatibility (all HTTP 400). But new
   // Delta API returns 409 as it has no backwards compatibility concern.
   RESOURCE_ALREADY_EXISTS(16, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -851,8 +852,13 @@ public class DeltaCommitRepository {
     }
     return new BaseException(
         ErrorCode.COMMIT_VERSION_CONFLICT,
-        "Commit version already accepted. Current table version is "
-            + lastCommitDAO.getCommitVersion());
+        "Commit version already accepted. Version "
+            + version
+            + " was accepted with commit file "
+            + existing.getCommitFilename()
+            + ", but the request carried "
+            + fileName
+            + ".");
   }
 
   /**
@@ -888,8 +894,11 @@ public class DeltaCommitRepository {
   static void verifyContentReplayOrThrowConflict(
       FileOperations fileOperations, CommitContentCheckRequiredException check) {
     String logDir = check.tableLocation + "/_delta_log";
-    String publishedPath = logDir + "/" + String.format("%020d.json", check.version);
-    String stagedPath = logDir + "/_staged_commits/" + check.stagedFileName;
+    // Locale.ROOT: the published file name is ASCII digits regardless of the server's locale, so it
+    // matches the actual _delta_log/<v>.json path (some locales render %d with non-ASCII digits).
+    String publishedPath = String.format(Locale.ROOT, "%s/%020d.json", logDir, check.version);
+    String stagedPath =
+        String.format(Locale.ROOT, "%s/_staged_commits/%s", logDir, check.stagedFileName);
     boolean sameContent;
     // getFileIO can vend credentials (cloud paths) and open resources, so it is acquired inside the
     // guarded block (and closed): a vend or read failure is equally "cannot determine" and must

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -18,6 +18,7 @@ import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.DeltaCommitDAO;
 import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.service.delta.DeltaUniformUtils;
 import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
@@ -27,6 +28,9 @@ import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
 import jakarta.persistence.PessimisticLockException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -36,6 +40,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -83,6 +90,24 @@ public class DeltaCommitRepository {
    */
   static class CommitAlreadyAcceptedException extends TransactionRollbackException {}
 
+  /**
+   * Thrown when the DB alone cannot decide whether a commit at an already-taken version is a replay
+   * or a conflict, because the version was backfilled and purged so its staged file name is no
+   * longer tracked. Rolls the transaction back (releasing the table lock) so the entry point can
+   * settle it out of the transaction by comparing the incoming staged commit file against the
+   * published {@code _delta_log/<version>.json} (see {@link #verifyContentReplayOrThrowConflict}).
+   *
+   * <p>Like {@link CommitAlreadyAcceptedException} this is a {@link TransactionRollbackException},
+   * not a client-facing error, and is always caught within {@link #postCommit} / {@link
+   * io.unitycatalog.server.persist.TableRepository#updateTableForDelta}.
+   */
+  @AllArgsConstructor
+  static class CommitContentCheckRequiredException extends TransactionRollbackException {
+    private final NormalizedURL tableLocation;
+    private final long version;
+    private final String stagedFileName;
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(DeltaCommitRepository.class);
 
   /**
@@ -104,12 +129,20 @@ public class DeltaCommitRepository {
    */
   private static final int NUM_COMMITS_PER_BATCH = 20;
 
+  /** Chunk size for the streamed commit-file content comparison in {@link #hasSameFileContent}. */
+  private static final int CONTENT_COMPARE_BUFFER_BYTES = 8192;
+
   private final SessionFactory sessionFactory;
   private final ServerProperties serverProperties;
+  private final FileOperations fileOperations;
 
-  public DeltaCommitRepository(SessionFactory sessionFactory, ServerProperties serverProperties) {
+  public DeltaCommitRepository(
+      SessionFactory sessionFactory,
+      ServerProperties serverProperties,
+      FileOperations fileOperations) {
     this.sessionFactory = sessionFactory;
     this.serverProperties = serverProperties;
+    this.fileOperations = fileOperations;
   }
 
   /**
@@ -250,7 +283,7 @@ public class DeltaCommitRepository {
    *
    * <p>Replaying a commit already accepted for this table is an idempotent no-op success (not a
    * conflict), so a client that lost the response can safely resend. See {@link
-   * #isAcceptedCommitReplay}.
+   * #exceptionForAlreadyTakenVersion}.
    *
    * @param commit the commit request containing version info, metadata, and backfill information
    * @throws BaseException if the commit is invalid, table is not found, or commit limits are
@@ -261,6 +294,10 @@ public class DeltaCommitRepository {
       postCommitInTransaction(commit);
     } catch (CommitAlreadyAcceptedException e) {
       // Idempotent replay: the transaction rolled back to a no-op. Report success.
+    } catch (CommitContentCheckRequiredException e) {
+      // Version was purged, so the DB couldn't decide: settle it out of the (rolled-back)
+      // transaction by comparing file content. A match is a no-op success; a difference throws.
+      verifyContentReplayOrThrowConflict(fileOperations, e);
     }
   }
 
@@ -516,9 +553,10 @@ public class DeltaCommitRepository {
    *   <li>Adding the new commit won't exceed the maximum commits per table limit
    * </ul>
    *
-   * <p>A resend of an already-accepted commit is detected here (see {@link
-   * CommitAlreadyAcceptedException}); a non-matching commit at an already-taken version is a
-   * genuine conflict.
+   * <p>A commit at an already-taken version is resolved by {@link
+   * #exceptionForAlreadyTakenVersion}: a recognized replay throws {@link
+   * CommitAlreadyAcceptedException}; a purged version that needs an out-of-transaction content
+   * check throws {@link CommitContentCheckRequiredException}; anything else is a genuine conflict.
    *
    * @param session the Hibernate session for database operations
    * @param tableId the unique identifier of the table
@@ -527,6 +565,7 @@ public class DeltaCommitRepository {
    * @param firstCommitDAO the first commit already in the database
    * @param lastCommitDAO the last commit already in the database
    * @throws CommitAlreadyAcceptedException if this is an idempotent replay of an accepted commit
+   * @throws CommitContentCheckRequiredException if a purged version needs a content check
    * @throws BaseException if the commit version is invalid, already exists, or violates constraints
    */
   private static void handleNormalCommit(
@@ -542,20 +581,14 @@ public class DeltaCommitRepository {
     long lastCommitVersion = lastCommitDAO.getCommitVersion();
     long newCommitVersion = commitInfo.getVersion();
     if (newCommitVersion <= lastCommitVersion) {
-      if (isAcceptedCommitReplay(
+      // This version is already taken: throw the outcome (replay, content-check, or conflict).
+      throw exceptionForAlreadyTakenVersion(
           session,
-          tableId,
+          tableInfoDAO,
           newCommitVersion,
           commitInfo.getFileName(),
           firstCommitDAO,
-          lastCommitDAO)) {
-        // A replay of an already-accepted commit.
-        throw new CommitAlreadyAcceptedException();
-      }
-      // A non-matching commit at an already-taken version is a genuine conflict.
-      throw new BaseException(
-          ErrorCode.COMMIT_VERSION_CONFLICT,
-          "Commit version already accepted. Current table version is " + lastCommitVersion);
+          lastCommitDAO);
     }
     if (newCommitVersion > lastCommitVersion + 1) {
       throw new BaseException(
@@ -759,27 +792,32 @@ public class DeltaCommitRepository {
   }
 
   /**
-   * Whether this {@code add-commit} at {@code version} is a replay of a commit already accepted for
-   * this table, rather than a fresh commit or a genuine conflict at an already-taken version. A
-   * client that lost the response to an accepted commit may safely resend the whole request;
-   * recognizing the replay lets the server report success instead of a spurious conflict.
+   * Returns the exception the caller must throw for an {@code add-commit} whose {@code version} is
+   * already taken. Returning (rather than throwing) keeps the {@code throw} at the call site, so
+   * this stays a total function that always yields an outcome. A client that lost the response to
+   * an accepted commit may safely resend; recognizing the replay lets the server report success
+   * (via a rolled-back no-op) instead of a spurious conflict.
    *
-   * <p>Covers only versions still tracked in the DB; a replay of a backfilled-and-purged version is
-   * conservatively reported as not-a-replay. The caller must hold the table lock (see {@link
-   * #lockTableForCommit}).
+   * <p>For a version still tracked in the DB, the client-generated per-commit-unique UUID in the
+   * file name is the dedup handle: same name -&gt; replay, different name -&gt; conflict. For a
+   * version already backfilled and purged, the name is no longer tracked, so the DB cannot decide
+   * and this defers to an out-of-transaction file-content check.
    *
-   * <p>Filename with the client-generated, per-commit-unique UUID is used for dedup.
+   * <p>The caller must hold the table lock (see {@link #lockTableForCommit}).
    *
-   * @return {@code true} only if this matches an already-accepted commit; {@code false} for a fresh
-   *     version, a genuine conflict, or a purged version
+   * @return a {@link CommitAlreadyAcceptedException} on a recognized replay; a {@link
+   *     CommitContentCheckRequiredException} when a purged version needs a content check; or a
+   *     {@link BaseException} ({@code COMMIT_VERSION_CONFLICT} for a genuine conflict, {@code
+   *     INTERNAL} if the tracked commit range is inconsistent)
    */
-  private static boolean isAcceptedCommitReplay(
+  private static RuntimeException exceptionForAlreadyTakenVersion(
       Session session,
-      UUID tableId,
+      TableInfoDAO tableInfoDAO,
       long version,
       String fileName,
       DeltaCommitDAO firstCommitDAO,
       DeltaCommitDAO lastCommitDAO) {
+    UUID tableId = tableInfoDAO.getId();
     // Resolve the commit tracked at `version` against the caller's already-read boundary commits,
     // querying the DB only for a version strictly between them (never re-reading the whole log).
     DeltaCommitDAO existing;
@@ -793,27 +831,28 @@ public class DeltaCommitRepository {
       // write lock, so no concurrent backfill can purge this version between reading the boundaries
       // and this lookup; an in-range version must therefore have a row. A missing row means the
       // uc_delta_commits table is internally inconsistent (a gap in the tracked range).
-      existing =
-          findCommitByVersion(session, tableId, version)
-              .orElseThrow(
-                  () ->
-                      new BaseException(
-                          ErrorCode.INTERNAL,
-                          "Inconsistent uc_delta_commits table for table "
-                              + tableId
-                              + ": no row tracked at in-range commit version "
-                              + version));
+      existing = findCommitByVersion(session, tableId, version).orElse(null);
+      if (existing == null) {
+        return new BaseException(
+            ErrorCode.INTERNAL,
+            "Inconsistent uc_delta_commits table for table "
+                + tableId
+                + ": no row tracked at in-range commit version "
+                + version);
+      }
     } else {
-      // Below the oldest tracked version, i.e. backfilled and purged. This could be a genuine
-      // replay, but the file name is no longer stored, so we can't confirm it. Conservatively
-      // treat it as a conflict.
-      // TODO: close this gap by comparing the incoming staged file against the published
-      // _delta_log/<v>.json.
-      return false;
+      // Below the oldest tracked version: backfilled and purged, so the file name is no longer
+      // stored and the DB alone can't tell a replay from a conflict. Defer to a content check.
+      return new CommitContentCheckRequiredException(
+          NormalizedURL.from(tableInfoDAO.getUrl()), version, fileName);
     }
-    // The file name embeds a client-generated, per-commit-unique UUID, used as the dedup handle: a
-    // match means the same commit replayed; a difference means another writer won that version.
-    return existing.getCommitFilename().equals(fileName);
+    if (existing.getCommitFilename().equals(fileName)) {
+      return new CommitAlreadyAcceptedException();
+    }
+    return new BaseException(
+        ErrorCode.COMMIT_VERSION_CONFLICT,
+        "Commit version already accepted. Current table version is "
+            + lastCommitDAO.getCommitVersion());
   }
 
   /**
@@ -830,6 +869,78 @@ public class DeltaCommitRepository {
     query.setParameter("tableId", tableId);
     query.setParameter("commitVersion", commitVersion);
     return query.uniqueResultOptional();
+  }
+
+  /**
+   * Settles a {@link CommitContentCheckRequiredException} out of the transaction by comparing the
+   * incoming staged commit file against the published {@code _delta_log/<version>.json} (both are
+   * immutable once written, so this is safe to read outside the table lock):
+   *
+   * <ul>
+   *   <li>identical content -&gt; a replay of the already-published commit; returns normally so the
+   *       caller reports an idempotent no-op success.
+   *   <li>a definitive difference -&gt; another writer won this version; throws {@code
+   *       COMMIT_VERSION_CONFLICT} (409).
+   *   <li>either file unreadable -&gt; {@code COMMIT_STATE_UNKNOWN} (500, retriable), so the client
+   *       retries rather than receiving a false conflict.
+   * </ul>
+   */
+  static void verifyContentReplayOrThrowConflict(
+      FileOperations fileOperations, CommitContentCheckRequiredException check) {
+    String logDir = check.tableLocation + "/_delta_log";
+    String publishedPath = logDir + "/" + String.format("%020d.json", check.version);
+    String stagedPath = logDir + "/_staged_commits/" + check.stagedFileName;
+    boolean sameContent;
+    // getFileIO can vend credentials (cloud paths) and open resources, so it is acquired inside the
+    // guarded block (and closed): a vend or read failure is equally "cannot determine" and must
+    // fail open to COMMIT_STATE_UNKNOWN.
+    try (FileIO fileIO = fileOperations.getFileIO(check.tableLocation)) {
+      sameContent =
+          hasSameFileContent(fileIO.newInputFile(publishedPath), fileIO.newInputFile(stagedPath));
+    } catch (Exception e) {
+      throw new BaseException(
+          ErrorCode.COMMIT_STATE_UNKNOWN,
+          "Could not determine whether commit version "
+              + check.version
+              + " is a replay: unable to read the staged or published commit file for the table at "
+              + check.tableLocation
+              + "; retry the request.",
+          e);
+    }
+    if (!sameContent) {
+      throw new BaseException(
+          ErrorCode.COMMIT_VERSION_CONFLICT,
+          "Commit version already accepted. Version " + check.version + " is already published.");
+    }
+  }
+
+  /**
+   * Whether two files have identical content, streamed in lockstep with a fixed buffer. The staged
+   * file is client-influenced, so -- unlike a client-side library -- the server must never read it
+   * wholesale into memory. Reading both streams in step bounds memory to one buffer and bounds the
+   * read to the smaller file: a client that inflates its staged file only forces a read up to the
+   * (real, bounded) published file's length before the size mismatch surfaces as a non-equal.
+   *
+   * <p>A missing file makes {@code newStream()} throw, which the caller turns into {@code
+   * COMMIT_STATE_UNKNOWN} -- deliberately not treated as "not equal", so a missing file never
+   * becomes a false conflict.
+   */
+  private static boolean hasSameFileContent(InputFile a, InputFile b) throws IOException {
+    try (InputStream streamA = a.newStream();
+        InputStream streamB = b.newStream()) {
+      byte[] bufA = new byte[CONTENT_COMPARE_BUFFER_BYTES];
+      byte[] bufB = new byte[CONTENT_COMPARE_BUFFER_BYTES];
+      while (true) {
+        int nA = streamA.readNBytes(bufA, 0, bufA.length);
+        int nB = streamB.readNBytes(bufB, 0, bufB.length);
+        if (nA == 0 && nB == 0) {
+          return true; // both reached EOF with all bytes equal
+        }
+        if (nA != nB || !Arrays.equals(bufA, 0, nA, bufB, 0, nB)) {
+          return false; // differing bytes, or one file is shorter (size mismatch)
+        }
+      }
+    }
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -1231,6 +1231,17 @@ public class DeltaCommitRepository {
         commitInfo.getFileName() != null && !commitInfo.getFileName().isEmpty(),
         "Field can not be empty: %s",
         DeltaCommitInfo.JSON_PROPERTY_FILE_NAME);
+    // The file name is client-supplied and the server later builds the staged-commit path it reads
+    // from it (_delta_log/_staged_commits/<fileName>). Require a single path segment so a name like
+    // "../<v>.json" cannot traverse out of that directory.
+    String fileName = commitInfo.getFileName();
+    ValidationUtils.checkArgument(
+        !fileName.contains("/")
+            && !fileName.contains("\\")
+            && !fileName.equals(".")
+            && !fileName.equals(".."),
+        "Field must be a single file name without path separators: %s",
+        DeltaCommitInfo.JSON_PROPERTY_FILE_NAME);
     ValidationUtils.checkArgument(
         commitInfo.getFileSize() != null && commitInfo.getFileSize() > 0,
         "Field must be positive: %s",

--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -2,6 +2,9 @@ package io.unitycatalog.server.persist;
 
 import io.unitycatalog.server.auth.decorator.KeyMapper;
 import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
+import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.service.credential.CloudCredentialVendor;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.ServerProperties;
 import lombok.Getter;
 import org.hibernate.SessionFactory;
@@ -14,6 +17,8 @@ import org.hibernate.SessionFactory;
 public class Repositories {
   private final SessionFactory sessionFactory;
   private final ExternalLocationUtils externalLocationUtils;
+  private final StorageCredentialVendor storageCredentialVendor;
+  private final FileOperations fileOperations;
 
   private final CatalogRepository catalogRepository;
   private final SchemaRepository schemaRepository;
@@ -32,8 +37,28 @@ public class Repositories {
   private final KeyMapper keyMapper;
 
   public Repositories(SessionFactory sessionFactory, ServerProperties serverProperties) {
+    this(sessionFactory, serverProperties, null);
+  }
+
+  /**
+   * @param cloudCredentialVendor an injected cloud credential vendor (e.g. a test mock), or {@code
+   *     null} to build the default from {@code serverProperties}. Owning the credential/file-IO
+   *     chain here lets repositories read table storage (e.g. Delta commit files) without
+   *     late-binding.
+   */
+  public Repositories(
+      SessionFactory sessionFactory,
+      ServerProperties serverProperties,
+      CloudCredentialVendor cloudCredentialVendor) {
     this.sessionFactory = sessionFactory;
     this.externalLocationUtils = new ExternalLocationUtils(sessionFactory);
+    CloudCredentialVendor resolvedCloudCredentialVendor =
+        cloudCredentialVendor != null
+            ? cloudCredentialVendor
+            : new CloudCredentialVendor(serverProperties);
+    this.storageCredentialVendor =
+        new StorageCredentialVendor(resolvedCloudCredentialVendor, externalLocationUtils);
+    this.fileOperations = new FileOperations(storageCredentialVendor, serverProperties);
 
     this.catalogRepository = new CatalogRepository(this, sessionFactory);
     this.schemaRepository = new SchemaRepository(this, sessionFactory);
@@ -47,7 +72,8 @@ public class Repositories {
     this.modelRepository = new ModelRepository(this, sessionFactory, serverProperties);
     this.credentialRepository = new CredentialRepository(this, sessionFactory, serverProperties);
     this.externalLocationRepository = new ExternalLocationRepository(this, sessionFactory);
-    this.deltaCommitRepository = new DeltaCommitRepository(sessionFactory, serverProperties);
+    this.deltaCommitRepository =
+        new DeltaCommitRepository(sessionFactory, serverProperties, fileOperations);
     this.dependencyRepository = new DependencyRepository();
 
     // KeyMapper uses all the repositories above.

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -309,6 +309,12 @@ public class TableRepository {
       // Idempotent replay: the transaction rolled back to a no-op. Return the current table state
       // (a fresh read, since the rolled-back transaction produced no response).
       return loadTableForDelta(catalog, schema, table);
+    } catch (DeltaCommitRepository.CommitContentCheckRequiredException e) {
+      // Version was purged, so the DB couldn't decide: settle it out of the (rolled-back)
+      // transaction by comparing file content. A match is a no-op success (return current state);
+      // a difference throws a conflict.
+      DeltaCommitRepository.verifyContentReplayOrThrowConflict(repositories.getFileOperations(), e);
+      return loadTableForDelta(catalog, schema, table);
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/persist/DeltaCommitContentCheckTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/DeltaCommitContentCheckTest.java
@@ -1,0 +1,101 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.persist.DeltaCommitRepository.CommitContentCheckRequiredException;
+import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Exercises {@link DeltaCommitRepository#verifyContentReplayOrThrowConflict} against a real
+ * (in-process, s3mock-backed) {@code S3FileIO}, so the cloud read path -- path construction, {@code
+ * newInputFile}/{@code newStream}, and the streamed lockstep comparison -- is covered rather than
+ * only the local {@code SimpleLocalFileIO} path the SDK tests use.
+ *
+ * <p>Like {@code MetadataServiceTest}, {@code getFileIO} is stubbed to return a real {@code
+ * S3FileIO}; credential vending itself is not exercised here.
+ */
+@ExtendWith(S3MockExtension.class)
+public class DeltaCommitContentCheckTest {
+
+  @RegisterExtension
+  public static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
+
+  private static final String BUCKET = "test-bucket";
+
+  private final FileOperations fileOperations = mock();
+  private final S3Client s3 = S3_MOCK.createS3ClientV2();
+
+  @BeforeEach
+  public void setUp() {
+    when(fileOperations.getFileIO(any())).thenReturn(new S3FileIO(() -> s3));
+    s3.createBucket(b -> b.bucket(BUCKET).build());
+  }
+
+  /** version 2 -> _delta_log/00000000000000000002.json (matches the %020d.json layout). */
+  private static final long VERSION = 2L;
+
+  private static final String STAGED_FILE_NAME = "00000000000000000002.abc-uuid.json";
+
+  @Test
+  public void contentCheckResolvesUnknownReplayAndConflict() {
+    // Each case uses a distinct table so object keys never collide.
+
+    // 1. Published file absent (only the staged file exists): the outcome cannot be determined, so
+    // it must fail open to a retriable 500 rather than a false conflict.
+    putStaged("tbl_unknown", "staged-commit\n");
+    assertThatThrownBy(() -> runContentCheck("tbl_unknown"))
+        .isInstanceOf(BaseException.class)
+        .extracting(e -> ((BaseException) e).getErrorCode())
+        .isEqualTo(ErrorCode.COMMIT_STATE_UNKNOWN);
+
+    // 2. Published and staged files are byte-identical: a recognized replay -> no exception.
+    putPublished("tbl_match", "{\"commitInfo\":{\"version\":2}}\n");
+    putStaged("tbl_match", "{\"commitInfo\":{\"version\":2}}\n");
+    assertThatCode(() -> runContentCheck("tbl_match")).doesNotThrowAnyException();
+
+    // 3. Published and staged files differ: another writer won this version -> 409 conflict.
+    putPublished("tbl_conflict", "published-commit\n");
+    putStaged("tbl_conflict", "a-different-commit\n");
+    assertThatThrownBy(() -> runContentCheck("tbl_conflict"))
+        .isInstanceOf(BaseException.class)
+        .extracting(e -> ((BaseException) e).getErrorCode())
+        .isEqualTo(ErrorCode.COMMIT_VERSION_CONFLICT);
+  }
+
+  private void runContentCheck(String tableName) {
+    DeltaCommitRepository.verifyContentReplayOrThrowConflict(
+        fileOperations,
+        new CommitContentCheckRequiredException(
+            NormalizedURL.from("s3://" + BUCKET + "/" + tableName), VERSION, STAGED_FILE_NAME));
+  }
+
+  private void putPublished(String tableName, String content) {
+    put(tableName + "/_delta_log/00000000000000000002.json", content);
+  }
+
+  private void putStaged(String tableName, String content) {
+    put(tableName + "/_delta_log/_staged_commits/" + STAGED_FILE_NAME, content);
+  }
+
+  private void put(String key, String content) {
+    s3.putObject(
+        b -> b.bucket(BUCKET).key(key).build(),
+        RequestBody.fromString(content, StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -23,6 +23,7 @@ import io.unitycatalog.client.delta.model.DeltaSetPropertiesUpdate;
 import io.unitycatalog.client.delta.model.DeltaSetProtocolUpdate;
 import io.unitycatalog.client.delta.model.DeltaSetSchemaUpdate;
 import io.unitycatalog.client.delta.model.DeltaSetTableCommentUpdate;
+import io.unitycatalog.client.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.client.delta.model.DeltaStructField;
 import io.unitycatalog.client.delta.model.DeltaStructFieldMetadata;
 import io.unitycatalog.client.delta.model.DeltaStructType;
@@ -47,6 +48,11 @@ import io.unitycatalog.server.service.delta.DeltaConsts.TableFeature;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.service.delta.UcManagedDeltaContract;
 import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -1285,6 +1291,61 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
       assertThat(r.getMetadata().getLastCommitVersion()).isEqualTo(1L);
       assertThat(r.getMetadata().getLastCommitTimestampMs()).isEqualTo(1700000001L);
     }
+
+    // -------- content-based idempotency for a backfilled-and-purged version --------
+    // Once a version is backfilled and purged, its staged file name is no longer tracked, so a
+    // replay is settled by comparing the incoming staged file against the published commit file.
+    {
+      DeltaStagingTableResponse staging = createDeltaStaging("tbl_content_idem_purged");
+      Handle h = createDeltaManaged("tbl_content_idem_purged", staging, Map.of());
+      String loc = staging.getLocation();
+      // Commit v1, v2, v3, keeping each update so the v2 object can be replayed verbatim below.
+      DeltaAddCommitUpdate[] commits = new DeltaAddCommitUpdate[3];
+      Handle cur = h;
+      for (int i = 0; i < commits.length; i++) {
+        long v = i + 1;
+        commits[i] =
+            new DeltaAddCommitUpdate()
+                .commit(
+                    new DeltaCommit()
+                        .version(v)
+                        .timestamp(1700000000L + v)
+                        .fileName(String.format("%08d.json", v))
+                        .fileSize(1024L)
+                        .fileModificationTimestamp(1700000000L + v));
+        cur = cur.withEtag(updateTable(cur, commits[i]).getMetadata().getEtag());
+      }
+      // Backfill v2 -> purge v1 and v2 from the DB (leaving [v3]).
+      DeltaLoadTableResponse afterBackfill =
+          updateTable(cur, new DeltaSetLatestBackfilledVersionUpdate().latestPublishedVersion(2L));
+      final Handle h3 = cur.withEtag(afterBackfill.getMetadata().getEtag());
+
+      // Publish v2 and stage a byte-identical file: the replay is recognized by content and is an
+      // idempotent no-op success (table still at v3).
+      byte[] v2Content = "delta-commit-v2\n".getBytes(StandardCharsets.UTF_8);
+      writeTableFile(loc, "_delta_log/00000000000000000002.json", v2Content);
+      writeTableFile(loc, "_delta_log/_staged_commits/00000002.json", v2Content);
+      DeltaLoadTableResponse replay = updateTable(h3, commits[1]);
+      assertThat(replay.getLatestTableVersion()).isEqualTo(3L);
+
+      // A staged file whose content differs from the published commit is a definitive conflict.
+      writeTableFile(
+          loc,
+          "_delta_log/_staged_commits/00000002.json",
+          "different\n".getBytes(StandardCharsets.UTF_8));
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h3, commits[1]),
+          DeltaErrorType.COMMIT_VERSION_CONFLICT_EXCEPTION,
+          "already accepted");
+    }
+  }
+
+  /** Write {@code content} to {@code relativePath} under the table's (file://) storage location. */
+  private void writeTableFile(String storageLocation, String relativePath, byte[] content)
+      throws IOException {
+    Path path = Path.of(URI.create(storageLocation + "/" + relativePath));
+    Files.createDirectories(path.getParent());
+    Files.write(path, content);
   }
 
   // ---------------------------------------------------------------- helpers

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkUpdateTableTest.java
@@ -1337,6 +1337,22 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
           () -> updateTable(h3, commits[1]),
           DeltaErrorType.COMMIT_VERSION_CONFLICT_EXCEPTION,
           "already accepted");
+
+      // The published file is absent (deleted here): the outcome cannot be determined, so the whole
+      // request fails open to a retriable COMMIT_STATE_UNKNOWN (500), never a false conflict.
+      deleteTablePath(loc, "_delta_log/00000000000000000002.json");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h3, commits[1]),
+          DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION,
+          "retry");
+
+      // The published path exists but cannot be read as a file (a directory stands in for a
+      // permission / non-not-found IO error): still COMMIT_STATE_UNKNOWN, not a false conflict.
+      createTableDir(loc, "_delta_log/00000000000000000002.json");
+      TestUtils.assertDeltaApiException(
+          () -> updateTable(h3, commits[1]),
+          DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION,
+          "retry");
     }
   }
 
@@ -1346,6 +1362,16 @@ public class SdkUpdateTableTest extends DeltaBaseTableCRUDTestEnv {
     Path path = Path.of(URI.create(storageLocation + "/" + relativePath));
     Files.createDirectories(path.getParent());
     Files.write(path, content);
+  }
+
+  /** Delete {@code relativePath} under the table's (file://) storage location. */
+  private void deleteTablePath(String storageLocation, String relativePath) throws IOException {
+    Files.delete(Path.of(URI.create(storageLocation + "/" + relativePath)));
+  }
+
+  /** Create {@code relativePath} as a directory under the table's (file://) storage location. */
+  private void createTableDir(String storageLocation, String relativePath) throws IOException {
+    Files.createDirectories(Path.of(URI.create(storageLocation + "/" + relativePath)));
   }
 
   // ---------------------------------------------------------------- helpers

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -373,7 +373,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // backfilled version has one; a missing file models log truncation, deletion, or a transient
     // storage read error). The content check cannot read it, so the outcome is unknown and surfaces
     // as a retriable 500 rather than a false conflict.
-    assertApiException(() -> deltaCommitsApi.commit(commit3), ErrorCode.INTERNAL, "retry");
+    assertApiException(
+        () -> deltaCommitsApi.commit(commit3), ErrorCode.COMMIT_STATE_UNKNOWN, "retry");
 
     // Commit one more version before deleting the table
     DeltaCommit commit5 =

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -36,7 +36,11 @@ import io.unitycatalog.server.service.delta.DeltaConsts;
 import io.unitycatalog.server.service.delta.DeltaConsts.TableProperties;
 import io.unitycatalog.server.service.delta.DeltaUniformUtils;
 import io.unitycatalog.server.utils.TestUtils;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -246,7 +250,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   @Test
-  public void testBasicCoordinatedCommitsCRUD() throws ApiException {
+  public void testBasicCoordinatedCommitsCRUD() throws ApiException, IOException {
     // Get commits on a table with no commits
     verifyDeltaCommits(
         /* expectedLatestTableVersion= */ 0);
@@ -346,14 +350,30 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaCommits(
         /* expectedLatestTableVersion= */ 4);
 
-    // Known limitation (see DeltaCommitRepository idempotency TODO): once a version is backfilled
-    // and purged, its file name is no longer tracked, so an idempotent replay of that same commit
-    // can no longer be recognized and surfaces as a conflict. Here versions 2 and 3 were purged by
-    // the backfill above, so replaying the identical commit2 conflicts rather than no-op'ing.
+    // Replay of a backfilled-and-purged version (v1/v2/v3 are purged; only the v4 marker remains)
+    // can no longer be matched by file name, so it is settled by comparing the incoming staged file
+    // against the published _delta_log/<v>.json.
+    String loc = tableInfo.getStorageLocation();
+    // Publish v2 and stage a byte-identical file -> replay recognized by content: idempotent no-op.
+    byte[] v2Content = "delta-commit-v2\n".getBytes(StandardCharsets.UTF_8);
+    writeTableFile(loc, "_delta_log/00000000000000000002.json", v2Content);
+    writeTableFile(loc, "_delta_log/_staged_commits/file2", v2Content);
+    deltaCommitsApi.commit(commit2);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 4);
+
+    // A staged file that differs from the published commit means another writer won v2: 409.
+    byte[] otherContent = "different\n".getBytes(StandardCharsets.UTF_8);
+    writeTableFile(loc, "_delta_log/_staged_commits/file2", otherContent);
     assertApiException(
         () -> deltaCommitsApi.commit(commit2),
         ErrorCode.COMMIT_VERSION_CONFLICT,
         "Commit version already accepted.");
+
+    // v3 is purged too. Its published _delta_log/<v>.json is absent here (in normal operation a
+    // backfilled version has one; a missing file models log truncation, deletion, or a transient
+    // storage read error). The content check cannot read it, so the outcome is unknown and surfaces
+    // as a retriable 500 rather than a false conflict.
+    assertApiException(() -> deltaCommitsApi.commit(commit3), ErrorCode.INTERNAL, "retry");
 
     // Commit one more version before deleting the table
     DeltaCommit commit5 =
@@ -395,6 +415,14 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     List<DeltaCommitDAO> remaining = getCommitDAOs(UUID.fromString(tableInfo.getTableId()));
     assertThat(remaining.size()).isEqualTo(2);
     verifyDeltaCommits(/* expectedLatestTableVersion= */ 2, /* expectedCommits= */ 2L, 1L);
+  }
+
+  /** Write {@code content} to {@code relativePath} under the table's (file://) storage location. */
+  private void writeTableFile(String storageLocation, String relativePath, byte[] content)
+      throws IOException {
+    Path path = Path.of(URI.create(storageLocation + "/" + relativePath));
+    Files.createDirectories(path.getParent());
+    Files.write(path, content);
   }
 
   private void checkCommitInvalidParameter(


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Once a commit version is backfilled, its staged file name is no longer tracked in DB, so the DB alone cannot tell a replay from a conflict. Resolve such a version by comparing the incoming staged file against the published commit file, outside the transaction.

- `classifyCommitReplay` is now the total factory `exceptionForAlreadyTakenVersion`, returning the exception to throw: replay, conflict, or a new `CommitContentCheckRequiredException` for a purged version.
- The entry points catch `CommitContentCheckRequiredException` and call `verifyContentReplayOrThrowConflict` out of the transaction: identical content is an idempotent no-op success, a definitive difference is a 409 conflict.
- Reads fail open: if the staged or published commit file cannot be read, return the new `COMMIT_STATE_UNKNOWN` (500, retriable) instead of a false conflict.
- `hasSameFileContent` streams both files in lockstep with a fixed buffer, so a client-influenced staged file is never read wholesale into memory (DoS-safe).
- `Repositories` now owns the `CloudCredentialVendor` -> `StorageCredentialVendor` -> `FileOperations` chain, giving the repository layer credentialed reads of table storage.

Tested on both entry points (REST `postCommit`, Delta `updateTableForDelta`): match, differ, and unreadable-published cases.
