### PR TITLE
[Server] Drop KMS encryption-context ARNs from STS session policies

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -22,6 +22,8 @@ import software.amazon.awssdk.regions.Region;
 
 public class AwsPolicyGenerator {
 
+  static final String AWS_PARTITION = "aws";
+
   static final List<String> SELECT_ACTIONS = List.of("s3:GetO*");
   static final List<String> UPDATE_ACTIONS = List.of(
       "s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
@@ -66,8 +68,6 @@ public class AwsPolicyGenerator {
       Action: []
       Resource:
         - "*"
-      Condition:
-        StringLike: {}
       """;
 
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
@@ -75,8 +75,12 @@ public class AwsPolicyGenerator {
 
   // This can support generating a policy across multiple buckets and paths, however, the assumed
   // role the policy is applied to for a scoped-session needs to have access across those buckets
+  /**
+   * Test helper: commercial {@link #AWS_PARTITION} (no role ARN or region). Production always
+   * calls {@link #generatePolicy(Set, List, String, Region)}.
+   */
   @SneakyThrows
-  public static String generatePolicy(
+  static String generatePolicy(
       Set<CredentialContext.Privilege> privileges,
       List<NormalizedURL> locations) {
     return generatePolicy(privileges, locations, null, null);
@@ -102,10 +106,10 @@ public class AwsPolicyGenerator {
     JsonNode operationsStatement = loadYaml(OPERATION_STATEMENT);
     policyStatement.add(operationsStatement);
     JsonNode kmsStatement = loadYaml(KMS_STATEMENT);
-    JsonNode stringLike = kmsStatement.findPath("StringLike");
-    if (stringLike instanceof ObjectNode stringLikeNode) {
-      stringLikeNode.put("kms:ViaService", kmsViaService(partition));
-    }
+    ((ObjectNode) kmsStatement)
+        .putObject("Condition")
+        .putObject("StringLike")
+        .put("kms:ViaService", kmsViaService(partition));
 
     // Add the appropriate S3 and KMS operations for the privileges requested
     ArrayNode actions = (ArrayNode) operationsStatement.findPath("Action");
@@ -209,7 +213,7 @@ public class AwsPolicyGenerator {
   }
 
   private static PartitionMetadata commercialPartition() {
-    return PartitionMetadata.of("aws");
+    return PartitionMetadata.of(AWS_PARTITION);
   }
 
   private static String s3Arn(PartitionMetadata partition, String resource) {

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -53,24 +53,22 @@ public class AwsPolicyGenerator {
       Resource: []
       """;
 
-  // The condition key S3 populates when it calls KMS on the caller's behalf. Its value is the ARN
-  // of the object being encrypted or decrypted, or the ARN of the bucket when the bucket has S3
-  // Bucket Keys enabled, in which case the data key is shared across the objects in the bucket.
-  static final String KMS_ENCRYPTION_CONTEXT_KEY = "kms:EncryptionContext:aws:s3:arn";
-
   // Unity Catalog doesn't know which KMS key a bucket is configured with, so the resource stays
-  // open and the statement is narrowed by condition instead: to KMS calls made through S3, and to
-  // the S3 ARNs this policy already grants access to. A session policy can only narrow what the
-  // assumed role is already allowed to do, so a role without KMS access still gets none.
+  // open and the statement is narrowed to KMS calls made through S3. A session policy can only
+  // narrow what the assumed role is already allowed to do, so a role without KMS access still
+  // gets none. Encryption-context ARNs are omitted on purpose: they duplicate every S3 resource
+  // in this policy, and on long managed-table paths that blows the STS packed-policy limit
+  // ("Packed policy consumes 100% of allotted space"). S3 resource statements already constrain
+  // which objects the session can Get/Put. GovCloud/China hit the limit sooner because those
+  // ARN prefixes are longer, but commercial paths of the same length overflow too.
   static final String KMS_STATEMENT = """
       Effect: Allow
       Action: []
       Resource:
         - "*"
       Condition:
-        StringLike:
-          "%s": []
-      """.formatted(KMS_ENCRYPTION_CONTEXT_KEY);
+        StringLike: {}
+      """;
 
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
@@ -89,8 +87,8 @@ public class AwsPolicyGenerator {
    *
    * <p>IAM partition is taken from {@code roleArn} when that ARN is well-formed ({@code
    * arn:aws-us-gov:...} → {@code aws-us-gov}), then from the STS region catalog, then commercial
-   * {@code aws}. The same partition is used for S3 resources, KMS encryption-context ARNs, and
-   * {@code kms:ViaService} ({@code s3.*.amazonaws.com} vs {@code s3.*.amazonaws.com.cn}).
+   * {@code aws}. The same partition is used for S3 resources and {@code kms:ViaService}
+   * ({@code s3.*.amazonaws.com} vs {@code s3.*.amazonaws.com.cn}).
    */
   @SneakyThrows
   public static String generatePolicy(
@@ -124,8 +122,6 @@ public class AwsPolicyGenerator {
               privileges, locations));
     }
 
-    ArrayNode kmsEncryptionContexts = (ArrayNode) kmsStatement.findPath(KMS_ENCRYPTION_CONTEXT_KEY);
-
     // Group each location by s3 bucket it's located in, then for each
     // bucket, add the bucket arn for the listBucket and operations statements,
     // then add each path as a conditional prefix
@@ -137,11 +133,6 @@ public class AwsPolicyGenerator {
       ArrayNode operationsResource = (ArrayNode) operationsStatement.findPath("Resource");
       bucketResource.add(s3Arn(partition, bucketName));
 
-      // A bucket with S3 Bucket Keys enabled encrypts under the bucket arn rather than the object
-      // arn, so the bucket has to be allowed as an encryption context on its own. That case can't
-      // be scoped to a path: the same data key covers every object in the bucket.
-      kmsEncryptionContexts.add(s3Arn(partition, bucketName));
-
       ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
       paths.forEach(path -> {
         // remove any preceding forward slashes
@@ -149,17 +140,14 @@ public class AwsPolicyGenerator {
 
         if (sanitizedPath.isEmpty()) {
           conditionalPrefixes.add("*");
-          addObjectArn(s3Arn(partition, bucketName + "/*"),
-              operationsResource, kmsEncryptionContexts);
+          operationsResource.add(s3Arn(partition, bucketName + "/*"));
         } else {
           conditionalPrefixes.add(sanitizedPath);
           conditionalPrefixes.add(sanitizedPath + "/");
           conditionalPrefixes.add(sanitizedPath + "/*");
 
-          addObjectArn(s3Arn(partition, bucketName + "/" + sanitizedPath + "/*"),
-              operationsResource, kmsEncryptionContexts);
-          addObjectArn(s3Arn(partition, bucketName + "/" + sanitizedPath),
-              operationsResource, kmsEncryptionContexts);
+          operationsResource.add(s3Arn(partition, bucketName + "/" + sanitizedPath + "/*"));
+          operationsResource.add(s3Arn(partition, bucketName + "/" + sanitizedPath));
         }
       });
     });
@@ -169,17 +157,6 @@ public class AwsPolicyGenerator {
     policyStatement.add(kmsStatement);
 
     return JSON_MAPPER.writeValueAsString(policyRoot);
-  }
-
-  /**
-   * Allows an object arn in the S3 operations statement, and allows the same arn as a KMS
-   * encryption context so that the KMS permissions cover exactly the objects the policy grants
-   * access to.
-   */
-  private static void addObjectArn(
-      String objectArn, ArrayNode operationsResource, ArrayNode kmsEncryptionContexts) {
-    operationsResource.add(objectArn);
-    kmsEncryptionContexts.add(objectArn);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -3,7 +3,6 @@ package io.unitycatalog.server.service.credential.aws;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.BUCKET_STATEMENT;
-import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.KMS_ENCRYPTION_CONTEXT_KEY;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.KMS_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.OPERATION_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.POLICY_STATEMENT;
@@ -199,54 +198,37 @@ public class AwsPolicyGeneratorTest {
   }
 
   @Test
-  public void testKmsStatementIsScopedToGrantedS3Arns() throws Exception {
+  public void testKmsStatementOmitsEncryptionContext() throws Exception {
     String policy =
         AwsPolicyGenerator.generatePolicy(
-            Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+            Set.of(UPDATE), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
 
     JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
-    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
-        .map(JsonNode::asText)
-        .containsExactly(
-            "arn:aws:s3:::my-bucket",
-            "arn:aws:s3:::my-bucket/path1/table1/*",
-            "arn:aws:s3:::my-bucket/path1/table1");
+    assertThat(statement.findPath("kms:ViaService").asText()).isEqualTo("s3.*.amazonaws.com");
+    assertThat(policy).doesNotContain("kms:EncryptionContext");
   }
 
   @Test
-  public void testKmsStatementCoversEveryBucket() throws Exception {
+  public void testLongManagedTablePathFitsStsSessionPolicyLimit() {
+    String location =
+        "s3://example-managed-bucket/"
+            + "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee_catalog/"
+            + "__unitystorage/schemas/11111111-2222-3333-4444-555555555555/"
+            + "tables/66666666-7777-8888-9999-000000000000";
     String policy =
         AwsPolicyGenerator.generatePolicy(
             Set.of(UPDATE),
-            Stream.of("s3://my-bucket1/path1/table1", "s3://my-bucket2")
-                .map(NormalizedURL::from)
-                .toList());
+            List.of(NormalizedURL.from(location)),
+            "arn:aws-us-gov:iam::123456789012:role/gov-role",
+            Region.of("us-gov-west-1"));
 
-    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
-    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
-        .map(JsonNode::asText)
-        .containsExactlyInAnyOrder(
-            "arn:aws:s3:::my-bucket1",
-            "arn:aws:s3:::my-bucket1/path1/table1/*",
-            "arn:aws:s3:::my-bucket1/path1/table1",
-            "arn:aws:s3:::my-bucket2",
-            "arn:aws:s3:::my-bucket2/*");
-  }
-
-  @Test
-  public void testKmsEncryptionContextEscapesIamSpecialCharacters() throws Exception {
-    String policy =
-        AwsPolicyGenerator.generatePolicy(
-            Set.of(UPDATE), List.of(NormalizedURL.from("s3://victim-bucket/*")));
-
-    JsonNode statement = findKmsStatement(JSON_MAPPER.readTree(policy));
-    assertThat(statement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
-        .map(JsonNode::asText)
-        .containsExactly(
-            "arn:aws:s3:::victim-bucket",
-            "arn:aws:s3:::victim-bucket/${*}/*",
-            "arn:aws:s3:::victim-bucket/${*}")
-        .doesNotContain("arn:aws:s3:::victim-bucket/*", "arn:aws:s3:::victim-bucket/*/*");
+    // STS rejects AssumeRole when the packed session policy hits 100%. The plaintext limit is
+    // 2048 characters; staying well under that keeps packed size in budget on long paths.
+    // GovCloud ARNs are used here because they are longer; commercial paths of the same length
+    // can overflow too when encryption-context ARNs duplicate every S3 resource.
+    assertThat(policy.length()).isLessThan(1600);
+    assertThat(policy).doesNotContain("kms:EncryptionContext");
+    assertThat(policy).contains("arn:aws-us-gov:s3:::example-managed-bucket");
   }
 
   @Test
@@ -347,13 +329,8 @@ public class AwsPolicyGeneratorTest {
     assertThat(root.get("Statement").get(1).get("Resource").get(0).asText())
         .isEqualTo(expectedBucketArn);
     JsonNode kmsStatement = findKmsStatement(root);
-    assertThat(kmsStatement.findPath(KMS_ENCRYPTION_CONTEXT_KEY))
-        .map(JsonNode::asText)
-        .containsExactly(
-            expectedBucketArn,
-            expectedBucketArn + "/path1/table1/*",
-            expectedBucketArn + "/path1/table1");
     assertThat(kmsStatement.findPath("kms:ViaService").asText()).isEqualTo(expectedViaService);
+    assertThat(policy).doesNotContain("kms:EncryptionContext");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -2,6 +2,7 @@ package io.unitycatalog.server.service.credential.aws;
 
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
+import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.AWS_PARTITION;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.BUCKET_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.KMS_STATEMENT;
 import static io.unitycatalog.server.service.credential.aws.AwsPolicyGenerator.OPERATION_STATEMENT;
@@ -261,7 +262,7 @@ public class AwsPolicyGeneratorTest {
 
   @Test
   public void testNullRegionDefaultsToAwsPartition() {
-    assertThat(AwsPolicyGenerator.partitionFromRegion(null).id()).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.partitionFromRegion(null).id()).isEqualTo(AWS_PARTITION);
   }
 
   @ParameterizedTest(name = "{index}: {0} -> {1}")
@@ -301,8 +302,8 @@ public class AwsPolicyGeneratorTest {
 
   @Test
   public void testBlankRoleAndRegionDefaultToAwsPartition() {
-    assertThat(AwsPolicyGenerator.iamPartition(null, null).id()).isEqualTo("aws");
-    assertThat(AwsPolicyGenerator.iamPartition("", null).id()).isEqualTo("aws");
+    assertThat(AwsPolicyGenerator.iamPartition(null, null).id()).isEqualTo(AWS_PARTITION);
+    assertThat(AwsPolicyGenerator.iamPartition("", null).id()).isEqualTo(AWS_PARTITION);
   }
 
   @ParameterizedTest(name = "{index}: {0} uses {1}")


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

#1774 added `kms:Decrypt` / `kms:GenerateDataKey*` so vended credentials can read SSE-KMS objects. It also listed every S3 ARN again under `kms:EncryptionContext:aws:s3:arn`. That duplication makes AssumeRole fail with `Packed policy consumes 100% of allotted space` on long managed-table paths.

This is not GovCloud-specific. STS packed-policy size is a general limit (plaintext cap 2048 characters). GovCloud and China hit it sooner because `arn:aws-us-gov:` / `arn:aws-cn:` are longer than `arn:aws:`, and those ARNs were copied into both S3 `Resource` and the KMS encryption-context list. Commercial AWS overflows too with a long enough path or several locations in one vend call.

**Change**

Keep the KMS actions and `kms:ViaService` (partition-aware DNS suffix from #1794). Drop the encryption-context ARN list. S3 `Resource` / prefix conditions already constrain which objects the session can Get/Put; a session policy cannot grant more than the assumed role already has.

**Testing**

- [x] `AwsPolicyGeneratorTest.testKmsStatementOmitsEncryptionContext`
- [x] `AwsPolicyGeneratorTest.testLongManagedTablePathFitsStsSessionPolicyLimit` (GovCloud ARNs, policy < 1600 chars)
- [x] `sbt "server/testOnly io.unitycatalog.server.service.credential.aws.AwsPolicyGeneratorTest io.unitycatalog.server.service.credential.CloudCredentialVendorTest"` (Java 17) — 47 passed

Made with [Cursor](https://cursor.com)
