### PR TITLE
[Server] Use IAM partition in AssumeRole session-policy S3 and KMS ARNs

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
@@ -61,7 +61,7 @@ public interface AwsCredentialGenerator {
     // contains a CredentialDAO and it will assume the role ARN in CredentialDAO instead.
     private final String staticAwsRoleArn;
     // Same region the STS client uses; used when the assumed role ARN does not carry a partition.
-    private final String awsRegion;
+    private final Region awsRegion;
 
     public StsAwsCredentialGenerator(StsClientBuilder builder, S3StorageConfig config) {
       // Get STS region
@@ -89,7 +89,7 @@ public interface AwsCredentialGenerator {
 
       this.stsClient = builder.region(region).credentialsProvider(credentialsProvider).build();
       this.staticAwsRoleArn = config.getAwsRoleArn();
-      this.awsRegion = region.id();
+      this.awsRegion = region;
     }
 
     @Override

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsCredentialGenerator.java
@@ -60,6 +60,8 @@ public interface AwsCredentialGenerator {
     // This is the role ARN to assume for the per-bucket config. Otherwise, the CredentialContext
     // contains a CredentialDAO and it will assume the role ARN in CredentialDAO instead.
     private final String staticAwsRoleArn;
+    // Same region the STS client uses; used when the assumed role ARN does not carry a partition.
+    private final String awsRegion;
 
     public StsAwsCredentialGenerator(StsClientBuilder builder, S3StorageConfig config) {
       // Get STS region
@@ -87,6 +89,7 @@ public interface AwsCredentialGenerator {
 
       this.stsClient = builder.region(region).credentialsProvider(credentialsProvider).build();
       this.staticAwsRoleArn = config.getAwsRoleArn();
+      this.awsRegion = region.id();
     }
 
     @Override
@@ -99,7 +102,9 @@ public interface AwsCredentialGenerator {
       // externalId is only from CredentialDAO. Per-bucket config does not need it.
       Optional<String> externalId = awsIamRole.map(AwsIamRoleResponse::getExternalId);
 
-      String awsPolicy = AwsPolicyGenerator.generatePolicy(ctx.getPrivileges(), ctx.getLocations());
+      String awsPolicy =
+          AwsPolicyGenerator.generatePolicy(
+              ctx.getPrivileges(), ctx.getLocations(), roleArn, awsRegion);
       String roleSessionName = "uc-%s".formatted(UUID.randomUUID());
 
       AssumeRoleRequest.Builder roleRequestBuilder =

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -3,6 +3,7 @@ package io.unitycatalog.server.service.credential.aws;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
@@ -15,6 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.regions.PartitionMetadata;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.RegionMetadata;
 
 public class AwsPolicyGenerator {
 
@@ -78,11 +82,33 @@ public class AwsPolicyGenerator {
   public static String generatePolicy(
       Set<CredentialContext.Privilege> privileges,
       List<NormalizedURL> locations) {
+    return generatePolicy(privileges, locations, null, null);
+  }
+
+  /**
+   * Builds the AssumeRole session policy for the given locations.
+   *
+   * <p>IAM partition is taken from {@code roleArn} when that ARN is well-formed ({@code
+   * arn:aws-us-gov:...} → {@code aws-us-gov}), then from the STS region catalog, then commercial
+   * {@code aws}. The same partition is used for S3 resources, KMS encryption-context ARNs, and
+   * {@code kms:ViaService} ({@code s3.*.amazonaws.com} vs {@code s3.*.amazonaws.com.cn}).
+   */
+  @SneakyThrows
+  public static String generatePolicy(
+      Set<CredentialContext.Privilege> privileges,
+      List<NormalizedURL> locations,
+      String roleArn,
+      String awsRegion) {
+    String partition = iamPartitionId(roleArn, awsRegion);
     JsonNode policyRoot = loadYaml(POLICY_STATEMENT);
     ArrayNode policyStatement = (ArrayNode) policyRoot.findPath("Statement");
     JsonNode operationsStatement = loadYaml(OPERATION_STATEMENT);
     policyStatement.add(operationsStatement);
     JsonNode kmsStatement = loadYaml(KMS_STATEMENT);
+    JsonNode stringLike = kmsStatement.findPath("StringLike");
+    if (stringLike instanceof ObjectNode stringLikeNode) {
+      stringLikeNode.put("kms:ViaService", kmsViaService(partition));
+    }
 
     // Add the appropriate S3 and KMS operations for the privileges requested
     ArrayNode actions = (ArrayNode) operationsStatement.findPath("Action");
@@ -110,12 +136,12 @@ public class AwsPolicyGenerator {
 
       ArrayNode bucketResource = (ArrayNode) listStatement.findPath("Resource");
       ArrayNode operationsResource = (ArrayNode) operationsStatement.findPath("Resource");
-      bucketResource.add(String.format("arn:aws:s3:::%s", bucketName));
+      bucketResource.add(s3Arn(partition, bucketName));
 
       // A bucket with S3 Bucket Keys enabled encrypts under the bucket arn rather than the object
       // arn, so the bucket has to be allowed as an encryption context on its own. That case can't
       // be scoped to a path: the same data key covers every object in the bucket.
-      kmsEncryptionContexts.add(String.format("arn:aws:s3:::%s", bucketName));
+      kmsEncryptionContexts.add(s3Arn(partition, bucketName));
 
       ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
       paths.forEach(path -> {
@@ -124,16 +150,16 @@ public class AwsPolicyGenerator {
 
         if (sanitizedPath.isEmpty()) {
           conditionalPrefixes.add("*");
-          addObjectArn(String.format("arn:aws:s3:::%s/*", bucketName),
+          addObjectArn(s3Arn(partition, bucketName + "/*"),
               operationsResource, kmsEncryptionContexts);
         } else {
           conditionalPrefixes.add(sanitizedPath);
           conditionalPrefixes.add(sanitizedPath + "/");
           conditionalPrefixes.add(sanitizedPath + "/*");
 
-          addObjectArn(String.format("arn:aws:s3:::%s/%s/*", bucketName, sanitizedPath),
+          addObjectArn(s3Arn(partition, bucketName + "/" + sanitizedPath + "/*"),
               operationsResource, kmsEncryptionContexts);
-          addObjectArn(String.format("arn:aws:s3:::%s/%s", bucketName, sanitizedPath),
+          addObjectArn(s3Arn(partition, bucketName + "/" + sanitizedPath),
               operationsResource, kmsEncryptionContexts);
         }
       });
@@ -155,6 +181,66 @@ public class AwsPolicyGenerator {
       String objectArn, ArrayNode operationsResource, ArrayNode kmsEncryptionContexts) {
     operationsResource.add(objectArn);
     kmsEncryptionContexts.add(objectArn);
+  }
+
+  /**
+   * IAM partition for S3 ARNs and KMS conditions. Prefers the assumed role ARN (the session is
+   * bound to that role's partition), then the STS region catalog, then commercial {@code aws}.
+   */
+  static String iamPartitionId(String roleArn, String awsRegion) {
+    String fromRole = partitionFromArn(roleArn);
+    if (fromRole != null) {
+      return fromRole;
+    }
+    return partitionFromRegion(awsRegion);
+  }
+
+  static String partitionFromArn(String arn) {
+    if (arn == null || arn.isBlank()) {
+      return null;
+    }
+    // arn:partition:service:region:account:resource
+    String[] parts = arn.split(":", 6);
+    if (parts.length < 2 || !"arn".equalsIgnoreCase(parts[0]) || parts[1].isBlank()) {
+      return null;
+    }
+    return parts[1];
+  }
+
+  static String partitionFromRegion(String awsRegion) {
+    if (awsRegion == null || awsRegion.isBlank()) {
+      return "aws";
+    }
+    try {
+      RegionMetadata metadata = Region.of(awsRegion).metadata();
+      if (metadata == null || metadata.partition() == null) {
+        return "aws";
+      }
+      String partitionId = metadata.partition().id();
+      return partitionId == null || partitionId.isBlank() ? "aws" : partitionId;
+    } catch (RuntimeException e) {
+      return "aws";
+    }
+  }
+
+  static String kmsViaService(String partition) {
+    return "s3.*." + partitionDnsSuffix(partition);
+  }
+
+  private static String partitionDnsSuffix(String partition) {
+    try {
+      PartitionMetadata metadata = PartitionMetadata.of(partition);
+      if (metadata != null && metadata.dnsSuffix() != null && !metadata.dnsSuffix().isBlank()) {
+        return metadata.dnsSuffix();
+      }
+    } catch (RuntimeException ignored) {
+      // Unknown partitions fall through to the commercial/China suffix map.
+    }
+    return "aws-cn".equals(partition) ? "amazonaws.com.cn" : "amazonaws.com";
+  }
+
+  private static String s3Arn(String partition, String resource) {
+    return String.format("arn:%s:s3:::%s", partition, resource);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -16,9 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.RegionMetadata;
 
 public class AwsPolicyGenerator {
 
@@ -69,7 +69,6 @@ public class AwsPolicyGenerator {
         - "*"
       Condition:
         StringLike:
-          "kms:ViaService": "s3.*.amazonaws.com"
           "%s": []
       """.formatted(KMS_ENCRYPTION_CONTEXT_KEY);
 
@@ -98,8 +97,8 @@ public class AwsPolicyGenerator {
       Set<CredentialContext.Privilege> privileges,
       List<NormalizedURL> locations,
       String roleArn,
-      String awsRegion) {
-    String partition = iamPartitionId(roleArn, awsRegion);
+      Region awsRegion) {
+    PartitionMetadata partition = iamPartition(roleArn, awsRegion);
     JsonNode policyRoot = loadYaml(POLICY_STATEMENT);
     ArrayNode policyStatement = (ArrayNode) policyRoot.findPath("Statement");
     JsonNode operationsStatement = loadYaml(OPERATION_STATEMENT);
@@ -187,60 +186,57 @@ public class AwsPolicyGenerator {
    * IAM partition for S3 ARNs and KMS conditions. Prefers the assumed role ARN (the session is
    * bound to that role's partition), then the STS region catalog, then commercial {@code aws}.
    */
-  static String iamPartitionId(String roleArn, String awsRegion) {
-    String fromRole = partitionFromArn(roleArn);
+  static PartitionMetadata iamPartition(String roleArn, Region awsRegion) {
+    PartitionMetadata fromRole = partitionFromArn(roleArn);
     if (fromRole != null) {
       return fromRole;
     }
     return partitionFromRegion(awsRegion);
   }
 
-  static String partitionFromArn(String arn) {
+  static PartitionMetadata partitionFromArn(String arn) {
     if (arn == null || arn.isBlank()) {
       return null;
     }
-    // arn:partition:service:region:account:resource
-    String[] parts = arn.split(":", 6);
-    if (parts.length < 2 || !"arn".equalsIgnoreCase(parts[0]) || parts[1].isBlank()) {
+    try {
+      String partition = Arn.fromString(arn).partition();
+      if (partition == null || partition.isBlank()) {
+        return null;
+      }
+      return PartitionMetadata.of(partition);
+    } catch (RuntimeException e) {
       return null;
     }
-    return parts[1];
   }
 
-  static String partitionFromRegion(String awsRegion) {
-    if (awsRegion == null || awsRegion.isBlank()) {
-      return "aws";
+  static PartitionMetadata partitionFromRegion(Region awsRegion) {
+    if (awsRegion == null) {
+      return commercialPartition();
     }
     try {
-      RegionMetadata metadata = Region.of(awsRegion).metadata();
-      if (metadata == null || metadata.partition() == null) {
-        return "aws";
-      }
-      String partitionId = metadata.partition().id();
-      return partitionId == null || partitionId.isBlank() ? "aws" : partitionId;
-    } catch (RuntimeException e) {
-      return "aws";
-    }
-  }
-
-  static String kmsViaService(String partition) {
-    return "s3.*." + partitionDnsSuffix(partition);
-  }
-
-  private static String partitionDnsSuffix(String partition) {
-    try {
-      PartitionMetadata metadata = PartitionMetadata.of(partition);
-      if (metadata != null && metadata.dnsSuffix() != null && !metadata.dnsSuffix().isBlank()) {
-        return metadata.dnsSuffix();
+      if (awsRegion.metadata() != null && awsRegion.metadata().partition() != null) {
+        return awsRegion.metadata().partition();
       }
     } catch (RuntimeException ignored) {
-      // Unknown partitions fall through to the commercial/China suffix map.
+      // Unknown regions fall through to commercial aws.
     }
-    return "aws-cn".equals(partition) ? "amazonaws.com.cn" : "amazonaws.com";
+    return commercialPartition();
   }
 
-  private static String s3Arn(String partition, String resource) {
-    return String.format("arn:%s:s3:::%s", partition, resource);
+  private static String kmsViaService(PartitionMetadata partition) {
+    String dnsSuffix = partition.dnsSuffix();
+    if (dnsSuffix == null || dnsSuffix.isBlank()) {
+      dnsSuffix = "aws-cn".equals(partition.id()) ? "amazonaws.com.cn" : "amazonaws.com";
+    }
+    return "s3.*." + dnsSuffix;
+  }
+
+  private static PartitionMetadata commercialPartition() {
+    return PartitionMetadata.of("aws");
+  }
+
+  private static String s3Arn(PartitionMetadata partition, String resource) {
+    return String.format("arn:%s:s3:::%s", partition.id(), resource);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -320,4 +320,62 @@ public class CloudCredentialVendorTest {
       assertThat(capturedRequest.externalId()).isEqualTo(expectedExternalId);
     }
   }
+
+  @Test
+  public void testGovCloudRoleArnUsesAwsUsGovS3ArnsInSessionPolicy() {
+    final String CREDENTIAL_ROLE_ARN =
+        "arn:aws-us-gov:iam::123456789012:role/external-location-role";
+    final String S3_PATH = "s3://gov-bucket/path/to/data";
+
+    CredentialDAO credentialDAO =
+        CredentialDAO.from(
+            new CreateCredentialRequest()
+                .name("test-credential")
+                .purpose(CredentialPurpose.STORAGE)
+                .awsIamRole(new AwsIamRoleRequest().roleArn(CREDENTIAL_ROLE_ARN)),
+            "test-user");
+
+    reset(externalLocationUtils);
+    doReturn(Optional.of(credentialDAO))
+        .when(externalLocationUtils)
+        .getExternalLocationCredentialDaoForPath(any());
+
+    when(serverProperties.getS3Configurations()).thenReturn(Map.of());
+    // Master region intentionally commercial: the assumed role ARN must still select aws-us-gov.
+    doReturn(S3StorageConfig.builder().region("us-east-1").build())
+        .when(serverProperties)
+        .getS3MasterRoleConfiguration();
+
+    StsClient mockStsClient = Mockito.mock(StsClient.class);
+    ArgumentCaptor<AssumeRoleRequest> requestCaptor =
+        ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Credentials stsCredentials =
+        Credentials.builder()
+            .accessKeyId("vendedAccessKey")
+            .secretAccessKey("vendedSecretKey")
+            .sessionToken("vendedSessionToken")
+            .build();
+    when(mockStsClient.assumeRole(requestCaptor.capture()))
+        .thenReturn(AssumeRoleResponse.builder().credentials(stsCredentials).build());
+
+    StsClientBuilder mockBuilder = Mockito.mock(StsClientBuilder.class);
+    when(mockBuilder.region(any())).thenReturn(mockBuilder);
+    when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockStsClient);
+
+    try (MockedStatic<StsClient> mockedStsClient = Mockito.mockStatic(StsClient.class)) {
+      mockedStsClient.when(StsClient::builder).thenReturn(mockBuilder);
+
+      AwsCredentialVendor awsCredentialVendor = new AwsCredentialVendor(serverProperties);
+      credentialsOperations = new CloudCredentialVendor(awsCredentialVendor, null, null);
+
+      vendCredential(S3_PATH, Set.of(CredentialContext.Privilege.SELECT));
+
+      AssumeRoleRequest capturedRequest = requestCaptor.getValue();
+      assertThat(capturedRequest.policy())
+          .contains("arn:aws-us-gov:s3:::gov-bucket")
+          .doesNotContain("arn:aws:s3:::gov-bucket")
+          .contains("kms:ViaService");
+    }
+  }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/CloudCredentialVendorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.AwsCredentials;
@@ -322,7 +323,7 @@ public class CloudCredentialVendorTest {
   }
 
   @Test
-  public void testGovCloudRoleArnUsesAwsUsGovS3ArnsInSessionPolicy() {
+  public void testGovCloudRoleArnUsesAwsUsGovS3ArnsInSessionPolicy() throws Exception {
     final String CREDENTIAL_ROLE_ARN =
         "arn:aws-us-gov:iam::123456789012:role/external-location-role";
     final String S3_PATH = "s3://gov-bucket/path/to/data";
@@ -374,8 +375,13 @@ public class CloudCredentialVendorTest {
       AssumeRoleRequest capturedRequest = requestCaptor.getValue();
       assertThat(capturedRequest.policy())
           .contains("arn:aws-us-gov:s3:::gov-bucket")
-          .doesNotContain("arn:aws:s3:::gov-bucket")
-          .contains("kms:ViaService");
+          .doesNotContain("arn:aws:s3:::gov-bucket");
+      assertThat(
+              new ObjectMapper()
+                  .readTree(capturedRequest.policy())
+                  .findPath("kms:ViaService")
+                  .asText())
+          .isEqualTo("s3.*.amazonaws.com");
     }
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -22,6 +22,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.awssdk.regions.Region;
 
 public class AwsPolicyGeneratorTest {
 
@@ -272,12 +273,13 @@ public class AwsPolicyGeneratorTest {
     "'', aws"
   })
   public void testPartitionFromRegion(String region, String expectedPartition) {
-    assertThat(AwsPolicyGenerator.partitionFromRegion(region)).isEqualTo(expectedPartition);
+    assertThat(AwsPolicyGenerator.partitionFromRegion(regionOrNull(region)).id())
+        .isEqualTo(expectedPartition);
   }
 
   @Test
   public void testNullRegionDefaultsToAwsPartition() {
-    assertThat(AwsPolicyGenerator.partitionFromRegion(null)).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.partitionFromRegion(null).id()).isEqualTo("aws");
   }
 
   @ParameterizedTest(name = "{index}: {0} -> {1}")
@@ -287,7 +289,7 @@ public class AwsPolicyGeneratorTest {
     "arn:aws-cn:iam::123456789012:role/r, aws-cn"
   })
   public void testPartitionFromArn(String roleArn, String expectedPartition) {
-    assertThat(AwsPolicyGenerator.partitionFromArn(roleArn)).isEqualTo(expectedPartition);
+    assertThat(AwsPolicyGenerator.partitionFromArn(roleArn).id()).isEqualTo(expectedPartition);
   }
 
   @Test
@@ -301,21 +303,24 @@ public class AwsPolicyGeneratorTest {
   @Test
   public void testRoleArnPartitionWinsOverMismatchedRegion() {
     assertThat(
-            AwsPolicyGenerator.iamPartitionId(
-                "arn:aws-us-gov:iam::123456789012:role/gov-role", "us-east-1"))
+            AwsPolicyGenerator.iamPartition(
+                    "arn:aws-us-gov:iam::123456789012:role/gov-role", Region.US_EAST_1)
+                .id())
         .isEqualTo("aws-us-gov");
   }
 
   @Test
   public void testRegionPartitionUsedWhenRoleArnMissing() {
-    assertThat(AwsPolicyGenerator.iamPartitionId(null, "us-gov-west-1")).isEqualTo("aws-us-gov");
-    assertThat(AwsPolicyGenerator.iamPartitionId("not-an-arn", "cn-north-1")).isEqualTo("aws-cn");
+    assertThat(AwsPolicyGenerator.iamPartition(null, Region.of("us-gov-west-1")).id())
+        .isEqualTo("aws-us-gov");
+    assertThat(AwsPolicyGenerator.iamPartition("not-an-arn", Region.of("cn-north-1")).id())
+        .isEqualTo("aws-cn");
   }
 
   @Test
   public void testBlankRoleAndRegionDefaultToAwsPartition() {
-    assertThat(AwsPolicyGenerator.iamPartitionId(null, null)).isEqualTo("aws");
-    assertThat(AwsPolicyGenerator.iamPartitionId("", "")).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.iamPartition(null, null).id()).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.iamPartition("", null).id()).isEqualTo("aws");
   }
 
   @ParameterizedTest(name = "{index}: {0} uses {1}")
@@ -332,7 +337,7 @@ public class AwsPolicyGeneratorTest {
             Set.of(SELECT),
             List.of(NormalizedURL.from("s3://my-bucket/path1/table1")),
             null,
-            region);
+            regionOrNull(region));
 
     JsonNode root = JSON_MAPPER.readTree(policy);
     assertThat(root.get("Statement").get(0).get("Resource"))
@@ -374,13 +379,17 @@ public class AwsPolicyGeneratorTest {
             Set.of(SELECT),
             List.of(NormalizedURL.from("s3://cn-bucket/path/table")),
             "arn:aws-cn:iam::123456789012:role/cn-role",
-            "us-east-1");
+            Region.US_EAST_1);
 
     assertThat(policy)
         .contains("arn:aws-cn:s3:::cn-bucket")
         .doesNotContain("arn:aws:s3:::cn-bucket");
     JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
     assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com.cn");
+  }
+
+  private static Region regionOrNull(String regionId) {
+    return regionId == null || regionId.isBlank() ? null : Region.of(regionId);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -261,6 +261,128 @@ public class AwsPolicyGeneratorTest {
         .containsExactly("s3:ListBucket");
   }
 
+  @ParameterizedTest(name = "{index}: region {0} -> partition {1}")
+  @CsvSource({
+    "us-east-1, aws",
+    "us-west-2, aws",
+    "us-gov-west-1, aws-us-gov",
+    "us-gov-east-1, aws-us-gov",
+    "cn-north-1, aws-cn",
+    "cn-northwest-1, aws-cn",
+    "'', aws"
+  })
+  public void testPartitionFromRegion(String region, String expectedPartition) {
+    assertThat(AwsPolicyGenerator.partitionFromRegion(region)).isEqualTo(expectedPartition);
+  }
+
+  @Test
+  public void testNullRegionDefaultsToAwsPartition() {
+    assertThat(AwsPolicyGenerator.partitionFromRegion(null)).isEqualTo("aws");
+  }
+
+  @ParameterizedTest(name = "{index}: {0} -> {1}")
+  @CsvSource({
+    "arn:aws:iam::123456789012:role/r, aws",
+    "arn:aws-us-gov:iam::123456789012:role/r, aws-us-gov",
+    "arn:aws-cn:iam::123456789012:role/r, aws-cn"
+  })
+  public void testPartitionFromArn(String roleArn, String expectedPartition) {
+    assertThat(AwsPolicyGenerator.partitionFromArn(roleArn)).isEqualTo(expectedPartition);
+  }
+
+  @Test
+  public void testMissingOrMalformedRoleArnHasNoPartition() {
+    assertThat(AwsPolicyGenerator.partitionFromArn(null)).isNull();
+    assertThat(AwsPolicyGenerator.partitionFromArn("")).isNull();
+    assertThat(AwsPolicyGenerator.partitionFromArn("not-an-arn")).isNull();
+    assertThat(AwsPolicyGenerator.partitionFromArn("arn:")).isNull();
+  }
+
+  @Test
+  public void testRoleArnPartitionWinsOverMismatchedRegion() {
+    assertThat(
+            AwsPolicyGenerator.iamPartitionId(
+                "arn:aws-us-gov:iam::123456789012:role/gov-role", "us-east-1"))
+        .isEqualTo("aws-us-gov");
+  }
+
+  @Test
+  public void testRegionPartitionUsedWhenRoleArnMissing() {
+    assertThat(AwsPolicyGenerator.iamPartitionId(null, "us-gov-west-1")).isEqualTo("aws-us-gov");
+    assertThat(AwsPolicyGenerator.iamPartitionId("not-an-arn", "cn-north-1")).isEqualTo("aws-cn");
+  }
+
+  @Test
+  public void testBlankRoleAndRegionDefaultToAwsPartition() {
+    assertThat(AwsPolicyGenerator.iamPartitionId(null, null)).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.iamPartitionId("", "")).isEqualTo("aws");
+  }
+
+  @ParameterizedTest(name = "{index}: {0} uses {1}")
+  @CsvSource({
+    "us-east-1, arn:aws:s3:::my-bucket, s3.*.amazonaws.com",
+    "us-gov-west-1, arn:aws-us-gov:s3:::my-bucket, s3.*.amazonaws.com",
+    "cn-north-1, arn:aws-cn:s3:::my-bucket, s3.*.amazonaws.com.cn",
+    "'', arn:aws:s3:::my-bucket, s3.*.amazonaws.com"
+  })
+  public void testSessionPolicyUsesRegionPartition(
+      String region, String expectedBucketArn, String expectedViaService) throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT),
+            List.of(NormalizedURL.from("s3://my-bucket/path1/table1")),
+            null,
+            region);
+
+    JsonNode root = JSON_MAPPER.readTree(policy);
+    assertThat(root.get("Statement").get(0).get("Resource"))
+        .map(JsonNode::asText)
+        .containsExactly(
+            expectedBucketArn + "/path1/table1/*", expectedBucketArn + "/path1/table1");
+    assertThat(root.get("Statement").get(1).get("Resource").get(0).asText())
+        .isEqualTo(expectedBucketArn);
+    JsonNode kmsStatement = findKmsStatement(root);
+    assertThat(kmsStatement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
+        .map(JsonNode::asText)
+        .containsExactly(
+            expectedBucketArn,
+            expectedBucketArn + "/path1/table1/*",
+            expectedBucketArn + "/path1/table1");
+    assertThat(kmsStatement.findPath("kms:ViaService").asText()).isEqualTo(expectedViaService);
+  }
+
+  @Test
+  public void testGovCloudRoleArnDrivesPartitionWithoutRegion() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE),
+            List.of(NormalizedURL.from("s3://gov-bucket/path/table")),
+            "arn:aws-us-gov:iam::123456789012:role/gov-role",
+            null);
+
+    assertThat(policy)
+        .contains("arn:aws-us-gov:s3:::gov-bucket")
+        .doesNotContain("arn:aws:s3:::gov-bucket");
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com");
+  }
+
+  @Test
+  public void testChinaPolicyUsesCnDnsSuffixForKmsViaService() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(SELECT),
+            List.of(NormalizedURL.from("s3://cn-bucket/path/table")),
+            "arn:aws-cn:iam::123456789012:role/cn-role",
+            "us-east-1");
+
+    assertThat(policy)
+        .contains("arn:aws-cn:s3:::cn-bucket")
+        .doesNotContain("arn:aws:s3:::cn-bucket");
+    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
+    assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com.cn");
+  }
+
   /**
    * Returns the statement that carries the KMS actions, or {@code null} when the policy has none.
    * Located by action prefix rather than by index so that the S3 statements the other tests assert


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Vended AWS credentials 403 on GovCloud (and would on China) because `AwsPolicyGenerator` hardcodes commercial S3 ARNs in the AssumeRole session policy:

```
arn:aws:s3:::bucket
```

Session permissions are the intersection of the role policy and that session policy. A GovCloud role policy uses `arn:aws-us-gov:s3:::...`, so the commercial ARNs grant nothing even though STS issued keys. The same strings are reused as `kms:EncryptionContext:aws:s3:arn` (from #1774), so KMS is wrong in those partitions too.

**Change**

IAM partition is resolved in this order:

1. Assumed role ARN (`arn:aws-us-gov:iam::...` → `aws-us-gov`) — the session is bound to that role's partition, even if `aws.region` / the STS client is commercial or unset.
2. STS region catalog (`us-gov-west-1` → `aws-us-gov`, `cn-north-1` → `aws-cn`).
3. Commercial `aws`, matching today's hardcoded ARNs, when both are missing or unrecognized.

That partition is applied to:

- S3 `Resource` ARNs
- KMS encryption-context ARNs (same helper, so the two lists cannot drift)
- `kms:ViaService` (`s3.*.amazonaws.com` for `aws` / `aws-us-gov`, `s3.*.amazonaws.com.cn` for `aws-cn`)

The two-arg `generatePolicy(privileges, locations)` overload is unchanged for callers and existing tests.

**Testing**

- [x] `AwsPolicyGeneratorTest` partition helpers, GovCloud/China policy ARNs, role-ARN precedence over region, China `kms:ViaService`
- [x] `CloudCredentialVendorTest.testGovCloudRoleArnUsesAwsUsGovS3ArnsInSessionPolicy` (GovCloud role + commercial master region still emits `arn:aws-us-gov:s3`)
- [x] `sbt "server/testOnly io.unitycatalog.server.service.credential.aws.AwsPolicyGeneratorTest io.unitycatalog.server.service.credential.CloudCredentialVendorTest"` (Java 17) — 48 passed


Made with [Cursor](https://cursor.com)