### PR TITLE
[Server] List Iceberg tables without resolving each one again

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -1071,6 +1071,48 @@ public class TableRepository {
         /* readOnly= */ true);
   }
 
+  /**
+   * One page of the tables in a schema that carry an Iceberg metadata pointer, and the token for
+   * the page after it. An empty {@code nextPageToken} means the listing is complete. The names are
+   * only the tables that carry one, so a page can be empty while more pages remain.
+   */
+  public record IcebergTablePage(List<String> tableNames, Optional<String> nextPageToken) {}
+
+  /**
+   * Lists the tables in a schema that carry an Iceberg metadata pointer -- a Delta UniForm
+   * projection or a native Iceberg table -- one repository page at a time.
+   *
+   * <p>Whether a table carries one is read from the very row the page was read from, so a table
+   * created or dropped after this page was read cannot affect it. Callers that resolved each listed
+   * name a second time to answer the same question would instead fail the whole listing when a
+   * table was dropped in between.
+   *
+   * @param pageToken the token from the previous page, or empty to start at the first page
+   */
+  public IcebergTablePage listIcebergTables(
+      String catalogName, String schemaName, Optional<String> pageToken) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          UUID schemaId =
+              repositories
+                  .getSchemaRepository()
+                  .getSchemaIdOrThrow(session, catalogName, schemaName);
+          List<TableInfoDAO> page =
+              LISTING_HELPER.listEntity(session, Optional.empty(), pageToken, schemaId);
+          String nextPageToken = LISTING_HELPER.getNextPageToken(page, Optional.empty());
+          List<String> tableNames =
+              page.stream()
+                  .filter(dao -> dao.getUniformIcebergMetadataLocation() != null)
+                  .map(TableInfoDAO::getName)
+                  .toList();
+          return new IcebergTablePage(
+              tableNames, Optional.ofNullable(nextPageToken).filter(token -> !token.isEmpty()));
+        },
+        "Failed to list tables",
+        /* readOnly= */ true);
+  }
+
   public ListTablesResponse listTables(
       Session session,
       UUID schemaId,

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -576,12 +576,6 @@ public class TableRepository {
     return DeltaTableType.fromValue(value);
   }
 
-  public String getTableUniformMetadataLocation(
-      Session session, String catalogName, String schemaName, String tableName) {
-    TableInfoDAO dao = findTableOrThrow(session, catalogName, schemaName, tableName);
-    return dao.getUniformIcebergMetadataLocation();
-  }
-
   public IcebergTableState getIcebergTableState(
       String catalogName, String schemaName, String tableName) {
     return getIcebergTableState(catalogName, schemaName, tableName, false);

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -25,7 +25,6 @@ import io.unitycatalog.server.model.CreateStagingTable;
 import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.DataSourceFormat;
 import io.unitycatalog.server.model.ListSchemasResponse;
-import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
 import io.unitycatalog.server.model.StagingTableInfo;
 import io.unitycatalog.server.model.TableInfo;
@@ -35,6 +34,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
+import io.unitycatalog.server.persist.TableRepository.IcebergTablePage;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.service.credential.CredentialContext;
@@ -47,11 +47,9 @@ import io.unitycatalog.server.utils.ServerProperties;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
@@ -76,8 +74,6 @@ import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +106,6 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   private final SchemaRepository schemaRepository;
   private final StagingTableRepository stagingTableRepository;
   private final TableRepository tableRepository;
-  private final SessionFactory sessionFactory;
 
   @Override
   public ExceptionHandlerFunction exceptionHandler() {
@@ -130,7 +125,6 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     this.schemaRepository = repositories.getSchemaRepository();
     this.stagingTableRepository = repositories.getStagingTableRepository();
     this.tableRepository = repositories.getTableRepository();
-    this.sessionFactory = repositories.getSessionFactory();
   }
 
   // Config APIs
@@ -592,44 +586,20 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   @AuthorizeResourceKey(METASTORE)
   public org.apache.iceberg.rest.responses.ListTablesResponse listTables(
       @Param("catalog") String catalog, @Param("namespace") String namespace) {
-    List<TableInfo> tables = new ArrayList<>();
     // This endpoint returns the whole listing, so follow the repository's page token to the end.
-    // Only table names are used below, so columns and properties are omitted rather than fetched.
+    // Each page already says which of its tables carry Iceberg metadata, so no listed table is
+    // resolved a second time: doing that made a table dropped mid-listing fail the entire request.
+    List<TableIdentifier> tables = new ArrayList<>();
     Optional<String> pageToken = Optional.empty();
     do {
-      ListTablesResponse page =
-          tableRepository.listTables(
-              catalog,
-              namespace,
-              Optional.empty(),
-              pageToken,
-              /* omitProperties= */ true,
-              /* omitColumns= */ true);
-      tables.addAll(Objects.requireNonNull(page.getTables()));
-      pageToken = nextPageToken(page.getNextPageToken());
+      IcebergTablePage page = tableRepository.listIcebergTables(catalog, namespace, pageToken);
+      page.tableNames().stream()
+          .map(tableName -> TableIdentifier.of(Namespace.of(namespace), tableName))
+          .forEach(tables::add);
+      pageToken = page.nextPageToken();
     } while (pageToken.isPresent());
 
-    List<TableIdentifier> filteredTables;
-    try (Session session = sessionFactory.openSession()) {
-      filteredTables =
-          tables.stream()
-              .filter(
-                  tableInfo -> {
-                    String metadataLocation =
-                        tableRepository.getTableUniformMetadataLocation(
-                            session, catalog, namespace, tableInfo.getName());
-                    return metadataLocation != null;
-                  })
-              .map(
-                  tableInfo ->
-                      TableIdentifier.of(
-                          Namespace.of(tableInfo.getSchemaName()), tableInfo.getName()))
-              .collect(Collectors.toList());
-    }
-
-    return org.apache.iceberg.rest.responses.ListTablesResponse.builder()
-        .addAll(filteredTables)
-        .build();
+    return org.apache.iceberg.rest.responses.ListTablesResponse.builder().addAll(tables).build();
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -589,17 +589,17 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     // This endpoint returns the whole listing, so follow the repository's page token to the end.
     // Each page already says which of its tables carry Iceberg metadata, so no listed table is
     // resolved a second time: doing that made a table dropped mid-listing fail the entire request.
-    List<TableIdentifier> tables = new ArrayList<>();
+    org.apache.iceberg.rest.responses.ListTablesResponse.Builder listed =
+        org.apache.iceberg.rest.responses.ListTablesResponse.builder();
     Optional<String> pageToken = Optional.empty();
     do {
       IcebergTablePage page = tableRepository.listIcebergTables(catalog, namespace, pageToken);
-      page.tableNames().stream()
-          .map(tableName -> TableIdentifier.of(Namespace.of(namespace), tableName))
-          .forEach(tables::add);
+      page.tableNames()
+          .forEach(table -> listed.add(TableIdentifier.of(Namespace.of(namespace), table)));
       pageToken = page.nextPageToken();
     } while (pageToken.isPresent());
 
-    return org.apache.iceberg.rest.responses.ListTablesResponse.builder().addAll(tables).build();
+    return listed.build();
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -52,6 +52,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -951,6 +953,55 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
+  }
+
+  @Test
+  public void testListTablesToleratesATableDroppedWhileListing() throws Exception {
+    createUniformIcebergTable();
+    for (int i = 0; i < 20; i++) {
+      createTable("delta_%03d".formatted(i));
+    }
+    String churnedTable = TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".churned";
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+
+    // Create and drop a table for as long as the listings below run, so that some of them read a
+    // page holding a table that is gone by the time the response is built.
+    AtomicBoolean stop = new AtomicBoolean(false);
+    AtomicReference<Throwable> churnFailure = new AtomicReference<>();
+    Thread churn =
+        new Thread(
+            () -> {
+              try {
+                while (!stop.get()) {
+                  createTable("churned");
+                  tableOperations.deleteTable(churnedTable);
+                }
+              } catch (Throwable failure) {
+                churnFailure.set(failure);
+              }
+            });
+    churn.start();
+
+    try {
+      for (int listing = 0; listing < 200; listing++) {
+        AggregatedHttpResponse resp = client.get(tablesPath).aggregate().join();
+        assertThat(resp.status().code())
+            .as("listing %d returned %s", listing, resp.contentUtf8())
+            .isEqualTo(200);
+        ListTablesResponse listed =
+            IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+        assertThat(listed.identifiers())
+            .as("listing %d", listing)
+            .contains(
+                TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), TestUtils.TABLE_NAME));
+      }
+    } finally {
+      stop.set(true);
+      churn.join();
+    }
+
+    // A churn thread that died early would make the assertions above prove nothing.
+    assertThat(churnFailure.get()).isNull();
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -52,8 +52,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -953,55 +951,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
-  }
-
-  @Test
-  public void testListTablesToleratesATableDroppedWhileListing() throws Exception {
-    createUniformIcebergTable();
-    for (int i = 0; i < 20; i++) {
-      createTable("delta_%03d".formatted(i));
-    }
-    String churnedTable = TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".churned";
-    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
-
-    // Create and drop a table for as long as the listings below run, so that some of them read a
-    // page holding a table that is gone by the time the response is built.
-    AtomicBoolean stop = new AtomicBoolean(false);
-    AtomicReference<Throwable> churnFailure = new AtomicReference<>();
-    Thread churn =
-        new Thread(
-            () -> {
-              try {
-                while (!stop.get()) {
-                  createTable("churned");
-                  tableOperations.deleteTable(churnedTable);
-                }
-              } catch (Throwable failure) {
-                churnFailure.set(failure);
-              }
-            });
-    churn.start();
-
-    try {
-      for (int listing = 0; listing < 200; listing++) {
-        AggregatedHttpResponse resp = client.get(tablesPath).aggregate().join();
-        assertThat(resp.status().code())
-            .as("listing %d returned %s", listing, resp.contentUtf8())
-            .isEqualTo(200);
-        ListTablesResponse listed =
-            IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
-        assertThat(listed.identifiers())
-            .as("listing %d", listing)
-            .contains(
-                TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), TestUtils.TABLE_NAME));
-      }
-    } finally {
-      stop.set(true);
-      churn.join();
-    }
-
-    // A churn thread that died early would make the assertions above prove nothing.
-    assertThat(churnFailure.get()).isNull();
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1798.

`listTables` on the Iceberg REST endpoint listed a schema's tables and then asked the repository,
once per listed table, whether that table carries UniForm Iceberg metadata. That question was
answered by resolving the table by name again, after the page had been read, so a table dropped in
between made `findTableOrThrow` raise `TABLE_NOT_FOUND` and the endpoint answered 404 -- naming a
table the client never asked about -- instead of listing the schema.

`TableRepository.listUniformIcebergTables` now reports which tables of a page are uniform from the
very rows the page was read from, and the endpoint builds its response out of those pages. Nothing is
resolved twice, so a table created or dropped after a page was read cannot affect that page, and a
page costs one query rather than one plus two per table it holds.

Measured against a running server, four threads listing one schema while four more created and
dropped tables in it for 20 seconds:

| | before | after |
| --- | --- | --- |
| listings that succeeded | 30172 | 50311 |
| listings that failed with 404 | 6641 | 0 |

The response for a quiet schema is unchanged, and so is paging: the listing still follows the
repository's page token to the end, so a page whose tables are all non-uniform contributes nothing
without ending the walk.

`testListTablesToleratesATableDroppedWhileListing` drives 200 listings while a table is created and
dropped alongside them. It fails on `main` (the sixth listing came back 404 in my run) and passes with
this change. The rest of `IcebergRestCatalogTest` passes unchanged, as do the table CRUD suites.
