### PR TITLE
Update docs for 0.6.0 release and Apache Spark 4.2 support

### DIFF
--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -58,7 +58,7 @@ Spark version:
     ```sh
     ./bin/spark-sql \
       --packages \
-        io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0 \
+        io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0 \
       --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
       --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
       --conf spark.sql.catalog.puppygraph=io.unitycatalog.spark.UCSingleCatalog \
@@ -70,7 +70,19 @@ Spark version:
     ```sh
     ./bin/spark-sql \
       --packages \
-        io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0 \
+        io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0 \
+      --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
+      --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
+      --conf spark.sql.catalog.puppygraph=io.unitycatalog.spark.UCSingleCatalog \
+      --conf spark.sql.catalog.puppygraph.uri=http://localhost:8080
+    ```
+
+=== "Spark 4.2.x"
+
+    ```sh
+    ./bin/spark-sql \
+      --packages \
+        io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0 \
       --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
       --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
       --conf spark.sql.catalog.puppygraph=io.unitycatalog.spark.UCSingleCatalog \

--- a/docs/integrations/unity-catalog-puppygraph.md
+++ b/docs/integrations/unity-catalog-puppygraph.md
@@ -25,6 +25,12 @@ Run one of the following from the cloned repository root directory, depending on
     build/sbt -DsparkVersion=4.1 clean package publishLocal spark/publishLocal
     ```
 
+=== "Spark 4.2.x"
+
+    ```sh
+    build/sbt -DsparkVersion=4.2 clean package publishLocal spark/publishLocal
+    ```
+
 ## Run the Unity Catalog Server
 
 Run the command to start a Unity Server.

--- a/docs/integrations/unity-catalog-spark.md
+++ b/docs/integrations/unity-catalog-spark.md
@@ -17,8 +17,8 @@ data stored in Unity Catalog through a controlled mechanism.
 - Provides easy access to different file formats without end users needing to know how the data is stored.
 
 !!! warning "Prerequisites"
-    For Apache Spark and Delta Lake to work together with Unity Catalog, use **Apache Spark 4.0.x or 4.1.x**,
-    **Delta Lake 4.3.1 or later**, and **Unity Catalog 0.5.0 or later**.
+    For Apache Spark and Delta Lake to work together with Unity Catalog, use **Apache Spark 4.0.x, 4.1.x, or 4.2.x**,
+    **Delta Lake 4.4.0 or later**, and **Unity Catalog 0.6.0 or later**.
 
     Starting with Unity Catalog 0.5.0, the Spark connector is published as separate Maven artifacts per Spark
     minor version. Pick the artifact that matches your Spark installation:
@@ -27,11 +27,14 @@ data stored in Unity Catalog through a controlled mechanism.
     | --- | --- | --- |
     | Apache Spark 4.0.x | `io.unitycatalog:unitycatalog-spark_4.0_2.13` | `io.delta:delta-spark_4.0_2.13` |
     | Apache Spark 4.1.x | `io.unitycatalog:unitycatalog-spark_4.1_2.13` | `io.delta:delta-spark_4.1_2.13` |
+    | Apache Spark 4.2.x | `io.unitycatalog:unitycatalog-spark_4.2_2.13` | `io.delta:delta-spark_4.2_2.13` |
 
-!!! tip "Metric views"
-    On Apache Spark 4.2 and later, the connector also supports Unity Catalog **metric views** —
-    reusable dimensions and measures defined over a source table or SQL query. See
-    [Metric Views](../usage/metric-views.md).
+    The Spark 4.2.x connector artifact is new in Unity Catalog 0.6.0.
+
+!!! tip "SQL views and metric views"
+    On Apache Spark 4.2 and later, the connector also supports Unity Catalog **SQL views** and
+    **metric views** — the latter being reusable dimensions and measures defined over a source table
+    or SQL query. See [Metric Views](../usage/metric-views.md).
 
 ## Download and Configure Unity Catalog for Apache Spark
 
@@ -39,7 +42,7 @@ The following steps are required to download and configure Unity Catalog for Apa
 
 ### Download Apache Spark
 
-[Download](https://spark.apache.org/downloads.html) Apache Spark 4.0.x or 4.1.x, or use one of the following commands.
+[Download](https://spark.apache.org/downloads.html) Apache Spark 4.0.x, 4.1.x, or 4.2.x, or use one of the following commands.
 
 === "Spark 4.0.x"
 
@@ -53,6 +56,13 @@ The following steps are required to download and configure Unity Catalog for Apa
     ```sh title="Download Apache Spark 4.1.0 using curl"
     curl -O https://archive.apache.org/dist/spark/spark-4.1.0/spark-4.1.0-bin-hadoop3.tgz
     tar xzf spark-4.1.0-bin-hadoop3.tgz
+    ```
+
+=== "Spark 4.2.x"
+
+    ```sh title="Download Apache Spark 4.2.0 using curl"
+    curl -O https://archive.apache.org/dist/spark/spark-4.2.0/spark-4.2.0-bin-hadoop3.tgz
+    tar xzf spark-4.2.0-bin-hadoop3.tgz
     ```
 
 ### [Optional] Configure server properties for cloud storage
@@ -117,7 +127,7 @@ You can run the code below to work with data stored in a Unity Catalog server. T
 
     bin/spark-sql --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -135,7 +145,7 @@ You can run the code below to work with data stored in a Unity Catalog server. T
 
     bin/pyspark --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -153,7 +163,7 @@ You can run the code below to work with data stored in a Unity Catalog server. T
 
     bin/spark-sql --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -171,7 +181,43 @@ You can run the code below to work with data stored in a Unity Catalog server. T
 
     bin/pyspark --name "local-uc-test" \
         --master "local[*]" \
-        --packages "io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0" \
+        --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+        --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN" \
+        --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
+    ```
+
+=== "Spark SQL (Spark 4.2.x)"
+
+    ```sh
+    export CATALOG_NAME=unity
+    export UC_URI=http://localhost:8080
+    export UC_TOKEN=
+
+    bin/spark-sql --name "local-uc-test" \
+        --master "local[*]" \
+        --packages "io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
+        --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+        --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN" \
+        --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
+    ```
+
+=== "PySpark (Spark 4.2.x)"
+
+    ```sh
+    export CATALOG_NAME=unity
+    export UC_URI=http://localhost:8080
+    export UC_TOKEN=
+
+    bin/pyspark --name "local-uc-test" \
+        --master "local[*]" \
+        --packages "io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -186,8 +232,8 @@ You can run the code below to work with data stored in a Unity Catalog server. T
 
 Notice the following packages (`--packages`) and configurations (`--conf`)
 
-- `--packages` points to the version-matched `delta-spark` and `unitycatalog-spark` artifacts. Use the Spark 4.0.x or
-  4.1.x coordinates from the prerequisites table above.
+- `--packages` points to the version-matched `delta-spark` and `unitycatalog-spark` artifacts. Use the Spark 4.0.x,
+  4.1.x, or 4.2.x coordinates from the prerequisites table above.
 - `spark.sql.catalog.spark_catalog` should be set to Delta's session catalog when working with Delta tables.
 - `spark.sql.catalog.<catalog_name>.uri` points to your local development UC instance.
 - `spark.sql.catalog.<catalog_name>.token` is empty when authentication is disabled; refer to [auth](../server/auth.md)
@@ -207,7 +253,7 @@ Notice the following packages (`--packages`) and configurations (`--conf`)
 
 If you would like to run this against cloud object storage, use the matching Spark and UC connector artifacts for
 your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0.x and **3.4.2** with Spark 4.1.x
-(`hadoop-azure` requires 3.4.1 or later; see [issue #1175](https://github.com/unitycatalog/unitycatalog/issues/1175)).
+and 4.2.x (`hadoop-azure` requires 3.4.1 or later; see [issue #1175](https://github.com/unitycatalog/unitycatalog/issues/1175)).
 
 === "AWS S3 (Spark 4.0.x)"
 
@@ -218,7 +264,7 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
 
     bin/spark-sql --name "s3-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-aws:3.4.1,io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+        --packages "org.apache.hadoop:hadoop-aws:3.4.1,io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem" \
@@ -237,7 +283,26 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
 
     bin/spark-sql --name "s3-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-aws:3.4.2,io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0" \
+        --packages "org.apache.hadoop:hadoop-aws:3.4.2,io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0" \
+        --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+        --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+        --conf "spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem" \
+        --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN" \
+        --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
+    ```
+
+=== "AWS S3 (Spark 4.2.x)"
+
+    ```sh
+    export CATALOG_NAME=unity
+    export UC_URI=http://localhost:8080
+    export UC_TOKEN=
+
+    bin/spark-sql --name "s3-uc-test" \
+        --master "local[*]" \
+        --packages "org.apache.hadoop:hadoop-aws:3.4.2,io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem" \
@@ -256,7 +321,7 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
 
     bin/spark-sql --name "azure-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-azure:3.4.1,io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+        --packages "org.apache.hadoop:hadoop-azure:3.4.1,io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -274,7 +339,25 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
 
     bin/spark-sql --name "azure-uc-test" \
         --master "local[*]" \
-        --packages "org.apache.hadoop:hadoop-azure:3.4.2,io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0" \
+        --packages "org.apache.hadoop:hadoop-azure:3.4.2,io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0" \
+        --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+        --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN" \
+        --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
+    ```
+
+=== "Azure ADLSgen2 (Spark 4.2.x)"
+
+    ```sh
+    export CATALOG_NAME=unity
+    export UC_URI=http://localhost:8080
+    export UC_TOKEN=
+
+    bin/spark-sql --name "azure-uc-test" \
+        --master "local[*]" \
+        --packages "org.apache.hadoop:hadoop-azure:3.4.2,io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
@@ -293,7 +376,7 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
     bin/spark-sql --name "gcs-uc-test" \
         --master "local[*]" \
         --jars "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/3.0.2/gcs-connector-3.0.2-shaded.jar" \
-        --packages "io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.0_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" \
@@ -314,7 +397,28 @@ your Spark version. Use `hadoop-aws` and `hadoop-azure` **3.4.1** with Spark 4.0
     bin/spark-sql --name "gcs-uc-test" \
         --master "local[*]" \
         --jars "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/3.0.2/gcs-connector-3.0.2-shaded.jar" \
-        --packages "io.delta:delta-spark_4.1_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.5.0" \
+        --packages "io.delta:delta-spark_4.1_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.1_2.13:0.6.0" \
+        --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+        --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+        --conf "spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" \
+        --conf "spark.hadoop.fs.AbstractFileSystem.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS" \
+        --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.uri=$UC_URI" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.token=$UC_TOKEN" \
+        --conf "spark.sql.defaultCatalog=$CATALOG_NAME"
+    ```
+
+=== "Google Cloud Storage (Spark 4.2.x)"
+
+    ```sh
+    export CATALOG_NAME=unity
+    export UC_URI=http://localhost:8080
+    export UC_TOKEN=
+
+    bin/spark-sql --name "gcs-uc-test" \
+        --master "local[*]" \
+        --jars "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/3.0.2/gcs-connector-3.0.2-shaded.jar" \
+        --packages "io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
         --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
         --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
         --conf "spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,13 +43,13 @@ should see:
 # | |__| | | | | | |_| |_| | | |___| (_| | || (_| | | (_) | (_| | #
 #  \____/|_| |_|_|\__|\__, |  \_____\__,_|\__\__,_|_|\___/ \__, | #
 #                      __/ |                                __/ | #
-#                     |___/      v0.5.0-SNAPSHOT           |___/  #
+#                     |___/      v0.7.0-SNAPSHOT           |___/  #
 ###################################################################
 ```
 
 !!! note "Server version string"
-    Released builds display `v0.5.0`. When you build from the `main` branch, the banner shows
-    `v0.5.0-SNAPSHOT`.
+    Released builds display `v0.6.0`. When you build from the `main` branch, the banner shows
+    `v0.7.0-SNAPSHOT`.
 
 Well, that was pretty easy!
 

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -360,7 +360,7 @@ export UC_TOKEN=$token
 
 bin/spark-sql --name "local-uc-test" \
     --master "local[*]" \
-    --packages "io.delta:delta-spark_4.0_2.13:4.3.1,io.unitycatalog:unitycatalog-spark_4.0_2.13:0.5.0" \
+    --packages "io.delta:delta-spark_4.2_2.13:4.4.0,io.unitycatalog:unitycatalog-spark_4.2_2.13:0.6.0" \
     --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
     --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
     --conf "spark.sql.catalog.$CATALOG_NAME=io.unitycatalog.spark.UCSingleCatalog" \

--- a/docs/usage/metric-views.md
+++ b/docs/usage/metric-views.md
@@ -44,8 +44,10 @@ bin/spark-sql --name "metric-view-test" \
     page, this command deliberately omits the `delta-spark` package and the
     `spark.sql.catalog.spark_catalog=...DeltaCatalog` conf, because the walkthrough below uses a
     parquet source table. The connector logs a benign `WARN ... DeltaCatalog is not available in
-    the classpath`, which is expected. A Delta source table is not an option on Spark 4.2
-    yet, since no `delta-spark_4.2_2.13` artifact is published.
+    the classpath`, which is expected. To use a Delta source table instead, add the
+    `io.delta:delta-spark_4.2_2.13:4.4.0` package and the
+    `spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog` conf, as shown
+    on the [Apache Spark integration](../integrations/unity-catalog-spark.md) page.
 
 ## Create a source table
 

--- a/docs/usage/metric-views.md
+++ b/docs/usage/metric-views.md
@@ -45,7 +45,8 @@ bin/spark-sql --name "metric-view-test" \
     `spark.sql.catalog.spark_catalog=...DeltaCatalog` conf, because the walkthrough below uses a
     parquet source table. The connector logs a benign `WARN ... DeltaCatalog is not available in
     the classpath`, which is expected. To use a Delta source table instead, add the
-    `io.delta:delta-spark_4.2_2.13:4.4.0` package and the
+    `io.delta:delta-spark_4.2_2.13:4.4.0` package, the
+    `spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension` conf, and the
     `spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog` conf, as shown
     on the [Apache Spark integration](../integrations/unity-catalog-spark.md) page.
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Add Apache Spark 4.2.x coverage to `docs/integrations/unity-catalog-spark.md`: prerequisites table, download tab, and local + S3/Azure/GCS run examples
- Bump connector coordinates to `unitycatalog-spark_4.x_2.13:0.6.0` and `delta-spark_4.x_2.13:4.4.0` across all Spark docs
- Note SQL views and metric views as Spark 4.2 features, and use `hadoop-aws`/`hadoop-azure` 3.4.2 for Spark 4.2.x
- Fix stale note in `docs/usage/metric-views.md`: a `delta-spark_4.2_2.13` artifact is now published in Delta 4.4.0
- Add a Spark 4.2.x tab to `docs/integrations/unity-catalog-puppygraph.md` and bump its coordinates
- Update the single Spark example in `docs/server/auth.md` to Spark 4.2 coordinates
- Bump the server banner in `docs/quickstart.md` to reflect the current version