### PR TITLE
Recover schema from Delta log when DeltaCatalog delegates createTable with empty columns

### DIFF
--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1,5 +1,6 @@
 package io.unitycatalog.spark
 
+import java.io.{BufferedReader, InputStreamReader}
 import java.net.URI
 import java.util
 import java.util.Locale
@@ -9,6 +10,7 @@ import scala.collection.convert.ImplicitConversions._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.existentials
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.unitycatalog.client.api.{SchemasApi, TablesApi}
 import io.unitycatalog.client.auth.TokenProvider
 import io.unitycatalog.client.model.{
@@ -863,6 +865,96 @@ private[spark] class UCProxy(
   }
 
   /**
+   * Recovers the table schema by reading it back from the Delta transaction log at `location`.
+   *
+   * `DeltaCatalog` commits the schema to `_delta_log` itself and then calls this catalog's
+   * legacy `createTable(ident, schema: StructType, ...)` overload with an *empty* schema -- it
+   * treats the transaction log as the source of truth and doesn't expect the underlying catalog
+   * to need the columns. Left as-is, that leaves UC's own metadata with zero columns, which
+   * breaks any UC-native reader of table metadata (non-Spark clients, `SHOW COLUMNS`, direct
+   * `TablesApi.getTable` callers, etc). We recover the real schema here so UC's record matches
+   * reality.
+   *
+   * Deliberately fails soft: returns `None` (instead of throwing) on any failure to fetch
+   * credentials, list/open the log, or parse a commit, so callers can fall back to the original
+   * (possibly empty) schema instead of failing the whole CREATE TABLE over a best-effort repair.
+   *
+   * Note: this does not depend on credential-shaped entries surviving in `properties` -- by the
+   * time `DeltaCatalog` calls back into this method, it may have rebuilt/stripped the property
+   * map, so any `fs.*` / `option.fs.*` overrides `UCSingleCatalog` originally vended upstream
+   * are not reliably present here. We fetch fresh READ-capable credentials for `location`
+   * directly instead of trying to recover them from `properties`.
+   */
+  private[spark] def readSchemaFromDeltaLog(
+      properties: util.Map[String, String]): Option[StructType] = {
+    val location = properties.get(TableCatalog.PROP_LOCATION)
+    if (location == null || location.isEmpty) return None
+
+    try {
+      val locationUri = CatalogUtils.stringToURI(location)
+      val conf = new Configuration(UCSingleCatalog.sessionHadoopConf())
+
+      val credentialProps = UCCredentialHadoopConfs
+        .builder(uri.toString, locationUri.getScheme)
+        .addAppVersions(ApiClientFactory.appEngineVersions())
+        .tokenProvider(tokenProvider)
+        .apiClient(apiClient)
+        .enableCredentialRenewal(renewCredEnabled)
+        .enableCredentialScopedFs(credScopedFsEnabled)
+        .hadoopConf(UCSingleCatalog.sessionHadoopConf())
+        .buildForPath(location, PathOperation.PATH_CREATE_TABLE)
+      credentialProps.asScala.foreach { case (k, v) => conf.set(k, v) }
+
+      val logDir = new Path(location, "_delta_log")
+      val fs = logDir.getFileSystem(conf)
+      if (!fs.exists(logDir)) return None
+
+      val commitFiles = fs.listStatus(logDir)
+        .filter(s => s.getPath.getName.endsWith(".json"))
+        .sortBy(_.getPath.getName) // ascending: 00000000000000000000.json first
+
+      val mapper = new ObjectMapper()
+      // Walk commits in order and keep the *last* schemaString seen, in case of schema
+      // evolution within the same batch of commits (unlikely on initial create, but cheap to
+      // handle correctly).
+      val schemaJson = commitFiles.iterator.flatMap { status =>
+        val in = fs.open(status.getPath)
+        try {
+          val reader = new BufferedReader(new InputStreamReader(in, "UTF-8"))
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).flatMap { line =>
+            if (line.trim.isEmpty) None
+            else {
+              val node = mapper.readTree(line)
+              val metaData = node.get("metaData")
+              if (metaData != null && metaData.has("schemaString")) {
+                Some(metaData.get("schemaString").asText())
+              } else {
+                None
+              }
+            }
+          }.toList // materialize before closing the stream
+        } finally {
+          in.close()
+        }
+      }.toSeq.lastOption
+
+      schemaJson.flatMap { json =>
+        try {
+          Some(DataType.fromJson(json).asInstanceOf[StructType])
+        } catch {
+          case e: Exception =>
+            logWarning(s"Failed to parse Delta schemaString from $logDir: ${e.getMessage}")
+            None
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logWarning(s"Failed to recover schema from Delta log at $location", e)
+        None
+    }
+  }
+
+  /**
    * Spark 4.2's `TableCatalog` made `createTable(ident, TableInfo)` the canonical entry
    * point; this legacy 4-arg method carries all the create-table logic, which keeps the diff
    * vs. main scoped to "add the new overload + 409 -> TableAlreadyExistsException catch required
@@ -871,6 +963,19 @@ private[spark] class UCProxy(
   override def createTable(ident: Identifier, schema: StructType, partitions: Array[Transform], properties: util.Map[String, String]): Table = {
     UCSingleCatalog.checkUnsupportedNestedNamespace(ident.namespace())
     UCSingleCatalog.requireProviderSpecified("CREATE TABLE", properties)
+
+    val format = properties.get("provider")
+
+    // `DeltaCatalog` calls into this overload with an empty `schema` once it has already
+    // committed the real schema to the Delta transaction log itself (see
+    // `readSchemaFromDeltaLog`'s scaladoc for why). Recover it here so UC's own metadata isn't
+    // left with zero columns.
+    val effectiveSchema =
+      if (schema.fields.isEmpty && format != null && format.equalsIgnoreCase("delta")) {
+        readSchemaFromDeltaLog(properties).getOrElse(schema)
+      } else {
+        schema
+      }
 
     val createTable = new CreateTable()
     createTable.setName(ident.name())
@@ -882,7 +987,6 @@ private[spark] class UCProxy(
     assert(storageLocation != null, "location should either be user specified or system generated.")
     val isManagedLocation = Option(properties.get(TableCatalog.PROP_IS_MANAGED_LOCATION))
       .exists(_.equalsIgnoreCase("true"))
-    val format = properties.get("provider")
     if (isManagedLocation) {
       assert(!hasExternalClause, "location is only generated for managed tables.")
       if (!format.equalsIgnoreCase(DataSourceFormat.DELTA.name)) {
@@ -896,7 +1000,7 @@ private[spark] class UCProxy(
 
     val partitionColNames: Seq[String] =
       UCColumnConversions.partitionColumnNames(partitions).asScala.toSeq
-    val columns: Seq[ColumnInfo] = schema.fields.toSeq.zipWithIndex.map { case (field, i) =>
+    val columns: Seq[ColumnInfo] = effectiveSchema.fields.toSeq.zipWithIndex.map { case (field, i) =>
       val column = new ColumnInfo()
       column.setName(field.name)
       if (field.getComment().isDefined) {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCProxyDeltaSchemaRecoveryTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCProxyDeltaSchemaRecoveryTest.java
@@ -1,0 +1,344 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.model.TableType;
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import scala.Option;
+
+/**
+ * Tests for the Delta-transaction-log schema recovery fix in {@link UCProxy}.
+ *
+ * <p>Background: when {@code DeltaCatalog} is on the classpath, it commits the real schema to
+ * the table's {@code _delta_log} itself and then calls back into {@link UCProxy}'s legacy {@code
+ * createTable(Identifier, StructType, ...)} overload with an <em>empty</em> schema, since it
+ * treats the transaction log (not the catalog) as the schema source of truth. Left unhandled,
+ * that leaves Unity Catalog's own table record with zero columns. {@link
+ * UCProxy#readSchemaFromDeltaLog} recovers the real schema by reading it back from the commit
+ * Delta already wrote, so UC's metadata matches reality.
+ */
+public class UCProxyDeltaSchemaRecoveryTest {
+
+  private static final Identifier IDENT = Identifier.of(new String[] {"schema"}, "table");
+  private static final Transform[] PARTITIONS = new Transform[0];
+  private static final StructType EMPTY_SCHEMA = new StructType();
+  private static final StructType ID_SCHEMA =
+      new StructType().add("id", DataTypes.IntegerType, false);
+  private static final StructType ID_NAME_SCHEMA =
+      new StructType()
+          .add("id", DataTypes.IntegerType, false)
+          .add("name", DataTypes.StringType, true);
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private TablesApi tablesApi;
+  private UCProxy ucProxy;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    tablesApi = mock(TablesApi.class);
+    ApiClient apiClient = mock(ApiClient.class);
+    TokenProvider tokenProvider =
+        TokenProvider.create(Map.of("type", "static", "token", "tok"));
+
+    ucProxy =
+        new UCProxy(
+            URI.create("http://localhost"),
+            tokenProvider,
+            /* renewCredEnabled= */ false,
+            /* credScopedFsEnabled= */ true,
+            /* serverSidePlanningEnabled= */ false,
+            apiClient,
+            tablesApi);
+    ucProxy.initialize("main", new CaseInsensitiveStringMap(Map.of()));
+  }
+
+  // ---------------------------------------------------------------------
+  // readSchemaFromDeltaLog
+  // ---------------------------------------------------------------------
+
+  @Test
+  public void testReadSchemaFromDeltaLogRecoversSchemaFromSingleCommit(@TempDir File tempDir)
+      throws Exception {
+    String location = fileLocation(tempDir);
+    writeCommit(tempDir, "00000000000000000000.json", protocolLine(), metaDataLine(ID_SCHEMA));
+
+    Option<StructType> result =
+        ucProxy.readSchemaFromDeltaLog(Map.of(TableCatalog.PROP_LOCATION, location));
+
+    assertThat(result.isDefined()).isTrue();
+    assertSchemaEquals(ID_SCHEMA, result.get());
+  }
+
+  @Test
+  public void testReadSchemaFromDeltaLogUsesLastCommitWhenSchemaEvolves(@TempDir File tempDir)
+      throws Exception {
+    String location = fileLocation(tempDir);
+    writeCommit(tempDir, "00000000000000000000.json", protocolLine(), metaDataLine(ID_SCHEMA));
+    writeCommit(tempDir, "00000000000000000001.json", metaDataLine(ID_NAME_SCHEMA));
+
+    Option<StructType> result =
+        ucProxy.readSchemaFromDeltaLog(Map.of(TableCatalog.PROP_LOCATION, location));
+
+    assertThat(result.isDefined()).isTrue();
+    assertSchemaEquals(ID_NAME_SCHEMA, result.get());
+  }
+
+  @Test
+  public void testReadSchemaFromDeltaLogToleratesNonMetadataActions(@TempDir File tempDir)
+      throws Exception {
+    // Realistic commit file: protocol + metaData + commitInfo actions on separate lines.
+    String location = fileLocation(tempDir);
+    writeCommit(
+        tempDir,
+        "00000000000000000000.json",
+        protocolLine(),
+        metaDataLine(ID_SCHEMA),
+        commitInfoLine());
+
+    Option<StructType> result =
+        ucProxy.readSchemaFromDeltaLog(Map.of(TableCatalog.PROP_LOCATION, location));
+
+    assertThat(result.isDefined()).isTrue();
+    assertSchemaEquals(ID_SCHEMA, result.get());
+  }
+
+  @Test
+  public void testReadSchemaFromDeltaLogReturnsEmptyWhenDeltaLogDirMissing(@TempDir File tempDir) {
+    String location = fileLocation(tempDir); // tempDir exists but has no _delta_log subdir
+
+    Option<StructType> result =
+        ucProxy.readSchemaFromDeltaLog(Map.of(TableCatalog.PROP_LOCATION, location));
+
+    assertThat(result.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void testReadSchemaFromDeltaLogReturnsEmptyWhenLocationPropertyMissing() {
+    Option<StructType> result = ucProxy.readSchemaFromDeltaLog(Map.of());
+
+    assertThat(result.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void testReadSchemaFromDeltaLogReturnsEmptyWhenCommitLineIsMalformed(
+      @TempDir File tempDir) throws Exception {
+    String location = fileLocation(tempDir);
+    // A malformed (non-JSON) line anywhere in the commit aborts recovery entirely -- this method
+    // fails soft for the whole operation rather than skipping just the bad line, since a
+    // truncated/corrupt commit file shouldn't be partially trusted.
+    writeCommit(tempDir, "00000000000000000000.json", "not-json", metaDataLine(ID_SCHEMA));
+
+    Option<StructType> result =
+        ucProxy.readSchemaFromDeltaLog(Map.of(TableCatalog.PROP_LOCATION, location));
+
+    assertThat(result.isEmpty()).isTrue();
+  }
+
+  // ---------------------------------------------------------------------
+  // createTable(ident, schema: StructType, ...) -- the legacy overload DeltaCatalog calls back
+  // into.
+  // ---------------------------------------------------------------------
+
+  @Test
+  public void testCreateTableRecoversSchemaFromDeltaLogWhenIncomingSchemaEmpty(
+      @TempDir File tempDir) throws Exception {
+    String location = fileLocation(tempDir);
+    writeCommit(tempDir, "00000000000000000000.json", metaDataLine(ID_NAME_SCHEMA));
+    mockGetTableForLoadTable(location, ID_NAME_SCHEMA, TableType.EXTERNAL);
+
+    ucProxy.createTable(
+        IDENT,
+        EMPTY_SCHEMA,
+        PARTITIONS,
+        Map.of(
+            TableCatalog.PROP_PROVIDER, "delta",
+            TableCatalog.PROP_LOCATION, location));
+
+    ArgumentCaptor<CreateTable> captor = ArgumentCaptor.forClass(CreateTable.class);
+    verify(tablesApi).createTable(captor.capture());
+    List<ColumnInfo> sentColumns = captor.getValue().getColumns();
+
+    assertThat(sentColumns).hasSize(2);
+    assertThat(sentColumns.get(0).getName()).isEqualTo("id");
+    assertThat(sentColumns.get(0).getTypeName()).isEqualTo(ColumnTypeName.INT);
+    assertThat(sentColumns.get(0).getNullable()).isFalse();
+    assertThat(sentColumns.get(1).getName()).isEqualTo("name");
+    assertThat(sentColumns.get(1).getTypeName()).isEqualTo(ColumnTypeName.STRING);
+    assertThat(sentColumns.get(1).getNullable()).isTrue();
+  }
+
+  @Test
+  public void testCreateTableDoesNotOverrideNonEmptySchema(@TempDir File tempDir)
+      throws Exception {
+    String location = fileLocation(tempDir);
+    // Delta log at this location disagrees with the schema passed in -- proves the recovery path
+    // is only consulted when the incoming schema is empty, never used to override a populated one.
+    writeCommit(tempDir, "00000000000000000000.json", metaDataLine(ID_NAME_SCHEMA));
+    mockGetTableForLoadTable(location, ID_SCHEMA, TableType.EXTERNAL);
+
+    ucProxy.createTable(
+        IDENT,
+        ID_SCHEMA,
+        PARTITIONS,
+        Map.of(
+            TableCatalog.PROP_PROVIDER, "delta",
+            TableCatalog.PROP_LOCATION, location));
+
+    ArgumentCaptor<CreateTable> captor = ArgumentCaptor.forClass(CreateTable.class);
+    verify(tablesApi).createTable(captor.capture());
+    List<ColumnInfo> sentColumns = captor.getValue().getColumns();
+
+    assertThat(sentColumns).hasSize(1);
+    assertThat(sentColumns.get(0).getName()).isEqualTo("id");
+  }
+
+  @Test
+  public void testCreateTableNonDeltaProviderWithEmptySchemaDoesNotAttemptRecovery(
+      @TempDir File tempDir) throws Exception {
+    String location = fileLocation(tempDir);
+    // A valid _delta_log happens to exist here, but the provider isn't delta, so recovery must
+    // not kick in -- confirms the gate is provider-aware, not just "schema is empty".
+    writeCommit(tempDir, "00000000000000000000.json", metaDataLine(ID_NAME_SCHEMA));
+    mockGetTableForLoadTable(location, EMPTY_SCHEMA, TableType.EXTERNAL);
+
+    ucProxy.createTable(
+        IDENT,
+        EMPTY_SCHEMA,
+        PARTITIONS,
+        Map.of(
+            TableCatalog.PROP_PROVIDER, "parquet",
+            TableCatalog.PROP_LOCATION, location));
+
+    ArgumentCaptor<CreateTable> captor = ArgumentCaptor.forClass(CreateTable.class);
+    verify(tablesApi).createTable(captor.capture());
+
+    assertThat(captor.getValue().getColumns()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------
+
+  private static String fileLocation(File dir) {
+    return "file://" + dir.getAbsolutePath();
+  }
+
+  private static void writeCommit(File tempDir, String fileName, String... lines)
+      throws Exception {
+    File deltaLogDir = new File(tempDir, "_delta_log");
+    deltaLogDir.mkdirs();
+    File commitFile = new File(deltaLogDir, fileName);
+    Files.write(
+        commitFile.toPath(), String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String metaDataLine(StructType schema) throws Exception {
+    Map<String, Object> metaData = new LinkedHashMap<>();
+    metaData.put("id", "meta-id");
+    metaData.put("format", Map.of("provider", "parquet", "options", Map.of()));
+    metaData.put("schemaString", schema.json());
+    metaData.put("partitionColumns", Collections.emptyList());
+    metaData.put("configuration", Collections.emptyMap());
+    metaData.put("createdTime", 1234567890L);
+
+    Map<String, Object> line = new LinkedHashMap<>();
+    line.put("metaData", metaData);
+    return MAPPER.writeValueAsString(line);
+  }
+
+  private static String protocolLine() throws Exception {
+    Map<String, Object> protocol = Map.of("minReaderVersion", 1, "minWriterVersion", 2);
+    Map<String, Object> line = new LinkedHashMap<>();
+    line.put("protocol", protocol);
+    return MAPPER.writeValueAsString(line);
+  }
+
+  private static String commitInfoLine() throws Exception {
+    Map<String, Object> commitInfo = Map.of("timestamp", 1234567890L, "operation", "CREATE TABLE");
+    Map<String, Object> line = new LinkedHashMap<>();
+    line.put("commitInfo", commitInfo);
+    return MAPPER.writeValueAsString(line);
+  }
+
+  /**
+   * Mocks {@code tablesApi.getTable(...)} so the {@code loadTable(ident)} call at the end of
+   * {@code UCProxy.createTable} succeeds. The returned {@link TableInfo}'s contents aren't the
+   * subject of these tests (the request captured via {@link CreateTable} is); this only needs to
+   * be internally consistent enough that {@code loadV1Table} doesn't throw.
+   */
+  private void mockGetTableForLoadTable(String location, StructType schema, TableType tableType) {
+    List<ColumnInfo> columns =
+        java.util.Arrays.stream(schema.fields())
+            .map(UCProxyDeltaSchemaRecoveryTest::toColumnInfo)
+            .collect(java.util.stream.Collectors.toList());
+
+    TableInfo tableInfo =
+        new TableInfo()
+            .name("table")
+            .schemaName("schema")
+            .catalogName("main")
+            .tableType(tableType)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .storageLocation(location)
+            .tableId("table-id")
+            .properties(Collections.emptyMap())
+            .columns(columns)
+            .createdAt(0L);
+
+    when(tablesApi.getTable(eq("main.schema.table"), any(), any())).thenReturn(tableInfo);
+  }
+
+  private static ColumnInfo toColumnInfo(StructField field) {
+    ColumnInfo column = new ColumnInfo();
+    column.setName(field.name());
+    column.setNullable(field.nullable());
+    column.setTypeText(field.dataType().catalogString());
+    column.setTypeName(
+        field.dataType() == DataTypes.IntegerType ? ColumnTypeName.INT : ColumnTypeName.STRING);
+    return column;
+  }
+
+  private static void assertSchemaEquals(StructType expected, StructType actual) {
+    assertThat(actual.fields()).hasSize(expected.fields().length);
+    for (int i = 0; i < expected.fields().length; i++) {
+      StructField expectedField = expected.fields()[i];
+      StructField actualField = actual.fields()[i];
+      assertThat(actualField.name()).isEqualTo(expectedField.name());
+      assertThat(actualField.dataType()).isEqualTo(expectedField.dataType());
+      assertThat(actualField.nullable()).isEqualTo(expectedField.nullable());
+    }
+  }
+}


### PR DESCRIPTION
**PR Checklist**
- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

## Problem

When creating a Delta table through `UCSingleCatalog` with `DeltaCatalog` on the classpath
(e.g. `CREATE TABLE ... USING DELTA LOCATION '...'`), the table is registered in Unity Catalog
with **zero columns**, even though the `CREATE TABLE` statement specifies a full schema.

Repro:
```sql
CREATE TABLE catalog.schema.users (id INT, name STRING, email STRING) USING DELTA LOCATION 's3://...'
```
Before this change, `TablesApi.getTable(...)` for this table returns an empty `columns` list.

## Root cause

`UCSingleCatalog.createTable` builds the correct schema from the caller's columns and delegates
to `DeltaCatalog` (`delegate.createTable(ident, schema, partitions, newProps)`). `DeltaCatalog`
commits that schema into the table's `_delta_log` itself — from Delta's point of view, the
transaction log is the source of truth for schema, not the catalog. As its last step it calls
back into the underlying delegate catalog (`UCProxy`, via the legacy
`TableCatalog.createTable(Identifier, StructType, ...)` overload) purely to register a
location/provider pointer, passing an **empty** `StructType` since it doesn't expect the
underlying catalog to need the columns.

`UCProxy.createTable` faithfully persists whatever schema it's given, so UC ends up with a
zero-column table record. This is invisible to Spark reads in the same session (Delta resolves
schema from its own log at read time), but breaks any UC-native consumer of table metadata —
direct `TablesApi.getTable` callers, `SHOW COLUMNS`, other non-Spark engines reading UC
directly, etc.

## Fix

In `UCProxy.createTable(ident, schema: StructType, ...)`, detect the empty-schema +
delta-provider case and recover the real schema by reading it back from the table's
`_delta_log` (already committed by `DeltaCatalog` at this point) before building the
`ColumnInfo`s sent to `TablesApi.createTable`.

- New method `UCProxy.readSchemaFromDeltaLog(properties)`: lists `_delta_log/*.json` in commit
  order, parses each commit's `metaData.schemaString`, and keeps the last one seen (handles the
  rare case of multiple commits/schema evolution within the same create).
- Credentials for reading the log are fetched fresh via the existing
  `UCCredentialHadoopConfs.builder(...).buildForPath(...)` chain, rather than relying on
  `properties` — by the time `DeltaCatalog` calls back into `UCProxy`, it may have
  rebuilt/stripped the property map, so any `fs.*` / `option.fs.*` credential overrides
  `UCSingleCatalog` originally vended upstream aren't reliably present here.
- The recovery is **best-effort**: any failure (missing log, credential failure, malformed
  commit line) is logged and swallowed, falling back to the original (possibly empty) schema.
  This can never turn a previously-working `CREATE TABLE` into a failure — worst case, behavior
  is unchanged from before this fix.
- The recovery is only attempted when the incoming schema is empty **and** the provider is
  `delta`; a non-empty schema is never overridden, and non-Delta providers are left untouched.

## Scope / non-goals

- This only affects the *external-table-with-location* Delta create path that goes through the
  legacy `TableCatalog.createTable(StructType, ...)` overload (the `hasLocationClause` branch in
  `UCSingleCatalog.createTable`). It does not touch the newer UC Delta REST API path
  (`shouldUseDeltaAPI` / `managedDeltaCreatePropsForDelegate`), which is the longer-term intended
  mechanism for schema agreement between Delta and UC.
- No behavior change when `DeltaCatalog` is not on the classpath, for non-Delta providers, or
  when the incoming schema is already non-empty.

## Testing

Added `UCProxyDeltaSchemaRecoveryTest` (JUnit5 / Mockito / AssertJ, matching the conventions in
`UCSingleCatalogStagingTableTest`):

- `readSchemaFromDeltaLog`: recovers schema from a single commit; picks up the latest schema
  across multiple commits (schema evolution); tolerates realistic multi-action commit files
  (protocol/metaData/commitInfo lines); returns empty when `_delta_log` is missing; returns
  empty when no location property is present; fails soft (returns empty) on a malformed commit
  line.
- `createTable`: recovers and sends the correct columns when the incoming schema is empty and
  the provider is `delta`; never overrides an already-populated incoming schema, even when the
  Delta log at the same location disagrees; does not attempt recovery for non-Delta providers
  even when a valid Delta log happens to be present at the location.

Also manually verified end-to-end against a local UC server: `CREATE TABLE ... USING DELTA
LOCATION ...` now returns the correct column count/types from `TablesApi.getTable(...)` after
this change, where it previously returned zero columns.