### PR TITLE
Managed tables: add soft-delete semantics

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -309,6 +309,9 @@ public class DeltaCommitRepository {
       Session session, TableInfoDAO dao, UUID tableId, Optional<String> tableFullNameForLogging) {
     try {
       session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
+      if (dao.getDeletedAt() != null) {
+        throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableId);
+      }
     } catch (PessimisticLockException e) {
       throw new BaseException(
           ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
@@ -1146,6 +1149,10 @@ public class DeltaCommitRepository {
    * @throws BaseException if the table doesn't meet requirements for Delta commits
    */
   private static void validateTable(TableInfoDAO tableInfoDAO) {
+    if (tableInfoDAO.getDeletedAt() != null) {
+      throw new BaseException(
+          ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableInfoDAO.getId());
+    }
     ValidationUtils.checkArgument(
         tableInfoDAO.getType() != null
             && tableInfoDAO.getType().equals(TableType.MANAGED.toString()),

--- a/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
@@ -277,19 +277,11 @@ public class SchemaRepository {
   private List<DeletedResource> deleteChildTables(
       Session session, UUID schemaId, String catalogName, String schemaName, boolean force) {
     List<DeletedResource> deleted = new ArrayList<>();
-    // first check if there are any child tables
     List<TableInfo> tables =
         repositories
             .getTableRepository()
-            .listTables(
-                session,
-                schemaId,
-                catalogName,
-                schemaName,
-                Optional.of(1),
-                Optional.empty(),
-                true,
-                true)
+            .listTablesIncludingDeleted(
+                session, schemaId, catalogName, schemaName, Optional.of(1), Optional.empty())
             .getTables();
     if (tables != null && !tables.isEmpty()) {
       if (!force) {
@@ -300,15 +292,13 @@ public class SchemaRepository {
         ListTablesResponse listTablesResponse =
             repositories
                 .getTableRepository()
-                .listTables(
+                .listTablesIncludingDeleted(
                     session,
                     schemaId,
                     catalogName,
                     schemaName,
                     Optional.empty(),
-                    Optional.ofNullable(nextToken),
-                    true,
-                    true);
+                    Optional.ofNullable(nextToken));
         for (TableInfo tableInfo : listTablesResponse.getTables()) {
           deleted.add(
               new DeletedResource(

--- a/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
@@ -42,10 +42,10 @@ public class StagingTableRepository {
 
   private void validateIfAlreadyExists(
       Session session, UUID schemaId, String tableName, NormalizedURL stagingLocation) {
-    // Check if table by the same name already exists. It's OK if a staging table with the same name
-    // already exist.
+    // Active tables and retained tombstones both reserve the name. It's OK if a staging table with
+    // the same name already exists.
     TableInfoDAO existingTable =
-        repositories.getTableRepository().findBySchemaIdAndName(session, schemaId, tableName);
+        repositories.getTableRepository().findAnyBySchemaIdAndName(session, schemaId, tableName);
     if (existingTable != null) {
       throw new BaseException(ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + tableName);
     }

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -40,6 +40,8 @@ import io.unitycatalog.server.utils.IdentityUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ValidationUtils;
+import jakarta.persistence.LockModeType;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -62,6 +64,7 @@ public class TableRepository {
   private final SessionFactory sessionFactory;
   private final Repositories repositories;
   private final ServerProperties serverProperties;
+  private final Duration managedTableRetention;
   private static final PagedListingHelper<TableInfoDAO> LISTING_HELPER =
       new PagedListingHelper<>(TableInfoDAO.class);
 
@@ -70,6 +73,7 @@ public class TableRepository {
     this.repositories = repositories;
     this.sessionFactory = sessionFactory;
     this.serverProperties = serverProperties;
+    this.managedTableRetention = serverProperties.getManagedTableRetentionDuration();
   }
 
   /**
@@ -78,6 +82,9 @@ public class TableRepository {
    * always finalize to MANAGED Delta.
    */
   public record TableStorageLocationInfo(NormalizedURL url, TableType tableType) {}
+
+  /** Result of a logical DROP, used by services to defer authorization cleanup when necessary. */
+  public record TableDeletionResult(UUID tableId, UUID schemaId, boolean softDeleted) {}
 
   /**
    * Retrieves the storage location for a table or staging table by its ID, plus the table type.
@@ -101,6 +108,10 @@ public class TableRepository {
           LOGGER.debug("Getting storage location of table by id: {}", tableId);
           TableInfoDAO tableInfoDAO = session.get(TableInfoDAO.class, tableId);
           if (tableInfoDAO != null) {
+            if (tableInfoDAO.getDeletedAt() != null) {
+              throw new BaseException(
+                  ErrorCode.TABLE_NOT_FOUND, "Table not found with id: " + tableId);
+            }
             return new TableStorageLocationInfo(
                 NormalizedURL.from(tableInfoDAO.getUrl()),
                 TableType.fromValue(tableInfoDAO.getType()));
@@ -108,7 +119,7 @@ public class TableRepository {
 
           LOGGER.debug("Getting storage location of staging table by id: {}", tableId);
           StagingTableDAO stagingTableDAO = session.get(StagingTableDAO.class, tableId);
-          if (stagingTableDAO != null) {
+          if (stagingTableDAO != null && !stagingTableDAO.isStageCommitted()) {
             // Staging rows always become MANAGED Delta on finalize, so project them as MANAGED.
             return new TableStorageLocationInfo(
                 NormalizedURL.from(stagingTableDAO.getStagingLocation()), TableType.MANAGED);
@@ -168,7 +179,7 @@ public class TableRepository {
         session -> {
           LOGGER.debug("Getting storage location of staging table by id: {}", stagingTableId);
           StagingTableDAO stagingTableDAO = session.get(StagingTableDAO.class, stagingTableId);
-          if (stagingTableDAO == null) {
+          if (stagingTableDAO == null || stagingTableDAO.isStageCommitted()) {
             throw new BaseException(
                 ErrorCode.TABLE_NOT_FOUND, "Staging table not found with id: " + stagingTableId);
           }
@@ -201,11 +212,15 @@ public class TableRepository {
 
           UUID schemaId;
           if (tableInfoDAO != null) {
+            if (tableInfoDAO.getDeletedAt() != null) {
+              throw new BaseException(
+                  ErrorCode.TABLE_NOT_FOUND, "Table not found with id: " + tableId);
+            }
             schemaId = tableInfoDAO.getSchemaId();
           } else {
             // Table not found, try to find a staging table instead
             StagingTableDAO stagingTableDAO = session.get(StagingTableDAO.class, tableId);
-            if (stagingTableDAO == null) {
+            if (stagingTableDAO == null || stagingTableDAO.isStageCommitted()) {
               throw new BaseException(
                   ErrorCode.TABLE_NOT_FOUND,
                   "Neither table nor staging table found with id: " + tableId);
@@ -568,7 +583,7 @@ public class TableRepository {
       Session session, String catalogName, String schemaName, String tableName) {
     UUID schemaId =
         repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalogName, schemaName);
-    TableInfoDAO dao = findBySchemaIdAndName(session, schemaId, tableName);
+    TableInfoDAO dao = findActiveBySchemaIdAndName(session, schemaId, tableName);
     if (dao == null) {
       throw new BaseException(
           ErrorCode.TABLE_NOT_FOUND,
@@ -644,9 +659,10 @@ public class TableRepository {
                   .getSchemaRepository()
                   .getSchemaIdOrThrow(session, catalogName, schemaName);
 
-          // Check if table already exists
+          // A tombstone reserves its name during retention so name-based restore stays
+          // unambiguous. Atomic cleanup handoff removes the row and releases the name.
           TableInfoDAO existingTable =
-              findBySchemaIdAndName(session, schemaId, createTable.getName());
+              findAnyBySchemaIdAndName(session, schemaId, createTable.getName());
           if (existingTable != null) {
             throw new BaseException(
                 ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + fullName);
@@ -818,7 +834,7 @@ public class TableRepository {
               .getSchemaIdOrThrow(session, dep.getDependencyCatalog(), dep.getDependencySchema());
       switch (dep.getDependencyType()) {
         case TABLE:
-          if (findBySchemaIdAndName(session, schemaId, dep.getDependencyName()) == null) {
+          if (findActiveBySchemaIdAndName(session, schemaId, dep.getDependencyName()) == null) {
             throw new BaseException(
                 ErrorCode.NOT_FOUND, "View dependency table does not exist: " + fullName);
           }
@@ -840,11 +856,46 @@ public class TableRepository {
     }
   }
 
-  public TableInfoDAO findBySchemaIdAndName(Session session, UUID schemaId, String name) {
+  private TableInfoDAO findActiveBySchemaIdAndName(Session session, UUID schemaId, String name) {
+    return findActiveBySchemaIdAndName(session, schemaId, name, false);
+  }
+
+  private TableInfoDAO findActiveBySchemaIdAndNameForUpdate(
+      Session session, UUID schemaId, String name) {
+    return findActiveBySchemaIdAndName(session, schemaId, name, true);
+  }
+
+  private TableInfoDAO findActiveBySchemaIdAndName(
+      Session session, UUID schemaId, String name, boolean forUpdate) {
+    String hql =
+        "FROM TableInfoDAO t WHERE t.schemaId = :schemaId AND t.name = :name"
+            + " AND t.deletedAt IS NULL";
+    return findBySchemaIdAndName(session, schemaId, name, hql, forUpdate);
+  }
+
+  TableInfoDAO findAnyBySchemaIdAndName(Session session, UUID schemaId, String name) {
+    return findAnyBySchemaIdAndName(session, schemaId, name, false);
+  }
+
+  private TableInfoDAO findAnyBySchemaIdAndNameForUpdate(
+      Session session, UUID schemaId, String name) {
+    return findAnyBySchemaIdAndName(session, schemaId, name, true);
+  }
+
+  private TableInfoDAO findAnyBySchemaIdAndName(
+      Session session, UUID schemaId, String name, boolean forUpdate) {
     String hql = "FROM TableInfoDAO t WHERE t.schemaId = :schemaId AND t.name = :name";
+    return findBySchemaIdAndName(session, schemaId, name, hql, forUpdate);
+  }
+
+  private TableInfoDAO findBySchemaIdAndName(
+      Session session, UUID schemaId, String name, String hql, boolean forUpdate) {
     Query<TableInfoDAO> query = session.createQuery(hql, TableInfoDAO.class);
     query.setParameter("schemaId", schemaId);
     query.setParameter("name", name);
+    if (forUpdate) {
+      query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
+    }
     LOGGER.debug("Finding table by schemaId: {} and name: {}", schemaId, name);
     return query.uniqueResult(); // Returns null if no result is found
   }
@@ -905,8 +956,42 @@ public class TableRepository {
       Optional<String> pageToken,
       Boolean omitProperties,
       Boolean omitColumns) {
+    return listTables(
+        session,
+        schemaId,
+        catalogName,
+        schemaName,
+        maxResults,
+        pageToken,
+        omitProperties,
+        omitColumns,
+        false);
+  }
+
+  /** Internal listing used by parent cascades, where tombstoned rows must also be removed. */
+  ListTablesResponse listTablesIncludingDeleted(
+      Session session,
+      UUID schemaId,
+      String catalogName,
+      String schemaName,
+      Optional<Integer> maxResults,
+      Optional<String> pageToken) {
+    return listTables(
+        session, schemaId, catalogName, schemaName, maxResults, pageToken, true, true, true);
+  }
+
+  private ListTablesResponse listTables(
+      Session session,
+      UUID schemaId,
+      String catalogName,
+      String schemaName,
+      Optional<Integer> maxResults,
+      Optional<String> pageToken,
+      Boolean omitProperties,
+      Boolean omitColumns,
+      boolean includeDeleted) {
     List<TableInfoDAO> tableInfoDAOList =
-        LISTING_HELPER.listEntity(session, maxResults, pageToken, schemaId);
+        listTableDaos(session, schemaId, maxResults, pageToken, includeDeleted);
     String nextPageToken = LISTING_HELPER.getNextPageToken(tableInfoDAOList, maxResults);
     List<TableInfo> result = new ArrayList<>();
     for (TableInfoDAO tableInfoDAO : tableInfoDAOList) {
@@ -922,11 +1007,35 @@ public class TableRepository {
     return new ListTablesResponse().tables(result).nextPageToken(nextPageToken);
   }
 
+  private List<TableInfoDAO> listTableDaos(
+      Session session,
+      UUID schemaId,
+      Optional<Integer> maxResults,
+      Optional<String> pageToken,
+      boolean includeDeleted) {
+    if (maxResults.isPresent() && maxResults.get() < 0) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "maxResults must be greater than or equal to 0");
+    }
+    StringBuilder hql = new StringBuilder("FROM TableInfoDAO t WHERE t.schemaId = :schemaId");
+    if (!includeDeleted) {
+      hql.append(" AND t.deletedAt IS NULL");
+    }
+    pageToken.ifPresent(ignored -> hql.append(" AND t.name > :pageToken"));
+    hql.append(" ORDER BY t.name");
+
+    Query<TableInfoDAO> query = session.createQuery(hql.toString(), TableInfoDAO.class);
+    query.setParameter("schemaId", schemaId);
+    pageToken.ifPresent(token -> query.setParameter("pageToken", token));
+    query.setMaxResults(PagedListingHelper.getPageSize(maxResults));
+    return query.getResultList();
+  }
+
   /**
    * Variant of {@link #deleteTable(String, String, String)} taking the table's three-part name as a
    * single dotted string.
    */
-  public TableInfoDAO deleteTable(String fullName) {
+  public TableDeletionResult deleteTable(String fullName) {
     String[] parts = fullName.split("\\.");
     if (parts.length != 3) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid table name: " + fullName);
@@ -934,33 +1043,58 @@ public class TableRepository {
     return deleteTable(parts[0], parts[1], parts[2]);
   }
 
-  /**
-   * Deletes a table and returns the deleted table's DAO. The DAO is detached; do not access its
-   * lazy fields.
-   */
-  public TableInfoDAO deleteTable(String catalog, String schema, String table) {
+  /** Logically drops a managed table, or immediately removes metadata for other table types. */
+  public TableDeletionResult deleteTable(String catalog, String schema, String table) {
     return TransactionManager.executeWithTransaction(
         sessionFactory,
         session -> {
           UUID schemaId =
               repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
-          return deleteTable(session, schemaId, table);
+          return dropTable(session, schemaId, table);
         },
         "Failed to delete table",
         /* readOnly = */ false);
   }
 
+  private TableDeletionResult dropTable(Session session, UUID schemaId, String tableName) {
+    TableInfoDAO tableInfoDAO = findActiveBySchemaIdAndNameForUpdate(session, schemaId, tableName);
+    if (tableInfoDAO == null) {
+      throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableName);
+    }
+    UUID tableId = tableInfoDAO.getId();
+    if (TableType.MANAGED.getValue().equals(tableInfoDAO.getType())) {
+      Date deletedAt = new Date();
+      tableInfoDAO.setDeletedAt(deletedAt);
+      tableInfoDAO.setPurgeAfter(Date.from(deletedAt.toInstant().plus(managedTableRetention)));
+      return new TableDeletionResult(tableId, schemaId, true);
+    }
+
+    purgeTableMetadata(session, tableInfoDAO);
+    return new TableDeletionResult(tableId, schemaId, false);
+  }
+
+  /**
+   * Permanently removes a table during a forced parent cascade. This retains the pre-lifecycle
+   * synchronous behavior until durable cleanup handoff is introduced.
+   */
   TableInfoDAO deleteTable(Session session, UUID schemaId, String tableName) {
-    TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, tableName);
+    TableInfoDAO tableInfoDAO = findAnyBySchemaIdAndNameForUpdate(session, schemaId, tableName);
     if (tableInfoDAO == null) {
       throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + tableName);
     }
     if (TableType.MANAGED.getValue().equals(tableInfoDAO.getType())) {
       try {
         FileOperations.deleteDirectory(NormalizedURL.from(tableInfoDAO.getUrl()));
-      } catch (Throwable e) {
+      } catch (RuntimeException e) {
         LOGGER.error("Error deleting table directory: {}", tableInfoDAO.getUrl(), e);
       }
+    }
+    purgeTableMetadata(session, tableInfoDAO);
+    return tableInfoDAO;
+  }
+
+  private void purgeTableMetadata(Session session, TableInfoDAO tableInfoDAO) {
+    if (TableType.MANAGED.getValue().equals(tableInfoDAO.getType())) {
       repositories
           .getDeltaCommitRepository()
           .permanentlyDeleteTableCommits(session, tableInfoDAO.getId());
@@ -973,7 +1107,40 @@ public class TableRepository {
     PropertyRepository.findProperties(session, tableInfoDAO.getId(), Constants.TABLE)
         .forEach(session::remove);
     session.remove(tableInfoDAO);
-    return tableInfoDAO;
+  }
+
+  /**
+   * Restores a soft-deleted managed table while its metadata still exists. The row lock serializes
+   * restore with other lifecycle mutations.
+   */
+  public TableInfo restoreTable(String fullName) {
+    String[] parts = fullName.split("\\.");
+    if (parts.length != 3) {
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid table name: " + fullName);
+    }
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories.getSchemaRepository().getSchemaIdOrThrow(session, parts[0], parts[1]);
+          TableInfoDAO tableInfoDAO =
+              findAnyBySchemaIdAndNameForUpdate(session, schemaId, parts[2]);
+          if (tableInfoDAO == null || tableInfoDAO.getDeletedAt() == null) {
+            throw new BaseException(
+                ErrorCode.TABLE_NOT_FOUND, "Dropped table not found: " + fullName);
+          }
+          tableInfoDAO.setDeletedAt(null);
+          tableInfoDAO.setPurgeAfter(null);
+
+          TableInfo restored = tableInfoDAO.toTableInfo(true, parts[0], parts[1]);
+          RepositoryUtils.attachProperties(
+              restored, restored.getTableId(), Constants.TABLE, session);
+          RepositoryUtils.attachDependencies(
+              restored, tableInfoDAO, session, repositories.getDependencyRepository());
+          return restored;
+        },
+        "Failed to restore table " + fullName,
+        /* readOnly = */ false);
   }
 
   /**
@@ -991,7 +1158,8 @@ public class TableRepository {
         session -> {
           UUID schemaId =
               repositories.getSchemaRepository().getSchemaIdOrThrow(session, catalog, schema);
-          TableInfoDAO tableInfoDAO = findBySchemaIdAndName(session, schemaId, table);
+          TableInfoDAO tableInfoDAO =
+              findActiveBySchemaIdAndNameForUpdate(session, schemaId, table);
           if (tableInfoDAO == null) {
             throw new BaseException(ErrorCode.TABLE_NOT_FOUND, "Table not found: " + table);
           }
@@ -1000,7 +1168,7 @@ public class TableRepository {
           if (table.equals(newName)) {
             return null;
           }
-          if (findBySchemaIdAndName(session, schemaId, newName) != null) {
+          if (findAnyBySchemaIdAndName(session, schemaId, newName) != null) {
             throw new BaseException(
                 ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + newName);
           }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -28,6 +28,7 @@ import lombok.experimental.SuperBuilder;
     name = "uc_tables",
     indexes = {
       @Index(name = "idx_name", columnList = "name"),
+      @Index(name = "idx_table_cleanup_eligibility", columnList = "type, purge_after"),
     })
 // Lombok annotations
 @Getter
@@ -57,6 +58,14 @@ public class TableInfoDAO extends IdentifiableDAO {
 
   @Column(name = "updated_by")
   private String updatedBy;
+
+  /** Time at which the table stopped being visible through catalog APIs. */
+  @Column(name = "deleted_at")
+  private Date deletedAt;
+
+  /** Earliest time at which the table may be handed to durable physical cleanup. */
+  @Column(name = "purge_after")
+  private Date purgeAfter;
 
   @Column(name = "data_source_format")
   private String dataSourceFormat;

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -22,7 +22,7 @@ import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.TableRepository;
-import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.TableRepository.TableDeletionResult;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
 import com.linecorp.armeria.common.HttpResponse;
@@ -145,8 +145,11 @@ public class TableService extends AuthorizedService {
   @AuthorizeExpression(AuthorizeExpressions.DELETE_TABLE)
   public HttpResponse deleteTable(
       @Param("full_name") @AuthorizeResourceKey(TABLE) String fullName) {
-    TableInfoDAO deleted = tableRepository.deleteTable(fullName);
-    removeHierarchicalAuthorizations(deleted.getId().toString(), deleted.getSchemaId().toString());
+    TableDeletionResult deletion = tableRepository.deleteTable(fullName);
+    if (!deletion.softDeleted()) {
+      removeHierarchicalAuthorizations(
+          deletion.tableId().toString(), deletion.schemaId().toString());
+    }
     return HttpResponse.of(HttpStatus.OK);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -42,6 +42,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.TableRepository.TableDeletionResult;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.service.AuthorizedService;
 import io.unitycatalog.server.service.credential.CredentialContext;
@@ -149,9 +150,8 @@ public class DeltaApiService extends AuthorizedService {
   /**
    * Delete a table by three-part name. Mirrors {@link
    * io.unitycatalog.server.service.TableService#deleteTable}, but returns 204 No Content per {@code
-   * delta.yaml} (the UC counterpart returns 200). {@code deleteTable} returns the deleted table's
-   * DAO, so the table and schema UUIDs for the authorization cleanup come from the same lookup that
-   * removed the table.
+   * delta.yaml} (the UC counterpart returns 200). Managed table authorization is retained while
+   * the table is restorable and is removed by the lifecycle worker after physical cleanup.
    */
   @Delete("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
   @AuthorizeExpression(AuthorizeExpressions.DELETE_TABLE)
@@ -159,8 +159,11 @@ public class DeltaApiService extends AuthorizedService {
       @Param("catalog") @AuthorizeResourceKey(CATALOG) String catalog,
       @Param("schema") @AuthorizeResourceKey(SCHEMA) String schema,
       @Param("table") @AuthorizeResourceKey(TABLE) String table) {
-    TableInfoDAO deleted = tableRepository.deleteTable(catalog, schema, table);
-    removeHierarchicalAuthorizations(deleted.getId().toString(), deleted.getSchemaId().toString());
+    TableDeletionResult deletion = tableRepository.deleteTable(catalog, schema, table);
+    if (!deletion.softDeleted()) {
+      removeHierarchicalAuthorizations(
+          deletion.tableId().toString(), deletion.schemaId().toString());
+    }
     return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -170,6 +170,30 @@ public class ServerProperties {
     }
   }
 
+  /** Validator for durations in an inclusive operational range. */
+  private static class DurationRangeValidator extends DurationValidator {
+    private final Duration minimum;
+    private final Duration maximum;
+
+    DurationRangeValidator(Duration minimum, Duration maximum) {
+      this.minimum = minimum;
+      this.maximum = maximum;
+    }
+
+    @Override
+    public void validate(String key, String value) {
+      super.validate(key, value);
+      Duration duration = Duration.parse(value);
+      if (duration.compareTo(minimum) < 0 || duration.compareTo(maximum) > 0) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            String.format(
+                "Invalid value '%s' for property '%s'. Expected a duration between %s and %s",
+                value, key, minimum, maximum));
+      }
+    }
+  }
+
   /** No-op validator that accepts any value */
   private static class NoOpValidator implements PropertyValidator {
     @Override
@@ -185,6 +209,8 @@ public class ServerProperties {
       new PositiveIntegerValidator();
   private static final NoOpValidator NOOP_VALIDATOR = new NoOpValidator();
   private static final DurationValidator DURATION_VALIDATOR = new DurationValidator();
+  private static final DurationRangeValidator RETENTION_DURATION_VALIDATOR =
+      new DurationRangeValidator(Duration.ZERO, Duration.ofDays(3650));
 
   @Getter
   public enum Property {
@@ -203,6 +229,8 @@ public class ServerProperties {
     MANAGED_TABLE_ENABLED("server.managed-table.enabled", "true", BOOLEAN_VALIDATOR),
     MANAGED_TABLE_USE_DELTA_API_ONLY(
         "server.managed-table.use-delta-api-only", "false", BOOLEAN_VALIDATOR),
+    MANAGED_TABLE_RETENTION_DURATION(
+        "server.managed-table.retention-duration", "PT0S", RETENTION_DURATION_VALIDATOR),
     UNIFORM_ICEBERG_V2_ALLOW_MISSING_DV(
         "server.managed-table.uniform-iceberg-v2.allow-missing-dv", "false", BOOLEAN_VALIDATOR),
     // `storage-root.*` are replaced by managed storage locations of catalog and schema.
@@ -493,6 +521,11 @@ public class ServerProperties {
           "MANAGED table is an is currently disabled. To enable it, set "
               + "'server.managed-table.enabled=true' in server.properties");
     }
+  }
+
+  /** Retention between a managed table's logical drop and cleanup eligibility. */
+  public Duration getManagedTableRetentionDuration() {
+    return Duration.parse(get(Property.MANAGED_TABLE_RETENTION_DURATION));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/lifecycle/ManagedTableSoftDeleteTest.java
+++ b/server/src/test/java/io/unitycatalog/server/lifecycle/ManagedTableSoftDeleteTest.java
@@ -1,0 +1,175 @@
+package io.unitycatalog.server.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.DataSourceFormat;
+import io.unitycatalog.server.model.TableInfo;
+import io.unitycatalog.server.model.TableType;
+import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.dao.CatalogInfoDAO;
+import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
+import io.unitycatalog.server.persist.dao.StagingTableDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import io.unitycatalog.server.persist.utils.TransactionManager;
+import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.ServerProperties.Property;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ManagedTableSoftDeleteTest {
+  private static final String CATALOG = "soft_delete_catalog";
+  private static final String SCHEMA = "soft_delete_schema";
+  private static final String TABLE = "soft_delete_table";
+
+  @TempDir Path temporaryDirectory;
+
+  private SessionFactory sessionFactory;
+  private Repositories repositories;
+  private UUID schemaId;
+
+  @BeforeEach
+  void setUp() {
+    Properties settings = new Properties();
+    settings.setProperty(Property.SERVER_ENV.getKey(), "test");
+    settings.setProperty(Property.MANAGED_TABLE_RETENTION_DURATION.getKey(), "PT0S");
+    ServerProperties serverProperties = new ServerProperties(settings);
+
+    Properties hibernateProperties = new Properties();
+    hibernateProperties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    hibernateProperties.setProperty(
+        "hibernate.connection.url",
+        "jdbc:h2:mem:managed-soft-delete-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+    hibernateProperties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+    sessionFactory = new HibernateConfigurator(hibernateProperties).getSessionFactory();
+    repositories = new Repositories(sessionFactory, serverProperties);
+
+    UUID catalogId = UUID.randomUUID();
+    schemaId = UUID.randomUUID();
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          session.persist(
+              CatalogInfoDAO.builder().id(catalogId).name(CATALOG).createdAt(new Date()).build());
+          session.persist(
+              SchemaInfoDAO.builder()
+                  .id(schemaId)
+                  .catalogId(catalogId)
+                  .name(SCHEMA)
+                  .createdAt(new Date())
+                  .build());
+          return null;
+        },
+        "Failed to persist test namespace",
+        /* readOnly = */ false);
+  }
+
+  @AfterEach
+  void tearDown() {
+    sessionFactory.close();
+  }
+
+  @Test
+  void dropHidesManagedTableUntilRestore() {
+    UUID tableId = persistManagedTable();
+    TableRepository tableRepository = repositories.getTableRepository();
+
+    assertThat(tableRepository.deleteTable(CATALOG, SCHEMA, TABLE).softDeleted()).isTrue();
+    assertTableNotFound(() -> tableRepository.getTable(fullName()));
+    assertTableNotFound(() -> tableRepository.getStorageLocationForTableOrStagingTable(tableId));
+    assertTableNotFound(() -> tableRepository.getCatalogSchemaIdsByTableOrStagingTableId(tableId));
+    assertThat(
+            tableRepository
+                .listTables(CATALOG, SCHEMA, Optional.empty(), Optional.empty(), true, true)
+                .getTables())
+        .isEmpty();
+
+    TableInfo restored = tableRepository.restoreTable(fullName());
+    assertThat(restored.getTableId()).isEqualTo(tableId.toString());
+    try (Session session = sessionFactory.openSession()) {
+      TableInfoDAO table = session.get(TableInfoDAO.class, tableId);
+      assertThat(table.getDeletedAt()).isNull();
+      assertThat(table.getPurgeAfter()).isNull();
+    }
+  }
+
+  @Test
+  void dropPersistsTheConfiguredRetentionDeadline() {
+    UUID tableId = persistManagedTable();
+    Properties settings = new Properties();
+    settings.setProperty(Property.SERVER_ENV.getKey(), "test");
+    settings.setProperty(Property.MANAGED_TABLE_RETENTION_DURATION.getKey(), "PT1H");
+    TableRepository retainedTableRepository =
+        new TableRepository(repositories, sessionFactory, new ServerProperties(settings));
+
+    retainedTableRepository.deleteTable(CATALOG, SCHEMA, TABLE);
+
+    try (Session session = sessionFactory.openSession()) {
+      TableInfoDAO table = session.get(TableInfoDAO.class, tableId);
+      assertThat(table.getPurgeAfter().getTime() - table.getDeletedAt().getTime())
+          .isEqualTo(Duration.ofHours(1).toMillis());
+    }
+  }
+
+  private UUID persistManagedTable() {
+    UUID tableId = UUID.randomUUID();
+    String storageLocation = temporaryDirectory.resolve(TABLE).toUri().toString();
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          Date now = new Date();
+          session.persist(
+              StagingTableDAO.builder()
+                  .id(tableId)
+                  .schemaId(schemaId)
+                  .name(TABLE)
+                  .stagingLocation(storageLocation)
+                  .createdAt(now)
+                  .accessedAt(now)
+                  .stageCommitted(true)
+                  .stageCommittedAt(now)
+                  .build());
+          session.persist(
+              TableInfoDAO.builder()
+                  .id(tableId)
+                  .schemaId(schemaId)
+                  .name(TABLE)
+                  .type(TableType.MANAGED.getValue())
+                  .dataSourceFormat(DataSourceFormat.DELTA.getValue())
+                  .url(storageLocation)
+                  .columns(List.of())
+                  .createdAt(now)
+                  .build());
+          return null;
+        },
+        "Failed to persist test table",
+        /* readOnly = */ false);
+    return tableId;
+  }
+
+  private String fullName() {
+    return CATALOG + "." + SCHEMA + "." + TABLE;
+  }
+
+  private static void assertTableNotFound(Runnable action) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BaseException.class)
+        .extracting(error -> ((BaseException) error).getErrorCode())
+        .isEqualTo(ErrorCode.TABLE_NOT_FOUND);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -362,18 +362,19 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaCommits(
         /* expectedLatestTableVersion= */ 5, /* expectedCommits= */ commit5);
 
-    // Verify commits are cleaned up upon table deletion
+    UUID tableId = UUID.fromString(tableInfo.getTableId());
+    int commitCountBeforeDrop = getCommitDAOs(tableId).size();
+    assertThat(commitCountBeforeDrop).isEqualTo(2);
+
+    // A logical drop hides the table but retains its commits so the table can be restored.
     tableOperations.deleteTable(TestUtils.TABLE_FULL_NAME);
-    // Verify the uc_delta_commits table is cleaned up. This has to be done by checking the DAOs
-    // because the getCommit api call would fail with NOT_FOUND once the table is gone.
     assertApiException(
         () ->
             getAllCommits(
                 tableInfo.getTableId(), tableInfo.getStorageLocation(), 0L, Optional.empty()),
         ErrorCode.NOT_FOUND,
         "Table not found");
-    List<DeltaCommitDAO> commitDAOs = getCommitDAOs(UUID.fromString(tableInfo.getTableId()));
-    assertThat(commitDAOs.size()).isEqualTo(0);
+    assertThat(getCommitDAOs(tableId).size()).isEqualTo(commitCountBeforeDrop);
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -207,6 +207,15 @@ public class ServerPropertiesTest {
   }
 
   @Test
+  public void testManagedTableLifecycleValidators() {
+    testValidProperty(Property.MANAGED_TABLE_RETENTION_DURATION, "PT0S");
+    testValidProperty(Property.MANAGED_TABLE_RETENTION_DURATION, "PT24H");
+
+    testInvalidProperty(
+        Property.MANAGED_TABLE_RETENTION_DURATION, "-PT1S", "Expected a duration between");
+  }
+
+  @Test
   public void testEffectiveCookieTimeout() {
     ServerProperties serverProperties = new ServerProperties();
     assertThat(serverProperties.getEffectiveCookieTimeout()).isEqualTo(Duration.parse("PT24H"));


### PR DESCRIPTION
## What changed

- Add `deleted_at` and `purge_after` lifecycle metadata to tables.
- Make managed-table `DROP TABLE` tombstone metadata and return immediately.
- Hide tombstoned tables from lookup, listing, Delta reads, and temporary credentials while reserving their names.
- Add a row-locked repository restore operation for the retention window.

## Why

Dropping a managed table should not wait for physical storage deletion. A tombstone also gives the lifecycle a reversible retention phase before cleanup becomes final.

## Stack

1 of 7. Base: `unitycatalog/unitycatalog:main`.

1. **Soft delete semantics** (this PR)
2. [Atomic cleanup handoff](https://github.com/timothyw553/unitycatalog/pull/6)
3. [Cleanup task leases](https://github.com/timothyw553/unitycatalog/pull/7)
4. [Lifecycle storage guards](https://github.com/timothyw553/unitycatalog/pull/8)
5. [Bounded multi-cloud deletion](https://github.com/timothyw553/unitycatalog/pull/10)
6. [Fair time-sliced worker](https://github.com/timothyw553/unitycatalog/pull/11)
7. [Server runtime wiring](https://github.com/timothyw553/unitycatalog/pull/9)

## Validation

- `ManagedTableSoftDeleteTest`
- `ServerPropertiesTest`
- Checkstyle and formatting
