### PR TITLE
[0.6] Make CreateTable.columns optional for metric views (#1787)

### DIFF
--- a/api/all.yaml
+++ b/api/all.yaml
@@ -1768,7 +1768,11 @@ components:
         data_source_format:
           $ref: '#/components/schemas/DataSourceFormat'
         columns:
-          description: The array of __ColumnInfo__ definitions of the table's columns.
+          description: >-
+            The array of __ColumnInfo__ definitions of the table's columns.
+            Optional for METRIC_VIEW (and other view-like types whose schema is
+            derived from view_definition); required for MANAGED and EXTERNAL
+            tables.
           type: array
           items:
             $ref: '#/components/schemas/ColumnInfo'
@@ -1793,7 +1797,6 @@ components:
         - catalog_name
         - schema_name
         - table_type
-        - columns
     StagingTableInfo:
       type: object
       properties:

--- a/clients/python/tests/test_metric_view.py
+++ b/clients/python/tests/test_metric_view.py
@@ -1,0 +1,126 @@
+import pytest
+
+from unitycatalog.client import (
+    CreateTable,
+    Dependency,
+    DependencyList,
+    TableDependency,
+    TableType,
+)
+from unitycatalog.client.exceptions import ApiException
+
+METRIC_VIEW_NAME = "uc_test_metric_view"
+METRIC_VIEW_FULL_NAME = f"unity.default.{METRIC_VIEW_NAME}"
+
+VIEW_DEFINITION = """\
+version: "0.1"
+source: unity.default.numbers
+dimensions:
+  - name: as_int
+    expr: as_int
+measures:
+  - name: row_count
+    expr: count(*)
+"""
+
+
+def _dependencies():
+    return DependencyList(
+        dependencies=[
+            Dependency(table=TableDependency(table_full_name="unity.default.numbers"))
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_metric_view_create_omits_columns(tables_api):
+    """METRIC_VIEW create must succeed when columns is omitted (schema from view_definition)."""
+    created = await tables_api.create_table(
+        CreateTable(
+            name=METRIC_VIEW_NAME,
+            catalog_name="unity",
+            schema_name="default",
+            table_type=TableType.METRIC_VIEW,
+            view_definition=VIEW_DEFINITION,
+            view_dependencies=_dependencies(),
+            comment="Python SDK metric view without columns",
+        )
+    )
+    try:
+        assert created.name == METRIC_VIEW_NAME
+        assert created.table_type == TableType.METRIC_VIEW
+        assert created.view_definition == VIEW_DEFINITION
+        assert created.storage_location is None
+        assert not created.columns
+
+        fetched = await tables_api.get_table(METRIC_VIEW_FULL_NAME)
+        assert fetched.table_type == TableType.METRIC_VIEW
+        assert fetched.view_definition == VIEW_DEFINITION
+        assert not fetched.columns
+        assert fetched.view_dependencies is not None
+        assert len(fetched.view_dependencies.dependencies) == 1
+        assert (
+            fetched.view_dependencies.dependencies[0].table.table_full_name
+            == "unity.default.numbers"
+        )
+
+        listed = await tables_api.list_tables("unity", "default")
+        assert any(
+            t.name == METRIC_VIEW_NAME and t.table_type == TableType.METRIC_VIEW
+            for t in listed.tables
+        )
+    finally:
+        await tables_api.delete_table(METRIC_VIEW_FULL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_metric_view_create_with_empty_columns(tables_api):
+    """Empty columns=[] remains a valid workaround / explicit no-schema payload."""
+    created = await tables_api.create_table(
+        CreateTable(
+            name=METRIC_VIEW_NAME,
+            catalog_name="unity",
+            schema_name="default",
+            table_type=TableType.METRIC_VIEW,
+            columns=[],
+            view_definition=VIEW_DEFINITION,
+            view_dependencies=_dependencies(),
+        )
+    )
+    try:
+        assert created.table_type == TableType.METRIC_VIEW
+        assert not created.columns
+    finally:
+        await tables_api.delete_table(METRIC_VIEW_FULL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_metric_view_create_requires_view_definition(tables_api):
+    with pytest.raises(ApiException) as exc_info:
+        await tables_api.create_table(
+            CreateTable(
+                name=METRIC_VIEW_NAME,
+                catalog_name="unity",
+                schema_name="default",
+                table_type=TableType.METRIC_VIEW,
+                view_dependencies=_dependencies(),
+            )
+        )
+    assert exc_info.value.status == 400
+    assert "view_definition is required for metric view" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_metric_view_create_requires_view_dependencies(tables_api):
+    with pytest.raises(ApiException) as exc_info:
+        await tables_api.create_table(
+            CreateTable(
+                name=METRIC_VIEW_NAME,
+                catalog_name="unity",
+                schema_name="default",
+                table_type=TableType.METRIC_VIEW,
+                view_definition=VIEW_DEFINITION,
+            )
+        )
+    assert exc_info.value.status == 400
+    assert "view_dependencies must contain at least one entry" in str(exc_info.value)

--- a/clients/python/tests/test_view.py
+++ b/clients/python/tests/test_view.py
@@ -1,0 +1,114 @@
+import pytest
+
+from unitycatalog.client import (
+    CreateTable,
+    Dependency,
+    DependencyList,
+    TableDependency,
+    TableType,
+)
+from unitycatalog.client.exceptions import ApiException
+
+VIEW_NAME = "uc_test_view"
+VIEW_FULL_NAME = f"unity.default.{VIEW_NAME}"
+
+VIEW_DEFINITION = "SELECT as_int FROM unity.default.numbers"
+
+
+def _dependencies():
+    return DependencyList(
+        dependencies=[
+            Dependency(table=TableDependency(table_full_name="unity.default.numbers"))
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_view_create_omits_columns(tables_api):
+    """VIEW create must succeed when columns is omitted (schema from view_definition)."""
+    created = await tables_api.create_table(
+        CreateTable(
+            name=VIEW_NAME,
+            catalog_name="unity",
+            schema_name="default",
+            table_type=TableType.VIEW,
+            view_definition=VIEW_DEFINITION,
+            view_dependencies=_dependencies(),
+            comment="Python SDK view without columns",
+        )
+    )
+    try:
+        assert created.name == VIEW_NAME
+        assert created.table_type == TableType.VIEW
+        assert created.view_definition == VIEW_DEFINITION
+        assert created.storage_location is None
+        assert not created.columns
+
+        fetched = await tables_api.get_table(VIEW_FULL_NAME)
+        assert fetched.table_type == TableType.VIEW
+        assert fetched.view_definition == VIEW_DEFINITION
+        assert not fetched.columns
+
+        listed = await tables_api.list_tables("unity", "default")
+        assert any(
+            t.name == VIEW_NAME and t.table_type == TableType.VIEW
+            for t in listed.tables
+        )
+    finally:
+        await tables_api.delete_table(VIEW_FULL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_view_create_with_empty_columns(tables_api):
+    """Empty columns=[] remains a valid workaround / explicit no-schema payload."""
+    created = await tables_api.create_table(
+        CreateTable(
+            name=VIEW_NAME,
+            catalog_name="unity",
+            schema_name="default",
+            table_type=TableType.VIEW,
+            columns=[],
+            view_definition=VIEW_DEFINITION,
+            view_dependencies=_dependencies(),
+        )
+    )
+    try:
+        assert created.table_type == TableType.VIEW
+        assert not created.columns
+    finally:
+        await tables_api.delete_table(VIEW_FULL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_view_create_omits_columns_and_dependencies(tables_api):
+    """view_dependencies is optional for a plain view; create still succeeds without columns."""
+    created = await tables_api.create_table(
+        CreateTable(
+            name=VIEW_NAME,
+            catalog_name="unity",
+            schema_name="default",
+            table_type=TableType.VIEW,
+            view_definition=VIEW_DEFINITION,
+        )
+    )
+    try:
+        assert created.table_type == TableType.VIEW
+        assert not created.columns
+    finally:
+        await tables_api.delete_table(VIEW_FULL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_view_create_requires_view_definition(tables_api):
+    with pytest.raises(ApiException) as exc_info:
+        await tables_api.create_table(
+            CreateTable(
+                name=VIEW_NAME,
+                catalog_name="unity",
+                schema_name="default",
+                table_type=TableType.VIEW,
+                view_dependencies=_dependencies(),
+            )
+        )
+    assert exc_info.value.status == 400
+    assert "view_definition is required for view" in str(exc_info.value)

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -622,8 +622,9 @@ public class TableRepository {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
     DataSourceFormat format = createTable.getDataSourceFormat();
+    // columns is optional for METRIC_VIEW / view-like types (schema comes from view_definition).
     List<ColumnInfo> columnInfos =
-        createTable.getColumns().stream()
+        Optional.ofNullable(createTable.getColumns()).orElse(List.of()).stream()
             .map(
                 c -> {
                   ColumnUtils.validateTypeJson(c, format);

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -111,6 +111,7 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   private CreateTable validMetricViewRequest() {
+    // columns left empty: metric views derive schema from view_definition.
     return new CreateTable()
         .name(METRIC_VIEW_NAME)
         .catalogName(TestUtils.CATALOG_NAME)
@@ -143,6 +144,9 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
     assertThat(created.getStorageLocation())
         .as("Metric views should have no storage location")
         .isNull();
+    assertThat(created.getColumns())
+        .as("Metric views created without columns should persist an empty column list")
+        .isNullOrEmpty();
 
     // --- Get and verify dependencies round-trip ---
     TableInfo fetched = tableOperations.getTable(METRIC_VIEW_FULL_NAME);
@@ -152,6 +156,7 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
     assertThat(fetched.getComment()).isEqualTo("Daily event counts by day");
     assertThat(fetched.getCreatedAt()).isNotNull();
     assertThat(fetched.getTableId()).isNotNull();
+    assertThat(fetched.getColumns()).isNullOrEmpty();
     assertThat(fetched.getViewDependencies()).isNotNull();
     assertThat(fetched.getViewDependencies().getDependencies()).hasSize(1);
     assertThat(fetched.getViewDependencies().getDependencies().get(0).getTable().getTableFullName())
@@ -178,6 +183,32 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
         () -> tableOperations.getTable(METRIC_VIEW_FULL_NAME),
         ErrorCode.TABLE_NOT_FOUND,
         METRIC_VIEW_FULL_NAME);
+  }
+
+  /**
+   * Explicit coverage for CreateTable.columns being optional on METRIC_VIEW: both a null columns
+   * field and an empty list must succeed (clients may omit the field or send []).
+   */
+  @ParameterizedTest(name = "create metric view with {0}")
+  @MethodSource("optionalColumnsCases")
+  public void testCreateMetricViewWithOptionalColumns(
+      String label, UnaryOperator<CreateTable> mutator) throws Exception {
+    createSourceTable();
+    CreateTable request = mutator.apply(validMetricViewRequest());
+
+    try {
+      TableInfo created = tableOperations.createTable(request);
+      assertThat(created.getTableType()).isEqualTo(TableType.METRIC_VIEW);
+      assertThat(created.getColumns()).isNullOrEmpty();
+      assertThat(tableOperations.getTable(METRIC_VIEW_FULL_NAME).getTableType())
+          .isEqualTo(TableType.METRIC_VIEW);
+    } finally {
+      try {
+        tableOperations.deleteTable(METRIC_VIEW_FULL_NAME);
+      } catch (ApiException ignored) {
+        // best-effort cleanup if create failed
+      }
+    }
   }
 
   private static Stream<Arguments> negativeCreateCases() {

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTestEnv.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseTableCRUDTestEnv.java
@@ -19,8 +19,11 @@ import io.unitycatalog.server.utils.TestUtils;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * Abstract base class that provides the test environment setup for table CRUD operations.
@@ -60,6 +63,17 @@ public abstract class BaseTableCRUDTestEnv extends BaseCRUDTest {
               .position(1)
               .comment("String column")
               .nullable(true));
+
+  /**
+   * Shared {@code @MethodSource} for view-like create tests: CreateTable.columns is optional, so a
+   * null columns field and an empty list must both be accepted (schema comes from view_definition).
+   */
+  protected static Stream<Arguments> optionalColumnsCases() {
+    return Stream.of(
+        Arguments.of("null columns", (UnaryOperator<CreateTable>) request -> request.columns(null)),
+        Arguments.of(
+            "empty columns", (UnaryOperator<CreateTable>) request -> request.columns(List.of())));
+  }
 
   @BeforeEach
   @Override

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.base.table;
 import static io.unitycatalog.server.utils.TestUtils.assertApiException;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.Dependency;
 import io.unitycatalog.client.model.DependencyList;
@@ -116,6 +117,31 @@ public abstract class BaseViewCRUDTest extends BaseTableCRUDTestEnv {
     assertThat(createdWithoutDeps.getTableType()).isEqualTo(TableType.VIEW);
     assertThat(tableOperations.getTable(VIEW_FULL_NAME).getName()).isEqualTo(VIEW_NAME);
     tableOperations.deleteTable(VIEW_FULL_NAME);
+  }
+
+  /**
+   * Explicit coverage for CreateTable.columns being optional on VIEW: both a null columns field and
+   * an empty list must succeed (a view's schema is derived from view_definition).
+   */
+  @ParameterizedTest(name = "create view with {0}")
+  @MethodSource("optionalColumnsCases")
+  public void testCreateViewWithOptionalColumns(String label, UnaryOperator<CreateTable> mutator)
+      throws Exception {
+    createSourceTable();
+    CreateTable request = mutator.apply(validViewRequest());
+
+    try {
+      TableInfo created = tableOperations.createTable(request);
+      assertThat(created.getTableType()).isEqualTo(TableType.VIEW);
+      assertThat(created.getColumns()).isNullOrEmpty();
+      assertThat(tableOperations.getTable(VIEW_FULL_NAME).getTableType()).isEqualTo(TableType.VIEW);
+    } finally {
+      try {
+        tableOperations.deleteTable(VIEW_FULL_NAME);
+      } catch (ApiException ignored) {
+        // best-effort cleanup if create failed
+      }
+    }
   }
 
   private static Stream<Arguments> negativeCreateCases() {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Backport of #1787 to `branch-0.6`.

`CreateTable.columns` was marked required in the OpenAPI spec, so the generated Python client rejected metric-view creates that omit `columns` (Pydantic `Field required`), even though the REST API accepts them — metric views derive schema from `view_definition` (dimensions/measures), not an explicit column list.

Changes:
- Remove `columns` from `CreateTable.required` in `api/all.yaml` and document when it is optional vs expected.
- Tolerate a null `columns` list in `TableRepository.createTableImpl` so clients that omit the field do not NPE.
- Java: `BaseViewCRUDTest` / `BaseMetricViewCRUDTest` cover create with `columns=null` and `columns=[]` (shared `optionalColumnsCases` factory in `BaseTableCRUDTestEnv`).
- Python: add `test_view.py` and `test_metric_view.py` covering omitted / empty `columns`, plus negative cases for missing `view_definition` / `view_dependencies`.

Verified locally: Java `SdkViewCRUDTest` + `SdkMetricViewCRUDTest` (19 passed) and Python view / metric-view tests (8 passed) on `branch-0.6`.