### PR TITLE
test(spark): E2E for the Delta REST API credential path (gated on delta-io/delta#7518)

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -220,11 +220,12 @@ class UCSingleCatalog
       ident: Identifier,
       writePrivileges: util.Set[TableWritePrivilege]): Table = {
     requireAddressableTableNameOrPathTable(ident)
+    val previousIntent = UCSingleCatalog.WRITE_INTENT.get()
     UCSingleCatalog.WRITE_INTENT.set(true)
     try {
       delegate.loadTable(ident, writePrivileges)
     } finally {
-      UCSingleCatalog.WRITE_INTENT.remove()
+      UCSingleCatalog.WRITE_INTENT.set(previousIntent)
     }
   }
 
@@ -1049,12 +1050,12 @@ private[spark] class UCProxy(
       credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
     } catch {
       case e: ApiException =>
-        logWarning(
-          s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
         if (UCSingleCatalog.WRITE_INTENT.get()) {
           // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
           throw e
         }
+        logWarning(
+          s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
         readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
     }
 

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -215,10 +215,7 @@ class UCSingleCatalog
     delegate.loadTable(ident, timestamp)
   }
 
-  // Spark resolves the target of INSERT / UPDATE / DELETE / MERGE through this overload, so it is
-  // the one place write intent is declared. Record it for `UCProxy.loadV1Table` (see
-  // `WRITE_INTENT` for why a thread-local and not the `writePrivileges` argument itself), and
-  // still forward the privileges so a future `DeltaCatalog` that honors them receives them.
+  // Spark resolves write targets (INSERT / UPDATE / DELETE / MERGE) through this overload.
   override def loadTable(
       ident: Identifier,
       writePrivileges: util.Set[TableWritePrivilege]): Table = {
@@ -745,12 +742,9 @@ object UCSingleCatalog {
   val LOAD_DELTA_CATALOG = ThreadLocal.withInitial[Boolean](() => true)
   val DELTA_CATALOG_LOADED = ThreadLocal.withInitial[Boolean](() => false)
 
-  // True while the current thread resolves a table Spark declared as a write target via
-  // `loadTable(ident, writePrivileges)`. Carried out-of-band because the `DeltaCatalog` layer
-  // between `UCSingleCatalog` and `UCProxy` does not override that overload -- its inherited
-  // default drops the privileges and forwards to the intent-less `loadTable(ident)` -- so the
-  // vend site in `UCProxy.loadV1Table` could not see the intent otherwise. Set/cleared only in
-  // `UCSingleCatalog.loadTable(ident, writePrivileges)`; resolution runs on the calling thread.
+  // True while the current thread resolves a declared write target. Thread-local because
+  // DeltaCatalog does not override `loadTable(ident, writePrivileges)` and drops the argument
+  // before it reaches the vend site in `UCProxy.loadV1Table`.
   private[spark] val WRITE_INTENT = ThreadLocal.withInitial[Boolean](() => false)
 
   /**
@@ -997,13 +991,9 @@ private[spark] class UCProxy(
     }
   }
 
-  // Table ids whose READ_WRITE credential request was denied, so intent-less loads (SELECT
-  // resolution) go straight to READ instead of re-paying the denied round-trip on every query.
-  // An entry is cleared when a declared write for the table succeeds; per catalog instance.
+  // Table ids denied READ_WRITE, so intent-less loads skip the doomed round-trip per query.
   private[spark] val writeDeniedTables = util.concurrent.ConcurrentHashMap.newKeySet[String]()
 
-  // READ-credential fallback shared by the intent-less load paths: on failure, fall back to
-  // server-side planning when enabled, otherwise propagate.
   private def readCredentialsOrServerSidePlanning(
       credBuilder: UCCredentialHadoopConfs.Builder,
       tableId: String,
@@ -1056,21 +1046,15 @@ private[spark] class UCProxy(
         .enableCredentialScopedFs(credScopedFsEnabled)
         .hadoopConf(UCSingleCatalog.sessionHadoopConf())
 
-    // Spark declares write targets through `loadTable(ident, writePrivileges)` (available on
-    // every supported Spark version); `UCSingleCatalog` records that in `WRITE_INTENT`. A load
-    // with no declared intent is almost always a read, but a few paths (e.g. Delta's OPTIMIZE)
-    // still resolve their write target through the intent-less overload, so the first such load
-    // still requests READ_WRITE and only after a denial is the table remembered as read-only.
-    // A later declared write always requests READ_WRITE again and clears the entry on success,
-    // so a newly granted MODIFY takes effect on the next write attempt.
+    // Intent-less loads still try READ_WRITE first: some write paths (e.g. Delta's OPTIMIZE)
+    // resolve through the intent-less overload. A denial is remembered per table so SELECTs stop
+    // re-paying it; a later granted declared write clears the entry.
     val extraSerdeProps = if (UCSingleCatalog.WRITE_INTENT.get()) {
-      // Declared write: vending READ credentials here would only defer the same authorization
-      // failure to the storage layer mid-job, so let the denial surface now.
+      // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
       val props = credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
       writeDeniedTables.remove(tableId)
       props
     } else if (writeDeniedTables.contains(tableId)) {
-      // A previous READ_WRITE request for this table was denied: skip the guaranteed round-trip.
       readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
     } else {
       try {

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1,6 +1,6 @@
 package io.unitycatalog.spark
 
-import java.net.{HttpURLConnection, URI}
+import java.net.URI
 import java.util
 import java.util.Locale
 
@@ -991,29 +991,6 @@ private[spark] class UCProxy(
     }
   }
 
-  // Table ids whose READ_WRITE credential request was 403-denied, mapped to the deadline until
-  // which intent-less loads skip the doomed round-trip. Entries expire (so a later grant reaches
-  // intent-less paths like OPTIMIZE without a session restart) and are cleared early by a
-  // successful declared write.
-  private[spark] val writeDeniedTables =
-    new util.concurrent.ConcurrentHashMap[String, java.lang.Long]()
-
-  private def markWriteDenied(tableId: String): Unit =
-    writeDeniedTables.put(
-      tableId, System.currentTimeMillis() + UCProxy.WRITE_DENIAL_TTL_MILLIS)
-
-  private def isWriteDenied(tableId: String): Boolean = {
-    val deadline = writeDeniedTables.get(tableId)
-    if (deadline == null) {
-      false
-    } else if (System.currentTimeMillis() >= deadline) {
-      writeDeniedTables.remove(tableId, deadline)
-      false
-    } else {
-      true
-    }
-  }
-
   private def readCredentialsOrServerSidePlanning(
       credBuilder: UCCredentialHadoopConfs.Builder,
       tableId: String,
@@ -1066,24 +1043,18 @@ private[spark] class UCProxy(
         .enableCredentialScopedFs(credScopedFsEnabled)
         .hadoopConf(UCSingleCatalog.sessionHadoopConf())
 
-    // Intent-less loads still try READ_WRITE first: some write paths (e.g. Delta's OPTIMIZE)
-    // resolve through the intent-less overload. A denial is remembered per table so SELECTs stop
-    // re-paying it; a later granted declared write clears the entry.
+    // Intent-less loads still request READ_WRITE first: write paths such as Delta's OPTIMIZE,
+    // ALTER TABLE and streaming sinks resolve their target through the intent-less overload.
     val extraSerdeProps = if (UCSingleCatalog.WRITE_INTENT.get()) {
       // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
-      val props = try {
+      try {
         credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
       } catch {
         case e: ApiException =>
           logWarning(s"READ_WRITE credential generation failed for declared write on table " +
             s"$identifier: ${e.getMessage}")
-          if (e.getCode == HttpURLConnection.HTTP_FORBIDDEN) markWriteDenied(tableId)
           throw e
       }
-      writeDeniedTables.remove(tableId)
-      props
-    } else if (isWriteDenied(tableId)) {
-      readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
     } else {
       try {
         credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
@@ -1091,9 +1062,6 @@ private[spark] class UCProxy(
         case e: ApiException =>
           logWarning(
             s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
-          // Only a permission denial is worth remembering; transient failures must keep the
-          // READ_WRITE-first retry on the next load.
-          if (e.getCode == HttpURLConnection.HTTP_FORBIDDEN) markWriteDenied(tableId)
           readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
       }
     }
@@ -1372,10 +1340,4 @@ private[spark] class UCProxy(
     schemasApi.deleteSchema(name + "." + namespace.head, cascade)
     true
   }
-}
-
-private[spark] object UCProxy {
-  // How long an intent-less load trusts a remembered READ_WRITE denial before probing again.
-  // Bounds the staleness window for a grant added after a denial (e.g. before an OPTIMIZE).
-  private[spark] val WRITE_DENIAL_TTL_MILLIS: Long = java.util.concurrent.TimeUnit.MINUTES.toMillis(5)
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1,6 +1,6 @@
 package io.unitycatalog.spark
 
-import java.net.URI
+import java.net.{HttpURLConnection, URI}
 import java.util
 import java.util.Locale
 
@@ -991,8 +991,28 @@ private[spark] class UCProxy(
     }
   }
 
-  // Table ids denied READ_WRITE, so intent-less loads skip the doomed round-trip per query.
-  private[spark] val writeDeniedTables = util.concurrent.ConcurrentHashMap.newKeySet[String]()
+  // Table ids whose READ_WRITE credential request was 403-denied, mapped to the deadline until
+  // which intent-less loads skip the doomed round-trip. Entries expire (so a later grant reaches
+  // intent-less paths like OPTIMIZE without a session restart) and are cleared early by a
+  // successful declared write.
+  private[spark] val writeDeniedTables =
+    new util.concurrent.ConcurrentHashMap[String, java.lang.Long]()
+
+  private def markWriteDenied(tableId: String): Unit =
+    writeDeniedTables.put(
+      tableId, System.currentTimeMillis() + UCProxy.WRITE_DENIAL_TTL_MILLIS)
+
+  private def isWriteDenied(tableId: String): Boolean = {
+    val deadline = writeDeniedTables.get(tableId)
+    if (deadline == null) {
+      false
+    } else if (System.currentTimeMillis() >= deadline) {
+      writeDeniedTables.remove(tableId, deadline)
+      false
+    } else {
+      true
+    }
+  }
 
   private def readCredentialsOrServerSidePlanning(
       credBuilder: UCCredentialHadoopConfs.Builder,
@@ -1051,10 +1071,18 @@ private[spark] class UCProxy(
     // re-paying it; a later granted declared write clears the entry.
     val extraSerdeProps = if (UCSingleCatalog.WRITE_INTENT.get()) {
       // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
-      val props = credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
+      val props = try {
+        credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
+      } catch {
+        case e: ApiException =>
+          logWarning(s"READ_WRITE credential generation failed for declared write on table " +
+            s"$identifier: ${e.getMessage}")
+          if (e.getCode == HttpURLConnection.HTTP_FORBIDDEN) markWriteDenied(tableId)
+          throw e
+      }
       writeDeniedTables.remove(tableId)
       props
-    } else if (writeDeniedTables.contains(tableId)) {
+    } else if (isWriteDenied(tableId)) {
       readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
     } else {
       try {
@@ -1063,7 +1091,9 @@ private[spark] class UCProxy(
         case e: ApiException =>
           logWarning(
             s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
-          writeDeniedTables.add(tableId)
+          // Only a permission denial is worth remembering; transient failures must keep the
+          // READ_WRITE-first retry on the next load.
+          if (e.getCode == HttpURLConnection.HTTP_FORBIDDEN) markWriteDenied(tableId)
           readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
       }
     }
@@ -1342,4 +1372,10 @@ private[spark] class UCProxy(
     schemasApi.deleteSchema(name + "." + namespace.head, cascade)
     true
   }
+}
+
+private[spark] object UCProxy {
+  // How long an intent-less load trusts a remembered READ_WRITE denial before probing again.
+  // Bounds the staleness window for a grant added after a denial (e.g. before an OPTIMIZE).
+  private[spark] val WRITE_DENIAL_TTL_MILLIS: Long = java.util.concurrent.TimeUnit.MINUTES.toMillis(5)
 }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1045,25 +1045,17 @@ private[spark] class UCProxy(
 
     // Intent-less loads still request READ_WRITE first: write paths such as Delta's OPTIMIZE,
     // ALTER TABLE and streaming sinks resolve their target through the intent-less overload.
-    val extraSerdeProps = if (UCSingleCatalog.WRITE_INTENT.get()) {
-      // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
-      try {
-        credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
-      } catch {
-        case e: ApiException =>
-          logWarning(s"READ_WRITE credential generation failed for declared write on table " +
-            s"$identifier: ${e.getMessage}")
+    val extraSerdeProps = try {
+      credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
+    } catch {
+      case e: ApiException =>
+        logWarning(
+          s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
+        if (UCSingleCatalog.WRITE_INTENT.get()) {
+          // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
           throw e
-      }
-    } else {
-      try {
-        credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
-      } catch {
-        case e: ApiException =>
-          logWarning(
-            s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
-          readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
-      }
+        }
+        readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
     }
 
     // For unrecognized schemes (e.g. file://) the credential switch returns empty without props;

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -215,6 +215,22 @@ class UCSingleCatalog
     delegate.loadTable(ident, timestamp)
   }
 
+  // Spark resolves the target of INSERT / UPDATE / DELETE / MERGE through this overload, so it is
+  // the one place write intent is declared. Record it for `UCProxy.loadV1Table` (see
+  // `WRITE_INTENT` for why a thread-local and not the `writePrivileges` argument itself), and
+  // still forward the privileges so a future `DeltaCatalog` that honors them receives them.
+  override def loadTable(
+      ident: Identifier,
+      writePrivileges: util.Set[TableWritePrivilege]): Table = {
+    requireAddressableTableNameOrPathTable(ident)
+    UCSingleCatalog.WRITE_INTENT.set(true)
+    try {
+      delegate.loadTable(ident, writePrivileges)
+    } finally {
+      UCSingleCatalog.WRITE_INTENT.remove()
+    }
+  }
+
   /**
    * Prevents file-format path identifiers (for example, `parquet`.`s3://bucket/path`) from reaching
    * catalog delegates that interpret them as Unity Catalog table names. Reporting these identifiers
@@ -729,6 +745,14 @@ object UCSingleCatalog {
   val LOAD_DELTA_CATALOG = ThreadLocal.withInitial[Boolean](() => true)
   val DELTA_CATALOG_LOADED = ThreadLocal.withInitial[Boolean](() => false)
 
+  // True while the current thread resolves a table Spark declared as a write target via
+  // `loadTable(ident, writePrivileges)`. Carried out-of-band because the `DeltaCatalog` layer
+  // between `UCSingleCatalog` and `UCProxy` does not override that overload -- its inherited
+  // default drops the privileges and forwards to the intent-less `loadTable(ident)` -- so the
+  // vend site in `UCProxy.loadV1Table` could not see the intent otherwise. Set/cleared only in
+  // `UCSingleCatalog.loadTable(ident, writePrivileges)`; resolution runs on the calling thread.
+  private[spark] val WRITE_INTENT = ThreadLocal.withInitial[Boolean](() => false)
+
   /**
    * UC external locations and the temporary path-credentials API use canonical lowercase
    * `s3://` URLs on the server. Hadoop clients may reference the same storage as `s3a://`
@@ -973,6 +997,31 @@ private[spark] class UCProxy(
     }
   }
 
+  // Table ids whose READ_WRITE credential request was denied, so intent-less loads (SELECT
+  // resolution) go straight to READ instead of re-paying the denied round-trip on every query.
+  // An entry is cleared when a declared write for the table succeeds; per catalog instance.
+  private[spark] val writeDeniedTables = util.concurrent.ConcurrentHashMap.newKeySet[String]()
+
+  // READ-credential fallback shared by the intent-less load paths: on failure, fall back to
+  // server-side planning when enabled, otherwise propagate.
+  private def readCredentialsOrServerSidePlanning(
+      credBuilder: UCCredentialHadoopConfs.Builder,
+      tableId: String,
+      identifier: TableIdentifier): util.Map[String, String] = {
+    try {
+      credBuilder.buildForTable(tableId, TableOperation.READ)
+    } catch {
+      case e: ApiException =>
+        logWarning(s"READ credential generation failed for table $identifier: ${e.getMessage}")
+        if (serverSidePlanningEnabled) {
+          enableServerSidePlanningConfig(identifier)
+          Map.empty[String, String].asJava
+        } else {
+          throw e
+        }
+    }
+  }
+
   // Single-RPC table path. Calls UC `getTable` once and routes view-like rows through a
   // version-specific hook (rejected from the table surface on 4.2; plain views resolved as
   // read-only V1 views on 4.0/4.1).
@@ -1007,27 +1056,32 @@ private[spark] class UCProxy(
         .enableCredentialScopedFs(credScopedFsEnabled)
         .hadoopConf(UCSingleCatalog.sessionHadoopConf())
 
-    // TODO: at this time, we don't know if the table will be read or written. For now we always
-    //       request READ_WRITE credentials as the server doesn't distinguish between READ and
-    //       READ_WRITE credentials as of today. When loading a table, Spark should tell if it's
-    //       for read or write, we can request the proper credential after fixing Spark.
-    val extraSerdeProps = try {
-      credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
-    } catch {
-      case e: ApiException =>
-        logWarning(s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
-        try {
-          credBuilder.buildForTable(tableId, TableOperation.READ)
-        } catch {
-          case e: ApiException =>
-            logWarning(s"READ credential generation failed for table $identifier: ${e.getMessage}")
-            if (serverSidePlanningEnabled) {
-              enableServerSidePlanningConfig(identifier)
-              Map.empty[String, String].asJava
-            } else {
-              throw e
-            }
-        }
+    // Spark declares write targets through `loadTable(ident, writePrivileges)` (available on
+    // every supported Spark version); `UCSingleCatalog` records that in `WRITE_INTENT`. A load
+    // with no declared intent is almost always a read, but a few paths (e.g. Delta's OPTIMIZE)
+    // still resolve their write target through the intent-less overload, so the first such load
+    // still requests READ_WRITE and only after a denial is the table remembered as read-only.
+    // A later declared write always requests READ_WRITE again and clears the entry on success,
+    // so a newly granted MODIFY takes effect on the next write attempt.
+    val extraSerdeProps = if (UCSingleCatalog.WRITE_INTENT.get()) {
+      // Declared write: vending READ credentials here would only defer the same authorization
+      // failure to the storage layer mid-job, so let the denial surface now.
+      val props = credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
+      writeDeniedTables.remove(tableId)
+      props
+    } else if (writeDeniedTables.contains(tableId)) {
+      // A previous READ_WRITE request for this table was denied: skip the guaranteed round-trip.
+      readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
+    } else {
+      try {
+        credBuilder.buildForTable(tableId, TableOperation.READ_WRITE)
+      } catch {
+        case e: ApiException =>
+          logWarning(
+            s"READ_WRITE credential generation failed for table $identifier: ${e.getMessage}")
+          writeDeniedTables.add(tableId)
+          readCredentialsOrServerSidePlanning(credBuilder, tableId, identifier)
+      }
     }
 
     // For unrecognized schemes (e.g. file://) the credential switch returns empty without props;

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
@@ -1,0 +1,176 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.spark.UCProxyTestFixture.CATALOG_NAME;
+import static io.unitycatalog.spark.UCProxyTestFixture.NAMESPACE;
+import static io.unitycatalog.spark.UCProxyTestFixture.SCHEMA_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs.TableOperation;
+import io.unitycatalog.hadoop.internal.CredPropsUtil;
+import io.unitycatalog.hadoop.internal.auth.AwsCredential;
+import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import io.unitycatalog.hadoop.internal.id.TableCredId;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the credential-operation choice in {@code UCProxy.loadV1Table}: a load with
+ * declared write intent (Spark's {@code loadTable(ident, writePrivileges)}, recorded in {@code
+ * UCSingleCatalog.WRITE_INTENT}) requests READ_WRITE and surfaces a denial immediately, while
+ * intent-less loads remember a READ_WRITE denial per table and go straight to READ afterwards
+ * instead of re-paying the denied round-trip on every query.
+ *
+ * <p>The UC credential endpoint is stubbed at the hadoop connector's {@link
+ * CredPropsUtil#genericCredFetcherFactory} seam, which sees the requested {@link TableOperation}
+ * via {@link TableCredId} and can grant or deny per operation.
+ */
+public class WriteIntentCredentialSuite {
+
+  private static final String LOCATION = "s3://test-bucket/tables/t";
+
+  private UCProxyTestFixture fixture;
+  private TableCatalog proxy;
+  private final AtomicInteger readWriteAttempts = new AtomicInteger();
+  private final AtomicInteger readAttempts = new AtomicInteger();
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    fixture = new UCProxyTestFixture().build();
+    proxy = fixture.proxy;
+    readWriteAttempts.set(0);
+    readAttempts.set(0);
+  }
+
+  @AfterEach
+  public void reset() {
+    CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
+    UCSingleCatalog$.MODULE$.WRITE_INTENT().remove();
+  }
+
+  @Test
+  public void intentLessLoadRemembersWriteDenialAndSkipsRetry() throws Exception {
+    String tableId = stubTable("t_denied");
+    denyReadWriteGrantRead();
+
+    // First intent-less load: READ_WRITE is attempted once, denied, and remembered; the load
+    // still succeeds on READ credentials.
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
+    assertThat(readWriteAttempts.get()).isEqualTo(1);
+    assertThat(readAttempts.get()).isEqualTo(1);
+    assertThat(writeDeniedTables()).containsExactly(tableId);
+
+    // Subsequent loads skip the guaranteed READ_WRITE denial entirely.
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
+    assertThat(readWriteAttempts.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void declaredWriteFailsFastOnDenialWithoutReadFallback() throws Exception {
+    stubTable("t_write_denied");
+    denyReadWriteGrantRead();
+
+    UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
+    // Vending READ credentials to a declared write would only defer the same failure to the
+    // storage layer mid-job, so the denial must surface here and READ must not be attempted.
+    assertThatThrownBy(() -> proxy.loadTable(Identifier.of(NAMESPACE, "t_write_denied")))
+        .isInstanceOf(ApiException.class);
+    assertThat(readWriteAttempts.get()).isEqualTo(1);
+    assertThat(readAttempts.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void successfulDeclaredWriteClearsDenialMemory() throws Exception {
+    String tableId = stubTable("t_regranted");
+    denyReadWriteGrantRead();
+
+    // Prime the denial memory through an intent-less load.
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
+    assertThat(writeDeniedTables()).containsExactly(tableId);
+
+    // The principal is granted write access; a declared write still requests READ_WRITE (the
+    // denial memory never gates declared writes) and, once granted, clears the memory so
+    // intent-less loads return to the READ_WRITE-first path.
+    grantAllOperations();
+    UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
+    assertThat(writeDeniedTables()).isEmpty();
+  }
+
+  /** Registers a mock UC table with an s3 location and returns its unique table id. */
+  private String stubTable(String name) throws Exception {
+    // Unique per test method: the hadoop connector's credential cache is JVM-global and keyed by
+    // (context, tableId, operation), so reusing ids would leak cached grants across tests.
+    String tableId = "table-id-" + name;
+    TableInfo ucTable =
+        new TableInfo()
+            .catalogName(CATALOG_NAME)
+            .schemaName(SCHEMA_NAME)
+            .name(name)
+            .tableId(tableId)
+            .tableType(TableType.EXTERNAL)
+            .storageLocation(LOCATION)
+            .dataSourceFormat(DataSourceFormat.PARQUET)
+            .columns(
+                List.of(
+                    new ColumnInfo()
+                        .name("id")
+                        .typeName(ColumnTypeName.INT)
+                        .typeText("int")
+                        .typeJson(
+                            "{\"name\":\"id\",\"type\":\"integer\","
+                                + "\"nullable\":true,\"metadata\":{}}")
+                        .nullable(true)
+                        .position(0)));
+    when(fixture.mockTablesApi.getTable(
+            eq(CATALOG_NAME + "." + SCHEMA_NAME + "." + name), eq(true), eq(true)))
+        .thenReturn(ucTable);
+    return tableId;
+  }
+
+  private void denyReadWriteGrantRead() {
+    stubFetcher(/* denyReadWrite= */ true);
+  }
+
+  private void grantAllOperations() {
+    stubFetcher(/* denyReadWrite= */ false);
+  }
+
+  private void stubFetcher(boolean denyReadWrite) {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) ->
+            () -> {
+              String operation = ((TableCredId) credId).tableOperation();
+              if (TableOperation.READ_WRITE.value().equals(operation)) {
+                readWriteAttempts.incrementAndGet();
+                if (denyReadWrite) {
+                  throw new ApiException("PERMISSION_DENIED: cannot vend READ_WRITE credential");
+                }
+              } else {
+                readAttempts.incrementAndGet();
+              }
+              return List.of(
+                  new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION));
+            };
+  }
+
+  @SuppressWarnings("unchecked")
+  private java.util.Set<String> writeDeniedTables() throws Exception {
+    // UCProxy is package-private Scala; read the tracked set through its generated accessor.
+    return (java.util.Set<String>)
+        fixture.proxyObj.getClass().getMethod("writeDeniedTables").invoke(fixture.proxyObj);
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
@@ -19,8 +19,10 @@ import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
+import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.AfterEach;
@@ -64,7 +66,7 @@ public class WriteIntentCredentialSuite {
     proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
     assertThat(readWriteAttempts.get()).isEqualTo(1);
     assertThat(readAttempts.get()).isEqualTo(1);
-    assertThat(writeDeniedTables()).containsExactly(tableId);
+    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
 
     // Subsequent loads must not retry the denied READ_WRITE.
     proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
@@ -89,12 +91,57 @@ public class WriteIntentCredentialSuite {
     denyReadWriteGrantRead();
 
     proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
-    assertThat(writeDeniedTables()).containsExactly(tableId);
+    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
 
     grantAllOperations();
     UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
     proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
     assertThat(writeDeniedTables()).isEmpty();
+  }
+
+  @Test
+  public void transientReadWriteFailureDoesNotPoisonDenialMemory() throws Exception {
+    stubTable("t_transient");
+    AtomicInteger calls = new AtomicInteger();
+    // First READ_WRITE attempt fails with a 503; everything afterwards is granted.
+    stubFetcher(() -> calls.getAndIncrement() == 0 ? 503 : 0);
+
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_transient"));
+    assertThat(writeDeniedTables()).isEmpty();
+
+    // The next load must retry READ_WRITE instead of trusting the transient failure.
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_transient"));
+    assertThat(readWriteAttempts.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void declaredWriteDenialSeedsMemoryForLaterReads() throws Exception {
+    String tableId = stubTable("t_write_seeds");
+    denyReadWriteGrantRead();
+
+    UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
+    assertThatThrownBy(() -> proxy.loadTable(Identifier.of(NAMESPACE, "t_write_seeds")))
+        .isInstanceOf(ApiException.class);
+    UCSingleCatalog$.MODULE$.WRITE_INTENT().remove();
+    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
+
+    // The failed write already proved the denial; reads skip the doomed round-trip.
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_write_seeds"));
+    assertThat(readWriteAttempts.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void expiredDenialEntryRestoresReadWriteFirstProbing() throws Exception {
+    String tableId = stubTable("t_expired");
+    denyReadWriteGrantRead();
+
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_expired"));
+    assertThat(readWriteAttempts.get()).isEqualTo(1);
+
+    // Simulate the TTL elapsing (e.g. a grant added later): the next load probes again.
+    writeDeniedTables().put(tableId, 0L);
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_expired"));
+    assertThat(readWriteAttempts.get()).isEqualTo(2);
   }
 
   /** Table ids are unique per test: the hadoop credential cache is JVM-global. */
@@ -127,22 +174,24 @@ public class WriteIntentCredentialSuite {
   }
 
   private void denyReadWriteGrantRead() {
-    stubFetcher(/* denyReadWrite= */ true);
+    stubFetcher(() -> HttpURLConnection.HTTP_FORBIDDEN);
   }
 
   private void grantAllOperations() {
-    stubFetcher(/* denyReadWrite= */ false);
+    stubFetcher(() -> 0);
   }
 
-  private void stubFetcher(boolean denyReadWrite) {
+  /** Stubs the fetcher; a non-zero status from {@code denyRwStatus} fails READ_WRITE requests. */
+  private void stubFetcher(IntSupplier denyRwStatus) {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) ->
             () -> {
               String operation = ((TableCredId) credId).tableOperation();
               if (TableOperation.READ_WRITE.value().equals(operation)) {
                 readWriteAttempts.incrementAndGet();
-                if (denyReadWrite) {
-                  throw new ApiException("PERMISSION_DENIED: cannot vend READ_WRITE credential");
+                int status = denyRwStatus.getAsInt();
+                if (status != 0) {
+                  throw new ApiException(status, "cannot vend READ_WRITE credential");
                 }
               } else {
                 readAttempts.incrementAndGet();
@@ -153,8 +202,8 @@ public class WriteIntentCredentialSuite {
   }
 
   @SuppressWarnings("unchecked")
-  private java.util.Set<String> writeDeniedTables() throws Exception {
-    return (java.util.Set<String>)
+  private java.util.Map<String, Long> writeDeniedTables() throws Exception {
+    return (java.util.Map<String, Long>)
         fixture.proxyObj.getClass().getMethod("writeDeniedTables").invoke(fixture.proxyObj);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
@@ -28,15 +28,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the credential-operation choice in {@code UCProxy.loadV1Table}: a load with
- * declared write intent (Spark's {@code loadTable(ident, writePrivileges)}, recorded in {@code
- * UCSingleCatalog.WRITE_INTENT}) requests READ_WRITE and surfaces a denial immediately, while
- * intent-less loads remember a READ_WRITE denial per table and go straight to READ afterwards
- * instead of re-paying the denied round-trip on every query.
- *
- * <p>The UC credential endpoint is stubbed at the hadoop connector's {@link
- * CredPropsUtil#genericCredFetcherFactory} seam, which sees the requested {@link TableOperation}
- * via {@link TableCredId} and can grant or deny per operation.
+ * Unit tests for the credential-operation choice in {@code UCProxy.loadV1Table}, with the UC
+ * credential endpoint stubbed at the {@link CredPropsUtil#genericCredFetcherFactory} seam. The
+ * end-to-end path (Spark SQL -> {@code UCSingleCatalog} -> DeltaCatalog -> vend site) is covered by
+ * {@code WriteIntentE2ETest}.
  */
 public class WriteIntentCredentialSuite {
 
@@ -66,14 +61,12 @@ public class WriteIntentCredentialSuite {
     String tableId = stubTable("t_denied");
     denyReadWriteGrantRead();
 
-    // First intent-less load: READ_WRITE is attempted once, denied, and remembered; the load
-    // still succeeds on READ credentials.
     proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
     assertThat(readWriteAttempts.get()).isEqualTo(1);
     assertThat(readAttempts.get()).isEqualTo(1);
     assertThat(writeDeniedTables()).containsExactly(tableId);
 
-    // Subsequent loads skip the guaranteed READ_WRITE denial entirely.
+    // Subsequent loads must not retry the denied READ_WRITE.
     proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
     assertThat(readWriteAttempts.get()).isEqualTo(1);
   }
@@ -84,8 +77,6 @@ public class WriteIntentCredentialSuite {
     denyReadWriteGrantRead();
 
     UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
-    // Vending READ credentials to a declared write would only defer the same failure to the
-    // storage layer mid-job, so the denial must surface here and READ must not be attempted.
     assertThatThrownBy(() -> proxy.loadTable(Identifier.of(NAMESPACE, "t_write_denied")))
         .isInstanceOf(ApiException.class);
     assertThat(readWriteAttempts.get()).isEqualTo(1);
@@ -97,23 +88,17 @@ public class WriteIntentCredentialSuite {
     String tableId = stubTable("t_regranted");
     denyReadWriteGrantRead();
 
-    // Prime the denial memory through an intent-less load.
     proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
     assertThat(writeDeniedTables()).containsExactly(tableId);
 
-    // The principal is granted write access; a declared write still requests READ_WRITE (the
-    // denial memory never gates declared writes) and, once granted, clears the memory so
-    // intent-less loads return to the READ_WRITE-first path.
     grantAllOperations();
     UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
     proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
     assertThat(writeDeniedTables()).isEmpty();
   }
 
-  /** Registers a mock UC table with an s3 location and returns its unique table id. */
+  /** Table ids are unique per test: the hadoop credential cache is JVM-global. */
   private String stubTable(String name) throws Exception {
-    // Unique per test method: the hadoop connector's credential cache is JVM-global and keyed by
-    // (context, tableId, operation), so reusing ids would leak cached grants across tests.
     String tableId = "table-id-" + name;
     TableInfo ucTable =
         new TableInfo()
@@ -169,7 +154,6 @@ public class WriteIntentCredentialSuite {
 
   @SuppressWarnings("unchecked")
   private java.util.Set<String> writeDeniedTables() throws Exception {
-    // UCProxy is package-private Scala; read the tracked set through its generated accessor.
     return (java.util.Set<String>)
         fixture.proxyObj.getClass().getMethod("writeDeniedTables").invoke(fixture.proxyObj);
   }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
@@ -19,10 +19,8 @@ import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.auth.AwsCredential;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
-import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntSupplier;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.AfterEach;
@@ -59,18 +57,13 @@ public class WriteIntentCredentialSuite {
   }
 
   @Test
-  public void intentLessLoadRemembersWriteDenialAndSkipsRetry() throws Exception {
-    String tableId = stubTable("t_denied");
+  public void intentLessLoadFallsBackToReadOnDenial() throws Exception {
+    stubTable("t_denied");
     denyReadWriteGrantRead();
 
     proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
     assertThat(readWriteAttempts.get()).isEqualTo(1);
     assertThat(readAttempts.get()).isEqualTo(1);
-    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
-
-    // Subsequent loads must not retry the denied READ_WRITE.
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_denied"));
-    assertThat(readWriteAttempts.get()).isEqualTo(1);
   }
 
   @Test
@@ -86,62 +79,14 @@ public class WriteIntentCredentialSuite {
   }
 
   @Test
-  public void successfulDeclaredWriteClearsDenialMemory() throws Exception {
-    String tableId = stubTable("t_regranted");
-    denyReadWriteGrantRead();
-
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
-    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
-
+  public void grantedDeclaredWriteRequestsReadWriteOnly() throws Exception {
+    stubTable("t_granted");
     grantAllOperations();
-    UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_regranted"));
-    assertThat(writeDeniedTables()).isEmpty();
-  }
-
-  @Test
-  public void transientReadWriteFailureDoesNotPoisonDenialMemory() throws Exception {
-    stubTable("t_transient");
-    AtomicInteger calls = new AtomicInteger();
-    // First READ_WRITE attempt fails with a 503; everything afterwards is granted.
-    stubFetcher(() -> calls.getAndIncrement() == 0 ? 503 : 0);
-
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_transient"));
-    assertThat(writeDeniedTables()).isEmpty();
-
-    // The next load must retry READ_WRITE instead of trusting the transient failure.
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_transient"));
-    assertThat(readWriteAttempts.get()).isEqualTo(2);
-  }
-
-  @Test
-  public void declaredWriteDenialSeedsMemoryForLaterReads() throws Exception {
-    String tableId = stubTable("t_write_seeds");
-    denyReadWriteGrantRead();
 
     UCSingleCatalog$.MODULE$.WRITE_INTENT().set(true);
-    assertThatThrownBy(() -> proxy.loadTable(Identifier.of(NAMESPACE, "t_write_seeds")))
-        .isInstanceOf(ApiException.class);
-    UCSingleCatalog$.MODULE$.WRITE_INTENT().remove();
-    assertThat(writeDeniedTables()).containsOnlyKeys(tableId);
-
-    // The failed write already proved the denial; reads skip the doomed round-trip.
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_write_seeds"));
+    proxy.loadTable(Identifier.of(NAMESPACE, "t_granted"));
     assertThat(readWriteAttempts.get()).isEqualTo(1);
-  }
-
-  @Test
-  public void expiredDenialEntryRestoresReadWriteFirstProbing() throws Exception {
-    String tableId = stubTable("t_expired");
-    denyReadWriteGrantRead();
-
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_expired"));
-    assertThat(readWriteAttempts.get()).isEqualTo(1);
-
-    // Simulate the TTL elapsing (e.g. a grant added later): the next load probes again.
-    writeDeniedTables().put(tableId, 0L);
-    proxy.loadTable(Identifier.of(NAMESPACE, "t_expired"));
-    assertThat(readWriteAttempts.get()).isEqualTo(2);
+    assertThat(readAttempts.get()).isEqualTo(0);
   }
 
   /** Table ids are unique per test: the hadoop credential cache is JVM-global. */
@@ -174,24 +119,23 @@ public class WriteIntentCredentialSuite {
   }
 
   private void denyReadWriteGrantRead() {
-    stubFetcher(() -> HttpURLConnection.HTTP_FORBIDDEN);
+    stubFetcher(true);
   }
 
   private void grantAllOperations() {
-    stubFetcher(() -> 0);
+    stubFetcher(false);
   }
 
-  /** Stubs the fetcher; a non-zero status from {@code denyRwStatus} fails READ_WRITE requests. */
-  private void stubFetcher(IntSupplier denyRwStatus) {
+  /** Stubs the fetcher, recording attempts per operation and optionally denying READ_WRITE. */
+  private void stubFetcher(boolean denyReadWrite) {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) ->
             () -> {
               String operation = ((TableCredId) credId).tableOperation();
               if (TableOperation.READ_WRITE.value().equals(operation)) {
                 readWriteAttempts.incrementAndGet();
-                int status = denyRwStatus.getAsInt();
-                if (status != 0) {
-                  throw new ApiException(status, "cannot vend READ_WRITE credential");
+                if (denyReadWrite) {
+                  throw new ApiException(403, "cannot vend READ_WRITE credential");
                 }
               } else {
                 readAttempts.incrementAndGet();
@@ -199,11 +143,5 @@ public class WriteIntentCredentialSuite {
               return List.of(
                   new AwsCredential("access-key", "secret-key", "session-token", null, LOCATION));
             };
-  }
-
-  @SuppressWarnings("unchecked")
-  private java.util.Map<String, Long> writeDeniedTables() throws Exception {
-    return (java.util.Map<String, Long>)
-        fixture.proxyObj.getClass().getMethod("writeDeniedTables").invoke(fixture.proxyObj);
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentCredentialSuite.java
@@ -90,7 +90,7 @@ public class WriteIntentCredentialSuite {
   }
 
   /** Table ids are unique per test: the hadoop credential cache is JVM-global. */
-  private String stubTable(String name) throws Exception {
+  private void stubTable(String name) throws Exception {
     String tableId = "table-id-" + name;
     TableInfo ucTable =
         new TableInfo()
@@ -115,7 +115,6 @@ public class WriteIntentCredentialSuite {
     when(fixture.mockTablesApi.getTable(
             eq(CATALOG_NAME + "." + SCHEMA_NAME + "." + name), eq(true), eq(true)))
         .thenReturn(ucTable);
-    return tableId;
   }
 
   private void denyReadWriteGrantRead() {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
@@ -1,0 +1,241 @@
+package io.unitycatalog.spark;
+
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static io.unitycatalog.server.utils.TestUtils.SCHEMA_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs.TableOperation;
+import io.unitycatalog.hadoop.internal.CredPropsUtil;
+import io.unitycatalog.hadoop.internal.CredPropsUtil.GenericCredentialFetcherFactory;
+import io.unitycatalog.hadoop.internal.auth.CredentialCache;
+import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import io.unitycatalog.hadoop.internal.id.TableCredId;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import io.unitycatalog.spark.utils.OptionsUtil;
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end coverage for write-intent credential selection: real Spark SQL through {@code
+ * UCSingleCatalog} -> DeltaCatalog -> {@code UCProxy} against a live UC server, with table
+ * credential fetches recorded (and selectively denied) at the {@link
+ * CredPropsUtil#genericCredFetcherFactory} seam. Complements {@code WriteIntentCredentialSuite},
+ * which unit-tests the vend-site logic in isolation.
+ */
+public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
+
+  // The test filesystem maps s3://test-bucket0/<path> to file:///<path>, so locations must
+  // embed an absolute local directory.
+  @TempDir private File dataDir;
+
+  /** One table-credential fetch: tableId + requested operation + write-intent flag at fetch. */
+  private static final class Fetch {
+    final String tableId;
+    final String operation;
+    final boolean writeIntent;
+
+    Fetch(String tableId, String operation, boolean writeIntent) {
+      this.tableId = tableId;
+      this.operation = operation;
+      this.writeIntent = writeIntent;
+    }
+  }
+
+  private final List<Fetch> fetches = new CopyOnWriteArrayList<>();
+  private final GenericCredentialFetcherFactory realFactory =
+      CredPropsUtil.genericCredFetcherFactory;
+
+  @AfterEach
+  public void resetSeam() {
+    CredPropsUtil.genericCredFetcherFactory = GenericCredentialFetcher::create;
+  }
+
+  // With the UC Delta REST API enabled (Delta >= 4.3), table loads vend credentials through
+  // delta-io's own client (DeltaTableCredId), not UCProxy.loadV1Table; intent selection there is
+  // upstream work. These tests pin the path this connector owns by disabling the Delta REST API.
+  private void disableDeltaRestApi() {
+    session
+        .conf()
+        .set("spark.sql.catalog." + CATALOG_NAME + "." + OptionsUtil.DELTA_API_ENABLED, "false");
+  }
+
+  @Test
+  public void sqlStatementsRequestCredentialsMatchingTheirIntent() {
+    session = createSparkSessionWithCatalogs(false, false, SPARK_CATALOG, CATALOG_NAME);
+    disableDeltaRestApi();
+    installRecorder(/* denyReadWriteForTableIds= */ Set.of());
+
+    String target = CATALOG_NAME + "." + SCHEMA_NAME + ".wi_target";
+    String source = CATALOG_NAME + "." + SCHEMA_NAME + ".wi_source";
+    sql(
+        "CREATE TABLE %s (i INT, s STRING) USING delta LOCATION 's3://test-bucket0%s/wi_target'",
+        target, dataDir);
+    sql(
+        "CREATE TABLE %s (i INT, s STRING) USING delta LOCATION 's3://test-bucket0%s/wi_source'",
+        source, dataDir);
+    sql("INSERT INTO %s VALUES (1, 'a')", source);
+
+    assertStatementIntent(true, "INSERT INTO %s VALUES (1, 'a'), (2, 'b')", target);
+    assertStatementIntent(false, "SELECT * FROM %s", target);
+    assertStatementIntent(true, "UPDATE %s SET s = 'c' WHERE i = 1", target);
+    assertStatementIntent(true, "DELETE FROM %s WHERE i = 2", target);
+
+    // MERGE resolves the target with intent and the source without, in the same statement.
+    fetches.clear();
+    clearCredentialCache();
+    sql(
+        "MERGE INTO %s USING %s ON %s.i = %s.i WHEN NOT MATCHED THEN INSERT *",
+        target, source, target, source);
+    assertThat(intentsFor(tableIdOf(target))).contains(true);
+    assertThat(intentsFor(tableIdOf(source))).containsOnly(false);
+    assertThat(currentWriteIntent()).isFalse();
+  }
+
+  @Test
+  public void readOnlyPrincipalPaysReadWriteDenialOncePerTable() {
+    session = createSparkSessionWithCatalogs(false, false, SPARK_CATALOG, CATALOG_NAME);
+    disableDeltaRestApi();
+    installRecorder(Set.of());
+
+    String table = CATALOG_NAME + "." + SCHEMA_NAME + ".wi_readonly";
+    sql(
+        "CREATE TABLE %s (i INT, s STRING) USING delta LOCATION 's3://test-bucket0%s/wi_ro'",
+        table, dataDir);
+    sql("INSERT INTO %s VALUES (1, 'a')", table);
+    String tableId = tableIdOf(table);
+
+    // From here on the "server" denies READ_WRITE for this table, as it would for a principal
+    // holding only SELECT.
+    installRecorder(Set.of(tableId));
+
+    // First SELECT: one denied READ_WRITE, then READ succeeds and the query returns data.
+    fetches.clear();
+    clearCredentialCache();
+    List<Row> rows = sql("SELECT * FROM %s", table);
+    assertThat(rows).hasSize(1);
+    List<String> operations = operationsFor(tableId);
+    assertThat(operations.get(0)).isEqualTo(TableOperation.READ_WRITE.value());
+    assertThat(operations).filteredOn(TableOperation.READ_WRITE.value()::equals).hasSize(1);
+    assertThat(operations).contains(TableOperation.READ.value());
+
+    // Subsequent SELECTs must not retry the denied READ_WRITE.
+    fetches.clear();
+    clearCredentialCache();
+    sql("SELECT * FROM %s", table);
+    assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ.value());
+
+    // A write on the denied table fails at analysis time, without a READ fallback fetch.
+    fetches.clear();
+    clearCredentialCache();
+    assertThatThrownBy(() -> sql("INSERT INTO %s VALUES (2, 'b')", table))
+        .hasMessageContaining("SIMULATED_DENIAL");
+    assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ_WRITE.value());
+    assertThat(currentWriteIntent()).isFalse();
+
+    // Once the "grant" returns, a declared write clears the denial memory and succeeds.
+    installRecorder(Set.of());
+    sql("INSERT INTO %s VALUES (3, 'c')", table);
+    fetches.clear();
+    clearCredentialCache();
+    sql("SELECT * FROM %s", table);
+    assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ_WRITE.value());
+  }
+
+  @Test
+  public void parquetV1WritePathDeclaresWriteIntent() {
+    session = createSparkSessionWithCatalogs(false, false, SPARK_CATALOG, CATALOG_NAME);
+    installRecorder(Set.of());
+
+    String table = CATALOG_NAME + "." + SCHEMA_NAME + ".wi_parquet";
+    sql(
+        "CREATE TABLE %s (i INT, s STRING) USING parquet LOCATION 's3://test-bucket0%s/wi_pq'",
+        table, dataDir);
+
+    assertStatementIntent(true, "INSERT INTO %s VALUES (1, 'a')", table);
+    assertStatementIntent(false, "SELECT * FROM %s", table);
+  }
+
+  /** Runs the statement and asserts the write-intent flag observed at every credential fetch. */
+  private void assertStatementIntent(boolean expectedIntent, String statement, Object... args) {
+    fetches.clear();
+    clearCredentialCache();
+    sql(statement, args);
+    assertThat(fetches).isNotEmpty();
+    assertThat(fetches.stream().map(f -> f.writeIntent).collect(Collectors.toSet()))
+        .containsExactly(expectedIntent);
+    assertThat(currentWriteIntent()).isFalse();
+  }
+
+  /**
+   * Records every table-credential fetch and denies READ_WRITE for the given table ids; all other
+   * fetches are served by the real factory against the live server.
+   */
+  private void installRecorder(Set<String> denyReadWriteForTableIds) {
+    CredPropsUtil.genericCredFetcherFactory =
+        (apiClient, credId) -> {
+          if (!(credId instanceof TableCredId)) {
+            return realFactory.create(apiClient, credId);
+          }
+          TableCredId tableCredId = (TableCredId) credId;
+          fetches.add(
+              new Fetch(tableCredId.tableId(), tableCredId.tableOperation(), currentWriteIntent()));
+          return () -> {
+            if (denyReadWriteForTableIds.contains(tableCredId.tableId())
+                && TableOperation.READ_WRITE.value().equals(tableCredId.tableOperation())) {
+              throw new ApiException("SIMULATED_DENIAL: READ_WRITE not permitted");
+            }
+            return realFactory.create(apiClient, credId).createCredentials();
+          };
+        };
+  }
+
+  private static boolean currentWriteIntent() {
+    return (Boolean) UCSingleCatalog$.MODULE$.WRITE_INTENT().get();
+  }
+
+  /** Clears the JVM-global credential cache so the next load reaches the recording seam. */
+  private static void clearCredentialCache() {
+    try {
+      java.lang.reflect.Field cacheField = CredPropsUtil.class.getDeclaredField("initialCredCache");
+      cacheField.setAccessible(true);
+      ((CredentialCache<?, ?>) cacheField.get(null)).clear();
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String tableIdOf(String fullName) {
+    try {
+      TableOperations tableOperations =
+          new SdkTableOperations(TestUtils.createApiClient(serverConfig));
+      return tableOperations.getTable(fullName).getTableId();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<Boolean> intentsFor(String tableId) {
+    return fetches.stream()
+        .filter(f -> f.tableId.equals(tableId))
+        .map(f -> f.writeIntent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> operationsFor(String tableId) {
+    return fetches.stream()
+        .filter(f -> f.tableId.equals(tableId))
+        .map(f -> f.operation)
+        .collect(Collectors.toList());
+  }
+}

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
@@ -125,6 +125,7 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
     List<Row> rows = sql("SELECT * FROM %s", table);
     assertThat(rows).hasSize(1);
     List<String> operations = operationsFor(tableId);
+    assertThat(operations).isNotEmpty();
     assertThat(operations.get(0)).isEqualTo(TableOperation.READ_WRITE.value());
     assertThat(operations).filteredOn(TableOperation.READ_WRITE.value()::equals).hasSize(1);
     assertThat(operations).contains(TableOperation.READ.value());
@@ -193,7 +194,7 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
           return () -> {
             if (denyReadWriteForTableIds.contains(tableCredId.tableId())
                 && TableOperation.READ_WRITE.value().equals(tableCredId.tableOperation())) {
-              throw new ApiException("SIMULATED_DENIAL: READ_WRITE not permitted");
+              throw new ApiException(403, "SIMULATED_DENIAL: READ_WRITE not permitted");
             }
             return realFactory.create(apiClient, credId).createCredentials();
           };

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
@@ -103,7 +103,7 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
   }
 
   @Test
-  public void readOnlyPrincipalPaysReadWriteDenialOncePerTable() {
+  public void readOnlyPrincipalReadsViaFallbackAndWritesFailFast() {
     session = createSparkSessionWithCatalogs(false, false, SPARK_CATALOG, CATALOG_NAME);
     disableDeltaRestApi();
     installRecorder(Set.of());
@@ -119,22 +119,13 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
     // holding only SELECT.
     installRecorder(Set.of(tableId));
 
-    // First SELECT: one denied READ_WRITE, then READ succeeds and the query returns data.
+    // SELECT: denied READ_WRITE, then READ succeeds and the query returns data.
     fetches.clear();
     clearCredentialCache();
     List<Row> rows = sql("SELECT * FROM %s", table);
     assertThat(rows).hasSize(1);
-    List<String> operations = operationsFor(tableId);
-    assertThat(operations).isNotEmpty();
-    assertThat(operations.get(0)).isEqualTo(TableOperation.READ_WRITE.value());
-    assertThat(operations).filteredOn(TableOperation.READ_WRITE.value()::equals).hasSize(1);
-    assertThat(operations).contains(TableOperation.READ.value());
-
-    // Subsequent SELECTs must not retry the denied READ_WRITE.
-    fetches.clear();
-    clearCredentialCache();
-    sql("SELECT * FROM %s", table);
-    assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ.value());
+    assertThat(operationsFor(tableId))
+        .containsExactly(TableOperation.READ_WRITE.value(), TableOperation.READ.value());
 
     // A write on the denied table fails at analysis time, without a READ fallback fetch.
     fetches.clear();
@@ -144,12 +135,11 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
     assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ_WRITE.value());
     assertThat(currentWriteIntent()).isFalse();
 
-    // Once the "grant" returns, a declared write clears the denial memory and succeeds.
+    // Once the "grant" returns, the declared write succeeds.
     installRecorder(Set.of());
-    sql("INSERT INTO %s VALUES (3, 'c')", table);
     fetches.clear();
     clearCredentialCache();
-    sql("SELECT * FROM %s", table);
+    sql("INSERT INTO %s VALUES (3, 'c')", table);
     assertThat(operationsFor(tableId)).containsOnly(TableOperation.READ_WRITE.value());
   }
 

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/WriteIntentE2ETest.java
@@ -11,6 +11,7 @@ import io.unitycatalog.hadoop.internal.CredPropsUtil;
 import io.unitycatalog.hadoop.internal.CredPropsUtil.GenericCredentialFetcherFactory;
 import io.unitycatalog.hadoop.internal.auth.CredentialCache;
 import io.unitycatalog.hadoop.internal.auth.GenericCredentialFetcher;
+import io.unitycatalog.hadoop.internal.id.DeltaTableCredId;
 import io.unitycatalog.hadoop.internal.id.TableCredId;
 import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
@@ -157,6 +158,70 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
     assertStatementIntent(false, "SELECT * FROM %s", table);
   }
 
+  // Requires a Delta build with delta-io/delta#7518 (intent-aware UC credential requests);
+  // skipped on older Delta. Locally: publish Delta with the patch and run with
+  // -DdeltaVersion=<snapshot> -DsparkVersion=4.2.0.
+  @Test
+  public void deltaRestApiPathHonorsDeclaredWriteIntent() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+        deltaSupportsWriteIntent(), "requires Delta with delta-io/delta#7518");
+    session = createSparkSessionWithCatalogs(false, false, SPARK_CATALOG, CATALOG_NAME);
+    installRecorder(Set.of());
+
+    String table = CATALOG_NAME + "." + SCHEMA_NAME + ".wi_rest";
+    String location = "s3://test-bucket0" + dataDir + "/wi_rest";
+    sql("CREATE TABLE %s (i INT, s STRING) USING delta LOCATION '%s'", table, location);
+    sql("INSERT INTO %s VALUES (1, 'a')", table);
+
+    // The "server" now denies READ_WRITE for this table (delta-path credentials are keyed by
+    // location).
+    installRecorder(Set.of(location));
+
+    // SELECT: denied READ_WRITE, then READ succeeds and the query returns data.
+    fetches.clear();
+    clearCredentialCache();
+    assertThat(sql("SELECT * FROM %s", table)).hasSize(1);
+    assertThat(operationsFor(location))
+        .containsExactly(TableOperation.READ_WRITE.value(), TableOperation.READ.value());
+
+    // Declared write reaches Delta through UCSingleCatalog -> DeltaCatalog and fails fast.
+    fetches.clear();
+    clearCredentialCache();
+    assertThatThrownBy(() -> sql("INSERT INTO %s VALUES (2, 'b')", table))
+        .hasStackTraceContaining("Credential fetch failed");
+    assertThat(operationsFor(location)).containsOnly(TableOperation.READ_WRITE.value());
+
+    // Once the "grant" returns, the declared write succeeds.
+    installRecorder(Set.of());
+    fetches.clear();
+    clearCredentialCache();
+    sql("INSERT INTO %s VALUES (3, 'c')", table);
+    assertThat(operationsFor(location)).containsOnly(TableOperation.READ_WRITE.value());
+  }
+
+  /**
+   * True when the Delta on the classpath declares the intent-carrying {@code loadTable} override
+   * somewhere in DeltaCatalog's class hierarchy (interfaces excluded: the TableCatalog default
+   * exists on every Spark and proves nothing).
+   */
+  private static boolean deltaSupportsWriteIntent() {
+    try {
+      Class<?> current = Class.forName("org.apache.spark.sql.delta.catalog.DeltaCatalog");
+      while (current != null && current != Object.class) {
+        try {
+          current.getDeclaredMethod(
+              "loadTable", org.apache.spark.sql.connector.catalog.Identifier.class, Set.class);
+          return true;
+        } catch (NoSuchMethodException notHere) {
+          current = current.getSuperclass();
+        }
+      }
+      return false;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
   /** Runs the statement and asserts the write-intent flag observed at every credential fetch. */
   private void assertStatementIntent(boolean expectedIntent, String statement, Object... args) {
     fetches.clear();
@@ -172,18 +237,24 @@ public class WriteIntentE2ETest extends BaseSparkIntegrationTest {
    * Records every table-credential fetch and denies READ_WRITE for the given table ids; all other
    * fetches are served by the real factory against the live server.
    */
-  private void installRecorder(Set<String> denyReadWriteForTableIds) {
+  private void installRecorder(Set<String> denyReadWriteForKeys) {
     CredPropsUtil.genericCredFetcherFactory =
         (apiClient, credId) -> {
-          if (!(credId instanceof TableCredId)) {
+          String key;
+          String operation;
+          if (credId instanceof TableCredId) {
+            key = ((TableCredId) credId).tableId();
+            operation = ((TableCredId) credId).tableOperation();
+          } else if (credId instanceof DeltaTableCredId) {
+            key = ((DeltaTableCredId) credId).location();
+            operation = ((DeltaTableCredId) credId).tableOperation();
+          } else {
             return realFactory.create(apiClient, credId);
           }
-          TableCredId tableCredId = (TableCredId) credId;
-          fetches.add(
-              new Fetch(tableCredId.tableId(), tableCredId.tableOperation(), currentWriteIntent()));
+          fetches.add(new Fetch(key, operation, currentWriteIntent()));
           return () -> {
-            if (denyReadWriteForTableIds.contains(tableCredId.tableId())
-                && TableOperation.READ_WRITE.value().equals(tableCredId.tableOperation())) {
+            if (denyReadWriteForKeys.contains(key)
+                && TableOperation.READ_WRITE.value().equals(operation)) {
               throw new ApiException(403, "SIMULATED_DENIAL: READ_WRITE not permitted");
             }
             return realFactory.create(apiClient, credId).createCredentials();


### PR DESCRIPTION
## Summary

Follow-up to #1803, split out so that PR is not coupled to the Delta-side work. **Stacked on #1803** — only the last commit (`test(spark): E2E for the Delta REST API credential path...`) is new here; review after #1803 merges.

#1803 fixes intent-aware credential selection on the connector's legacy path. On the Delta REST API path (default with Delta >= 4.3), credentials are vended by delta-io's client, and the matching fix is delta-io/delta#7518. This PR adds the connector-side E2E for that path: `WriteIntentE2ETest.deltaRestApiPathHonorsDeclaredWriteIntent` drives real SQL through `UCSingleCatalog` -> `DeltaCatalog` -> delta's UC client against a live UC server with the Delta REST API **enabled**, asserting on the recorded credential operations:

- a SELECT under a READ_WRITE denial requests READ_WRITE, is denied, and is served READ;
- a declared INSERT fails fast with no READ fallback — the write intent must survive both #1803's forwarding and delta-io/delta#7518's plumbing to produce this;
- once the grant returns, the declared write requests READ_WRITE only and succeeds.

The test is gated on a reflection check for Delta's intent-carrying `loadTable(ident, writePrivileges)` overload: on the pinned Delta 4.3.1 it aborts with a named JUnit assumption, and it activates automatically when the pin picks up a Delta release carrying delta-io/delta#7518. No CI impact until then.

## How we tested

On stock Delta 4.3.1 (what CI runs) the REST-path case is cleanly skipped via assumption; the other three cases pass. The active case was last exercised against a 4.4.0-SNAPSHOT of delta-io/delta#7518 before both PRs dropped their per-table denial memory per review; the remaining assertions are a strict subset of what passed then.
