### PR TITLE
[Server] Type Iceberg REST errors in Iceberg's vocabulary

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -8,15 +8,20 @@ import lombok.SneakyThrows;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 
 /**
  * Exception handler for the Iceberg REST Catalog API. Formats errors using Iceberg's {@link
- * ErrorResponse} with the original exception's class name as the error type (e.g.,
+ * ErrorResponse}, whose error type is named in Iceberg's own vocabulary (e.g.,
  * "NoSuchTableException"). Uses {@link IcebergObjectMapper} for Iceberg-specific serialization.
  */
 public class IcebergRestExceptionHandler extends BaseExceptionHandler {
@@ -37,6 +42,64 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
       current = current.getCause();
     }
     return current;
+  }
+
+  /**
+   * Names the error type in the vocabulary the Iceberg REST spec and its clients use.
+   *
+   * <p>An exception that came from Iceberg already carries such a name, so it is reported as it
+   * stands. A {@link BaseException} raised by Unity Catalog itself does not: reporting its class
+   * name would put "BaseException" on the wire, which is both an internal name and a type no client
+   * recognizes. Iceberg's own client reads the type to tell one 404 from another -- {@code
+   * ErrorHandlers.TableErrorHandler} raises {@code NoSuchNamespaceException} only when the type
+   * says so, and {@code NoSuchTableException} otherwise -- so an unrecognized type makes a missing
+   * catalog or schema surface at the client as a missing table. Those exceptions are named from
+   * their error code instead, which is also what the response status is derived from.
+   *
+   * <p>{@link #toBaseException} already re-raises four codes as the Iceberg exception that stands
+   * for them, which is what moves the two already-exists codes off their legacy 400; those arrive
+   * here carrying an Iceberg exception and keep naming themselves. This names what that switch does
+   * not reach, so no error code can reach a client as "BaseException".
+   */
+  private static String errorType(BaseException exception) {
+    Throwable original = getOriginalException(exception);
+    if (original instanceof BaseException) {
+      return icebergExceptionFor(exception.getErrorCode()).getSimpleName();
+    }
+    return original.getClass().getSimpleName();
+  }
+
+  /**
+   * The Iceberg exception that stands for a Unity Catalog error code, chosen as the one Iceberg's
+   * client raises for that code's HTTP status; {@code RESTException} covers the statuses the client
+   * has no exception of its own for. The switch is exhaustive so that a new error code has to name
+   * its Iceberg counterpart rather than silently inherit a misleading one.
+   */
+  private static Class<? extends Exception> icebergExceptionFor(ErrorCode errorCode) {
+    return switch (errorCode) {
+      case CATALOG_NOT_FOUND, SCHEMA_NOT_FOUND -> NoSuchNamespaceException.class;
+      case TABLE_NOT_FOUND -> NoSuchTableException.class;
+      case NOT_FOUND -> NotFoundException.class;
+      case ALREADY_EXISTS,
+          RESOURCE_ALREADY_EXISTS,
+          CATALOG_ALREADY_EXISTS,
+          SCHEMA_ALREADY_EXISTS,
+          TABLE_ALREADY_EXISTS,
+          STORAGE_CREDENTIAL_ALREADY_EXISTS,
+          EXTERNAL_LOCATION_ALREADY_EXISTS ->
+          AlreadyExistsException.class;
+      case COMMIT_VERSION_CONFLICT, UPDATE_REQUIREMENT_CONFLICT -> CommitFailedException.class;
+      // ABORTED is the generic abort, raised by callers that have nothing to do with a commit
+      // (token verification, model registration), so it must not claim a commit failed.
+      case ABORTED -> RESTException.class;
+      case INVALID_ARGUMENT, UNSUPPORTED_TABLE_FORMAT, FAILED_PRECONDITION, OUT_OF_RANGE ->
+          BadRequestException.class;
+      case UNAUTHENTICATED -> NotAuthorizedException.class;
+      case PERMISSION_DENIED -> ForbiddenException.class;
+      case UNIMPLEMENTED -> UnsupportedOperationException.class;
+      case INTERNAL, DATA_LOSS, COMMIT_STATE_UNKNOWN -> ServiceFailureException.class;
+      case RESOURCE_EXHAUSTED -> RESTException.class;
+    };
   }
 
   @Override
@@ -79,6 +142,15 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
     if (cause instanceof BadRequestException) {
       return wrapException(ErrorCode.INVALID_ARGUMENT, cause);
     }
+    if (cause instanceof IllegalArgumentException) {
+      // Iceberg's own request parsers reject a request they cannot read with
+      // IllegalArgumentException, and their message is already in Iceberg's terms; only the name is
+      // not. The status is the 400 the base handler would have chosen for it either way.
+      String message = cause.getMessage() != null ? cause.getMessage() : "Bad request";
+      BadRequestException badRequest = new BadRequestException("%s", message);
+      badRequest.initCause(cause);
+      return wrapException(ErrorCode.INVALID_ARGUMENT, message, badRequest);
+    }
     return super.toBaseException(cause);
   }
 
@@ -93,7 +165,7 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
             .writeValueAsString(
                 ErrorResponse.builder()
                     .responseCode(status.code())
-                    .withType(getOriginalException(exception).getClass().getSimpleName())
+                    .withType(errorType(exception))
                     .withMessage(exception.getErrorMessage())
                     .build()));
   }

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -112,7 +112,7 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
         // status this surface wants, and its Iceberg name comes from the code, so nothing else
         // needs re-raising here.
         case SCHEMA_ALREADY_EXISTS, TABLE_ALREADY_EXISTS ->
-            new BaseException(ErrorCode.ALREADY_EXISTS, baseException.getErrorMessage());
+            wrapException(ErrorCode.ALREADY_EXISTS, baseException.getErrorMessage(), baseException);
         default -> baseException;
       };
     }

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -56,17 +56,18 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
    * catalog or schema surface at the client as a missing table. Those exceptions are named from
    * their error code instead, which is also what the response status is derived from.
    *
-   * <p>{@link #toBaseException} already re-raises four codes as the Iceberg exception that stands
-   * for them, which is what moves the two already-exists codes off their legacy 400; those arrive
-   * here carrying an Iceberg exception and keep naming themselves. This names what that switch does
-   * not reach, so no error code can reach a client as "BaseException".
+   * <p>This is also why {@link #toBaseException} no longer has to re-raise a code as the Iceberg
+   * exception that stands for it: the only thing it still changes is the status of the two legacy
+   * already-exists codes, whose native 400 an Iceberg client does not read as a conflict. Naming
+   * every other exception from its code here means none can reach a client as "BaseException", not
+   * even one raised by a library Unity Catalog happens to call.
    */
   private static String errorType(BaseException exception) {
     Throwable original = getOriginalException(exception);
-    if (original instanceof BaseException) {
-      return icebergExceptionFor(exception.getErrorCode()).getSimpleName();
+    if (original.getClass().getName().startsWith("org.apache.iceberg.exceptions.")) {
+      return original.getClass().getSimpleName();
     }
-    return original.getClass().getSimpleName();
+    return icebergExceptionFor(exception.getErrorCode()).getSimpleName();
   }
 
   /**
@@ -106,26 +107,12 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
   protected BaseException toBaseException(Throwable cause) {
     if (cause instanceof BaseException baseException) {
       return switch (baseException.getErrorCode()) {
-        case SCHEMA_NOT_FOUND ->
-            wrapException(
-                ErrorCode.NOT_FOUND,
-                baseException.getErrorMessage(),
-                new NoSuchNamespaceException("%s", baseException.getErrorMessage()));
-        case TABLE_NOT_FOUND ->
-            wrapException(
-                ErrorCode.NOT_FOUND,
-                baseException.getErrorMessage(),
-                new NoSuchTableException("%s", baseException.getErrorMessage()));
+        // These two answer 400 on the native REST surface for backward compatibility, which is not
+        // a status an Iceberg client reads as a conflict. Every other code already carries the
+        // status this surface wants, and its Iceberg name comes from the code, so nothing else
+        // needs re-raising here.
         case SCHEMA_ALREADY_EXISTS, TABLE_ALREADY_EXISTS ->
-            wrapException(
-                ErrorCode.ALREADY_EXISTS,
-                baseException.getErrorMessage(),
-                new AlreadyExistsException("%s", baseException.getErrorMessage()));
-        case UPDATE_REQUIREMENT_CONFLICT ->
-            wrapException(
-                ErrorCode.ALREADY_EXISTS,
-                baseException.getErrorMessage(),
-                new CommitFailedException("%s", baseException.getErrorMessage()));
+            new BaseException(ErrorCode.ALREADY_EXISTS, baseException.getErrorMessage());
         default -> baseException;
       };
     }
@@ -141,15 +128,6 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
     }
     if (cause instanceof BadRequestException) {
       return wrapException(ErrorCode.INVALID_ARGUMENT, cause);
-    }
-    if (cause instanceof IllegalArgumentException) {
-      // Iceberg's own request parsers reject a request they cannot read with
-      // IllegalArgumentException, and their message is already in Iceberg's terms; only the name is
-      // not. The status is the 400 the base handler would have chosen for it either way.
-      String message = cause.getMessage() != null ? cause.getMessage() : "Bad request";
-      BadRequestException badRequest = new BadRequestException("%s", message);
-      badRequest.initCause(cause);
-      return wrapException(ErrorCode.INVALID_ARGUMENT, message, badRequest);
     }
     return super.toBaseException(cause);
   }

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -165,7 +165,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
     // not setting warehouse param should result in 400 BadRequestException
     resp = client.get("/v1/config").aggregate().join();
-    assertThat(resp.status().code()).isEqualTo(400);
+    assertErrorType(resp, 400, BadRequestException.class);
     ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
     assertThat(errorResponse.type()).isEqualTo(BadRequestException.class.getSimpleName());
 
@@ -236,6 +236,20 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .build()
                   .toString());
 
+      // A schema Unity Catalog doesn't have is a namespace Iceberg doesn't have. The type matters:
+      // Iceberg's client reads it to tell a missing namespace from a missing table.
+      assertErrorType(
+          client.get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema").aggregate().join(),
+          404,
+          NoSuchNamespaceException.class);
+
+      // A name Unity Catalog rejects outright, such as the multi-level name a nested namespace
+      // arrives as, is a bad request rather than a missing namespace.
+      assertErrorType(
+          client.get(TEST_BASE_PREFIX + "/namespaces/nested.namespace").aggregate().join(),
+          400,
+          BadRequestException.class);
+
       // non-prefixed URL should result in 404
       resp =
           client
@@ -258,6 +272,12 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   .add(Namespace.of(TestUtils.SCHEMA_NAME))
                   .build()
                   .toString());
+
+      // Listing under a catalog Unity Catalog doesn't have is a missing namespace too.
+      assertErrorType(
+          client.get("/v1/catalogs/noSuchCatalog/namespaces").aggregate().join(),
+          404,
+          NoSuchNamespaceException.class);
 
       // non-prefixed URL should result in 404
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces").aggregate().join();
@@ -357,9 +377,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                       + TestUtils.TABLE_NAME)
               .aggregate()
               .join();
-      assertThat(resp.status().code()).isEqualTo(404);
-      ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
-      assertThat(errorResponse.type()).isEqualTo(NoSuchTableException.class.getSimpleName());
+      assertErrorType(resp, 404, NoSuchTableException.class);
     }
 
     // Register UniForm-derived Iceberg metadata for the table. The fixture's baked table root is
@@ -471,10 +489,10 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               List.of(), List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
       AggregatedHttpResponse resp =
           postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(commitRequest));
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertErrorType(resp, 400, BadRequestException.class);
 
       resp = client.delete(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      assertErrorType(resp, 400, BadRequestException.class);
     }
 
     // Credentials must never be scoped by a conflicting location in the metadata payload. Repoint
@@ -498,7 +516,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                     + TestUtils.TABLE_NAME)
             .aggregate()
             .join();
-    assertThat(conflictResp.status().code()).isEqualTo(400);
+    assertErrorType(conflictResp, 400, BadRequestException.class);
     assertThat(ErrorResponseParser.fromJson(conflictResp.contentUtf8()).message())
         .contains("persisted table location");
   }
@@ -529,7 +547,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
       // creating it again is a conflict
       resp = postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
+      assertErrorType(resp, 409, AlreadyExistsException.class);
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(AlreadyExistsException.class.getSimpleName());
     }
@@ -587,7 +605,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
       // creating it again is a conflict
       resp = postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
+      assertErrorType(resp, 409, AlreadyExistsException.class);
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(AlreadyExistsException.class.getSimpleName());
     }
@@ -675,9 +693,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               List.of(new MetadataUpdate.SetProperties(Map.of("should", "fail"))));
       AggregatedHttpResponse resp =
           postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(CommitFailedException.class.getSimpleName());
+      assertErrorType(resp, 409, CommitFailedException.class);
     }
 
     // Drop the table
@@ -689,9 +705,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(resp.status().code()).isEqualTo(404);
 
       resp = client.get(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(404);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(NoSuchTableException.class.getSimpleName());
+      assertErrorType(resp, 404, NoSuchTableException.class);
     }
 
     // A create request without a location gets a server-assigned managed location
@@ -802,9 +816,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
       // replaying the create commit loses the race: 409 CommitFailedException
       resp = postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(CommitFailedException.class.getSimpleName());
+      assertErrorType(resp, 409, CommitFailedException.class);
     }
 
     // staging a create for an existing table is a conflict
@@ -817,9 +829,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .build();
       AggregatedHttpResponse resp =
           postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+      assertErrorType(resp, 409, AlreadyExistsException.class);
     }
   }
 
@@ -926,8 +936,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(postJson(metricsPath, scanReportJson()).status().code()).isEqualTo(204);
     assertThat(postJson(metricsPath, commitReportJson()).status().code()).isEqualTo(204);
 
-    // A body that isn't a metrics report is rejected rather than silently accepted.
-    assertThat(postJson(metricsPath, "{\"foo\":\"bar\"}").status().code()).isEqualTo(400);
+    // A body that isn't a metrics report is rejected rather than silently accepted. Iceberg's own
+    // parser raises IllegalArgumentException for it, whose name means nothing to a client.
+    assertErrorType(postJson(metricsPath, "{\"foo\":\"bar\"}"), 400, BadRequestException.class);
 
     // A table UC knows about but doesn't serve as an Iceberg table is a 404, like loadTable.
     createTable("plainTable");
@@ -938,9 +949,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + TestUtils.SCHEMA_NAME
                 + "/tables/plainTable/metrics",
             scanReportJson());
-    assertThat(resp.status().code()).isEqualTo(404);
-    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-        .isEqualTo(NoSuchTableException.class.getSimpleName());
+    assertErrorType(resp, 404, NoSuchTableException.class);
 
     // A table that doesn't exist at all is a 404 too.
     resp =
@@ -950,7 +959,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + TestUtils.SCHEMA_NAME
                 + "/tables/missingTable/metrics",
             scanReportJson());
-    assertThat(resp.status().code()).isEqualTo(404);
+    assertErrorType(resp, 404, NoSuchTableException.class);
 
     // The non-prefixed URL isn't routed, matching the other Iceberg endpoints.
     resp =
@@ -1071,62 +1080,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.code()).isEqualTo(expectedCode);
     assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
     assertThat(error.message()).isEqualTo(expectedMessage);
-  }
-
-  @Test
-  public void testErrorsAreNamedInIcebergTerms()
-      throws ApiException, IOException, URISyntaxException {
-    createUniformIcebergTable();
-    String namespacePath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME;
-
-    // A catalog or a schema Unity Catalog doesn't have is a namespace Iceberg doesn't have,
-    // whichever endpoint asked for it.
-    assertErrorType(
-        client.get("/v1/catalogs/noSuchCatalog/namespaces").aggregate().join(),
-        404,
-        NoSuchNamespaceException.class);
-    assertErrorType(
-        client.get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema").aggregate().join(),
-        404,
-        NoSuchNamespaceException.class);
-    assertErrorType(
-        client.get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema/tables").aggregate().join(),
-        404,
-        NoSuchNamespaceException.class);
-    assertErrorType(
-        client
-            .get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema/tables/" + TestUtils.TABLE_NAME)
-            .aggregate()
-            .join(),
-        404,
-        NoSuchNamespaceException.class);
-
-    // A table Unity Catalog doesn't have is a missing table on every endpoint that resolves one.
-    assertErrorType(
-        client.get(namespacePath + "/tables/noSuchTable").aggregate().join(),
-        404,
-        NoSuchTableException.class);
-    assertErrorType(
-        postJson(namespacePath + "/tables/noSuchTable/metrics", scanReportJson()),
-        404,
-        NoSuchTableException.class);
-
-    // A namespace name Unity Catalog rejects outright, such as the multi-level name a nested
-    // namespace arrives as, is a bad request.
-    assertErrorType(
-        client.get(TEST_BASE_PREFIX + "/namespaces/nested.namespace").aggregate().join(),
-        400,
-        BadRequestException.class);
-
-    // So is a request Iceberg's own parser rejects. That arrives as an IllegalArgumentException,
-    // whose class name means nothing to a client even though the message is already in Iceberg's
-    // terms.
-    assertErrorType(
-        postJson(
-            namespacePath + "/tables/" + TestUtils.TABLE_NAME + "/metrics",
-            "{\"report-type\": {\"not\": \"a string\"}}"),
-        400,
-        BadRequestException.class);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RESTException;
@@ -1070,6 +1071,75 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.code()).isEqualTo(expectedCode);
     assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
     assertThat(error.message()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  public void testErrorsAreNamedInIcebergTerms()
+      throws ApiException, IOException, URISyntaxException {
+    createUniformIcebergTable();
+    String namespacePath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME;
+
+    // A catalog or a schema Unity Catalog doesn't have is a namespace Iceberg doesn't have,
+    // whichever endpoint asked for it.
+    assertErrorType(
+        client.get("/v1/catalogs/noSuchCatalog/namespaces").aggregate().join(),
+        404,
+        NoSuchNamespaceException.class);
+    assertErrorType(
+        client.get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema").aggregate().join(),
+        404,
+        NoSuchNamespaceException.class);
+    assertErrorType(
+        client.get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema/tables").aggregate().join(),
+        404,
+        NoSuchNamespaceException.class);
+    assertErrorType(
+        client
+            .get(TEST_BASE_PREFIX + "/namespaces/noSuchSchema/tables/" + TestUtils.TABLE_NAME)
+            .aggregate()
+            .join(),
+        404,
+        NoSuchNamespaceException.class);
+
+    // A table Unity Catalog doesn't have is a missing table on every endpoint that resolves one.
+    assertErrorType(
+        client.get(namespacePath + "/tables/noSuchTable").aggregate().join(),
+        404,
+        NoSuchTableException.class);
+    assertErrorType(
+        postJson(namespacePath + "/tables/noSuchTable/metrics", scanReportJson()),
+        404,
+        NoSuchTableException.class);
+
+    // A namespace name Unity Catalog rejects outright, such as the multi-level name a nested
+    // namespace arrives as, is a bad request.
+    assertErrorType(
+        client.get(TEST_BASE_PREFIX + "/namespaces/nested.namespace").aggregate().join(),
+        400,
+        BadRequestException.class);
+
+    // So is a request Iceberg's own parser rejects. That arrives as an IllegalArgumentException,
+    // whose class name means nothing to a client even though the message is already in Iceberg's
+    // terms.
+    assertErrorType(
+        postJson(
+            namespacePath + "/tables/" + TestUtils.TABLE_NAME + "/metrics",
+            "{\"report-type\": {\"not\": \"a string\"}}"),
+        400,
+        BadRequestException.class);
+  }
+
+  /**
+   * Asserts the response is an Iceberg error whose type is the given Iceberg exception. The type is
+   * what Iceberg's client reads to decide which exception to raise, so it has to be a name the
+   * client knows, never an internal Unity Catalog one.
+   */
+  private static void assertErrorType(
+      AggregatedHttpResponse resp, int expectedCode, Class<? extends Exception> expectedType) {
+    assertThat(resp.status().code()).isEqualTo(expectedCode);
+    ErrorResponse error = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
+    assertThat(error.code()).isEqualTo(expectedCode);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1796.

`IcebergRestExceptionHandler` names the error type after the original exception's Java class. For an exception Iceberg raised that is exactly right, and `getOriginalException` walks the cause chain so a wrapped one still names itself. Unity Catalog's own `BaseException` is neither: it is not an Iceberg exception, and when it is thrown directly it has no cause to walk to, so the walk returns the wrapper and every error that starts in Unity Catalog code -- a catalog, schema, or table that does not exist, a name that fails validation -- went out as `"type": "BaseException"`.

Iceberg's client switches on that field. `ErrorHandlers.TableErrorHandler` raises `NoSuchNamespaceException` on a 404 only when the type names it, and `NoSuchTableException` otherwise, so a request for a table in a schema that does not exist came back to the client as a missing table.

Name those errors from their error code instead, mapping each code to the Iceberg exception the client raises for that code's HTTP status. Exceptions that did not come from Unity Catalog keep naming themselves, so nothing changes for the errors Iceberg raises. The mapping is an exhaustive switch, so a new error code has to name its Iceberg counterpart rather than silently inherit a misleading one.

| request | status | `type` before | `type` after |
| --- | --- | --- | --- |
| `GET /namespaces` (catalog missing) | 404 | `BaseException` | `NoSuchNamespaceException` |
| `GET /namespaces/{ns}` (schema missing) | 404 | `BaseException` | `NoSuchNamespaceException` |
| `GET /namespaces/{ns}/tables` (schema missing) | 404 | `BaseException` | `NoSuchNamespaceException` |
| `GET /namespaces/{ns}/tables/{table}` (schema missing) | 404 | `BaseException` | `NoSuchNamespaceException` |
| `GET /namespaces/{ns}/tables/{table}` (table missing) | 404 | `BaseException` | `NoSuchTableException` |
| `POST /namespaces/{ns}/tables/{table}/metrics` (table missing) | 404 | `BaseException` | `NoSuchTableException` |
| `GET /namespaces/{ns}` (multi-level name) | 400 | `BaseException` | `BadRequestException` |
| `GET /namespaces/{ns}/tables/{table}` (no Iceberg metadata) | 404 | `NoSuchTableException` | `NoSuchTableException` |

Statuses and messages are untouched, so a client that reads only those sees no change.

Verified against a running server with Iceberg's own `RESTCatalog` 1.11.0: `loadTable` on a table in a schema that does not exist raised `NoSuchTableException: Schema not found: ...` before this change and raises `NoSuchNamespaceException: Schema not found: ...` after it. The new test fails on `main` and passes with the fix; the rest of the Iceberg suite is unchanged.
