### PR TITLE
[0.6][Docker] Add env var to provide COURSIER_CACHE location. Fixes bug with the Docker build for non root (#1759)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ FROM amazoncorretto:17-alpine3.20-jdk@sha256:c045f0537bc890f9e61924f33f35e9667f6
 ARG HOME
 ENV HOME=$HOME
 
+# The JVM derives user.home from the passwd entry (/root for uid 0) and ignores
+# HOME, so coursier would otherwise cache jars in /root/.cache, outside the tree
+# the runtime stage copies. sbt bakes absolute jar paths into
+# server/target/classpath, so this directory must resolve identically in both
+# stages or the server starts with some classpath entries missing.
+ENV COURSIER_CACHE=$HOME/.cache/coursier/v1
+
 # Corporate Maven mirror for the sbt launcher / Ivy (see build/sbt).
 # Pass at build time: --build-arg MAVEN_PROXY_URL=$MAVEN_PROXY_URL
 ARG MAVEN_PROXY_URL


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
Backport #1759

Added new env variable, set to write to the docker user's home cache dir.

```
ENV COURSIER_CACHE=$HOME/.cache/coursier/v1
```

Without the addition of the cache location variable, the result is the server starting up and exiting with code 1.

```
server-1 | Error: Unable to initialize main class io.unitycatalog.server.UnityCatalogServer
server-1 | Caused by: java.lang.NoClassDefFoundError: io/vertex/core/Verticle
server-1 exited with code 1
```

This resolves the bug I reported in
https://github.com/unitycatalog/unitycatalog/issues/1755.

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
