### PR TITLE
[Server] List every namespace and table from the Iceberg REST endpoints

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -25,6 +25,7 @@ import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.JsonUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ValidationUtils;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -122,19 +123,24 @@ public class IcebergRestCatalogService implements RegisteredService {
       // nested namespaces is not supported, so child namespaces will be empty
       namespaces = Collections.emptyList();
     } else {
-      String respContent =
-          schemaService
-              .listSchemas(catalog, Optional.of(Integer.MAX_VALUE), Optional.empty())
-              .aggregate()
-              .join()
-              .contentUtf8();
-      ListSchemasResponse resp =
-          JsonUtils.getInstance().readValue(respContent, ListSchemasResponse.class);
-      assert resp.getSchemas() != null;
-      namespaces =
-          resp.getSchemas().stream()
-              .map(schemaInfo -> Namespace.of(schemaInfo.getName()))
-              .collect(Collectors.toList());
+      namespaces = new ArrayList<>();
+      // This endpoint returns the whole listing, so follow the repository's page token to the end
+      Optional<String> pageToken = Optional.empty();
+      do {
+        String respContent =
+            schemaService
+                .listSchemas(catalog, Optional.empty(), pageToken)
+                .aggregate()
+                .join()
+                .contentUtf8();
+        ListSchemasResponse resp =
+            JsonUtils.getInstance().readValue(respContent, ListSchemasResponse.class);
+        assert resp.getSchemas() != null;
+        resp.getSchemas().stream()
+            .map(schemaInfo -> Namespace.of(schemaInfo.getName()))
+            .forEach(namespaces::add);
+        pageToken = nextPageToken(resp.getNextPageToken());
+      } while (pageToken.isPresent());
     }
 
     return ListNamespacesResponse.builder().addAll(namespaces).build();
@@ -258,13 +264,20 @@ public class IcebergRestCatalogService implements RegisteredService {
   public org.apache.iceberg.rest.responses.ListTablesResponse listTables(
       @Param("catalog") String catalog, @Param("namespace") String namespace)
       throws JsonProcessingException {
-    ListTablesResponse tables =
-        tableRepository.listTables(
-            catalog, namespace, Optional.of(Integer.MAX_VALUE), Optional.empty(), false, false);
+    List<TableInfo> tables = new ArrayList<>();
+    // This endpoint returns the whole listing, so follow the repository's page token to the end
+    Optional<String> pageToken = Optional.empty();
+    do {
+      ListTablesResponse page =
+          tableRepository.listTables(catalog, namespace, Optional.empty(), pageToken, false, false);
+      tables.addAll(Objects.requireNonNull(page.getTables()));
+      pageToken = nextPageToken(page.getNextPageToken());
+    } while (pageToken.isPresent());
+
     List<TableIdentifier> filteredTables;
     try (Session session = sessionFactory.openSession()) {
       filteredTables =
-          Objects.requireNonNull(tables.getTables()).stream()
+          tables.stream()
               .filter(
                   tableInfo -> {
                     String metadataLocation =
@@ -282,5 +295,12 @@ public class IcebergRestCatalogService implements RegisteredService {
     return org.apache.iceberg.rest.responses.ListTablesResponse.builder()
         .addAll(filteredTables)
         .build();
+  }
+
+  /**
+   * Wraps the page token a listing returned, treating a missing or empty token as "no more pages".
+   */
+  private static Optional<String> nextPageToken(String token) {
+    return Optional.ofNullable(token).filter(t -> !t.isEmpty());
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -265,11 +265,19 @@ public class IcebergRestCatalogService implements RegisteredService {
       @Param("catalog") String catalog, @Param("namespace") String namespace)
       throws JsonProcessingException {
     List<TableInfo> tables = new ArrayList<>();
-    // This endpoint returns the whole listing, so follow the repository's page token to the end
+    // This endpoint returns the whole listing, so follow the repository's page token to the end.
+    // Only the table names are used below, so the columns and properties the repository would
+    // otherwise attach to every table are omitted rather than fetched and discarded.
     Optional<String> pageToken = Optional.empty();
     do {
       ListTablesResponse page =
-          tableRepository.listTables(catalog, namespace, Optional.empty(), pageToken, false, false);
+          tableRepository.listTables(
+              catalog,
+              namespace,
+              Optional.empty(),
+              pageToken,
+              /* omitProperties = */ true,
+              /* omitColumns = */ true);
       tables.addAll(Objects.requireNonNull(page.getTables()));
       pageToken = nextPageToken(page.getNextPageToken());
     } while (pageToken.isPresent());

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -25,6 +25,7 @@ import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,6 +71,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
   private static final String TEST_BASE_PREFIX = "/v1/catalogs/" + TestUtils.CATALOG_NAME;
   private static final String TEST_BASE_NON_PREFIX = "/v1";
+  private static final int PAGE_SIZE = PagedListingHelper.DEFAULT_PAGE_SIZE;
 
   @TempDir private Path icebergTableLocation;
 
@@ -423,6 +426,55 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(resp.status().code()).isEqualTo(404);
   }
 
+  @Test
+  public void testListNamespacesReturnsEveryNamespace() throws ApiException, IOException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    // One namespace more than the repository returns in a single page
+    List<String> created = new ArrayList<>();
+    for (int i = 0; i <= PAGE_SIZE; i++) {
+      String name = "schema_%03d".formatted(i);
+      schemaOperations.createSchema(
+          new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(name));
+      created.add(name);
+    }
+
+    AggregatedHttpResponse resp = client.get(TEST_BASE_PREFIX + "/namespaces").aggregate().join();
+
+    assertThat(resp.status().code()).isEqualTo(200);
+    ListNamespacesResponse listed =
+        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListNamespacesResponse.class);
+    assertThat(listed.namespaces()).map(Namespace::toString).containsExactlyElementsOf(created);
+  }
+
+  @Test
+  public void testListTablesReturnsTablesBeyondTheFirstPage()
+      throws ApiException, IOException, URISyntaxException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    // Fill the first page with tables the Iceberg endpoints don't serve, so that the only uniform
+    // table sorts onto the second page
+    for (int i = 0; i < PAGE_SIZE; i++) {
+      createTable("delta_%03d".formatted(i));
+    }
+    setUniformMetadata(createTable("uniform_table"), writeIcebergMetadata());
+
+    AggregatedHttpResponse resp =
+        client
+            .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables")
+            .aggregate()
+            .join();
+
+    assertThat(resp.status().code()).isEqualTo(200);
+    ListTablesResponse listed =
+        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+    assertThat(listed.identifiers())
+        .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
+  }
+
   private AggregatedHttpResponse postJson(String path, String json) {
     return client
         .execute(
@@ -465,8 +517,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
     schemaOperations.createSchema(
         new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
-    TableInfo tableInfo = createTable(TestUtils.TABLE_NAME);
+    setUniformMetadata(createTable(TestUtils.TABLE_NAME), metadataFile);
+  }
 
+  /** Makes a table visible to the Iceberg endpoints by giving it uniform Iceberg metadata. */
+  private void setUniformMetadata(TableInfo tableInfo, Path metadataFile) {
     try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
       Transaction tx = session.beginTransaction();
       UUID tableId = UUID.fromString(Objects.requireNonNull(tableInfo.getTableId()));


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1790.

`listNamespaces` and `listTables` asked the repositories for `Integer.MAX_VALUE` results, intending to fetch everything, but `PagedListingHelper.getPageSize` caps the page size at `DEFAULT_PAGE_SIZE` (100). Both endpoints therefore returned at most one page, discarded the `nextPageToken` that came with it, and returned no `next-page-token` of their own, so the truncation was invisible to the client.

`listTables` was affected more severely: it filters the page it received down to the tables that have uniform Iceberg metadata, and tables are listed in ascending name order, so a schema whose first 100 tables are not uniform returned an empty list even though uniform tables existed.

**Change**

Both endpoints now follow the repository's page token to the end.

The response shape is unchanged. Per the Iceberg REST spec, a server that does not support pagination should ignore `pageToken` and return all results in a single response with `next-page-token` omitted, which is what these endpoints do, so nothing changes for clients other than the missing entries appearing.

`pageToken` / `pageSize` passthrough is deliberately left out of this PR. The issue describes why it needs a separate decision: `pageSize` cannot be honoured above 100 without changing the shared `PagedListingHelper`, and for `listTables` the token would have to expose the repository cursor rather than the last identifier returned. Happy to follow up on that if maintainers want it.

**Testing**

Two tests added to `IcebergRestCatalogTest`, both confirmed to fail before the change and pass after it:

- `testListNamespacesReturnsEveryNamespace` — one namespace more than a single page. Before the change the last namespace is missing.
- `testListTablesReturnsTablesBeyondTheFirstPage` — a full page of non-uniform tables ahead of one uniform table. Before the change the response is `[]`.

Both derive their size from `PagedListingHelper.DEFAULT_PAGE_SIZE` rather than hardcoding 100.

The rest of the server test suite is unaffected: 422 tests, 22 skipped, 398 passing, and 2 failures that fail the same way on an unmodified tree (`CloudCredentialVendorTest.testGenerateGcpTemporaryCredentials`, which expects the absence of GCP credentials, and `SdkModelCRUDTest.testModelCRUD`).
