### PR TITLE
Reject metric view creation with an empty column list

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -622,8 +622,12 @@ public class TableRepository {
     ValidationUtils.validateSqlObjectName(createTable.getName());
     String callerId = IdentityUtils.findPrincipalEmailAddress();
     DataSourceFormat format = createTable.getDataSourceFormat();
+    // `columns` arrives as null (not an empty list) when a client omits the field entirely, so
+    // normalize before streaming. Whether an empty column list is acceptable is a per-table-type
+    // rule decided in the create branches below, and those checks must be the ones that reject the
+    // request so the caller gets INVALID_ARGUMENT instead of an NPE here.
     List<ColumnInfo> columnInfos =
-        createTable.getColumns().stream()
+        Optional.ofNullable(createTable.getColumns()).orElse(List.of()).stream()
             .map(
                 c -> {
                   ColumnUtils.validateTypeJson(c, format);
@@ -767,6 +771,17 @@ public class TableRepository {
   }
 
   private void validateMetricView(Session session, CreateTable createTable) {
+    // A metric view exposes its dimensions and measures as columns, and engines resolve queries
+    // against that column list. A metric view with no columns is therefore accepted by the server
+    // but unusable by any reader, so reject it rather than persisting an unreadable entity.
+    // Column-level validation beyond this (that each column matches the view_definition YAML) needs
+    // the YAML semantics and stays with the engine that owns them.
+    // Checked ahead of validateViewLike so this request-shape rule is reported without first
+    // spending dependency-existence lookups on a request that cannot be accepted either way.
+    if (Optional.ofNullable(createTable.getColumns()).orElse(List.of()).isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "columns must contain at least one entry for metric view");
+    }
     validateViewLike(session, createTable, "metric view");
     // A metric view's dependencies are always client-supplied; require at least one.
     if (Optional.ofNullable(createTable.getViewDependencies())

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -771,17 +771,6 @@ public class TableRepository {
   }
 
   private void validateMetricView(Session session, CreateTable createTable) {
-    // A metric view exposes its dimensions and measures as columns, and engines resolve queries
-    // against that column list. A metric view with no columns is therefore accepted by the server
-    // but unusable by any reader, so reject it rather than persisting an unreadable entity.
-    // Column-level validation beyond this (that each column matches the view_definition YAML) needs
-    // the YAML semantics and stays with the engine that owns them.
-    // Checked ahead of validateViewLike so this request-shape rule is reported without first
-    // spending dependency-existence lookups on a request that cannot be accepted either way.
-    if (Optional.ofNullable(createTable.getColumns()).orElse(List.of()).isEmpty()) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "columns must contain at least one entry for metric view");
-    }
     validateViewLike(session, createTable, "metric view");
     // A metric view's dependencies are always client-supplied; require at least one.
     if (Optional.ofNullable(createTable.getViewDependencies())
@@ -802,6 +791,16 @@ public class TableRepository {
     if (createTable.getViewDefinition() == null || createTable.getViewDefinition().isEmpty()) {
       throw new BaseException(
           ErrorCode.INVALID_ARGUMENT, "view_definition is required for " + entityLabel);
+    }
+    // A view (plain or metric) exposes its output as columns, and a reader resolves queries against
+    // that column list, so a view with no columns is accepted by the server but unusable by any
+    // engine. Reject it rather than persisting an unreadable entity. Column-level validation beyond
+    // this (that each column matches the view definition) needs the definition semantics and stays
+    // with the engine that owns them. Checked ahead of the dependency-existence lookups below so
+    // this request-shape rule is reported without first spending those on an unusable request.
+    if (Optional.ofNullable(createTable.getColumns()).orElse(List.of()).isEmpty()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "columns must contain at least one entry for " + entityLabel);
     }
     // view_dependencies is optional here (shared by view + metric view):
     //  - a plain view may omit it (e.g. the Spark connector sends null when it cannot derive

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -4,6 +4,7 @@ import static io.unitycatalog.server.utils.TestUtils.assertApiException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
 import io.unitycatalog.client.model.CreateFunction;
 import io.unitycatalog.client.model.CreateFunctionRequest;
@@ -110,12 +111,41 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
     return depList;
   }
 
+  /**
+   * The dimension/measure columns a reader resolves queries against, matching the dimensions and
+   * measures declared in {@link #VIEW_DEFINITION_ASSET_SOURCE}. A metric view must be created with
+   * a non-empty column list, so every valid request below carries these.
+   */
+  protected static final List<ColumnInfo> METRIC_VIEW_COLUMNS =
+      List.of(
+          new ColumnInfo()
+              .name("event_day")
+              .typeText("DATE")
+              .typeJson(
+                  "{\"name\":\"event_day\",\"type\":\"date\","
+                      + "\"nullable\":true,\"metadata\":{}}")
+              .typeName(ColumnTypeName.DATE)
+              .position(0)
+              .comment("Event day dimension")
+              .nullable(true),
+          new ColumnInfo()
+              .name("event_count")
+              .typeText("BIGINT")
+              .typeJson(
+                  "{\"name\":\"event_count\",\"type\":\"long\","
+                      + "\"nullable\":true,\"metadata\":{}}")
+              .typeName(ColumnTypeName.LONG)
+              .position(1)
+              .comment("Event count measure")
+              .nullable(true));
+
   private CreateTable validMetricViewRequest() {
     return new CreateTable()
         .name(METRIC_VIEW_NAME)
         .catalogName(TestUtils.CATALOG_NAME)
         .schemaName(TestUtils.SCHEMA_NAME)
         .tableType(TableType.METRIC_VIEW)
+        .columns(METRIC_VIEW_COLUMNS)
         .viewDefinition(VIEW_DEFINITION_ASSET_SOURCE)
         .viewDependencies(makeDependencyList(SOURCE_TABLE_FULL_NAME));
   }
@@ -157,6 +187,13 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
     assertThat(fetched.getViewDependencies().getDependencies().get(0).getTable().getTableFullName())
         .isEqualTo(SOURCE_TABLE_FULL_NAME);
 
+    // Columns are required on create, so they must also round-trip back to the reader that needs
+    // them to resolve queries against the metric view.
+    assertThat(fetched.getColumns()).isNotNull();
+    assertThat(fetched.getColumns())
+        .extracting(ColumnInfo::getName)
+        .containsExactly("event_day", "event_count");
+
     // Verify properties round-trip
     assertThat(fetched.getProperties()).isNotNull();
     assertThat(fetched.getProperties().get("team")).isEqualTo("analytics");
@@ -187,6 +224,18 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
             (UnaryOperator<CreateTable>) request -> request.viewDefinition(null),
             ErrorCode.INVALID_ARGUMENT,
             "view_definition is required for metric view"),
+        Arguments.of(
+            "empty column list",
+            (UnaryOperator<CreateTable>) request -> request.columns(List.of()),
+            ErrorCode.INVALID_ARGUMENT,
+            "columns must contain at least one entry for metric view"),
+        Arguments.of(
+            // A client that omits `columns` entirely sends null rather than an empty list. This
+            // must be rejected the same way, not surface as an internal error.
+            "missing columns",
+            (UnaryOperator<CreateTable>) request -> request.columns(null),
+            ErrorCode.INVALID_ARGUMENT,
+            "columns must contain at least one entry for metric view"),
         Arguments.of(
             "missing view_dependencies",
             (UnaryOperator<CreateTable>) request -> request.viewDependencies(null),

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -115,7 +115,6 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
    * The dimension/measure columns a reader resolves queries against, matching the dimensions and
    * measures declared in {@link #VIEW_DEFINITION_ASSET_SOURCE}. A metric view must be created with
    * a non-empty column list, so every valid request below carries these.
-   *
    */
   protected static final List<ColumnInfo> METRIC_VIEW_COLUMNS =
       List.of(

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -115,6 +115,11 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
    * The dimension/measure columns a reader resolves queries against, matching the dimensions and
    * measures declared in {@link #VIEW_DEFINITION_ASSET_SOURCE}. A metric view must be created with
    * a non-empty column list, so every valid request below carries these.
+   *
+   * <p>Each column's {@code type_json} metadata carries the two required metric-view keys: {@code
+   * metric_view.type} ({@code dimension} or {@code measure}) and {@code metric_view.expr} (the
+   * originating YAML expression). Both are JSON strings, and the {@code expr} values match the
+   * corresponding entries in {@link #VIEW_DEFINITION_ASSET_SOURCE}.
    */
   protected static final List<ColumnInfo> METRIC_VIEW_COLUMNS =
       List.of(
@@ -123,7 +128,9 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
               .typeText("DATE")
               .typeJson(
                   "{\"name\":\"event_day\",\"type\":\"date\","
-                      + "\"nullable\":true,\"metadata\":{}}")
+                      + "\"nullable\":true,\"metadata\":{"
+                      + "\"metric_view.type\":\"dimension\","
+                      + "\"metric_view.expr\":\"date_trunc('day', event_time)\"}}")
               .typeName(ColumnTypeName.DATE)
               .position(0)
               .comment("Event day dimension")
@@ -133,7 +140,9 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
               .typeText("BIGINT")
               .typeJson(
                   "{\"name\":\"event_count\",\"type\":\"long\","
-                      + "\"nullable\":true,\"metadata\":{}}")
+                      + "\"nullable\":true,\"metadata\":{"
+                      + "\"metric_view.type\":\"measure\","
+                      + "\"metric_view.expr\":\"count(*)\"}}")
               .typeName(ColumnTypeName.LONG)
               .position(1)
               .comment("Event count measure")
@@ -188,11 +197,17 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
         .isEqualTo(SOURCE_TABLE_FULL_NAME);
 
     // Columns are required on create, so they must also round-trip back to the reader that needs
-    // them to resolve queries against the metric view.
+    // them to resolve queries against the metric view. The per-column metric_view.type and
+    // metric_view.expr metadata is what makes a column resolvable as a dimension or a measure, so
+    // assert type_json survives verbatim rather than only checking the column names.
     assertThat(fetched.getColumns()).isNotNull();
     assertThat(fetched.getColumns())
         .extracting(ColumnInfo::getName)
         .containsExactly("event_day", "event_count");
+    assertThat(fetched.getColumns())
+        .extracting(ColumnInfo::getTypeJson)
+        .containsExactly(
+            METRIC_VIEW_COLUMNS.get(0).getTypeJson(), METRIC_VIEW_COLUMNS.get(1).getTypeJson());
 
     // Verify properties round-trip
     assertThat(fetched.getProperties()).isNotNull();

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseMetricViewCRUDTest.java
@@ -116,10 +116,6 @@ public abstract class BaseMetricViewCRUDTest extends BaseTableCRUDTestEnv {
    * measures declared in {@link #VIEW_DEFINITION_ASSET_SOURCE}. A metric view must be created with
    * a non-empty column list, so every valid request below carries these.
    *
-   * <p>Each column's {@code type_json} metadata carries the two required metric-view keys: {@code
-   * metric_view.type} ({@code dimension} or {@code measure}) and {@code metric_view.expr} (the
-   * originating YAML expression). Both are JSON strings, and the {@code expr} values match the
-   * corresponding entries in {@link #VIEW_DEFINITION_ASSET_SOURCE}.
    */
   protected static final List<ColumnInfo> METRIC_VIEW_COLUMNS =
       List.of(

--- a/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/BaseViewCRUDTest.java
@@ -126,6 +126,18 @@ public abstract class BaseViewCRUDTest extends BaseTableCRUDTestEnv {
             ErrorCode.INVALID_ARGUMENT,
             "view_definition is required for view"),
         Arguments.of(
+            "empty column list",
+            (UnaryOperator<CreateTable>) request -> request.columns(List.of()),
+            ErrorCode.INVALID_ARGUMENT,
+            "columns must contain at least one entry for view"),
+        Arguments.of(
+            // A client that omits `columns` entirely sends null rather than an empty list. This
+            // must be rejected the same way, not surface as an internal error.
+            "missing columns",
+            (UnaryOperator<CreateTable>) request -> request.columns(null),
+            ErrorCode.INVALID_ARGUMENT,
+            "columns must contain at least one entry for view"),
+        Arguments.of(
             "non-existent dependency",
             (UnaryOperator<CreateTable>)
                 request ->


### PR DESCRIPTION
## What

Reject creation of a view or metric view whose `columns` list is null or empty.

A view (plain or metric) exposes its output as columns, and a reader resolves queries against that column list. The server previously accepted a view or metric view with no columns and persisted an entity that no engine can read. 

## Changes

- Reject a null or empty `columns` list in `validateViewLike`, so the rule covers both `VIEW` and `METRIC_VIEW`, with `INVALID_ARGUMENT`. The message carries the entity label: a plain view reports `columns must contain at least one entry for view`, a metric view reports `... for metric view`. The check runs ahead of the dependency-existence lookups, so a request-shape error is returned without first spending those lookups.
- Normalize `columns` before streaming it in `createTableImpl`. `columns` deserializes to null when a client omits the field, so a request carrying `"columns": null` previously failed with a `NullPointerException` and an internal error instead of `INVALID_ARGUMENT`.

## Scope

`VIEW` and `METRIC_VIEW` only. Other table types keep their existing behavior; for them the normalization only converts the former `NullPointerException` on a null `columns` field into the same handling as an empty list, which they already accept.

The Spark connector is unaffected: it always sends columns for both plain views and metric views, resolved from the view output schema, so no valid connector request is rejected.

## Tests

- The metric-view and plain-view happy-path requests now supply columns; the metric-view test columns also carry the required `metric_view.type` and `metric_view.expr` metadata, and the test asserts `type_json` round-trips verbatim.
- Added empty-list and null-list negative cases to both the view and metric-view suites.
- Full `server/test` passes (424).

---

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated