### PR TITLE
Invalidate access tokens on logout

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -33,6 +33,7 @@ public class Repositories {
   private final ExternalLocationRepository externalLocationRepository;
   private final DeltaCommitRepository deltaCommitRepository;
   private final DependencyRepository dependencyRepository;
+  private final TokenRevocationRepository tokenRevocationRepository;
 
   private final KeyMapper keyMapper;
 
@@ -75,6 +76,7 @@ public class Repositories {
     this.deltaCommitRepository =
         new DeltaCommitRepository(sessionFactory, serverProperties, fileOperations);
     this.dependencyRepository = new DependencyRepository();
+    this.tokenRevocationRepository = new TokenRevocationRepository(this, sessionFactory);
 
     // KeyMapper uses all the repositories above.
     this.keyMapper = new KeyMapper(this);

--- a/server/src/main/java/io/unitycatalog/server/persist/TokenRevocationRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TokenRevocationRepository.java
@@ -1,5 +1,6 @@
 package io.unitycatalog.server.persist;
 
+import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.persist.dao.TokenRevocationDAO;
 import io.unitycatalog.server.persist.utils.TransactionManager;
 import java.util.Date;
@@ -32,9 +33,15 @@ public class TokenRevocationRepository {
   }
 
   /**
-   * Records a token's jti as revoked until {@code expiresAt}. Idempotent: revoking a jti that is
-   * already present just refreshes its retained expiry. This touches only the token's own row, so
-   * concurrent revocations of different sessions do not contend.
+   * Records a token's jti as revoked. A {@code null} {@code expiresAt} means the token has no
+   * expiry, so its revocation is permanent; otherwise the row is kept until {@code expiresAt}. This
+   * touches only the token's own row, so concurrent revocations of different sessions do not
+   * contend.
+   *
+   * <p>Idempotent under concurrency: if the same token is revoked twice at once, one insert wins
+   * and the other fails on the jti primary key; that is treated as success, since the token is
+   * revoked either way. The expiry is derived from the token, so both inserts carry the same value
+   * and there is nothing to reconcile.
    *
    * <p>After the revocation commits, an asynchronous, best-effort cleanup of expired rows is
    * triggered in a separate transaction. It is deliberately fire-and-forget: a failed sweep (e.g.
@@ -42,21 +49,24 @@ public class TokenRevocationRepository {
    * token and the next revocation will retry the cleanup.
    */
   public void revoke(UUID jti, Date expiresAt) {
-    TransactionManager.executeWithTransaction(
-        sessionFactory,
-        session -> {
-          TokenRevocationDAO existing = session.get(TokenRevocationDAO.class, jti);
-          if (existing == null) {
+    try {
+      TransactionManager.executeWithTransaction(
+          sessionFactory,
+          session -> {
             session.persist(TokenRevocationDAO.builder().jti(jti).expiresAt(expiresAt).build());
-          } else {
-            // existing is managed, so the updated expiry is flushed on commit.
-            existing.setExpiresAt(expiresAt);
-          }
-          LOGGER.debug("Revoked token jti={} until {}", jti, expiresAt);
-          return null;
-        },
-        "Failed to revoke token",
-        /* readOnly = */ false);
+            LOGGER.debug("Revoked token jti={} until {}", jti, expiresAt);
+            return null;
+          },
+          "Failed to revoke token",
+          /* readOnly= */ false);
+    } catch (BaseException e) {
+      // A concurrent logout of the same token can insert the row first, failing this transaction on
+      // the jti primary key. The token is revoked either way, so ignore the failure once the row is
+      // present, and rethrow anything else.
+      if (!isRevoked(jti)) {
+        throw e;
+      }
+    }
 
     CompletableFuture.runAsync(this::deleteExpiredQuietly);
   }
@@ -79,7 +89,7 @@ public class TokenRevocationRepository {
           return purge.executeUpdate();
         },
         "Failed to delete expired token revocations",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   private void deleteExpiredQuietly() {
@@ -97,5 +107,13 @@ public class TokenRevocationRepository {
    */
   public boolean isRevoked(Session session, UUID jti) {
     return session.get(TokenRevocationDAO.class, jti) != null;
+  }
+
+  private boolean isRevoked(UUID jti) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> isRevoked(session, jti),
+        "Failed to check token revocation",
+        /* readOnly= */ true);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/TokenRevocationRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TokenRevocationRepository.java
@@ -1,0 +1,101 @@
+package io.unitycatalog.server.persist;
+
+import io.unitycatalog.server.persist.dao.TokenRevocationDAO;
+import io.unitycatalog.server.persist.utils.TransactionManager;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.MutationQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks the JWT IDs (jti) of access tokens that have been revoked by logout.
+ *
+ * <p>The denylist is stored in the database and {@link #isRevoked} is consulted directly on the
+ * authenticated request path, so a revoked token is rejected on its next request and there is no
+ * in-memory cache to keep in sync. The per-request cost is a single primary-key lookup on a small
+ * table, on the same connection the request already uses for its user lookup.
+ *
+ * <p>The table is kept bounded by removing rows once their retained expiry has passed. That cleanup
+ * runs off the revocation path (see {@link #revoke}) so a table-wide delete never contends with, or
+ * delays, the single-row revocation write.
+ */
+public class TokenRevocationRepository {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenRevocationRepository.class);
+  private final SessionFactory sessionFactory;
+
+  public TokenRevocationRepository(Repositories repositories, SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
+  }
+
+  /**
+   * Records a token's jti as revoked until {@code expiresAt}. Idempotent: revoking a jti that is
+   * already present just refreshes its retained expiry. This touches only the token's own row, so
+   * concurrent revocations of different sessions do not contend.
+   *
+   * <p>After the revocation commits, an asynchronous, best-effort cleanup of expired rows is
+   * triggered in a separate transaction. It is deliberately fire-and-forget: a failed sweep (e.g.
+   * lock contention with another sweep) is harmless, since an expired row can never match a live
+   * token and the next revocation will retry the cleanup.
+   */
+  public void revoke(UUID jti, Date expiresAt) {
+    TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          TokenRevocationDAO existing = session.get(TokenRevocationDAO.class, jti);
+          if (existing == null) {
+            session.persist(TokenRevocationDAO.builder().jti(jti).expiresAt(expiresAt).build());
+          } else {
+            // existing is managed, so the updated expiry is flushed on commit.
+            existing.setExpiresAt(expiresAt);
+          }
+          LOGGER.debug("Revoked token jti={} until {}", jti, expiresAt);
+          return null;
+        },
+        "Failed to revoke token",
+        /* readOnly = */ false);
+
+    CompletableFuture.runAsync(this::deleteExpiredQuietly);
+  }
+
+  /**
+   * Removes revocation rows whose retained expiry has passed, in its own transaction. Returns the
+   * number of rows deleted. An expired token is already rejected by expiration checking, so its
+   * denylist row is only taking up space by the time this removes it.
+   *
+   * <p>Public for testing; callers should rely on the automatic cleanup triggered by {@link
+   * #revoke}.
+   */
+  public int deleteExpired() {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          MutationQuery purge =
+              session.createMutationQuery("DELETE FROM TokenRevocationDAO WHERE expiresAt < :now");
+          purge.setParameter("now", new Date());
+          return purge.executeUpdate();
+        },
+        "Failed to delete expired token revocations",
+        /* readOnly = */ false);
+  }
+
+  private void deleteExpiredQuietly() {
+    try {
+      deleteExpired();
+    } catch (Exception e) {
+      LOGGER.debug("Best-effort cleanup of expired token revocations failed", e);
+    }
+  }
+
+  /**
+   * Returns whether the given jti has been revoked. Session-scoped so it can share the caller's
+   * transaction (the authenticated request path checks this alongside the user lookup in one
+   * transaction). It is a single primary-key lookup, as it runs on every request.
+   */
+  public boolean isRevoked(Session session, UUID jti) {
+    return session.get(TokenRevocationDAO.class, jti) != null;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TokenRevocationDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TokenRevocationDAO.java
@@ -1,0 +1,49 @@
+package io.unitycatalog.server.persist.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.util.Date;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * A revoked access token, keyed by its JWT ID (jti). A row is written when a session is logged out,
+ * and is consulted on every authenticated request so the token is no longer accepted. Storing the
+ * denylist in the database means a revoked token is rejected on its next request without relying on
+ * any in-memory state.
+ *
+ * <p>Rows are retained only until {@link #expiresAt}: once a token would expire on its own there is
+ * nothing left to revoke, so expired rows are purged once their expiry has passed. The table
+ * therefore stays bounded by the number of not-yet-expired revocations.
+ */
+@Entity
+@Table(
+    name = "uc_token_revocations",
+    // Index the expiry so the periodic cleanup delete is a range scan rather than a full scan.
+    indexes = {@Index(name = "idx_token_revocations_expires_at", columnList = "expires_at")})
+// Lombok annotations
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class TokenRevocationDAO {
+  // jti is the token's JWT ID. This server always mints it as a random UUID, and the denylist only
+  // ever holds tokens it issued, so it is stored as a native UUID (compact primary key, consistent
+  // with other DAO ids).
+  @Id
+  @Column(name = "jti")
+  private UUID jti;
+
+  @Column(name = "expires_at", nullable = false)
+  private Date expiresAt;
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TokenRevocationDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TokenRevocationDAO.java
@@ -21,8 +21,9 @@ import lombok.Setter;
  * any in-memory state.
  *
  * <p>Rows are retained only until {@link #expiresAt}: once a token would expire on its own there is
- * nothing left to revoke, so expired rows are purged once their expiry has passed. The table
- * therefore stays bounded by the number of not-yet-expired revocations.
+ * nothing left to revoke, so expired rows are purged once their expiry has passed. A {@code null}
+ * expiry marks a token that never expires, so its revocation is permanent and the row is kept
+ * indefinitely. The table therefore stays bounded by the number of not-yet-expired revocations.
  */
 @Entity
 @Table(
@@ -44,6 +45,8 @@ public class TokenRevocationDAO {
   @Column(name = "jti")
   private UUID jti;
 
-  @Column(name = "expires_at", nullable = false)
+  // When null, the revoked token has no expiry, so the revocation is permanent: the cleanup delete
+  // (expires_at < now) never matches a null row, so it is kept indefinitely.
+  @Column(name = "expires_at")
   private Date expiresAt;
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -15,6 +15,7 @@ import io.unitycatalog.server.persist.dao.RegisteredModelInfoDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.dao.TokenRevocationDAO;
 import io.unitycatalog.server.persist.dao.UserDAO;
 import io.unitycatalog.server.persist.dao.VolumeInfoDAO;
 import io.unitycatalog.server.utils.ServerProperties;
@@ -81,6 +82,7 @@ public class HibernateConfigurator {
       configuration.addAnnotatedClass(ExternalLocationDAO.class);
       configuration.addAnnotatedClass(DeltaCommitDAO.class);
       configuration.addAnnotatedClass(DependencyDAO.class);
+      configuration.addAnnotatedClass(TokenRevocationDAO.class);
 
       ServiceRegistry serviceRegistry =
           new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();

--- a/server/src/main/java/io/unitycatalog/server/service/AuthDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthDecorator.java
@@ -17,9 +17,14 @@ import io.unitycatalog.control.model.User;
 import io.unitycatalog.server.exception.AuthorizationException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.TokenRevocationRepository;
 import io.unitycatalog.server.persist.UserRepository;
+import io.unitycatalog.server.persist.dao.UserDAO;
+import io.unitycatalog.server.persist.utils.TransactionManager;
 import io.unitycatalog.server.security.SecurityContext;
 import io.unitycatalog.server.utils.JwksOperations;
+import java.util.UUID;
+import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +43,8 @@ public class AuthDecorator implements DecoratingHttpServiceFunction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthDecorator.class);
   private final UserRepository userRepository;
+  private final TokenRevocationRepository tokenRevocationRepository;
+  private final SessionFactory sessionFactory;
 
   public static final String UC_TOKEN_KEY = "UC_TOKEN";
 
@@ -51,6 +58,8 @@ public class AuthDecorator implements DecoratingHttpServiceFunction {
   public AuthDecorator(SecurityContext securityContext, Repositories repositories) {
     this.jwksOperations = new JwksOperations(securityContext);
     this.userRepository = repositories.getUserRepository();
+    this.tokenRevocationRepository = repositories.getTokenRevocationRepository();
+    this.sessionFactory = repositories.getSessionFactory();
   }
 
   @Override
@@ -81,24 +90,42 @@ public class AuthDecorator implements DecoratingHttpServiceFunction {
 
     // Internal tokens don't need audience validation
     JWTVerifier jwtVerifier = jwksOperations.verifierForIssuerAndKey(issuer, keyId, alg);
-    decodedJWT = jwtVerifier.verify(decodedJWT);
+    DecodedJWT verifiedJWT = jwtVerifier.verify(decodedJWT);
 
-    String subject = decodedJWT.getSubject();
+    String subject = verifiedJWT.getSubject();
+    // Tokens this server issues always carry a UUID jti; an absent or non-UUID jti fails here
+    // (acceptable, since only issued tokens are revoked).
+    UUID jti = UUID.fromString(verifiedJWT.getId());
 
-    User user;
-    try {
-      user = userRepository.getUserByEmail(subject);
-    } catch (Exception e) {
-      LOGGER.debug("User not found: {}", subject);
-      user = null;
+    // Check token revocation and look up the user in a single transaction. This runs on every
+    // authenticated request, so sharing one session keeps the auth path to a single connection
+    // checkout. Expired tokens are already rejected by the verifier above, so only live tokens
+    // reach the revocation check; a revoked token (e.g. from logout) is denied before the lookup.
+    UserDAO userDAO =
+        TransactionManager.executeWithTransaction(
+            sessionFactory,
+            session -> {
+              if (tokenRevocationRepository.isRevoked(session, jti)) {
+                throw new AuthorizationException(
+                    ErrorCode.PERMISSION_DENIED, "Access token has been revoked.");
+              }
+              return userRepository.getUserByEmail(session, subject);
+            },
+            "Failed to authorize request",
+            /* readOnly = */ true);
+
+    if (userDAO == null) {
+      throw new AuthorizationException(
+          ErrorCode.PERMISSION_DENIED, "User does not exist: " + subject);
     }
-    if (user == null || user.getState() != User.StateEnum.ENABLED) {
+    User user = userDAO.toUser();
+    if (user.getState() != User.StateEnum.ENABLED) {
       throw new AuthorizationException(ErrorCode.PERMISSION_DENIED, "User not allowed: " + subject);
     }
 
     LOGGER.debug("Access allowed for subject: {}", subject);
 
-    ctx.setAttr(DECODED_JWT_ATTR, decodedJWT);
+    ctx.setAttr(DECODED_JWT_ATTR, verifiedJWT);
 
     return delegate.serve(ctx, req);
   }

--- a/server/src/main/java/io/unitycatalog/server/service/AuthDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthDecorator.java
@@ -112,7 +112,7 @@ public class AuthDecorator implements DecoratingHttpServiceFunction {
               return userRepository.getUserByEmail(session, subject);
             },
             "Failed to authorize request",
-            /* readOnly = */ true);
+            /* readOnly= */ true);
 
     if (userDAO == null) {
       throw new AuthorizationException(

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -46,8 +46,6 @@ import io.unitycatalog.server.utils.ServerProperties;
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -226,13 +224,10 @@ public class AuthService implements RegisteredService {
         && JwtTokenType.ACCESS
             .name()
             .equals(decodedJWT.getClaim(JwtClaim.TOKEN_TYPE.key()).asString())) {
-      // Retain the denylist entry until the token would have expired anyway. Access tokens always
-      // carry an exp; fall back to the configured access-token lifetime if one is somehow absent.
-      Date expiresAt =
-          decodedJWT.getExpiresAt() != null
-              ? decodedJWT.getExpiresAt()
-              : Date.from(Instant.now().plus(serverProperties.getAccessTokenTimeout()));
-      tokenRevocationRepository.revoke(UUID.fromString(decodedJWT.getId()), expiresAt);
+      // Retain the denylist entry until the token would have expired anyway. A null exp means the
+      // token never expires, so revoke it permanently (the repository keeps a null-expiry row).
+      tokenRevocationRepository.revoke(
+          UUID.fromString(decodedJWT.getId()), decodedJWT.getExpiresAt());
     }
 
     return request.headers().cookies().stream()

--- a/server/src/main/java/io/unitycatalog/server/service/AuthService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthService.java
@@ -36,16 +36,21 @@ import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.GlobalExceptionHandler;
 import io.unitycatalog.server.exception.OAuthInvalidRequestException;
 import io.unitycatalog.server.persist.Repositories;
+import io.unitycatalog.server.persist.TokenRevocationRepository;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.security.JwtClaim;
+import io.unitycatalog.server.security.JwtTokenType;
 import io.unitycatalog.server.security.SecurityContext;
 import io.unitycatalog.server.utils.JwksOperations;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +63,7 @@ public class AuthService implements RegisteredService {
   private final SecurityContext securityContext;
   private final JwksOperations jwksOperations;
   private final ServerProperties serverProperties;
+  private final TokenRevocationRepository tokenRevocationRepository;
 
   private static final String EMPTY_RESPONSE = "{}";
 
@@ -74,6 +80,7 @@ public class AuthService implements RegisteredService {
     this.jwksOperations = new JwksOperations(securityContext);
     this.serverProperties = serverProperties;
     this.userRepository = repositories.getUserRepository();
+    this.tokenRevocationRepository = repositories.getTokenRevocationRepository();
   }
 
   /**
@@ -209,7 +216,25 @@ public class AuthService implements RegisteredService {
 
   @Post("/logout")
   @AuthorizeExpression("#principal != null")
-  public HttpResponse logout(HttpRequest request) {
+  public HttpResponse logout(ServiceRequestContext ctx, HttpRequest request) {
+    // Revoke the presented access token so it cannot be reused after logout. The auth decorator has
+    // already verified this token and stored the decoded form on the request context. Only ACCESS
+    // tokens represent a login session; the server's SERVICE token (the admin bootstrap credential
+    // in token.txt) is not a session and is shared across callers, so logout leaves it untouched.
+    DecodedJWT decodedJWT = ctx.attr(AuthDecorator.DECODED_JWT_ATTR);
+    if (decodedJWT != null
+        && JwtTokenType.ACCESS
+            .name()
+            .equals(decodedJWT.getClaim(JwtClaim.TOKEN_TYPE.key()).asString())) {
+      // Retain the denylist entry until the token would have expired anyway. Access tokens always
+      // carry an exp; fall back to the configured access-token lifetime if one is somehow absent.
+      Date expiresAt =
+          decodedJWT.getExpiresAt() != null
+              ? decodedJWT.getExpiresAt()
+              : Date.from(Instant.now().plus(serverProperties.getAccessTokenTimeout()));
+      tokenRevocationRepository.revoke(UUID.fromString(decodedJWT.getId()), expiresAt);
+    }
+
     return request.headers().cookies().stream()
         .filter(c -> c.name().equals(AuthDecorator.UC_TOKEN_KEY))
         .findFirst()

--- a/server/src/test/java/io/unitycatalog/server/persist/TokenRevocationRepositoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/TokenRevocationRepositoryTest.java
@@ -1,0 +1,85 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Properties;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TokenRevocationRepositoryTest {
+
+  private static SessionFactory sessionFactory;
+  private static TokenRevocationRepository repository;
+
+  @BeforeAll
+  public static void setUp() {
+    // Use a dedicated in-memory database so the test is hermetic and does not touch the on-disk
+    // dev database referenced by etc/conf/hibernate.properties.
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:token_revocation_test;DB_CLOSE_DELAY=-1");
+    properties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+    sessionFactory = new HibernateConfigurator(properties).getSessionFactory();
+    repository = new TokenRevocationRepository(null, sessionFactory);
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    sessionFactory.close();
+  }
+
+  private boolean isRevoked(UUID jti) {
+    try (Session session = sessionFactory.openSession()) {
+      return repository.isRevoked(session, jti);
+    }
+  }
+
+  @Test
+  public void testRevokeThenIsRevoked() {
+    UUID jti = UUID.randomUUID();
+    assertThat(isRevoked(jti)).isFalse();
+
+    repository.revoke(jti, hoursFromNow(1));
+
+    assertThat(isRevoked(jti)).isTrue();
+  }
+
+  @Test
+  public void testRevokeIsIdempotent() {
+    UUID jti = UUID.randomUUID();
+    repository.revoke(jti, hoursFromNow(1));
+    // Revoking the same jti again refreshes the expiry rather than failing on the duplicate key.
+    repository.revoke(jti, hoursFromNow(2));
+
+    assertThat(isRevoked(jti)).isTrue();
+  }
+
+  @Test
+  public void testDeleteExpiredRemovesOnlyExpiredEntries() {
+    UUID expired = UUID.randomUUID();
+    UUID live = UUID.randomUUID();
+    repository.revoke(expired, hoursFromNow(-1));
+    repository.revoke(live, hoursFromNow(1));
+
+    // Call cleanup explicitly rather than assert on its return count: revoke() also fires an
+    // asynchronous best-effort cleanup, which may already have removed the expired row. Only the
+    // resulting state is deterministic.
+    repository.deleteExpired();
+
+    assertThat(isRevoked(expired)).isFalse();
+    assertThat(isRevoked(live)).isTrue();
+  }
+
+  private static Date hoursFromNow(long hours) {
+    return Date.from(Instant.now().plus(Duration.ofHours(hours)));
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/TokenRevocationRepositoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/TokenRevocationRepositoryTest.java
@@ -57,8 +57,20 @@ public class TokenRevocationRepositoryTest {
   public void testRevokeIsIdempotent() {
     UUID jti = UUID.randomUUID();
     repository.revoke(jti, hoursFromNow(1));
-    // Revoking the same jti again refreshes the expiry rather than failing on the duplicate key.
+    // Revoking the same jti again is a no-op rather than failing on the duplicate primary key.
     repository.revoke(jti, hoursFromNow(2));
+
+    assertThat(isRevoked(jti)).isTrue();
+  }
+
+  @Test
+  public void testPermanentRevocationSurvivesCleanup() {
+    // A null expiry means the token never expires, so its revocation is permanent and cleanup must
+    // not remove it.
+    UUID jti = UUID.randomUUID();
+    repository.revoke(jti, null);
+
+    repository.deleteExpired();
 
     assertThat(isRevoked(jti)).isTrue();
   }

--- a/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/AuthServiceTest.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.UUID;
@@ -74,6 +75,33 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
     assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
   }
 
+  @Test
+  public void testLogoutRevokesAccessTokenButNotServiceToken() {
+    // Logout revokes the presented ACCESS token: the first request (which logs out) is accepted,
+    // and the same token is then rejected on any further request.
+    String accessToken = createAccessToken();
+    assertThat(logout(accessToken).status())
+        .as("access token before logout")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(logout(accessToken).status())
+        .as("access token after logout")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    // SERVICE tokens are long-lived machine credentials, not login sessions: logout must leave them
+    // usable so it cannot brick the shipped admin credential.
+    String serviceToken = securityContext.getServiceToken();
+    assertThat(logout(serviceToken).status())
+        .as("service token before logout")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(logout(serviceToken).status())
+        .as("service token after logout")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  private AggregatedHttpResponse logout(String token) {
+    return client.execute(buildLogoutRequestHeaderWithToken(token)).aggregate().join();
+  }
+
   private RequestHeaders buildLogoutRequestHeader(boolean includeCookie) {
     RequestHeadersBuilder builder =
         RequestHeaders.builder()
@@ -97,10 +125,17 @@ public class AuthServiceTest extends BaseAuthCRUDTest {
         .build();
   }
 
-  private String createExpiredAccessToken() {
-    Date issuedAt = new Date(System.currentTimeMillis() - Duration.ofHours(2).toMillis());
-    Date expiresAt = new Date(System.currentTimeMillis() - Duration.ofHours(1).toMillis());
+  private String createAccessToken() {
+    return signedAccessToken(new Date(), Date.from(Instant.now().plus(Duration.ofHours(1))));
+  }
 
+  private String createExpiredAccessToken() {
+    return signedAccessToken(
+        Date.from(Instant.now().minus(Duration.ofHours(2))),
+        Date.from(Instant.now().minus(Duration.ofHours(1))));
+  }
+
+  private String signedAccessToken(Date issuedAt, Date expiresAt) {
     return JWT.create()
         .withSubject(securityContext.getServiceName())
         .withIssuer(INTERNAL)


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Add `TokenRevocationDAO` (`uc_token_revocations` table, keyed by token `jti`) and `TokenRevocationRepository` to record revoked tokens in the database, with an index on `expires_at` and best-effort asynchronous cleanup of expired rows.
- On `/logout`, revoke the presented `ACCESS` token's `jti` until its `exp`; `SERVICE` tokens are left untouched since they are not login sessions.
- In `AuthDecorator`, reject a revoked `jti` after signature/expiry verification, checked in the same transaction as the user lookup.
- Register `TokenRevocationDAO` in `HibernateConfigurator` and wire `TokenRevocationRepository` into `Repositories`.
- Add `TokenRevocationRepositoryTest` and extend `AuthServiceTest` to cover `ACCESS` token revocation and the `SERVICE` token no-op.