### PR TITLE
fix(server): negotiate protocol-versions in Delta GET /delta/v1/config

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -122,11 +122,12 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
           ErrorCode.INVALID_ARGUMENT, "Must supply a proper catalog in catalog parameter.");
     }
 
+    String protocolVersion = DeltaProtocolVersionNegotiator.negotiate(protocolVersions);
+
     // Verify catalog exists
     catalogRepository.getCatalog(catalog);
 
-    // For now, we only have 1.0 as the first protocol version. Input protocolVersions is ignored.
-    return new DeltaCatalogConfig().endpoints(ENDPOINTS).protocolVersion("1.0");
+    return new DeltaCatalogConfig().endpoints(ENDPOINTS).protocolVersion(protocolVersion);
   }
 
   // ==================== Load Table API ====================

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
@@ -1,0 +1,106 @@
+package io.unitycatalog.server.service.delta;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Protocol-version negotiation for {@code GET /delta/v1/config}.
+ *
+ * <p>The client sends {@code protocol-versions}: a comma-separated list of the highest protocol
+ * version it supports per major version (e.g. {@code "1.1,2.3"} means it supports 1.0-1.1 and
+ * 2.0-2.3). The server picks the highest version both sides support, or rejects the request with
+ * {@code INVALID_PARAMETER_VALUE} naming the versions it supports.
+ */
+final class DeltaProtocolVersionNegotiator {
+
+  /** Protocol versions this server implements, in ascending order. */
+  static final List<String> SUPPORTED_VERSIONS = List.of("1.0");
+
+  private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)");
+
+  private static final List<Version> SUPPORTED =
+      SUPPORTED_VERSIONS.stream()
+          .map(v -> Version.tryParse(v).orElseThrow(IllegalArgumentException::new))
+          .toList();
+
+  private DeltaProtocolVersionNegotiator() {}
+
+  /**
+   * Returns the highest protocol version supported by both the client and this server.
+   *
+   * @param clientProtocolVersions the raw {@code protocol-versions} query parameter
+   * @throws BaseException with {@link ErrorCode#INVALID_ARGUMENT} if the parameter is missing,
+   *     malformed, or shares no version with the server
+   */
+  static String negotiate(String clientProtocolVersions) {
+    if (clientProtocolVersions == null || clientProtocolVersions.isBlank()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Must supply the protocol-versions parameter: a comma-separated list of the highest "
+              + "protocol versions the client supports per major version (e.g. \"1.0\"). "
+              + supportedVersionsMessage());
+    }
+
+    Map<Integer, Integer> clientMaxMinorByMajor = new HashMap<>();
+    for (String token : clientProtocolVersions.split(",", -1)) {
+      Version version =
+          Version.tryParse(token.trim())
+              .orElseThrow(
+                  () ->
+                      new BaseException(
+                          ErrorCode.INVALID_ARGUMENT,
+                          String.format(
+                              "Invalid protocol-versions parameter \"%s\": entry \"%s\" is not "
+                                  + "of the form <major>.<minor>. %s",
+                              clientProtocolVersions, token.trim(), supportedVersionsMessage())));
+      clientMaxMinorByMajor.merge(version.major(), version.minor(), Math::max);
+    }
+
+    return SUPPORTED.stream()
+        .filter(v -> clientMaxMinorByMajor.getOrDefault(v.major(), -1) >= v.minor())
+        .max(Comparator.naturalOrder())
+        .map(Version::toString)
+        .orElseThrow(
+            () ->
+                new BaseException(
+                    ErrorCode.INVALID_ARGUMENT,
+                    String.format(
+                        "No mutually supported protocol version: client supports \"%s\". %s",
+                        clientProtocolVersions.trim(), supportedVersionsMessage())));
+  }
+
+  private static String supportedVersionsMessage() {
+    return "Server supports protocol versions: " + String.join(", ", SUPPORTED_VERSIONS) + ".";
+  }
+
+  private record Version(int major, int minor) implements Comparable<Version> {
+    private static final Comparator<Version> ORDER =
+        Comparator.comparingInt(Version::major).thenComparingInt(Version::minor);
+
+    static Optional<Version> tryParse(String value) {
+      Matcher matcher = VERSION_PATTERN.matcher(value);
+      if (!matcher.matches()) {
+        return Optional.empty();
+      }
+      return Optional.of(
+          new Version(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))));
+    }
+
+    @Override
+    public int compareTo(Version other) {
+      return ORDER.compare(this, other);
+    }
+
+    @Override
+    public String toString() {
+      return major + "." + minor;
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
@@ -2,11 +2,6 @@ package io.unitycatalog.server.service.delta;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,18 +12,19 @@ import java.util.regex.Pattern;
  * version it supports per major version (e.g. {@code "1.1,2.3"} means it supports 1.0-1.1 and
  * 2.0-2.3). The server picks the highest version both sides support, or rejects the request with
  * {@code INVALID_PARAMETER_VALUE} naming the versions it supports.
+ *
+ * <p>The server implements exactly one protocol version today, so negotiation reduces to: every
+ * entry is well-formed, and some entry covers {@link #CURRENT_VERSION}. If a second version is
+ * added, this class is the single place that must learn to compare minors within a major.
  */
 final class DeltaProtocolVersionNegotiator {
 
-  /** Protocol versions this server implements, in ascending order. */
-  static final List<String> SUPPORTED_VERSIONS = List.of("1.0");
+  /** The only protocol version this server implements. */
+  static final String CURRENT_VERSION = "1.0";
+
+  private static final int CURRENT_MAJOR = 1;
 
   private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)");
-
-  private static final List<Version> SUPPORTED =
-      SUPPORTED_VERSIONS.stream()
-          .map(v -> Version.tryParse(v).orElseThrow(IllegalArgumentException::new))
-          .toList();
 
   private DeltaProtocolVersionNegotiator() {}
 
@@ -48,59 +44,34 @@ final class DeltaProtocolVersionNegotiator {
               + supportedVersionsMessage());
     }
 
-    Map<Integer, Integer> clientMaxMinorByMajor = new HashMap<>();
+    boolean clientSupportsCurrentVersion = false;
     for (String token : clientProtocolVersions.split(",", -1)) {
-      Version version =
-          Version.tryParse(token.trim())
-              .orElseThrow(
-                  () ->
-                      new BaseException(
-                          ErrorCode.INVALID_ARGUMENT,
-                          String.format(
-                              "Invalid protocol-versions parameter \"%s\": entry \"%s\" is not "
-                                  + "of the form <major>.<minor>. %s",
-                              clientProtocolVersions, token.trim(), supportedVersionsMessage())));
-      clientMaxMinorByMajor.merge(version.major(), version.minor(), Math::max);
+      String entry = token.trim();
+      Matcher matcher = VERSION_PATTERN.matcher(entry);
+      if (!matcher.matches()) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            String.format(
+                "Invalid protocol-versions parameter \"%s\": entry \"%s\" is not of the form "
+                    + "<major>.<minor>. %s",
+                clientProtocolVersions, entry, supportedVersionsMessage()));
+      }
+      // The entry is the client's highest supported minor for that major, so any 1.x entry
+      // covers 1.0 (minors are non-negative).
+      clientSupportsCurrentVersion |= Integer.parseInt(matcher.group(1)) == CURRENT_MAJOR;
     }
 
-    return SUPPORTED.stream()
-        .filter(v -> clientMaxMinorByMajor.getOrDefault(v.major(), -1) >= v.minor())
-        .max(Comparator.naturalOrder())
-        .map(Version::toString)
-        .orElseThrow(
-            () ->
-                new BaseException(
-                    ErrorCode.INVALID_ARGUMENT,
-                    String.format(
-                        "No mutually supported protocol version: client supports \"%s\". %s",
-                        clientProtocolVersions.trim(), supportedVersionsMessage())));
+    if (!clientSupportsCurrentVersion) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          String.format(
+              "No mutually supported protocol version: client supports \"%s\". %s",
+              clientProtocolVersions.trim(), supportedVersionsMessage()));
+    }
+    return CURRENT_VERSION;
   }
 
   private static String supportedVersionsMessage() {
-    return "Server supports protocol versions: " + String.join(", ", SUPPORTED_VERSIONS) + ".";
-  }
-
-  private record Version(int major, int minor) implements Comparable<Version> {
-    private static final Comparator<Version> ORDER =
-        Comparator.comparingInt(Version::major).thenComparingInt(Version::minor);
-
-    static Optional<Version> tryParse(String value) {
-      Matcher matcher = VERSION_PATTERN.matcher(value);
-      if (!matcher.matches()) {
-        return Optional.empty();
-      }
-      return Optional.of(
-          new Version(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))));
-    }
-
-    @Override
-    public int compareTo(Version other) {
-      return ORDER.compare(this, other);
-    }
-
-    @Override
-    public String toString() {
-      return major + "." + minor;
-    }
+    return "Server supports protocol versions: " + CURRENT_VERSION + ".";
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiator.java
@@ -24,7 +24,8 @@ final class DeltaProtocolVersionNegotiator {
 
   private static final int CURRENT_MAJOR = 1;
 
-  private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)");
+  // Bounded digit counts keep Integer.parseInt safe; no real protocol version comes close.
+  private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d{1,4})\\.(\\d{1,5})");
 
   private DeltaProtocolVersionNegotiator() {}
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
@@ -65,4 +65,30 @@ public class SdkDeltaConfigTest extends BaseServerTest {
         DeltaErrorType.NO_SUCH_CATALOG_EXCEPTION,
         "nonexistent");
   }
+
+  @Test
+  public void testProtocolVersionNegotiation() throws Exception {
+    // A client that supports newer minors / other majors still negotiates down to 1.0.
+    DeltaCatalogConfig config = configApi.getConfig(TestUtils.CATALOG_NAME, "1.3,2.0");
+    assertThat(config.getProtocolVersion()).isEqualTo("1.0");
+    assertThat(config.getEndpoints()).isNotEmpty();
+
+    // Error: missing protocol-versions returns 400 with InvalidParameterValueException
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, ""),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "protocol-versions");
+
+    // Error: malformed protocol-versions returns 400 with InvalidParameterValueException
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, "1"),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "is not of the form <major>.<minor>");
+
+    // Error: no shared protocol version returns 400 naming the versions the server supports
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, "2.0"),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "Server supports protocol versions: 1.0");
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiatorTest.java
@@ -1,0 +1,65 @@
+package io.unitycatalog.server.service.delta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class DeltaProtocolVersionNegotiatorTest {
+
+  @ParameterizedTest(name = "client={0} -> {1}")
+  @CsvSource({
+    "1.0, 1.0",
+    // Client supports 1.0-1.5; server's 1.0 is the highest in common.
+    "1.5, 1.0",
+    // Multiple majors; only major 1 overlaps.
+    "'1.0,2.3', 1.0",
+    "'2.3,1.2', 1.0",
+    // Whitespace around entries is tolerated.
+    "' 1.0 , 2.0 ', 1.0",
+    // Duplicate majors take the highest minor.
+    "'1.0,1.7', 1.0",
+    // A non-overlapping entry alongside an overlapping one does not break negotiation.
+    "'0.9,1.0', 1.0",
+  })
+  public void negotiatesHighestMutuallySupportedVersion(String client, String expected) {
+    assertThat(DeltaProtocolVersionNegotiator.negotiate(client)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  public void rejectsMissingParameter(String client) {
+    assertInvalidArgument(client, "Must supply the protocol-versions parameter");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"1", "1.", ".0", "v1.0", "1.0.0", "abc", "1.0,", ",1.0", "1.0,,2.0", "1.x"})
+  public void rejectsMalformedEntries(String client) {
+    assertInvalidArgument(client, "is not of the form <major>.<minor>");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"2.0", "0.9", "0.0", "2.0,3.1"})
+  public void rejectsWhenNoVersionIsShared(String client) {
+    assertInvalidArgument(client, "No mutually supported protocol version");
+  }
+
+  private static void assertInvalidArgument(String client, String messageSubstring) {
+    assertThatThrownBy(() -> DeltaProtocolVersionNegotiator.negotiate(client))
+        .isInstanceOf(BaseException.class)
+        .satisfies(
+            e ->
+                assertThat(((BaseException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT))
+        .hasMessageContaining(messageSubstring)
+        // Every rejection names the versions the server supports so the client can adapt.
+        .hasMessageContaining("Server supports protocol versions: 1.0.");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaProtocolVersionNegotiatorTest.java
@@ -40,7 +40,22 @@ public class DeltaProtocolVersionNegotiatorTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {"1", "1.", ".0", "v1.0", "1.0.0", "abc", "1.0,", ",1.0", "1.0,,2.0", "1.x"})
+      strings = {
+        "1",
+        "1.",
+        ".0",
+        "v1.0",
+        "1.0.0",
+        "abc",
+        "1.0,",
+        ",1.0",
+        "1.0,,2.0",
+        "1.x",
+        // Oversized digit runs must be rejected as malformed, not overflow Integer.parseInt
+        // into a 500.
+        "99999999999999.0",
+        "1.999999999999"
+      })
   public void rejectsMalformedEntries(String client) {
     assertInvalidArgument(client, "is not of the form <major>.<minor>");
   }


### PR DESCRIPTION
## Summary

Implements protocol-version negotiation in `GET /delta/v1/config`, per `spec/protocols/ManagedTablesSpec.md` § Get Configuration and `api/delta.yaml`.

Today `DeltaApiService.getConfig` ignores the required `protocol-versions` query parameter and unconditionally answers `protocol-version: "1.0"` — a missing, malformed, or non-overlapping version list all get `200 / "1.0"`. The spec defines this endpoint as the protocol's version-negotiation bootstrap:

- `protocol-versions` is **required**: the highest version the client supports per major version (`"1.1,2.3"` = client supports 1.0–1.1 and 2.0–2.3).
- The server selects the **highest mutually supported** version.
- No overlap → `400 InvalidParameterValueException` naming the versions the server supports; the client treats that like an unsupported server and falls back to the legacy table APIs.

Behaviour after this PR:

| `protocol-versions` | Response |
|---|---|
| `1.0` / `1.3` / `1.0,2.0` / `2.3,1.2` (any list whose major-1 cap ≥ 1.0) | `200`, `protocol-version: "1.0"` |
| missing / blank | `400 INVALID_PARAMETER_VALUE` — names the parameter, its format, and the supported versions |
| malformed entry (`1`, `abc`, `1.0,`, `1.0.0`) | `400 INVALID_PARAMETER_VALUE` — names the bad entry and the supported versions |
| no overlap (`2.0`, `0.9`) | `400 INVALID_PARAMETER_VALUE` — `No mutually supported protocol version: client supports "2.0". Server supports protocol versions: 1.0.` |

Design notes:

- Negotiation lives in a small package-private `DeltaProtocolVersionNegotiator`. Since the server implements exactly one version, negotiation reduces to "every entry well-formed, some entry covers 1.0" — no version model or comparator until a second version exists, and no pre-built version→endpoints map: with one version that would be speculative structure. The class is the single place that must grow minor-comparison when `1.1` ships.
- Entries are strictly `<major>.<minor>` as in every spec example; a bare `1` is rejected rather than read as `1.0`. For a versioning handshake, an unambiguous grammar seemed preferable to leniency, and the error message tells the client exactly what was expected. Happy to relax if maintainers prefer.
- Every 400 message ends with `Server supports protocol versions: 1.0.`, which is the part of the spec that lets a client decide whether to fall back.
- Validation order: `catalog` present → `protocol-versions` negotiated → catalog exists (404). Request-shape errors are reported before the repository lookup.

**Compatibility:** no released Delta client calls `/delta/v1/config` yet (Delta Kernel's `UCTokenBasedRestClient` and UC's own connectors go straight to the `/v1/...` endpoints), and every in-repo caller already sends `"1.0"`. Tightening the parameter now means no client is ever built against the lenient behaviour before a second protocol version exists.

Fixes #1785.

## How we tested

New unit test `DeltaProtocolVersionNegotiatorTest` (24 parameterized cases: negotiation down to 1.0 across minors/majors/whitespace/duplicates, missing parameter, 10 malformed shapes, no-overlap) and a new `testProtocolVersionNegotiation` in the existing E2E `SdkDeltaConfigTest` (negotiates `1.3,2.0` → `1.0`; `""`, `1`, `2.0` → `400 INVALID_PARAMETER_VALUE` via `TestUtils.assertDeltaApiException`).

```
build/sbt "server/testOnly io.unitycatalog.server.service.delta.DeltaProtocolVersionNegotiatorTest io.unitycatalog.server.sdk.delta.SdkDeltaConfigTest io.unitycatalog.server.sdk.access.delta.DeltaConfigAccessControlTest"
[info] Passed: Total 27, Failed 0, Errors 0, Passed 27

build/sbt "server/testOnly io.unitycatalog.server.sdk.delta.* io.unitycatalog.server.service.delta.* io.unitycatalog.server.sdk.access.delta.*"
[info] Passed: Total 108, Failed 0, Errors 0, Passed 108
```
