### PR TITLE
Do not send vended credential properties to the server in createTable

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -916,8 +916,14 @@ private[spark] class UCProxy(
     createTable.setColumns(columns)
     createTable.setDataSourceFormat(convertDatasourceFormat(format))
     // Do not send the V2 table properties as they are made part of the `createTable` already.
-    val propertiesToServer =
-      properties.view.filterKeys(!UCTableProperties.V2_TABLE_PROPERTIES.contains(_)).toMap
+    // Also strip the vended filesystem credential properties (fs.* and their option.-prefixed
+    // duplicates, e.g. fs.s3a.session.token): they are session-scoped Hadoop configs injected by
+    // UCSingleCatalog for the local write path, not table metadata, and must never be persisted
+    // in the catalog.
+    val propertiesToServer = properties.view
+      .filterKeys(!UCTableProperties.V2_TABLE_PROPERTIES.contains(_))
+      .filterKeys(k => !k.startsWith("fs.") && !k.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
+      .toMap
     createTable.setProperties(propertiesToServer)
     try {
       tablesApi.createTable(createTable)

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -16,12 +16,15 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest {
   @TempDir protected File dataDir;
@@ -138,6 +141,36 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
         }
       }
     }
+  }
+
+  /**
+   * The connector injects vended filesystem credentials (fs.s3a.access.key, fs.s3a.session.token,
+   * fs.unitycatalog.*, and their option.-prefixed duplicates) into the table property map so the
+   * local Spark session can write to the table location. None of them -- nor the reserved Spark V2
+   * markers -- may be forwarded to the UC server as table properties: they are session-scoped
+   * credentials, and values like an STS session token (~1100 chars) also overflow the server
+   * property store. Create the table via Spark SQL, then fetch it back through the SDK and assert
+   * the server kept none of those keys.
+   */
+  @ParameterizedTest
+  @MethodSource("cloudParameters")
+  public void testCreateExternalTableSendsNoCredentialProperties(
+      String scheme, boolean renewCredEnabled, boolean credScopedFsEnabled) throws ApiException {
+    session =
+        createSparkSessionWithCatalogs(
+            renewCredEnabled, credScopedFsEnabled, SPARK_CATALOG, CATALOG_NAME);
+
+    String fullTableName = setupTable(scheme, CATALOG_NAME, TEST_TABLE);
+    sql("INSERT INTO %s VALUES (1, 'a')", fullTableName);
+    validateRows(sql("SELECT * FROM %s", fullTableName), Pair.of(1, "a"));
+
+    TableInfo tableInfo = tableOperations.getTable(fullTableName);
+    java.util.Map<String, String> serverProperties =
+        tableInfo.getProperties() == null ? java.util.Map.of() : tableInfo.getProperties();
+    assertThat(serverProperties.keySet())
+        .noneMatch(key -> key.startsWith("fs."))
+        .noneMatch(key -> key.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
+        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains);
   }
 
   @Test


### PR DESCRIPTION
UCSingleCatalog injects vended filesystem credentials (fs.s3a.access.key,  fs.s3a.secret.key, fs.s3a.session.token, fs.s3a.aws.credentials.provider,  fs.unitycatalog.*, plus their option.-prefixed duplicates) into the table  property map so the local Spark session can write to the table location.
  UCProxy.createTable forwarded these properties to the server as ordinary  table properties: it only filtered V2_TABLE_PROPERTIES. This breaks  external table creation on S3 whenever credential vending is configured,
  the ~1100-char STS session token overflows the server's
  uc_properties.property_value VARCHAR(255) column and createTable fails:

    io.unitycatalog.client.ApiException: createTable call failed with: 500 -
    {"error_code":"INTERNAL","message":"Error creating table: ... Value too
    long for column \"PROPERTY_VALUE CHARACTER VARYING(255)\" ..."}

  It is also a security issue: temporary AWS credentials were being  persisted into the catalog database as table metadata.

  Fix: strip fs.* and option.fs.* keys from the properties sent to the  server. They are session-scoped Hadoop configs for the local write path,  not table metadata.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

strip fs.* and option.fs.* keys from the properties sent to the server. They are session-scoped Hadoop configs for the local write path, not table metadata.
