### PR TITLE
Upgrade google-java-format so javafmt actually checks modern Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ IntelliJ is the recommended IDE to use when developing Unity Catalog. The below 
 Java code adheres to the [Google style](https://google.github.io/styleguide/javaguide.html), which is verified via `build/sbt javafmtCheckAll` during builds.
 In order to automatically fix Java code style issues, please use `build/sbt javafmtAll`.
 
+The build uses [sbt-java-formatter](https://github.com/sbt/sbt-java-formatter) 0.12.0 with
+`javafmtFormatterCompatibleJavaVersion := 17` (google-java-format **1.28.0**). Point IDE plugins
+at that same GJF version; a newer plugin will fight `javafmtCheck`.
+
 ### Configuring Code Formatter for Eclipse/IntelliJ
 
 Follow the instructions for [Eclipse](https://github.com/google/google-java-format#eclipse) or

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ IntelliJ is the recommended IDE to use when developing Unity Catalog. The below 
 Java code adheres to the [Google style](https://google.github.io/styleguide/javaguide.html), which is verified via `build/sbt javafmtCheckAll` during builds.
 In order to automatically fix Java code style issues, please use `build/sbt javafmtAll`.
 
-The build uses [sbt-java-formatter](https://github.com/sbt/sbt-java-formatter) 0.12.0 with
+The build uses [sbt-java-formatter](https://github.com/sbt/sbt-java-formatter) 0.13.1 with
 `javafmtFormatterCompatibleJavaVersion := 17` (google-java-format **1.28.0**). Point IDE plugins
 at that same GJF version; a newer plugin will fight `javafmtCheck`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -131,6 +131,10 @@ resolvers ++= Seq(
   "Maven Central" at "https://repo1.maven.org/maven2/",
 )
 
+// GJF 1.28.0: newest google-java-format that runs on the JDK 17 CI image without a
+// second JDK. Import sort/prune stay on (plugin defaults, same as 0.8.0).
+ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
+
 // enforce java code style
 def javafmtCheckSettings() = Seq(
   (Compile / compile) := ((Compile / compile) dependsOn (Compile / javafmtAll)).value

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ resolvers ++= Seq(
 )
 
 // GJF 1.28.0: newest google-java-format that runs on the JDK 17 CI image without a
-// second JDK. Import sort/prune stay on (plugin defaults, same as 0.8.0).
+// second JDK. Import sort/prune stay on (plugin defaults).
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
 // enforce java code style

--- a/clients/java/src/main/java/io/unitycatalog/client/internal/Clock.java
+++ b/clients/java/src/main/java/io/unitycatalog/client/internal/Clock.java
@@ -6,7 +6,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public interface Clock {
-  /** @return the current time of the clock. */
+  /**
+   * @return the current time of the clock.
+   */
   Instant now();
 
   /**

--- a/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
+++ b/connectors/hadoop/src/main/java/io/unitycatalog/hadoop/internal/UCHadoopConfConstants.java
@@ -49,6 +49,7 @@ public class UCHadoopConfConstants {
 
   /** The storage prefix covered by a file system or a UC credential. */
   public static final String UC_CREDENTIAL_PREFIX_KEY = "fs.unitycatalog.credential.prefix";
+
   /**
    * Stable id derived from the credential context ({@code catalogUri}, storage {@code scheme}, and
    * {@code TokenProvider.configs()}) to isolate caches per credential context.

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/auth/AuthConfigUtils.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/auth/AuthConfigUtils.java
@@ -32,7 +32,8 @@ public class AuthConfigUtils {
     if (token != null) {
       Preconditions.checkArgument(
           !newConfigs.containsKey(AuthConfigUtils.STATIC_TOKEN),
-          "Static token was configured twice, choose only one: 'token' (legacy) or 'auth.token' (new-style).");
+          "Static token was configured twice, choose only one: 'token' (legacy) or 'auth.token'"
+              + " (new-style).");
 
       newConfigs.put(TYPE, STATIC_TYPE);
       newConfigs.put(STATIC_TOKEN, token);

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/AbstractViewReadIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/AbstractViewReadIntegrationTest.java
@@ -46,6 +46,7 @@ public abstract class AbstractViewReadIntegrationTest extends BaseSparkIntegrati
 
   protected static final String EMPLOYEES_TABLE_FULL_NAME =
       CATALOG_NAME + "." + SCHEMA_NAME + "." + EMPLOYEES_TABLE_NAME;
+
   /** EXTERNAL Delta table in a different catalog AND schema, referenced FULLY-QUALIFIED. */
   protected static final String DEPARTMENTS_TABLE_NAME = "departments";
 
@@ -59,6 +60,7 @@ public abstract class AbstractViewReadIntegrationTest extends BaseSparkIntegrati
   protected static final String[] QUERY_OUTPUT_COLUMNS = {
     "123", "e_id", "emp_name", "budget", "tags", "emp_info"
   };
+
   /** Declared view column names -- intentionally different from {@link #QUERY_OUTPUT_COLUMNS}. */
   protected static final String[] DECLARED_COLUMNS = {
     "num", "emp", "person", "dept_budget", "dept_tags", "person_info"

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/BaseSparkIntegrationTest.java
@@ -31,6 +31,7 @@ public abstract class BaseSparkIntegrationTest extends BaseCRUDTest {
 
   protected ArrayList<String> createdCatalogs = new ArrayList<>();
   protected static final String SPARK_CATALOG = "spark_catalog";
+
   /** S3 bucket with no credentials configured on server - for testing SSP fallback. */
   public static final String NO_CREDS_BUCKET = "test-bucket-2-no-creds";
 

--- a/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewReadOnlySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.0-4.1/io/unitycatalog/spark/UCViewReadOnlySuite.java
@@ -34,11 +34,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Spark-4.0/4.1 view tests -- the pre-view-API counterpart to the Spark-4.2
- * {@code UCViewProxySuite} (resolved per Spark version via the {@code scala-shims/} test dirs).
- * Spark 4.0/4.1 have no view-catalog APIs ({@code RelationCatalog}, {@code ViewCatalog},
- * {@code View}), so there is no create/replace/rename/drop-through-view surface; view DDL cannot
- * be routed to the connector.
+ * Spark-4.0/4.1 view tests -- the pre-view-API counterpart to the Spark-4.2 {@code
+ * UCViewProxySuite} (resolved per Spark version via the {@code scala-shims/} test dirs). Spark
+ * 4.0/4.1 have no view-catalog APIs ({@code RelationCatalog}, {@code ViewCatalog}, {@code View}),
+ * so there is no create/replace/rename/drop-through-view surface; view DDL cannot be routed to the
+ * connector.
  *
  * <p>Plain SQL views ({@code TableType.VIEW}) are still readable: they appear on the table listing
  * and {@code loadTable} returns a V1 VIEW {@code CatalogTable} that Spark resolves from its SQL
@@ -189,8 +189,7 @@ public class UCViewReadOnlySuite {
 
   @Test
   public void testAlterTableUnsupported() {
-    assertThatThrownBy(
-            () -> proxy.alterTable(Identifier.of(NAMESPACE, "mv1"), new TableChange[0]))
+    assertThatThrownBy(() -> proxy.alterTable(Identifier.of(NAMESPACE, "mv1"), new TableChange[0]))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -198,8 +197,7 @@ public class UCViewReadOnlySuite {
   public void testRenameTableUnsupported() {
     assertThatThrownBy(
             () ->
-                proxy.renameTable(
-                    Identifier.of(NAMESPACE, "mv1"), Identifier.of(NAMESPACE, "mv2")))
+                proxy.renameTable(Identifier.of(NAMESPACE, "mv1"), Identifier.of(NAMESPACE, "mv2")))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 

--- a/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
+++ b/connectors/spark/src/test/scala-shims/spark-4.2/io/unitycatalog/spark/UCViewProxySuite.java
@@ -36,27 +36,27 @@ import org.apache.spark.sql.connector.catalog.Relation;
 import org.apache.spark.sql.connector.catalog.RelationCatalog;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableSummary;
-import org.apache.spark.sql.connector.catalog.ViewCatalog;
 import org.apache.spark.sql.connector.catalog.View;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
- * Spark-4.2-only view-side unit tests for {@code UCProxy}. Composes the shared
- * {@link UCProxyTestFixture} (which builds the mock-backed proxy) and adds the
- * {@code RelationCatalog} / {@code ViewCatalog} casts plus the view CRUD / metric-view tests.
+ * Spark-4.2-only view-side unit tests for {@code UCProxy}. Composes the shared {@link
+ * UCProxyTestFixture} (which builds the mock-backed proxy) and adds the {@code RelationCatalog} /
+ * {@code ViewCatalog} casts plus the view CRUD / metric-view tests.
  *
  * <p>This file lives under {@code src/test/scala-shims/spark-4.2/}, so the cross-Spark build only
  * compiles and runs it for the Spark 4.2 build, where {@code UCProxy} actually mixes in the V2 view
- * catalog surface ({@code Relation}, {@code View}, {@code RelationCatalog},
- * {@code ViewCatalog}, the V2 {@code TableInfo}). The version-agnostic table/namespace tests live
- * in {@code UCProxySuite} under {@code src/test/java/} and run on all Spark versions.
+ * catalog surface ({@code Relation}, {@code View}, {@code RelationCatalog}, {@code ViewCatalog},
+ * the V2 {@code TableInfo}). The version-agnostic table/namespace tests live in {@code
+ * UCProxySuite} under {@code src/test/java/} and run on all Spark versions.
  *
- * <p>The Spark V2 {@code Dependency} / {@code DependencyList} / {@code TableDependency} /
- * {@code TableInfo} types are used fully-qualified to disambiguate from the UC-client homonyms
- * imported above.
+ * <p>The Spark V2 {@code Dependency} / {@code DependencyList} / {@code TableDependency} / {@code
+ * TableInfo} types are used fully-qualified to disambiguate from the UC-client homonyms imported
+ * above.
  */
 public class UCViewProxySuite {
 
@@ -821,8 +821,9 @@ public class UCViewProxySuite {
                         .name("c")
                         .typeName(ColumnTypeName.INT)
                         .typeText("int")
-                        .typeJson("{\"name\":\"c\",\"type\":\"integer\",\"nullable\":true,"
-                            + "\"metadata\":{}}")
+                        .typeJson(
+                            "{\"name\":\"c\",\"type\":\"integer\",\"nullable\":true,"
+                                + "\"metadata\":{}}")
                         .nullable(true)
                         .position(0)));
     when(mockTablesApi.getTable(eq("test_catalog.test_schema.v1"), eq(true), eq(true)))

--- a/dev/checkstyle-config.xml
+++ b/dev/checkstyle-config.xml
@@ -182,8 +182,7 @@
         </module>
         <!-- Indentation and CommentsIndentation are owned by google-java-format.
              Checkstyle 9.3 misreads the continuation indent GJF emits for switch
-             expressions and annotation array initializers. The previous formatter
-             (GJF 1.7) never formatted those files because it could not parse them. -->
+             expressions and annotation array initializers. -->
 
         <module name="LeftCurly"/>
         <module name="RightCurly"/>

--- a/dev/checkstyle-config.xml
+++ b/dev/checkstyle-config.xml
@@ -165,7 +165,6 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
-        <module name="CommentsIndentation"/>
         <module name="UnusedImports"/>
         <module name="RedundantImport"/>
         <module name="RedundantModifier"/>
@@ -181,14 +180,10 @@
             <property name="format" value="new (java\.lang\.)?(Byte|Integer|Long|Short)\("/>
             <property name="message" value="Use static factory 'valueOf' or 'parseXXX' instead of the deprecated constructors." />
         </module>
-        <module name="Indentation">
-            <property name="basicOffset" value="2"/>
-            <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="2"/>
-            <property name="throwsIndent" value="2"/>
-            <property name="lineWrappingIndentation" value="2"/>
-            <property name="arrayInitIndent" value="2"/>
-        </module>
+        <!-- Indentation and CommentsIndentation are owned by google-java-format.
+             Checkstyle 9.3 misreads the continuation indent GJF emits for switch
+             expressions and annotation array initializers. The previous formatter
+             (GJF 1.7) never formatted those files because it could not parse them. -->
 
         <module name="LeftCurly"/>
         <module name="RightCurly"/>

--- a/examples/cli/src/main/java/io/unitycatalog/cli/TableCli.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/TableCli.java
@@ -215,8 +215,8 @@ public class TableCli {
     return objectWriter.writeValueAsString(
         tablesApi.getTable(
             fullName,
-            /* readStreamingTableAsManaged = */ true,
-            /* readMaterializedViewAsManaged = */ true));
+            /* readStreamingTableAsManaged= */ true,
+            /* readMaterializedViewAsManaged= */ true));
   }
 
   private static String readTable(
@@ -226,8 +226,8 @@ public class TableCli {
     TableInfo info =
         tablesApi.getTable(
             fullTableName,
-            /* readStreamingTableAsManaged = */ true,
-            /* readMaterializedViewAsManaged = */ true);
+            /* readStreamingTableAsManaged= */ true,
+            /* readMaterializedViewAsManaged= */ true);
     if (!DataSourceFormat.DELTA.equals(info.getDataSourceFormat())) {
       throw new CliException("Only Delta tables are supported for read operations");
     }
@@ -256,8 +256,8 @@ public class TableCli {
     TableInfo info =
         tablesApi.getTable(
             fullTableName,
-            /* readStreamingTableAsManaged = */ true,
-            /* readMaterializedViewAsManaged = */ true);
+            /* readStreamingTableAsManaged= */ true,
+            /* readMaterializedViewAsManaged= */ true);
     if (!DataSourceFormat.DELTA.equals(info.getDataSourceFormat())) {
       throw new CliException("Only Delta tables are supported for write operations");
     }

--- a/examples/cli/src/main/java/io/unitycatalog/cli/UnityCatalogCli.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/UnityCatalogCli.java
@@ -96,7 +96,8 @@ public class UnityCatalogCli {
           } else {
             if (option.getValue() == null) {
               System.out.println(
-                  "Error occurred while parsing the command. Please check the command and try again. Missing argument for option: version");
+                  "Error occurred while parsing the command. Please check the command and try"
+                      + " again. Missing argument for option: version");
               CliUtils.printHelp();
               return;
             } else {

--- a/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelWriteUtils.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/delta/DeltaKernelWriteUtils.java
@@ -143,7 +143,9 @@ public class DeltaKernelWriteUtils {
     }
   }
 
-  /** @return */
+  /**
+   * @return
+   */
   static FilteredColumnarBatch generateUnpartitionedDataBatch(
       StructType tableSchema, int count, int offset) {
     ColumnVector[] vectors = createVectorsFromSchema(tableSchema, count, offset);

--- a/examples/cli/src/main/java/io/unitycatalog/cli/utils/CliParams.java
+++ b/examples/cli/src/main/java/io/unitycatalog/cli/utils/CliParams.java
@@ -10,11 +10,13 @@ public enum CliParams {
   SOURCE("source", "The URI location of the source artifacts for the model version.", "source"),
   PROPERTIES(
       "properties",
-      "The properties of the entity. Need to be in json format. For example: \"{\"key1\": \"value1\", \"key2\": \"value2\"}\".",
+      "The properties of the entity. Need to be in json format. For example: \"{\"key1\":"
+          + " \"value1\", \"key2\": \"value2\"}\".",
       "properties"),
   FULL_NAME(
       "full_name",
-      "The full name in the format catalog_name.schema_name for schema, or catalog_name.schema_name.table_name for table/function/volume",
+      "The full name in the format catalog_name.schema_name for schema, or"
+          + " catalog_name.schema_name.table_name for table/function/volume",
       "full_name"),
   STORAGE_LOCATION(
       "storage_location",
@@ -24,15 +26,20 @@ public enum CliParams {
   PAGE_TOKEN("page_token", "Opaque token to retrieve the next page of results.", "page_token"),
   TABLE_TYPE(
       "table_type",
-      "The type of the table. Supported values are MANAGED and EXTERNAL. For create table only EXTERNAL tables are supported in this CLI example.",
+      "The type of the table. Supported values are MANAGED and EXTERNAL. For create table only"
+          + " EXTERNAL tables are supported in this CLI example.",
       "table_type"),
   DATA_SOURCE_FORMAT(
       "format",
-      "The format of the data source. Supported values are DELTA, PARQUET, ORC, JSON, CSV, AVRO and TEXT.",
+      "The format of the data source. Supported values are DELTA, PARQUET, ORC, JSON, CSV, AVRO and"
+          + " TEXT.",
       "data_source_format"),
   COLUMNS(
       "columns",
-      "The columns of the table. Each column spec should be in the sql-like format  \"column_name column_data_type\".Supported data types are BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, DATE, TIMESTAMP, TIMESTAMP_NTZ, STRING, BINARY, DECIMAL. Multiple columns should be separated by a comma. For example: \"id INT, name STRING\".",
+      "The columns of the table. Each column spec should be in the sql-like format  \"column_name"
+          + " column_data_type\".Supported data types are BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT,"
+          + " DOUBLE, DATE, TIMESTAMP, TIMESTAMP_NTZ, STRING, BINARY, DECIMAL. Multiple columns"
+          + " should be separated by a comma. For example: \"id INT, name STRING\".",
       "columns"),
   VOLUME_TYPE(
       "volume_type",

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/BaseSparkTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/BaseSparkTest.java
@@ -24,12 +24,14 @@ public class BaseSparkTest {
             .appName("test")
             .master("local[*]")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-            .config("spark.sql.catalog.spark_catalog",
+            .config(
+                "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             // s3 conf
             .config("spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
             // GCS conf
-            .config("spark.hadoop.fs.AbstractFileSystem.gs.impl",
+            .config(
+                "spark.hadoop.fs.AbstractFileSystem.gs.impl",
                 "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
 
     for (String catalog : catalogs) {

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkDeltaTableCRUDTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkDeltaTableCRUDTest.java
@@ -32,16 +32,19 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
 
   @AfterAll
   public static void teardownSchema() {
-    locationTypes().forEach(locationType ->
-        spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
+    locationTypes()
+        .forEach(
+            locationType ->
+                spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
     spark.sql(format("DROP SCHEMA IF EXISTS %s", SCHEMA));
   }
 
   private List<String> getData(String table) {
-    return spark.sql(format("SELECT * FROM %s ORDER BY as_int ASC", table))
-        .toJSON().collectAsList();
+    return spark
+        .sql(format("SELECT * FROM %s ORDER BY as_int ASC", table))
+        .toJSON()
+        .collectAsList();
   }
-
 
   @SneakyThrows
   @ParameterizedTest
@@ -52,13 +55,12 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
     String location = baseLocation + "/integration/" + RUN_ID + "/numbers";
     String table = getTableName(locationType);
 
-    spark.sql(format(
-        "CREATE TABLE %s(as_int INT, as_double DOUBLE) USING DELTA LOCATION '%s'",
-        table, location));
+    spark.sql(
+        format(
+            "CREATE TABLE %s(as_int INT, as_double DOUBLE) USING DELTA LOCATION '%s'",
+            table, location));
 
-    assertThat(getData(table))
-        .as("Data after CREATE should be empty")
-        .isEqualTo(List.of());
+    assertThat(getData(table)).as("Data after CREATE should be empty").isEqualTo(List.of());
   }
 
   @ParameterizedTest
@@ -66,18 +68,19 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
   @Order(2)
   public void insert(LocationType locationType) {
     String table = getTableName(locationType);
-    spark.sql(format(
-        "INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)",
-        table));
+    spark.sql(
+        format(
+            "INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)",
+            table));
 
     assertThat(getData(table))
         .as("Data after INSERT")
-        .isEqualTo(List.of(
-            "{\"as_int\":0,\"as_double\":0.0}",
-            "{\"as_int\":1,\"as_double\":1.5}",
-            "{\"as_int\":42,\"as_double\":244.25}",
-            "{\"as_int\":539,\"as_double\":425.66102859000944}"
-        ));
+        .isEqualTo(
+            List.of(
+                "{\"as_int\":0,\"as_double\":0.0}",
+                "{\"as_int\":1,\"as_double\":1.5}",
+                "{\"as_int\":42,\"as_double\":244.25}",
+                "{\"as_int\":539,\"as_double\":425.66102859000944}"));
   }
 
   @ParameterizedTest
@@ -85,26 +88,28 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
   @Order(3)
   public void merge(LocationType locationType) {
     String table = getTableName(locationType);
-    spark.sql(format("""
-        MERGE INTO %s target
-        USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5)
-          AS mock_data(as_int, as_double)) source
-        ON source.as_int = target.as_int
-        WHEN MATCHED THEN DELETE
-        WHEN NOT MATCHED THEN INSERT *
-        """, table));
+    spark.sql(
+        format(
+            """
+            MERGE INTO %s target
+            USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5)
+              AS mock_data(as_int, as_double)) source
+            ON source.as_int = target.as_int
+            WHEN MATCHED THEN DELETE
+            WHEN NOT MATCHED THEN INSERT *
+            """,
+            table));
 
     assertThat(getData(table))
         .as("Data after MERGE")
-        .isEqualTo(List.of(
-            "{\"as_int\":0,\"as_double\":0.0}",
-            "{\"as_int\":3,\"as_double\":3.75}",
-            "{\"as_int\":5,\"as_double\":2.5}",
-            "{\"as_int\":42,\"as_double\":244.25}",
-            "{\"as_int\":539,\"as_double\":425.66102859000944}"
-        ));
+        .isEqualTo(
+            List.of(
+                "{\"as_int\":0,\"as_double\":0.0}",
+                "{\"as_int\":3,\"as_double\":3.75}",
+                "{\"as_int\":5,\"as_double\":2.5}",
+                "{\"as_int\":42,\"as_double\":244.25}",
+                "{\"as_int\":539,\"as_double\":425.66102859000944}"));
   }
-
 
   @ParameterizedTest
   @MethodSource("locationTypes")
@@ -115,10 +120,10 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
 
     assertThat(getData(table))
         .as("Data after DELETE")
-        .isEqualTo(List.of(
-            "{\"as_int\":42,\"as_double\":244.25}",
-            "{\"as_int\":539,\"as_double\":425.66102859000944}"
-        ));
+        .isEqualTo(
+            List.of(
+                "{\"as_int\":42,\"as_double\":244.25}",
+                "{\"as_int\":539,\"as_double\":425.66102859000944}"));
   }
 
   @ParameterizedTest
@@ -126,13 +131,12 @@ public class SparkDeltaTableCRUDTest extends BaseSparkTest {
   @Order(5)
   public void update(LocationType locationType) {
     String table = getTableName(locationType);
-    spark.sql(format(
-        "UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table));
+    spark.sql(format("UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table));
     assertThat(getData(table))
         .as("Data after UPDATE")
-        .isEqualTo(List.of(
-            "{\"as_int\":42,\"as_double\":63.0}",
-            "{\"as_int\":539,\"as_double\":425.66102859000944}"
-        ));
+        .isEqualTo(
+            List.of(
+                "{\"as_int\":42,\"as_double\":63.0}",
+                "{\"as_int\":539,\"as_double\":425.66102859000944}"));
   }
 }

--- a/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkParquetTableCRUDTest.java
+++ b/integration-tests/src/test/java/io/unitycatalog/integrationtests/SparkParquetTableCRUDTest.java
@@ -35,16 +35,19 @@ public class SparkParquetTableCRUDTest extends BaseSparkTest {
 
   @AfterAll
   public static void teardownSchema() {
-    locationTypes().forEach(locationType ->
-        spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
+    locationTypes()
+        .forEach(
+            locationType ->
+                spark.sql(format("DROP TABLE IF EXISTS %s", getTableName(locationType))));
     spark.sql(format("DROP SCHEMA IF EXISTS %s", SCHEMA));
   }
 
   private List<String> getData(String table) {
-    return spark.sql(format("SELECT * FROM %s ORDER BY as_int ASC", table))
-        .toJSON().collectAsList();
+    return spark
+        .sql(format("SELECT * FROM %s ORDER BY as_int ASC", table))
+        .toJSON()
+        .collectAsList();
   }
-
 
   @SneakyThrows
   @ParameterizedTest
@@ -55,13 +58,12 @@ public class SparkParquetTableCRUDTest extends BaseSparkTest {
     String location = baseLocation + "/integration/" + RUN_ID + "/numbers";
     String table = getTableName(locationType);
 
-    spark.sql(format(
-        "CREATE TABLE %s(as_int INT, as_double DOUBLE) USING PARQUET LOCATION '%s'",
-        table, location));
+    spark.sql(
+        format(
+            "CREATE TABLE %s(as_int INT, as_double DOUBLE) USING PARQUET LOCATION '%s'",
+            table, location));
 
-    assertThat(getData(table))
-        .as("Data after CREATE should be empty")
-        .isEqualTo(List.of());
+    assertThat(getData(table)).as("Data after CREATE should be empty").isEqualTo(List.of());
   }
 
   @ParameterizedTest
@@ -69,18 +71,19 @@ public class SparkParquetTableCRUDTest extends BaseSparkTest {
   @Order(2)
   public void insert(LocationType locationType) {
     String table = getTableName(locationType);
-    spark.sql(format(
-        "INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)",
-        table));
+    spark.sql(
+        format(
+            "INSERT INTO %s VALUES (0, 0), (1, 1.5), (42, 244.25), (539, 425.66102859000944)",
+            table));
 
     assertThat(getData(table))
         .as("Data after INSERT")
-        .isEqualTo(List.of(
-            "{\"as_int\":0,\"as_double\":0.0}",
-            "{\"as_int\":1,\"as_double\":1.5}",
-            "{\"as_int\":42,\"as_double\":244.25}",
-            "{\"as_int\":539,\"as_double\":425.66102859000944}"
-        ));
+        .isEqualTo(
+            List.of(
+                "{\"as_int\":0,\"as_double\":0.0}",
+                "{\"as_int\":1,\"as_double\":1.5}",
+                "{\"as_int\":42,\"as_double\":244.25}",
+                "{\"as_int\":539,\"as_double\":425.66102859000944}"));
   }
 
   @ParameterizedTest
@@ -88,26 +91,29 @@ public class SparkParquetTableCRUDTest extends BaseSparkTest {
   @Order(3)
   public void merge(LocationType locationType) {
     String table = getTableName(locationType);
-    assertThatThrownBy(() -> spark.sql(format("""
-        MERGE INTO %s target
-        USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5)
-          AS mock_data(as_int, as_double)) source
-        ON source.as_int = target.as_int
-        WHEN MATCHED THEN DELETE
-        WHEN NOT MATCHED THEN INSERT *
-        """, table)))
+    assertThatThrownBy(
+            () ->
+                spark.sql(
+                    format(
+                        """
+                        MERGE INTO %s target
+                        USING (SELECT * FROM VALUES (1, 1.001), (3, 3.75), (5, 2.5)
+                          AS mock_data(as_int, as_double)) source
+                        ON source.as_int = target.as_int
+                        WHEN MATCHED THEN DELETE
+                        WHEN NOT MATCHED THEN INSERT *
+                        """,
+                        table)))
         .isInstanceOf(SparkUnsupportedOperationException.class)
         .hasMessageContaining("MERGE INTO TABLE is not supported temporarily");
   }
-
 
   @ParameterizedTest
   @MethodSource("locationTypes")
   @Order(4)
   public void delete(LocationType locationType) {
     String table = getTableName(locationType);
-    assertThatThrownBy(() ->
-        spark.sql(format("DELETE FROM %s WHERE as_int < 20", table)))
+    assertThatThrownBy(() -> spark.sql(format("DELETE FROM %s WHERE as_int < 20", table)))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining("does not support DELETE");
   }
@@ -118,8 +124,10 @@ public class SparkParquetTableCRUDTest extends BaseSparkTest {
   public void update(LocationType locationType) {
     String table = getTableName(locationType);
 
-    assertThatThrownBy(() -> spark.sql(format(
-        "UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table)))
+    assertThatThrownBy(
+            () ->
+                spark.sql(
+                    format("UPDATE %s SET as_double = as_int * 1.5 WHERE as_int = 42", table)))
         .isInstanceOf(SparkUnsupportedOperationException.class)
         .hasMessageContaining("UPDATE TABLE is not supported temporarily");
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,7 +28,10 @@ addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.9.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
+// 0.8.0 bundled google-java-format 1.7, which cannot parse text blocks or switch
+// expressions and silently skipped those files. 0.12.0 forks GJF; the Java 17
+// line (see build.sbt) is google-java-format 1.28.0.
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.12.0")
 
 addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // By default, sbt-checkstyle-plugin uses checkstyle version 6.15, but we should set it to use the

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,9 +28,8 @@ addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.9.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
-// 0.8.0 bundled google-java-format 1.7, which cannot parse text blocks or switch
-// expressions and silently skipped those files. 0.13.1 forks GJF; the Java 17
-// line (see build.sbt) is still google-java-format 1.28.0.
+// GJF 1.28.0 on Java 17 (see build.sbt). 0.8.0/1.7 skipped text blocks
+// and switch expressions.
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.13.1")
 
 addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,8 +28,7 @@ addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.9.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
-// GJF 1.28.0 on Java 17 (see build.sbt). 0.8.0/1.7 skipped text blocks
-// and switch expressions.
+// Java 17 uses google-java-format 1.28.0 (see build.sbt).
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.13.1")
 
 addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,9 +29,9 @@ addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.9.0")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
 // 0.8.0 bundled google-java-format 1.7, which cannot parse text blocks or switch
-// expressions and silently skipped those files. 0.12.0 forks GJF; the Java 17
-// line (see build.sbt) is google-java-format 1.28.0.
-addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.12.0")
+// expressions and silently skipped those files. 0.13.1 forks GJF; the Java 17
+// line (see build.sbt) is still google-java-format 1.28.0.
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.13.1")
 
 addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // By default, sbt-checkstyle-plugin uses checkstyle version 6.15, but we should set it to use the

--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -75,8 +75,7 @@ public class ArmeriaServerBuilder {
         Server.builder()
             .localPort(port, SessionProtocol.HTTP)
             .serviceUnder("/docs", new DocService());
-    this.armeriaServerBuilder.service(
-        "/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
+    this.armeriaServerBuilder.service("/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
     this.basePath = basePath;
     this.controlPath = controlPath;
     this.authorizationEnabled = serverProperties.isAuthorizationEnabled();
@@ -139,8 +138,7 @@ public class ArmeriaServerBuilder {
    * @param authDecorator authentication decorator; runs first at request time
    */
   ArmeriaServerBuilder withSecurityDecorators(
-      DecoratingHttpServiceFunction accessDecorator,
-      DecoratingHttpServiceFunction authDecorator) {
+      DecoratingHttpServiceFunction accessDecorator, DecoratingHttpServiceFunction authDecorator) {
     Objects.requireNonNull(accessDecorator, "accessDecorator");
     Objects.requireNonNull(authDecorator, "authDecorator");
     for (DecoratingHttpServiceFunction decorator : List.of(accessDecorator, authDecorator)) {
@@ -200,18 +198,20 @@ public class ArmeriaServerBuilder {
    * converters.
    */
   private void register(ServiceProtocol protocol, String relativePath, RegisteredService service) {
-    RequestConverterFunction requestConverter = switch (protocol) {
-      case AUTH, UC, SCIM -> bodyConverter(ucMapper);
-      case ICEBERG -> bodyConverter(icebergMapper);
-      case DELTA -> bodyConverter(deltaMapper);
-    };
+    RequestConverterFunction requestConverter =
+        switch (protocol) {
+          case AUTH, UC, SCIM -> bodyConverter(ucMapper);
+          case ICEBERG -> bodyConverter(icebergMapper);
+          case DELTA -> bodyConverter(deltaMapper);
+        };
     // Auth and UC services have no response converter; they return HttpResponse.ofJson directly.
-    List<JacksonResponseConverterFunction> responseConverters = switch (protocol) {
-      case AUTH, UC -> List.of();
-      case SCIM -> List.of(scimResponseConverter);
-      case ICEBERG -> List.of(icebergResponseConverter);
-      case DELTA -> List.of(deltaResponseConverter);
-    };
+    List<JacksonResponseConverterFunction> responseConverters =
+        switch (protocol) {
+          case AUTH, UC -> List.of();
+          case SCIM -> List.of(scimResponseConverter);
+          case ICEBERG -> List.of(icebergResponseConverter);
+          case DELTA -> List.of(deltaResponseConverter);
+        };
     // The service names its own dialect, so both paths use the same value: exceptionHandlers()
     // covers exceptions thrown inside the handler, the per-service decorator covers those thrown by
     // decorators sitting outside it.

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -61,6 +61,7 @@ public class UnityCatalogServer implements AutoCloseable {
   private final Server server;
   private final SecurityContext securityContext;
   private final HibernateConfigurator hibernateConfigurator;
+
   /** True when this server built the configurator itself and must therefore close it. */
   private final boolean ownsHibernateConfigurator;
 

--- a/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/AuthorizeExpressions.java
@@ -8,13 +8,13 @@ import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
  * <p>When the same logical operation is exposed through multiple endpoints (e.g. the UC REST API
  * and the UC Delta API both vending table credentials), each endpoint's
  * {@code @AuthorizeExpression} must grant identical access -- otherwise a caller's permissions
- * depend on which URL they happen to hit. Extracting the expression here makes the two sites
- * share a single source of truth, so drift becomes a compile-time impossibility instead of a
- * runtime surprise.
+ * depend on which URL they happen to hit. Extracting the expression here makes the two sites share
+ * a single source of truth, so drift becomes a compile-time impossibility instead of a runtime
+ * surprise.
  *
- * <p>Convention: each constant is named {@code <ACTION>_<RESOURCE>} (e.g.
- * {@link #VEND_TABLE_CREDENTIAL}) to describe the authorized operation, not the endpoint. Add
- * new constants here whenever a second call site needs the same policy.
+ * <p>Convention: each constant is named {@code <ACTION>_<RESOURCE>} (e.g. {@link
+ * #VEND_TABLE_CREDENTIAL}) to describe the authorized operation, not the endpoint. Add new
+ * constants here whenever a second call site needs the same policy.
  */
 public final class AuthorizeExpressions {
 
@@ -22,10 +22,9 @@ public final class AuthorizeExpressions {
 
   /**
    * Authorization policy for reading table metadata (UC REST {@code GET /tables/{name}} and Delta
-   * REST Catalog {@code loadTable}). Metastore admin and catalog owner pass unconditionally;
-   * schema owner passes with catalog {@code USE_CATALOG}; regular callers need {@code USE_SCHEMA}
-   * + {@code USE_CATALOG} plus any of {@code OWNER} / {@code SELECT} / {@code MODIFY} on the
-   * table itself.
+   * REST Catalog {@code loadTable}). Metastore admin and catalog owner pass unconditionally; schema
+   * owner passes with catalog {@code USE_CATALOG}; regular callers need {@code USE_SCHEMA} + {@code
+   * USE_CATALOG} plus any of {@code OWNER} / {@code SELECT} / {@code MODIFY} on the table itself.
    */
   public static final String GET_TABLE =
       """
@@ -38,10 +37,10 @@ public final class AuthorizeExpressions {
       """;
 
   /**
-   * Authorization policy for creating a staging table (UC REST {@code POST /staging-tables} and
-   * UC Delta API {@code createStagingTable}). Catalog {@code USE_CATALOG}/{@code OWNER}
-   * plus either schema {@code OWNER} or schema {@code USE_SCHEMA}+{@code CREATE_TABLE}. Catalog
-   * OWNER alone is not sufficient.
+   * Authorization policy for creating a staging table (UC REST {@code POST /staging-tables} and UC
+   * Delta API {@code createStagingTable}). Catalog {@code USE_CATALOG}/{@code OWNER} plus either
+   * schema {@code OWNER} or schema {@code USE_SCHEMA}+{@code CREATE_TABLE}. Catalog OWNER alone is
+   * not sufficient.
    */
   public static final String CREATE_STAGING_TABLE =
       """
@@ -52,11 +51,11 @@ public final class AuthorizeExpressions {
       """;
 
   /**
-   * Authorization policy for creating a table (UC REST {@code POST /tables} and UC Delta API
-   * {@code createTable}). Catalog {@code USE_CATALOG}/{@code OWNER} plus either schema
-   * {@code OWNER} or schema {@code USE_SCHEMA}+{@code CREATE_TABLE}. For EXTERNAL tables, the
-   * caller additionally needs {@code OWNER}/{@code CREATE_EXTERNAL_TABLE} on the external location
-   * (if one resolves) and the storage path must not overlap a data securable.
+   * Authorization policy for creating a table (UC REST {@code POST /tables} and UC Delta API {@code
+   * createTable}). Catalog {@code USE_CATALOG}/{@code OWNER} plus either schema {@code OWNER} or
+   * schema {@code USE_SCHEMA}+{@code CREATE_TABLE}. For EXTERNAL tables, the caller additionally
+   * needs {@code OWNER}/{@code CREATE_EXTERNAL_TABLE} on the external location (if one resolves)
+   * and the storage path must not overlap a data securable.
    *
    * <p>The {@code #table_type} SpEL variable comes from {@code @AuthorizeKey(key = "table-type")};
    * kebab-case payload keys surface with hyphens mapped to underscores (see {@link
@@ -89,9 +88,9 @@ public final class AuthorizeExpressions {
       """;
 
   /**
-   * Authorization policy for deleting a table, shared by the UC REST and Delta REST Catalog
-   * delete endpoints. Metastore admin alone is intentionally not sufficient -- the caller must
-   * hold {@code OWNER} somewhere in the catalog / schema / table hierarchy.
+   * Authorization policy for deleting a table, shared by the UC REST and Delta REST Catalog delete
+   * endpoints. Metastore admin alone is intentionally not sufficient -- the caller must hold {@code
+   * OWNER} somewhere in the catalog / schema / table hierarchy.
    */
   public static final String DELETE_TABLE =
       """
@@ -107,18 +106,20 @@ public final class AuthorizeExpressions {
    * table name as well as permission to create the new name in the same schema.
    */
   public static final String RENAME_TABLE =
-      "(" + DELETE_TABLE + """
-      ) &&
-      (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
-        (#authorize(#principal, #schema, OWNER) ||
-          #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE)))
-      """;
+      "("
+          + DELETE_TABLE
+          + """
+          ) &&
+          (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
+            (#authorize(#principal, #schema, OWNER) ||
+              #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_TABLE)))
+          """;
 
   /**
-   * Authorization policy for vending table credentials. Admin-above-the-table privileges on
-   * their own are not sufficient; the caller must have an explicit table-level privilege
-   * matching the requested operation. {@code READ} needs OWNER or SELECT; {@code READ_WRITE}
-   * needs OWNER, or both SELECT and MODIFY.
+   * Authorization policy for vending table credentials. Admin-above-the-table privileges on their
+   * own are not sufficient; the caller must have an explicit table-level privilege matching the
+   * requested operation. {@code READ} needs OWNER or SELECT; {@code READ_WRITE} needs OWNER, or
+   * both SELECT and MODIFY.
    */
   public static final String VEND_TABLE_CREDENTIAL =
       """

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.auth.decorator;
 
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+
 import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CredentialInfo;
@@ -10,20 +14,14 @@ import io.unitycatalog.server.model.SchemaInfo;
 import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.TableInfo;
 import io.unitycatalog.server.model.VolumeInfo;
-
+import io.unitycatalog.server.service.AuthorizedService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.unitycatalog.server.service.AuthorizedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.unitycatalog.server.model.SecurableType.CATALOG;
-import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
-import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
 /**
  * Filters list responses based on user authorization permissions.
@@ -167,17 +165,18 @@ public class ResultFilter {
   }
 
   private UUID resolveResourceId(SecurableType securableType, Object item) {
-    String id = switch (securableType) {
-      case TABLE -> ((TableInfo)item).getTableId();
-      case VOLUME -> ((VolumeInfo)item).getVolumeId();
-      case FUNCTION -> ((FunctionInfo)item).getFunctionId();
-      case REGISTERED_MODEL -> ((RegisteredModelInfo)item).getId();
-      case CATALOG -> ((CatalogInfo)item).getId();
-      case SCHEMA -> ((SchemaInfo)item).getSchemaId();
-      case CREDENTIAL -> ((CredentialInfo)item).getId();
-      case EXTERNAL_LOCATION -> ((ExternalLocationInfo)item).getId();
-      default -> throw new RuntimeException("Unsupported securable type: " + securableType);
-    };
+    String id =
+        switch (securableType) {
+          case TABLE -> ((TableInfo) item).getTableId();
+          case VOLUME -> ((VolumeInfo) item).getVolumeId();
+          case FUNCTION -> ((FunctionInfo) item).getFunctionId();
+          case REGISTERED_MODEL -> ((RegisteredModelInfo) item).getId();
+          case CATALOG -> ((CatalogInfo) item).getId();
+          case SCHEMA -> ((SchemaInfo) item).getSchemaId();
+          case CREDENTIAL -> ((CredentialInfo) item).getId();
+          case EXTERNAL_LOCATION -> ((ExternalLocationInfo) item).getId();
+          default -> throw new RuntimeException("Unsupported securable type: " + securableType);
+        };
     return UUID.fromString(id);
   }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessDecorator.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.auth.decorator;
 
+import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PARAM;
+import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PAYLOAD;
+import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.SYSTEM;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.HttpRequest;
@@ -21,9 +25,6 @@ import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.UserRepository;
 import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -33,10 +34,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PARAM;
-import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.PAYLOAD;
-import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.SYSTEM;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Armeria access control Decorator.
@@ -50,10 +49,10 @@ import static io.unitycatalog.server.auth.decorator.AuthorizeKeyLocator.Source.S
  *
  * <p>2. {@code @AuthorizeResourceKey} - This annotation maps a request value to a unity catalog
  * resource (catalog, schema, table, etc.) for the authorization context. The source is chosen by
- * whether the annotated method parameter also carries {@code @Param}: if present, the value is
- * read from the URL query or path; if absent, from the request body field named by
- * {@code @AuthorizeResourceKey.key()}. May be used at the method level (server-level resources
- * like METASTORE) or at the parameter level, and may be specified more than once per method.
+ * whether the annotated method parameter also carries {@code @Param}: if present, the value is read
+ * from the URL query or path; if absent, from the request body field named by
+ * {@code @AuthorizeResourceKey.key()}. May be used at the method level (server-level resources like
+ * METASTORE) or at the parameter level, and may be specified more than once per method.
  *
  * <p>3. {@code @AuthorizeKey} - Works like {@code @AuthorizeResourceKey} for source selection, but
  * for non-resource request values (operation mode, table type, flag, etc.) exposed directly as a
@@ -87,6 +86,7 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
    */
   public static final AttributeKey<PayloadAuthorizer> PAYLOAD_AUTHORIZER =
       AttributeKey.valueOf(UnityAccessDecorator.class, "PAYLOAD_AUTHORIZER");
+
   private final KeyMapper keyMapper;
   private final UserRepository userRepository;
 
@@ -141,7 +141,8 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
       UUID principal,
       List<AuthorizeKeyLocator> locators,
       String expression,
-      Optional<ResponseAuthorizeFilter> filterAnnotation) throws Exception {
+      Optional<ResponseAuthorizeFilter> filterAnnotation)
+      throws Exception {
     //
     // Based on the query and payload parameters defined on the service method (that
     // have been gathered as Locators), we'll attempt to find the entity/resource that
@@ -153,30 +154,29 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     // Split up the locators by type, because we have to extract the value from the request
     // different ways for different types
 
-    List<AuthorizeKeyLocator> systemLocators = locators.stream()
-        .filter(l -> l.getSource().equals(SYSTEM))
-        .toList();
-    List<AuthorizeKeyLocator> paramLocators = locators.stream()
-        .filter(l -> l.getSource().equals(PARAM))
-        .toList();
-    List<AuthorizeKeyLocator> payloadLocators = locators.stream()
-        .filter(l -> l.getSource().equals(PAYLOAD))
-        .toList();
+    List<AuthorizeKeyLocator> systemLocators =
+        locators.stream().filter(l -> l.getSource().equals(SYSTEM)).toList();
+    List<AuthorizeKeyLocator> paramLocators =
+        locators.stream().filter(l -> l.getSource().equals(PARAM)).toList();
+    List<AuthorizeKeyLocator> payloadLocators =
+        locators.stream().filter(l -> l.getSource().equals(PAYLOAD)).toList();
 
     // Add system-type keys, just metastore for now.
     systemLocators.forEach(l -> resourceKeys.put(l.getType().get(), "metastore"));
 
     // Extract the query/path parameter values just by grabbing them from the request
-    paramLocators.forEach(l -> {
-      String value = ctx.pathParam(l.getKey()) != null
-          ? ctx.pathParam(l.getKey())
-          : ctx.queryParam(l.getKey());
-      if (l.getType().isPresent()) {
-        resourceKeys.put(l.getType().get(), value);
-      } else {
-        nonResourceValues.put(l.getVariableName(), value);
-      }
-    });
+    paramLocators.forEach(
+        l -> {
+          String value =
+              ctx.pathParam(l.getKey()) != null
+                  ? ctx.pathParam(l.getKey())
+                  : ctx.queryParam(l.getKey());
+          if (l.getType().isPresent()) {
+            resourceKeys.put(l.getType().get(), value);
+          } else {
+            nonResourceValues.put(l.getVariableName(), value);
+          }
+        });
 
     EvaluationAction evaluateAction =
         filterAnnotation
@@ -366,10 +366,10 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
 
     @Override
     protected void beforeRequest(
-      UUID principal,
-      String expression,
-      Map<SecurableType, UUID> resourceIds,
-      Map<String, Object> nonResourceValues) {
+        UUID principal,
+        String expression,
+        Map<SecurableType, UUID> resourceIds,
+        Map<String, Object> nonResourceValues) {
       resultFilter =
           new ResultFilter(
               evaluator, principal, expression, resourceIds, nonResourceValues, keyMapper);
@@ -470,9 +470,8 @@ public class UnityAccessDecorator implements DecoratingHttpServiceFunction {
     HttpService annotated = httpService.as(AnnotatedService.class);
     if (annotated instanceof AnnotatedService service) {
 
-      LOGGER.debug("serviceName = {}, methodName = {}",
-          service.serviceName(),
-          service.methodName());
+      LOGGER.debug(
+          "serviceName = {}, methodName = {}", service.serviceName(), service.methodName());
 
       Class<?> clazz = Class.forName(service.serviceName());
       List<Method> methods = findMethodsByName(clazz, service.methodName());

--- a/server/src/main/java/io/unitycatalog/server/exception/BaseExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/BaseExceptionHandler.java
@@ -20,8 +20,7 @@ public abstract class BaseExceptionHandler implements ExceptionHandlerFunction {
   private static volatile boolean includeStackTrace = false;
 
   @Override
-  public HttpResponse handleException(
-      ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+  public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
     return createErrorResponse(toBaseException(cause));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/CatalogRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/CatalogRepository.java
@@ -84,7 +84,7 @@ public class CatalogRepository {
           return catalogInfo;
         },
         "Failed to add catalog",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**
@@ -100,7 +100,7 @@ public class CatalogRepository {
         sessionFactory,
         session -> listCatalogs(session, maxResults, pageToken),
         "Failed to list catalogs",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ListCatalogsResponse listCatalogs(
@@ -128,7 +128,7 @@ public class CatalogRepository {
               catalogInfo, catalogInfo.getId(), Constants.CATALOG, session);
         },
         "Failed to get catalog",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public CatalogInfoDAO getCatalogDaoOrThrow(Session session, String name) {
@@ -189,7 +189,7 @@ public class CatalogRepository {
               catalogInfo, catalogInfo.getId(), Constants.CATALOG, session);
         },
         "Failed to update catalog",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public List<DeletedResource> deleteCatalog(String name, boolean force) {
@@ -261,6 +261,6 @@ public class CatalogRepository {
           return deleted;
         },
         "Failed to delete catalog",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/CredentialRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/CredentialRepository.java
@@ -56,7 +56,7 @@ public class CredentialRepository {
           return dao.toCredentialInfo(getAwsS3MasterRoleArn());
         },
         "Failed to add storage credential",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public CredentialInfo getCredential(String name) {
@@ -71,7 +71,7 @@ public class CredentialRepository {
           return dao.toCredentialInfo(getAwsS3MasterRoleArn());
         },
         "Failed to get storage credential",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   protected String getCredentialName(Session session, UUID id) {
@@ -96,8 +96,7 @@ public class CredentialRepository {
         sessionFactory,
         session -> {
           List<CredentialDAO> daoList =
-              LISTING_HELPER.listEntity(
-                  session, maxResults, pageToken, /* parentEntityId = */ null);
+              LISTING_HELPER.listEntity(session, maxResults, pageToken, /* parentEntityId= */ null);
           String nextPageToken = LISTING_HELPER.getNextPageToken(daoList, maxResults);
           List<CredentialInfo> results = new ArrayList<>();
           for (CredentialDAO dao : daoList) {
@@ -111,7 +110,7 @@ public class CredentialRepository {
           return new ListCredentialsResponse().credentials(results).nextPageToken(nextPageToken);
         },
         "Failed to list storage credentials",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public CredentialInfo updateCredential(String name, UpdateCredentialRequest updateCredential) {
@@ -149,7 +148,7 @@ public class CredentialRepository {
           return existingCredential.toCredentialInfo(getAwsS3MasterRoleArn());
         },
         "Failed to update storage credential",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public UUID deleteCredential(String name, boolean force) {
@@ -178,7 +177,7 @@ public class CredentialRepository {
           return existingCredential.getId();
         },
         "Failed to delete credential",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   protected ExternalLocationDAO getExternalLocationDAOUsingCredential(

--- a/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/DeltaCommitRepository.java
@@ -327,7 +327,7 @@ public class DeltaCommitRepository {
           return null;
         },
         "Error committing to table: " + commit.getTableId(),
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**
@@ -997,8 +997,8 @@ public class DeltaCommitRepository {
       Session session, UUID tableId, long commitVersion) {
     NativeQuery<?> query =
         session.createNativeQuery(
-            "UPDATE uc_delta_commits SET is_backfilled_latest_commit = true WHERE table_id = :tableId "
-                + "AND commit_version = :commitVersion");
+            "UPDATE uc_delta_commits SET is_backfilled_latest_commit = true WHERE table_id ="
+                + " :tableId AND commit_version = :commitVersion");
     query.setParameter("tableId", tableId);
     query.setParameter("commitVersion", commitVersion);
     query.executeUpdate();

--- a/server/src/main/java/io/unitycatalog/server/persist/ExternalLocationRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ExternalLocationRepository.java
@@ -96,7 +96,7 @@ public class ExternalLocationRepository {
           return externalLocationDAO.toExternalLocationInfo(credentialDAO.getName());
         },
         "Failed to add external location",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public ExternalLocationInfo getExternalLocation(String name) {
@@ -115,7 +115,7 @@ public class ExternalLocationRepository {
           return externalLocationDAO.toExternalLocationInfo(credentialName);
         },
         "Failed to get external location",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   protected ExternalLocationDAO getExternalLocationDAO(Session session, String name) {
@@ -133,8 +133,7 @@ public class ExternalLocationRepository {
         sessionFactory,
         session -> {
           List<ExternalLocationDAO> daoList =
-              LISTING_HELPER.listEntity(
-                  session, maxResults, pageToken, /* parentEntityId = */ null);
+              LISTING_HELPER.listEntity(session, maxResults, pageToken, /* parentEntityId= */ null);
           String nextPageToken = LISTING_HELPER.getNextPageToken(daoList, maxResults);
           List<ExternalLocationInfo> results = new ArrayList<>();
           for (ExternalLocationDAO dao : daoList) {
@@ -149,7 +148,7 @@ public class ExternalLocationRepository {
               .nextPageToken(nextPageToken);
         },
         "Failed to list external locations",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ExternalLocationInfo updateExternalLocation(
@@ -205,7 +204,7 @@ public class ExternalLocationRepository {
           return existingLocation.toExternalLocationInfo(credentialName);
         },
         "Failed to update external location",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**
@@ -256,7 +255,7 @@ public class ExternalLocationRepository {
           return existingLocation;
         },
         "Failed to delete external location",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/FunctionRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/FunctionRepository.java
@@ -112,7 +112,7 @@ public class FunctionRepository {
           return functionInfo;
         },
         "Failed to create function",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   private void addNamespaceData(FunctionInfo functionInfo, String catalogName, String schemaName) {
@@ -145,7 +145,7 @@ public class FunctionRepository {
           return listFunctions(session, schemaId, catalogName, schemaName, maxResults, pageToken);
         },
         "Failed to list functions",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ListFunctionsResponse listFunctions(
@@ -190,7 +190,7 @@ public class FunctionRepository {
           return functionInfo;
         },
         "Failed to get function",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public void addNamespaceInfo(FunctionInfo functionInfo, String catalogName, String schemaName) {
@@ -233,7 +233,7 @@ public class FunctionRepository {
           return null;
         },
         "Failed to delete function",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public void deleteFunction(Session session, UUID schemaId, String functionName) {

--- a/server/src/main/java/io/unitycatalog/server/persist/MetastoreRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/MetastoreRepository.java
@@ -33,7 +33,7 @@ public class MetastoreRepository {
           return metastoreDAO.toGetMetastoreSummaryResponse();
         },
         "Failed to get metastore summary",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public UUID getMetastoreId() {
@@ -61,6 +61,6 @@ public class MetastoreRepository {
           return metastoreDAO;
         },
         "Failed to initialize metastore",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/ModelRepository.java
@@ -95,7 +95,8 @@ public class ModelRepository {
 
   public ModelVersionInfoDAO getModelVersionDao(Session session, UUID modelId, Long version) {
     String hql =
-        "FROM ModelVersionInfoDAO t WHERE t.registeredModelId = :registeredModelId AND t.version = :version";
+        "FROM ModelVersionInfoDAO t WHERE t.registeredModelId = :registeredModelId AND t.version ="
+            + " :version";
     Query<ModelVersionInfoDAO> query = session.createQuery(hql, ModelVersionInfoDAO.class);
     query.setParameter("registeredModelId", modelId);
     query.setParameter("version", version.toString());
@@ -126,7 +127,8 @@ public class ModelRepository {
   public List<ModelVersionInfoDAO> getModelVersionsDao(
       Session session, UUID registeredModelId, String token, int maxResults) {
     String hql =
-        "FROM ModelVersionInfoDAO t WHERE t.registeredModelId = :registeredModelId AND t.version > :token ORDER BY t.version ASC";
+        "FROM ModelVersionInfoDAO t WHERE t.registeredModelId = :registeredModelId AND t.version >"
+            + " :token ORDER BY t.version ASC";
     Query<ModelVersionInfoDAO> query = session.createQuery(hql, ModelVersionInfoDAO.class);
     query.setParameter("registeredModelId", registeredModelId);
     query.setParameter("token", Long.parseLong(token));

--- a/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
@@ -92,7 +92,7 @@ public class SchemaRepository {
           return schemaInfo;
         },
         "Failed to create schema",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   private void addNamespaceData(SchemaInfo schemaInfo, String catalogName) {
@@ -137,7 +137,7 @@ public class SchemaRepository {
         sessionFactory,
         session -> getSchemaIdOrThrow(session, catalogName, schemaName),
         "Failed to get schema id",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   private void validateSchemaNotExistInCatalog(
@@ -180,7 +180,7 @@ public class SchemaRepository {
           return listSchemas(session, catalogId, catalogName, maxResults, pageToken);
         },
         "Failed to list schemas",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ListSchemasResponse listSchemas(
@@ -213,7 +213,7 @@ public class SchemaRepository {
               schemaInfo, schemaInfo.getSchemaId(), Constants.SCHEMA, session);
         },
         "Failed to get schema",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public SchemaInfo updateSchema(String fullName, UpdateSchema updateSchema) {
@@ -255,7 +255,7 @@ public class SchemaRepository {
           return convertFromDAO(session, schemaInfoDAO, fullName);
         },
         "Failed to update schema",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public List<DeletedResource> deleteSchema(String fullName, boolean force) {
@@ -271,7 +271,7 @@ public class SchemaRepository {
               session, catalog.getId(), names.catalogName(), names.schemaName(), force);
         },
         "Failed to delete schema",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   private List<DeletedResource> deleteChildTables(

--- a/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StagingTableRepository.java
@@ -115,7 +115,7 @@ public class StagingTableRepository {
               createStagingTable.getCatalogName(), createStagingTable.getSchemaName());
         },
         "Error creating table: " + getTableFullName(createStagingTable),
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -125,7 +125,7 @@ public class TableRepository {
               "Neither table nor staging table found with id: " + tableId);
         },
         "Failed to get storage location of table or staging table",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -144,7 +144,7 @@ public class TableRepository {
           return NormalizedURL.from(dao.getUrl());
         },
         "Failed to get storage location of table " + catalog + "." + schema + "." + table,
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -159,7 +159,7 @@ public class TableRepository {
         sessionFactory,
         session -> findTableOrThrow(session, catalog, schema, table),
         "Failed to find table " + catalog + "." + schema + "." + table,
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -182,7 +182,7 @@ public class TableRepository {
           return NormalizedURL.from(stagingTableDAO.getStagingLocation());
         },
         "Failed to get storage location of staging table",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -229,7 +229,7 @@ public class TableRepository {
           return Pair.of(schemaInfoDAO.getCatalogId(), schemaId);
         },
         "Failed to get table or staging table by ID",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public TableInfo getTable(String fullName) {
@@ -253,7 +253,7 @@ public class TableRepository {
           return tableInfo;
         },
         "Failed to get table",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -279,7 +279,7 @@ public class TableRepository {
           return buildLoadTableResponse(session, dao, Optional.empty(), catalog, schema, table);
         },
         "Failed to load table",
-        /* readOnly = */ true,
+        /* readOnly= */ true,
         Optional.of(TRANSACTION_REPEATABLE_READ));
   }
 
@@ -374,7 +374,7 @@ public class TableRepository {
               session, dao, Optional.of(properties.asMap()), catalog, schema, table);
         },
         "Failed to update table " + tableFullName,
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   /**
@@ -608,7 +608,7 @@ public class TableRepository {
               dao.getId(), dataSourceFormat, dao.getUniformIcebergMetadataLocation(), dao.getUrl());
         },
         "Failed to load Iceberg table state for " + fullName,
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -682,7 +682,7 @@ public class TableRepository {
           return null;
         },
         "Failed to update Iceberg metadata location for " + fullName,
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   private TableInfoDAO findTableOrThrow(
@@ -903,7 +903,9 @@ public class TableRepository {
             // view_dependencies is optional (see validateViewLike); treat an absent list as empty.
             List<DependencyDAO> depDAOs =
                 Optional.ofNullable(createTable.getViewDependencies())
-                    .map(DependencyList::getDependencies).orElse(List.of()).stream()
+                    .map(DependencyList::getDependencies)
+                    .orElse(List.of())
+                    .stream()
                     .map(dep -> DependencyDAO.from(dep, tableUUID, dependentType))
                     .toList();
             repositories
@@ -915,7 +917,7 @@ public class TableRepository {
           return mapper.apply(session, tableInfoDAO, tableInfo);
         },
         "Error creating table: " + fullName,
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   @FunctionalInterface
@@ -1060,7 +1062,7 @@ public class TableRepository {
               omitColumns);
         },
         "Failed to list tables",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ListTablesResponse listTables(
@@ -1114,7 +1116,7 @@ public class TableRepository {
           return deleteTable(session, schemaId, table);
         },
         "Failed to delete table",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   TableInfoDAO deleteTable(Session session, UUID schemaId, String tableName) {
@@ -1178,6 +1180,6 @@ public class TableRepository {
           return null;
         },
         "Failed to rename table " + catalog + "." + schema + "." + table,
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/UserRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/UserRepository.java
@@ -54,7 +54,7 @@ public class UserRepository {
           return user;
         },
         "Failed to create user",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public List<User> listUsers(int startIndex, int maxUsers, Predicate<User> filter) {
@@ -98,7 +98,7 @@ public class UserRepository {
           return users.subList(0, Math.min(users.size(), maxUsers));
         },
         "Failed to list users",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public User getUser(String id) {
@@ -112,7 +112,7 @@ public class UserRepository {
           return userDAO.toUser();
         },
         "Failed to get user",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public UserDAO getUserById(Session session, String id) {
@@ -133,7 +133,7 @@ public class UserRepository {
           return userDAO.toUser();
         },
         "Failed to get user by email",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public UserDAO getUserByEmail(Session session, String email) {
@@ -175,7 +175,7 @@ public class UserRepository {
           return userDAO.toUser();
         },
         "Failed to update user",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public void deleteUser(String id) {
@@ -193,7 +193,7 @@ public class UserRepository {
           }
         },
         "Failed to delete user",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public UUID findPrincipalId() {

--- a/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/VolumeRepository.java
@@ -105,7 +105,7 @@ public class VolumeRepository {
               createVolumeRequest.getCatalogName(), createVolumeRequest.getSchemaName());
         },
         "Failed to create volume",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public VolumeInfo getVolume(String fullName) {
@@ -123,7 +123,7 @@ public class VolumeRepository {
               .toVolumeInfo(catalogName, schemaName);
         },
         "Failed to get volume",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public VolumeInfoDAO getVolumeDAO(
@@ -159,7 +159,7 @@ public class VolumeRepository {
           return volumeInfo;
         },
         "Failed to get volume by ID",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   /**
@@ -188,7 +188,7 @@ public class VolumeRepository {
           return listVolumes(session, schemaId, catalogName, schemaName, maxResults, pageToken);
         },
         "Failed to list volumes",
-        /* readOnly = */ true);
+        /* readOnly= */ true);
   }
 
   public ListVolumesResponseContent listVolumes(
@@ -250,7 +250,7 @@ public class VolumeRepository {
           return volumeInfo.toVolumeInfo(catalog, schema);
         },
         "Failed to update volume",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public void deleteVolume(String name) {
@@ -268,7 +268,7 @@ public class VolumeRepository {
           return null;
         },
         "Failed to delete volume",
-        /* readOnly = */ false);
+        /* readOnly= */ false);
   }
 
   public void deleteVolume(Session session, UUID schemaId, String volumeName) {

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/CredentialDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/CredentialDAO.java
@@ -127,7 +127,7 @@ public class CredentialDAO extends IdentifiableDAO {
         masterAwsIamRoleArn.ifPresent(awsIamRole::setUnityCatalogIamArn);
         credentialInfo.setAwsIamRole(awsIamRole);
         break;
-        // TODO: support Azure and GCP.
+      // TODO: support Azure and GCP.
       default:
         throw new IllegalArgumentException("Unknown credential type: " + credentialType);
     }

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/ExternalLocationUtils.java
@@ -1,5 +1,8 @@
 package io.unitycatalog.server.persist.utils;
 
+import static io.unitycatalog.server.utils.Constants.MANAGED_STORAGE_CATALOG_PREFIX;
+import static io.unitycatalog.server.utils.Constants.MANAGED_STORAGE_SCHEMA_PREFIX;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
@@ -27,9 +30,6 @@ import org.apache.hadoop.fs.Path;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
-
-import static io.unitycatalog.server.utils.Constants.MANAGED_STORAGE_CATALOG_PREFIX;
-import static io.unitycatalog.server.utils.Constants.MANAGED_STORAGE_SCHEMA_PREFIX;
 
 /**
  * Utility class for performing path-based database queries on Unity Catalog entities.
@@ -198,8 +198,9 @@ public class ExternalLocationUtils {
       case TABLE -> ((TableInfoDAO) dao).getSchemaId();
       case VOLUME -> ((VolumeInfoDAO) dao).getSchemaId();
       case REGISTERED_MODEL -> ((RegisteredModelInfoDAO) dao).getSchemaId();
-      default -> throw new BaseException(
-          ErrorCode.UNIMPLEMENTED, "Unknown securable type: " + securableType);
+      default ->
+          throw new BaseException(
+              ErrorCode.UNIMPLEMENTED, "Unknown securable type: " + securableType);
     };
   }
 
@@ -297,8 +298,7 @@ public class ExternalLocationUtils {
       // This is an invalid internal state. We never allow external locations with
       // overlapping URLs.
       throw new BaseException(
-          ErrorCode.INTERNAL,
-          "More than one external location with URL '" + url + "' exist.");
+          ErrorCode.INTERNAL, "More than one external location with URL '" + url + "' exist.");
     }
 
     // Get the credential that is assigned to the external location
@@ -582,8 +582,8 @@ public class ExternalLocationUtils {
   }
 
   /**
-   * Gets the managed storage location for creating child entities (tables, volumes, models)
-   * within a catalog/schema.
+   * Gets the managed storage location for creating child entities (tables, volumes, models) within
+   * a catalog/schema.
    *
    * <p>This method returns the storageLocation of the schema if set, otherwise falls back to the
    * catalog's storageLocation. If neither is set, throws an exception.
@@ -599,8 +599,8 @@ public class ExternalLocationUtils {
   }
 
   /**
-   * Gets the managed storage location for creating child entities (tables, volumes, models)
-   * within a catalog/schema, with a fallback option.
+   * Gets the managed storage location for creating child entities (tables, volumes, models) within
+   * a catalog/schema, with a fallback option.
    *
    * <p>The resolution order is:
    *
@@ -612,8 +612,8 @@ public class ExternalLocationUtils {
    * </ol>
    *
    * @param catalogAndSchemaDao the catalog and schema DAOs
-   * @param fallbackStorageRoot supplier that provides an optional fallback storage root from
-   *                            server properties
+   * @param fallbackStorageRoot supplier that provides an optional fallback storage root from server
+   *     properties
    * @return the storage location to use as root for child entity storage
    * @throws BaseException with ErrorCode.FAILED_PRECONDITION if no storage root is available
    */
@@ -635,7 +635,7 @@ public class ExternalLocationUtils {
                   new BaseException(
                       ErrorCode.FAILED_PRECONDITION,
                       "None of catalog, schema or storage-root.tables server property has managed "
-                        + "location configured."));
+                          + "location configured."));
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
@@ -94,8 +94,7 @@ public class FileOperations {
   }
 
   /** Returns a FileIO configured for the requested storage privileges. */
-  public FileIO getFileIO(
-      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
+  public FileIO getFileIO(NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
     return switch (UriScheme.fromURI(path.toUri())) {
       // Local paths are served by SimpleLocalFileIO (backed by java.nio + iceberg-core). We
       // deliberately do NOT route these through ResolvingFileIO: it resolves the file:// scheme to
@@ -145,8 +144,7 @@ public class FileOperations {
       // scheme, so fail loudly rather than silently returning an empty (credential-less) config
       // that would later surface as an opaque access-denied error.
       throw new BaseException(
-          ErrorCode.INTERNAL,
-          "No recognized storage credential was vended for location: " + path);
+          ErrorCode.INTERNAL, "No recognized storage credential was vended for location: " + path);
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
@@ -62,15 +62,16 @@ public class RepositoryUtils {
         return entityInfo;
       }
       Class<?> entityClass = PROPERTY_TYPE_MAP.getOrDefault(entityType, Map.class);
-      Method setPropertiesMethod =
-          entityInfo.getClass().getMethod("setProperties", entityClass);
+      Method setPropertiesMethod = entityInfo.getClass().getMethod("setProperties", entityClass);
       Map<String, String> propertyMap = PropertyDAO.toMap(propertyDAOList);
-      Object propertiesArgument = switch (entityClass.getSimpleName()) {
-        case "Map" -> propertyMap;
-        case "String" -> propertyMap.toString();
-        default -> throw new IllegalArgumentException(
-            "Unsupported parameter type: " + entityClass.getSimpleName());
-      };
+      Object propertiesArgument =
+          switch (entityClass.getSimpleName()) {
+            case "Map" -> propertyMap;
+            case "String" -> propertyMap.toString();
+            default ->
+                throw new IllegalArgumentException(
+                    "Unsupported parameter type: " + entityClass.getSimpleName());
+          };
       setPropertiesMethod.invoke(entityInfo, propertiesArgument);
       return entityInfo;
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
@@ -106,8 +107,7 @@ public class RepositoryUtils {
     return parts;
   }
 
-  public static String getAssetFullName(
-      String catalogName, String schemaName, String assetName) {
+  public static String getAssetFullName(String catalogName, String schemaName, String assetName) {
     return catalogName + "." + schemaName + "." + assetName;
   }
 
@@ -133,8 +133,8 @@ public class RepositoryUtils {
 
   public record CatalogAndSchemaDaoOpt(
       Optional<CatalogInfoDAO> catalogInfoDAO, Optional<SchemaInfoDAO> schemaInfoDAO) {}
-  public record CatalogAndSchemaDao(
-      CatalogInfoDAO catalogInfoDAO, SchemaInfoDAO schemaInfoDAO) {}
+
+  public record CatalogAndSchemaDao(CatalogInfoDAO catalogInfoDAO, SchemaInfoDAO schemaInfoDAO) {}
 
   public static CatalogAndSchemaDaoOpt getCatalogAndSchemaDaoOpt(
       Session session, String catalogName, String schemaName) {
@@ -171,9 +171,8 @@ public class RepositoryUtils {
   /**
    * Retrieves the catalog and schema names for a given schema ID.
    *
-   * <p>This method performs a lookup to find the schema by its UUID, then retrieves
-   * the associated catalog information. It returns both the catalog and schema names
-   * as a pair.
+   * <p>This method performs a lookup to find the schema by its UUID, then retrieves the associated
+   * catalog information. It returns both the catalog and schema names as a pair.
    *
    * @param session the Hibernate session used to query the database
    * @param schemaId the unique identifier of the schema
@@ -184,13 +183,12 @@ public class RepositoryUtils {
   public static CatalogAndSchemaNames getCatalogAndSchemaNames(Session session, UUID schemaId) {
     SchemaInfoDAO schemaInfoDAO = session.get(SchemaInfoDAO.class, schemaId);
     if (schemaInfoDAO == null) {
-      throw new BaseException(
-              ErrorCode.SCHEMA_NOT_FOUND, "Schema not found: " + schemaId);
+      throw new BaseException(ErrorCode.SCHEMA_NOT_FOUND, "Schema not found: " + schemaId);
     }
     CatalogInfoDAO catalogInfoDAO = session.get(CatalogInfoDAO.class, schemaInfoDAO.getCatalogId());
     if (catalogInfoDAO == null) {
       throw new BaseException(
-              ErrorCode.CATALOG_NOT_FOUND, "Catalog not found: " + schemaInfoDAO.getCatalogId());
+          ErrorCode.CATALOG_NOT_FOUND, "Catalog not found: " + schemaInfoDAO.getCatalogId());
     }
     return new CatalogAndSchemaNames(catalogInfoDAO.getName(), schemaInfoDAO.getName());
   }

--- a/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/AuthorizedService.java
@@ -138,7 +138,8 @@ public abstract class AuthorizedService {
       if (resultFilter == null) {
         throw new BaseException(
             ErrorCode.INTERNAL,
-            "Authorization filter not initialized — ensure the request goes through UnityAccessDecorator.");
+            "Authorization filter not initialized — ensure the request goes through"
+                + " UnityAccessDecorator.");
       }
       resultFilter.filter(securableType, items);
     }

--- a/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CatalogService.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
@@ -9,9 +13,9 @@ import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CreateCatalog;
 import io.unitycatalog.server.model.ListCatalogsResponse;
@@ -22,14 +26,9 @@ import io.unitycatalog.server.persist.MetastoreRepository;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.model.DeletedResource;
 import io.unitycatalog.server.utils.ServerProperties;
-import lombok.SneakyThrows;
-
 import java.util.List;
 import java.util.Optional;
-
-import static io.unitycatalog.server.model.SecurableType.CATALOG;
-import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
-import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import lombok.SneakyThrows;
 
 public class CatalogService extends AuthorizedService implements UnityCatalogRestService {
   private final CatalogRepository catalogRepository;
@@ -61,24 +60,26 @@ public class CatalogService extends AuthorizedService implements UnityCatalogRes
    * location (rather than tables etc.) owns the path.
    */
   @Post("")
-  @AuthorizeExpression("""
-      #authorizeAny(#principal, #metastore, OWNER, CREATE_CATALOG) &&
-      (#storage_root == null ||
-       (#no_overlap_with_data_securable &&
-        #external_location != null &&
-        #authorizeAny(#principal, #external_location, OWNER, CREATE_MANAGED_STORAGE)))
-    """)
+  @AuthorizeExpression(
+      """
+        #authorizeAny(#principal, #metastore, OWNER, CREATE_CATALOG) &&
+        (#storage_root == null ||
+         (#no_overlap_with_data_securable &&
+          #external_location != null &&
+          #authorizeAny(#principal, #external_location, OWNER, CREATE_MANAGED_STORAGE)))
+      """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse createCatalog(
       @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_root")
-      @AuthorizeKey(key = "storage_root")
-      CreateCatalog createCatalog) {
+          @AuthorizeKey(key = "storage_root")
+          CreateCatalog createCatalog) {
     CatalogInfo catalogInfo = catalogRepository.addCatalog(createCatalog);
     initializeBasicAuthorization(catalogInfo.getId());
     return HttpResponse.ofJson(catalogInfo);
   }
 
-  private static final String LIST_AND_GET_AUTH_EXPRESSION = """
+  private static final String LIST_AND_GET_AUTH_EXPRESSION =
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG)
       """;
@@ -90,8 +91,8 @@ public class CatalogService extends AuthorizedService implements UnityCatalogRes
   public HttpResponse listCatalogs(
       @Param("max_results") Optional<Integer> maxResults,
       @Param("page_token") Optional<String> pageToken) {
-    ListCatalogsResponse listCatalogsResponse = catalogRepository.listCatalogs(
-        maxResults, pageToken);
+    ListCatalogsResponse listCatalogsResponse =
+        catalogRepository.listCatalogs(maxResults, pageToken);
     applyResponseFilter(SecurableType.CATALOG, listCatalogsResponse.getCatalogs());
     return HttpResponse.ofJson(listCatalogsResponse);
   }
@@ -104,18 +105,19 @@ public class CatalogService extends AuthorizedService implements UnityCatalogRes
   }
 
   @Patch("/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #catalog, OWNER)
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse updateCatalog(
-      @Param("name") @AuthorizeResourceKey(CATALOG) String name,
-      UpdateCatalog updateCatalog) {
+      @Param("name") @AuthorizeResourceKey(CATALOG) String name, UpdateCatalog updateCatalog) {
     return HttpResponse.ofJson(catalogRepository.updateCatalog(name, updateCatalog));
   }
 
   @Delete("/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER)
       """)
@@ -123,8 +125,7 @@ public class CatalogService extends AuthorizedService implements UnityCatalogRes
   public HttpResponse deleteCatalog(
       @Param("name") @AuthorizeResourceKey(CATALOG) String name,
       @Param("force") Optional<Boolean> force) {
-    List<DeletedResource> deleted =
-        catalogRepository.deleteCatalog(name, force.orElse(false));
+    List<DeletedResource> deleted = catalogRepository.deleteCatalog(name, force.orElse(false));
     clearDeletedResourceAuthorizations(deleted);
     return HttpResponse.of(HttpStatus.OK);
   }

--- a/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/CredentialService.java
@@ -3,10 +3,17 @@ package io.unitycatalog.server.service;
 import static io.unitycatalog.server.model.SecurableType.CREDENTIAL;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Patch;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateCredentialRequest;
 import io.unitycatalog.server.model.CredentialInfo;
 import io.unitycatalog.server.model.ListCredentialsResponse;
@@ -18,13 +25,6 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
 import java.util.UUID;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Post;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.Patch;
 import lombok.SneakyThrows;
 
 /**
@@ -63,7 +63,8 @@ public class CredentialService extends AuthorizedService implements UnityCatalog
     return HttpResponse.ofJson(credentialInfo);
   }
 
-  private static final String LIST_AND_GET_AUTH_EXPRESSION = """
+  private static final String LIST_AND_GET_AUTH_EXPRESSION =
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorizeAny(#principal, #credential, OWNER, CREATE_EXTERNAL_LOCATION)
       """;
@@ -89,7 +90,8 @@ public class CredentialService extends AuthorizedService implements UnityCatalog
   }
 
   @Patch("/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #credential, OWNER)
       """)
@@ -101,7 +103,8 @@ public class CredentialService extends AuthorizedService implements UnityCatalog
   }
 
   @Delete("/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #credential, OWNER)
       """)
@@ -109,10 +112,8 @@ public class CredentialService extends AuthorizedService implements UnityCatalog
   public HttpResponse deleteCredential(
       @Param("name") @AuthorizeResourceKey(CREDENTIAL) String name,
       @Param("force") Optional<Boolean> force) {
-    UUID deletedCredentialId =
-        credentialRepository.deleteCredential(name, force.orElse(false));
+    UUID deletedCredentialId = credentialRepository.deleteCredential(name, force.orElse(false));
     removeAuthorizations(deletedCredentialId.toString());
     return HttpResponse.of(HttpStatus.OK);
   }
-
 }

--- a/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/DeltaCommitsService.java
@@ -1,5 +1,8 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.TABLE;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Get;
@@ -15,12 +18,7 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.utils.ServerProperties;
 import lombok.SneakyThrows;
 
-import static io.unitycatalog.server.model.SecurableType.METASTORE;
-import static io.unitycatalog.server.model.SecurableType.TABLE;
-
-/**
- * REST API service for Delta commits to Delta tables in Unity Catalog.
- */
+/** REST API service for Delta commits to Delta tables in Unity Catalog. */
 public class DeltaCommitsService extends AuthorizedService implements UnityCatalogRestService {
 
   private final DeltaCommitRepository deltaCommitRepository;
@@ -38,8 +36,7 @@ public class DeltaCommitsService extends AuthorizedService implements UnityCatal
   @AuthorizeExpression(AuthorizeExpressions.UPDATE_TABLE)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse postCommit(
-      @AuthorizeResourceKey(value = TABLE, key = "table_id")
-      DeltaCommit commit) {
+      @AuthorizeResourceKey(value = TABLE, key = "table_id") DeltaCommit commit) {
     // The UC REST commit endpoint only accepts MANAGED Delta tables (enforced downstream by
     // validateTableForCommit), so the gate applies unconditionally here.
     serverProperties.checkDeltaApiOnlyEnabled(
@@ -49,15 +46,15 @@ public class DeltaCommitsService extends AuthorizedService implements UnityCatal
   }
 
   @Get("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
         #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
         #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
         #authorizeAny(#principal, #table, OWNER, SELECT)
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse getCommits(
-    @AuthorizeResourceKey(value = TABLE, key = "table_id")
-    DeltaGetCommits rpc) {
+      @AuthorizeResourceKey(value = TABLE, key = "table_id") DeltaGetCommits rpc) {
     // Same as postCommit above -- managed-Delta-only by contract; gate unconditionally.
     serverProperties.checkDeltaApiOnlyEnabled(
         "GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table} (commits[])");

--- a/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ExternalLocationService.java
@@ -5,7 +5,6 @@ import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 
 import com.linecorp.armeria.common.HttpResponse;
-import io.unitycatalog.server.model.SecurableType;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.Get;
@@ -14,11 +13,12 @@ import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateExternalLocation;
 import io.unitycatalog.server.model.ExternalLocationInfo;
 import io.unitycatalog.server.model.ListExternalLocationsResponse;
+import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.UpdateExternalLocation;
 import io.unitycatalog.server.persist.ExternalLocationRepository;
 import io.unitycatalog.server.persist.MetastoreRepository;
@@ -43,26 +43,28 @@ public class ExternalLocationService extends AuthorizedService implements UnityC
   }
 
   @Post("")
-  @AuthorizeExpression("""
-    #authorize(#principal, #metastore, OWNER) ||
-    (#authorize(#principal, #metastore, CREATE_EXTERNAL_LOCATION) &&
-     #authorizeAny(#principal, #credential, OWNER, CREATE_EXTERNAL_LOCATION))
-    """)
+  @AuthorizeExpression(
+      """
+      #authorize(#principal, #metastore, OWNER) ||
+      (#authorize(#principal, #metastore, CREATE_EXTERNAL_LOCATION) &&
+       #authorizeAny(#principal, #credential, OWNER, CREATE_EXTERNAL_LOCATION))
+      """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse createExternalLocation(
       @AuthorizeResourceKey(value = CREDENTIAL, key = "credential_name")
-      CreateExternalLocation createExternalLocation) {
+          CreateExternalLocation createExternalLocation) {
     ExternalLocationInfo externalLocationInfo =
         externalLocationRepository.addExternalLocation(createExternalLocation);
     initializeBasicAuthorization(externalLocationInfo.getId());
     return HttpResponse.ofJson(externalLocationInfo);
   }
 
-  private static final String LIST_AND_GET_AUTH_EXPRESSION = """
-    #authorize(#principal, #metastore, OWNER) ||
-    #authorizeAny(#principal, #external_location, OWNER, READ_FILES, WRITE_FILES,
-      CREATE_EXTERNAL_TABLE, CREATE_EXTERNAL_VOLUME, CREATE_MANAGED_STORAGE)
-    """;
+  private static final String LIST_AND_GET_AUTH_EXPRESSION =
+      """
+      #authorize(#principal, #metastore, OWNER) ||
+      #authorizeAny(#principal, #external_location, OWNER, READ_FILES, WRITE_FILES,
+        CREATE_EXTERNAL_TABLE, CREATE_EXTERNAL_VOLUME, CREATE_MANAGED_STORAGE)
+      """;
 
   @Get("")
   @AuthorizeExpression(LIST_AND_GET_AUTH_EXPRESSION)
@@ -86,26 +88,28 @@ public class ExternalLocationService extends AuthorizedService implements UnityC
   }
 
   @Patch("/{name}")
-  @AuthorizeExpression("""
-    #authorize(#principal, #metastore, OWNER) ||
-    (#authorize(#principal, #external_location, OWNER) &&
-     (#credential == null ||
-      #authorizeAny(#principal, #credential, OWNER, CREATE_EXTERNAL_LOCATION)))
-    """)
+  @AuthorizeExpression(
+      """
+      #authorize(#principal, #metastore, OWNER) ||
+      (#authorize(#principal, #external_location, OWNER) &&
+       (#credential == null ||
+        #authorizeAny(#principal, #credential, OWNER, CREATE_EXTERNAL_LOCATION)))
+      """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse updateExternalLocation(
       @Param("name") @AuthorizeResourceKey(EXTERNAL_LOCATION) String name,
       @AuthorizeResourceKey(value = CREDENTIAL, key = "credential_name")
-      UpdateExternalLocation updateRequest) {
+          UpdateExternalLocation updateRequest) {
     return HttpResponse.ofJson(
         externalLocationRepository.updateExternalLocation(name, updateRequest));
   }
 
   @Delete("/{name}")
-  @AuthorizeExpression("""
-    #authorize(#principal, #metastore, OWNER) ||
-    #authorize(#principal, #external_location, OWNER)
-    """)
+  @AuthorizeExpression(
+      """
+      #authorize(#principal, #metastore, OWNER) ||
+      #authorize(#principal, #external_location, OWNER)
+      """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse deleteExternalLocation(
       @Param("name") @AuthorizeResourceKey(EXTERNAL_LOCATION) String name,
@@ -115,5 +119,4 @@ public class ExternalLocationService extends AuthorizedService implements UnityC
     removeAuthorizations(externalLocationDAO.getId().toString());
     return HttpResponse.of(HttpStatus.OK);
   }
-
 }

--- a/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/FunctionService.java
@@ -5,16 +5,22 @@ import static io.unitycatalog.server.model.SecurableType.FUNCTION;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateFunctionRequest;
-import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.model.FunctionInfo;
 import io.unitycatalog.server.model.ListFunctionsResponse;
 import io.unitycatalog.server.model.SchemaInfo;
+import io.unitycatalog.server.model.SecurableType;
 import io.unitycatalog.server.persist.CatalogRepository;
 import io.unitycatalog.server.persist.FunctionRepository;
 import io.unitycatalog.server.persist.MetastoreRepository;
@@ -22,12 +28,6 @@ import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
 public class FunctionService extends AuthorizedService implements UnityCatalogRestService {
@@ -51,17 +51,18 @@ public class FunctionService extends AuthorizedService implements UnityCatalogRe
 
   @Post("")
   // TODO: for now, we are not supporting CREATE FUNCTION privilege
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA)
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse createFunction(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = CATALOG, key = "function_info.catalog_name"),
-        @AuthorizeResourceKey(value = SCHEMA, key = "function_info.schema_name")
-      })
-      CreateFunctionRequest createFunctionRequest) {
+            @AuthorizeResourceKey(value = CATALOG, key = "function_info.catalog_name"),
+            @AuthorizeResourceKey(value = SCHEMA, key = "function_info.schema_name")
+          })
+          CreateFunctionRequest createFunctionRequest) {
     FunctionInfo functionInfo = functionRepository.createFunction(createFunctionRequest);
 
     String catalogName = functionInfo.getCatalogName();
@@ -73,7 +74,8 @@ public class FunctionService extends AuthorizedService implements UnityCatalogRe
   }
 
   @Get("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) &&
@@ -97,7 +99,8 @@ public class FunctionService extends AuthorizedService implements UnityCatalogRe
 
   @Get("/{name}")
   @AuthorizeResourceKey(METASTORE)
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) &&
@@ -112,7 +115,8 @@ public class FunctionService extends AuthorizedService implements UnityCatalogRe
 
   @Delete("/{name}")
   @AuthorizeResourceKey(METASTORE)
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       (#authorize(#principal, #function, OWNER) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
@@ -131,6 +135,4 @@ public class FunctionService extends AuthorizedService implements UnityCatalogRe
 
     return HttpResponse.of(HttpStatus.OK);
   }
-
 }
-

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -533,8 +533,7 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
         tableMetadata.location().contains(Constants.MANAGED_STORAGE_PREFIX)
             ? TableType.MANAGED
             : TableType.EXTERNAL;
-    return finalizeIcebergTableCreation(
-        catalog, namespace, table, tableType, tableMetadata, true);
+    return finalizeIcebergTableCreation(catalog, namespace, table, tableType, tableMetadata, true);
   }
 
   private boolean ucTableExists(String catalog, String namespace, String table) {

--- a/server/src/main/java/io/unitycatalog/server/service/ModelService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/ModelService.java
@@ -1,5 +1,10 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.CATALOG;
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
+import static io.unitycatalog.server.model.SecurableType.SCHEMA;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
@@ -9,9 +14,9 @@ import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateModelVersion;
 import io.unitycatalog.server.model.CreateRegisteredModel;
 import io.unitycatalog.server.model.FinalizeModelVersion;
@@ -28,15 +33,8 @@ import io.unitycatalog.server.persist.ModelRepository;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.utils.ServerProperties;
-
 import java.util.Optional;
-
 import lombok.SneakyThrows;
-
-import static io.unitycatalog.server.model.SecurableType.CATALOG;
-import static io.unitycatalog.server.model.SecurableType.METASTORE;
-import static io.unitycatalog.server.model.SecurableType.REGISTERED_MODEL;
-import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
 public class ModelService extends AuthorizedService implements UnityCatalogRestService {
 
@@ -58,7 +56,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
           #authorize(#principal, #schema, OWNER)) ||
       (#authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
@@ -68,10 +67,10 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
       """)
   public HttpResponse createRegisteredModel(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name")
-      })
-      CreateRegisteredModel createRegisteredModel) {
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name")
+          })
+          CreateRegisteredModel createRegisteredModel) {
     assert createRegisteredModel != null;
     RegisteredModelInfo createRegisteredModelResponse =
         modelRepository.createRegisteredModel(createRegisteredModel);
@@ -85,7 +84,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
     return HttpResponse.ofJson(createRegisteredModelResponse);
   }
 
-  private static final String LIST_AND_GET_AUTH_EXPRESSION = """
+  private static final String LIST_AND_GET_AUTH_EXPRESSION =
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -121,7 +121,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Patch("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #registered_model, OWNER) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
@@ -137,7 +138,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Delete("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -161,18 +163,19 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Post("/versions")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #registered_model, OWNER) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
       """)
   public HttpResponse createModelVersion(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = REGISTERED_MODEL, key = "model_name")
-      })
-      CreateModelVersion createModelVersion) {
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = REGISTERED_MODEL, key = "model_name")
+          })
+          CreateModelVersion createModelVersion) {
     assert createModelVersion != null;
     assert createModelVersion.getModelName() != null;
     assert createModelVersion.getCatalogName() != null;
@@ -184,7 +187,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Get("/{full_name}/versions")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -201,7 +205,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Get("/{full_name}/versions/{version}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -219,7 +224,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Patch("/{full_name}/versions/{version}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #registered_model, OWNER) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
@@ -236,7 +242,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Delete("/{full_name}/versions/{version}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -253,7 +260,8 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Patch("/{full_name}/versions/{version}/finalize")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #registered_model, OWNER) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG))
@@ -267,6 +275,4 @@ public class ModelService extends AuthorizedService implements UnityCatalogRestS
         modelRepository.finalizeModelVersion(finalizeModelVersion);
     return HttpResponse.ofJson(finalizeModelVersionResponse);
   }
-
 }
-

--- a/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/PermissionService.java
@@ -10,6 +10,10 @@ import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.TABLE;
 import static io.unitycatalog.server.model.SecurableType.VOLUME;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Patch;
 import io.unitycatalog.control.model.User;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
@@ -43,10 +47,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Patch;
 
 public class PermissionService implements UnityCatalogRestService {
 
@@ -79,69 +79,59 @@ public class PermissionService implements UnityCatalogRestService {
   // TODO: Refactor these endpoints to use a common method with dynamic resource id lookup
   @Get("/metastore/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getMetastoreAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getMetastoreAuthorization(@Param("name") String name) {
     return getAuthorization(METASTORE, name);
   }
 
   @Get("/catalog/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getCatalogAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getCatalogAuthorization(@Param("name") String name) {
     return getAuthorization(CATALOG, name);
   }
 
   @Get("/schema/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getSchemaAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getSchemaAuthorization(@Param("name") String name) {
     return getAuthorization(SCHEMA, name);
   }
 
   @Get("/table/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getTableAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getTableAuthorization(@Param("name") String name) {
     return getAuthorization(TABLE, name);
   }
 
   @Get("/function/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getFunctionAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getFunctionAuthorization(@Param("name") String name) {
     return getAuthorization(FUNCTION, name);
   }
 
   @Get("/volume/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getVolumeAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getVolumeAuthorization(@Param("name") String name) {
     return getAuthorization(VOLUME, name);
   }
 
   @Get("/registered_model/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getRegisteredModelAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getRegisteredModelAuthorization(@Param("name") String name) {
     return getAuthorization(REGISTERED_MODEL, name);
   }
 
   @Get("/external_location/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getExternalLocationAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getExternalLocationAuthorization(@Param("name") String name) {
     return getAuthorization(EXTERNAL_LOCATION, name);
   }
 
   @Get("/credential/{name}")
   @AuthorizeExpression(AuthorizeExpressions.GET_RESOURCE_AUTHORIZATION)
-  public HttpResponse getCredentialAuthorization(
-      @Param("name") String name) {
+  public HttpResponse getCredentialAuthorization(@Param("name") String name) {
     return getAuthorization(CREDENTIAL, name);
   }
 
-  private HttpResponse getAuthorization(
-      SecurableType securableType, String name) {
+  private HttpResponse getAuthorization(SecurableType securableType, String name) {
 
     // Only show permissions for the authenticated identity unless they are the owner
     // or if the authenticated identity is the owner of the parent resource(s)
@@ -207,7 +197,8 @@ public class PermissionService implements UnityCatalogRestService {
   }
 
   @Patch("/schema/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG))
@@ -219,7 +210,8 @@ public class PermissionService implements UnityCatalogRestService {
   }
 
   @Patch("/table/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -234,7 +226,8 @@ public class PermissionService implements UnityCatalogRestService {
   }
 
   @Patch("/function/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -249,7 +242,8 @@ public class PermissionService implements UnityCatalogRestService {
   }
 
   @Patch("/volume/{name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #catalog, USE_CATALOG) && #authorize(#principal, #schema, OWNER)) ||
@@ -265,7 +259,8 @@ public class PermissionService implements UnityCatalogRestService {
 
   @Patch("/registered_model/{name}")
   @AuthorizeExpression(
-      "#authorize(#principal, #metastore, OWNER) || #authorize(#principal, #registered_model, OWNER)")
+      "#authorize(#principal, #metastore, OWNER) || #authorize(#principal, #registered_model,"
+          + " OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse updateRegisteredModelAuthorization(
       @Param("name") @AuthorizeResourceKey(REGISTERED_MODEL) String name,
@@ -275,7 +270,8 @@ public class PermissionService implements UnityCatalogRestService {
 
   @Patch("/external_location/{name}")
   @AuthorizeExpression(
-      "#authorize(#principal, #metastore, OWNER) || #authorize(#principal, #external_location, OWNER)")
+      "#authorize(#principal, #metastore, OWNER) || #authorize(#principal, #external_location,"
+          + " OWNER)")
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse updateExternalLocationAuthorization(
       @Param("name") @AuthorizeResourceKey(EXTERNAL_LOCATION) String name,
@@ -346,18 +342,20 @@ public class PermissionService implements UnityCatalogRestService {
 
   private UUID getResourceId(SecurableType securableType, String name) {
 
-    String resourceId = switch (securableType) {
-      case METASTORE -> metastoreRepository.getMetastoreId().toString();
-      case CATALOG -> catalogRepository.getCatalog(name).getId();
-      case SCHEMA -> schemaRepository.getSchema(name).getSchemaId();
-      case TABLE -> tableRepository.getTable(name).getTableId();
-      case FUNCTION -> functionRepository.getFunction(name).getFunctionId();
-      case VOLUME -> volumeRepository.getVolume(name).getVolumeId();
-      case REGISTERED_MODEL -> modelRepository.getRegisteredModel(name).getId();
-      case EXTERNAL_LOCATION -> externalLocationRepository.getExternalLocation(name).getId();
-      case CREDENTIAL -> credentialRepository.getCredential(name).getId();
-      default -> throw new BaseException(ErrorCode.FAILED_PRECONDITION, "Unknown resource type");
-    };
+    String resourceId =
+        switch (securableType) {
+          case METASTORE -> metastoreRepository.getMetastoreId().toString();
+          case CATALOG -> catalogRepository.getCatalog(name).getId();
+          case SCHEMA -> schemaRepository.getSchema(name).getSchemaId();
+          case TABLE -> tableRepository.getTable(name).getTableId();
+          case FUNCTION -> functionRepository.getFunction(name).getFunctionId();
+          case VOLUME -> volumeRepository.getVolume(name).getVolumeId();
+          case REGISTERED_MODEL -> modelRepository.getRegisteredModel(name).getId();
+          case EXTERNAL_LOCATION -> externalLocationRepository.getExternalLocation(name).getId();
+          case CREDENTIAL -> credentialRepository.getCredential(name).getId();
+          default ->
+              throw new BaseException(ErrorCode.FAILED_PRECONDITION, "Unknown resource type");
+        };
 
     return UUID.fromString(Objects.requireNonNull(resourceId));
   }

--- a/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/SchemaService.java
@@ -5,12 +5,19 @@ import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
 import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Patch;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CatalogInfo;
 import io.unitycatalog.server.model.CreateSchema;
 import io.unitycatalog.server.model.ListSchemasResponse;
@@ -25,13 +32,6 @@ import io.unitycatalog.server.persist.model.DeletedResource;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.List;
 import java.util.Optional;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Patch;
-import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
 public class SchemaService extends AuthorizedService implements UnityCatalogRestService {
@@ -66,7 +66,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
    * location (rather than tables etc.) owns the path.
    */
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #catalog, OWNER) ||
        #authorizeAll(#principal, #catalog, USE_CATALOG, CREATE_SCHEMA)) &&
       (#storage_root == null ||
@@ -77,11 +78,11 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse createSchema(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
-        @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_root")
-      })
-      @AuthorizeKey(key = "storage_root")
-      CreateSchema createSchema) {
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
+            @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_root")
+          })
+          @AuthorizeKey(key = "storage_root")
+          CreateSchema createSchema) {
     SchemaInfo schemaInfo = schemaRepository.createSchema(createSchema);
 
     CatalogInfo catalogInfo = catalogRepository.getCatalog(schemaInfo.getCatalogName());
@@ -91,7 +92,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Get("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, USE_SCHEMA) &&
@@ -110,7 +112,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Get("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
@@ -122,7 +125,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Patch("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #schema, OWNER) ||
       #authorizeAll(#principal, #catalog, USE_CATALOG, USE_SCHEMA) ||
@@ -139,7 +143,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Delete("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) &&
@@ -150,11 +155,8 @@ public class SchemaService extends AuthorizedService implements UnityCatalogRest
       @Param("full_name") @AuthorizeResourceKey(SCHEMA) String fullName,
       @Param("force") Optional<Boolean> force) {
     schemaRepository.getSchema(fullName);
-    List<DeletedResource> deleted =
-        schemaRepository.deleteSchema(fullName, force.orElse(false));
+    List<DeletedResource> deleted = schemaRepository.deleteSchema(fullName, force.orElse(false));
     clearDeletedResourceAuthorizations(deleted);
     return HttpResponse.of(HttpStatus.OK);
   }
-
 }
-

--- a/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/StagingTableService.java
@@ -34,19 +34,20 @@ public class StagingTableService extends AuthorizedService implements UnityCatal
 
   static final String disableGoogleJavaFormat =
       """
-    Google Java Format and Checkstyle disagree on how to indent annotation array initializers in
-    method parameters. This doc string is just a hack to stop Google Java Format from messing up
-    with this file.""";
+      Google Java Format and Checkstyle disagree on how to indent annotation array initializers in
+      method parameters. This doc string is just a hack to stop Google Java Format from messing up
+      with this file.\
+      """;
 
   @Post("")
   @AuthorizeExpression(AuthorizeExpressions.CREATE_STAGING_TABLE)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse createStagingTable(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name")
-      })
-      CreateStagingTable createStagingTable) {
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name")
+          })
+          CreateStagingTable createStagingTable) {
     assert createStagingTable != null;
     // A staging table can only ever finalize into a MANAGED Delta table, so the
     // managed-tables-use-delta-api-only gate applies unconditionally here.

--- a/server/src/main/java/io/unitycatalog/server/service/TableService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TableService.java
@@ -6,13 +6,19 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.TABLE;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateTable;
 import io.unitycatalog.server.model.ListTablesResponse;
 import io.unitycatalog.server.model.SchemaInfo;
@@ -24,12 +30,6 @@ import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
 public class TableService extends AuthorizedService implements UnityCatalogRestService {
@@ -78,16 +78,15 @@ public class TableService extends AuthorizedService implements UnityCatalogRestS
   @AuthorizeExpression(AuthorizeExpressions.CREATE_TABLE)
   public HttpResponse createTable(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
-        @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_location")
-      })
-      @AuthorizeKey(key = "table_type")
-      CreateTable createTable) {
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
+            @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_location")
+          })
+          @AuthorizeKey(key = "table_type")
+          CreateTable createTable) {
     assert createTable != null;
     serverProperties.checkDeltaApiOnlyForManagedTable(
-        createTable.getTableType(),
-        "POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables");
+        createTable.getTableType(), "POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables");
     TableInfo tableInfo = tableRepository.createTable(createTable);
 
     SchemaInfo schemaInfo =
@@ -107,7 +106,8 @@ public class TableService extends AuthorizedService implements UnityCatalogRestS
   }
 
   @Get("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) &&
@@ -126,13 +126,14 @@ public class TableService extends AuthorizedService implements UnityCatalogRestS
       @Param("omit_properties") Optional<Boolean> omitProperties,
       @Param("omit_columns") Optional<Boolean> omitColumns) {
 
-    ListTablesResponse listTablesResponse = tableRepository.listTables(
-        catalogName,
-        schemaName,
-        maxResults,
-        pageToken,
-        omitProperties.orElse(false),
-        omitColumns.orElse(false));
+    ListTablesResponse listTablesResponse =
+        tableRepository.listTables(
+            catalogName,
+            schemaName,
+            maxResults,
+            pageToken,
+            omitProperties.orElse(false),
+            omitColumns.orElse(false));
 
     applyResponseFilter(SecurableType.TABLE, listTablesResponse.getTables());
     return HttpResponse.ofJson(listTablesResponse);

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryModelVersionCredentialsService.java
@@ -6,10 +6,12 @@ import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
 import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
+import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
-import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.GenerateTemporaryModelVersionCredential;
@@ -19,25 +21,24 @@ import io.unitycatalog.server.model.ModelVersionStatus;
 import io.unitycatalog.server.persist.ModelRepository;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.utils.RepositoryUtils;
-import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.NormalizedURL;
 import java.util.Set;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.annotation.Post;
 
 public class TemporaryModelVersionCredentialsService implements UnityCatalogRestService {
   private final ModelRepository modelRepository;
   private final StorageCredentialVendor storageCredentialVendor;
 
-  public TemporaryModelVersionCredentialsService(StorageCredentialVendor storageCredentialVendor,
-                                                 Repositories repositories) {
+  public TemporaryModelVersionCredentialsService(
+      StorageCredentialVendor storageCredentialVendor, Repositories repositories) {
     this.storageCredentialVendor = storageCredentialVendor;
     this.modelRepository = repositories.getModelRepository();
   }
 
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
       #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
       (#operation == 'READ_MODEL_VERSION'
@@ -46,12 +47,12 @@ public class TemporaryModelVersionCredentialsService implements UnityCatalogRest
       """)
   public HttpResponse generateTemporaryModelVersionCredentials(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = REGISTERED_MODEL, key = "model_name")
-      })
-      @AuthorizeKey(key = "operation")
-      GenerateTemporaryModelVersionCredential generateTemporaryModelVersionCredentials) {
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = REGISTERED_MODEL, key = "model_name")
+          })
+          @AuthorizeKey(key = "operation")
+          GenerateTemporaryModelVersionCredential generateTemporaryModelVersionCredentials) {
 
     long modelVersion = generateTemporaryModelVersionCredentials.getVersion();
     String catalogName = generateTemporaryModelVersionCredentials.getCatalogName();
@@ -62,9 +63,11 @@ public class TemporaryModelVersionCredentialsService implements UnityCatalogRest
     ModelVersionInfo modelVersionInfo = modelRepository.getModelVersion(fullName, modelVersion);
     String storageLocation = modelVersionInfo.getStorageLocation();
     if (storageLocation.toLowerCase().startsWith("file")) {
-      String errorMsg = String.format(
-          "Cannot request credentials on a model version with a file based storage location: %s/%d",
-          fullName, modelVersion);
+      String errorMsg =
+          String.format(
+              "Cannot request credentials on a model version with a file based storage location:"
+                  + " %s/%d",
+              fullName, modelVersion);
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, errorMsg);
     }
     ModelVersionOperation requestedOperation =
@@ -72,16 +75,19 @@ public class TemporaryModelVersionCredentialsService implements UnityCatalogRest
     // Must enforce that the status of the model version matches the requested credential type.
     if (modelVersionInfo.getStatus() == ModelVersionStatus.FAILED_REGISTRATION
         || modelVersionInfo.getStatus() == ModelVersionStatus.MODEL_VERSION_STATUS_UNKNOWN) {
-      String errorMsg = String.format(
-          "Cannot request credentials on a model version with status %s: %s/%d",
-          modelVersionInfo.getStatus().getValue(), fullName, modelVersion);
+      String errorMsg =
+          String.format(
+              "Cannot request credentials on a model version with status %s: %s/%d",
+              modelVersionInfo.getStatus().getValue(), fullName, modelVersion);
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, errorMsg);
     }
     if ((modelVersionInfo.getStatus() != ModelVersionStatus.PENDING_REGISTRATION
         && requestedOperation == ModelVersionOperation.READ_WRITE_MODEL_VERSION)) {
-      String errorMsg = String.format(
-          "Cannot request read/write credentials on a model version that has been finalized: %s/%d",
-          fullName, modelVersion);
+      String errorMsg =
+          String.format(
+              "Cannot request read/write credentials on a model version that has been finalized:"
+                  + " %s/%d",
+              fullName, modelVersion);
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, errorMsg);
     }
     return HttpResponse.ofJson(
@@ -95,8 +101,11 @@ public class TemporaryModelVersionCredentialsService implements UnityCatalogRest
     return switch (modelVersionOperation) {
       case READ_MODEL_VERSION -> Set.of(SELECT);
       case READ_WRITE_MODEL_VERSION -> Set.of(SELECT, UPDATE);
-      case UNKNOWN_MODEL_VERSION_OPERATION -> throw new BaseException(ErrorCode.INVALID_ARGUMENT,
-          "Unknown operation in the request: " + ModelVersionOperation.UNKNOWN_MODEL_VERSION_OPERATION);
+      case UNKNOWN_MODEL_VERSION_OPERATION ->
+          throw new BaseException(
+              ErrorCode.INVALID_ARGUMENT,
+              "Unknown operation in the request: "
+                  + ModelVersionOperation.UNKNOWN_MODEL_VERSION_OPERATION);
     };
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryPathCredentialsService.java
@@ -1,23 +1,22 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
+import static io.unitycatalog.server.model.SecurableType.METASTORE;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
+import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.model.GenerateTemporaryPathCredential;
 import io.unitycatalog.server.model.PathOperation;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.NormalizedURL;
-
 import java.util.Collections;
 import java.util.Set;
-
-import static io.unitycatalog.server.model.SecurableType.EXTERNAL_LOCATION;
-import static io.unitycatalog.server.model.SecurableType.METASTORE;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
 public class TemporaryPathCredentialsService implements UnityCatalogRestService {
   private final StorageCredentialVendor storageCredentialVendor;
@@ -58,7 +57,8 @@ public class TemporaryPathCredentialsService implements UnityCatalogRestService 
   // e. Additionally for all data securables, it requires USE_CATALOG and USE_SCHEMA (or OWNER)
   //  of the parent catalog and schema.
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #operation == 'PATH_READ' ? (
         #authorize(#principal, #metastore, OWNER) ||
         (#table != null &&
@@ -105,9 +105,8 @@ public class TemporaryPathCredentialsService implements UnityCatalogRestService 
       """)
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse generateTemporaryPathCredential(
-      @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "url")
-      @AuthorizeKey(key = "operation")
-      GenerateTemporaryPathCredential generateTemporaryPathCredential) {
+      @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "url") @AuthorizeKey(key = "operation")
+          GenerateTemporaryPathCredential generateTemporaryPathCredential) {
     return HttpResponse.ofJson(
         storageCredentialVendor.vendCredential(
             NormalizedURL.from(generateTemporaryPathCredential.getUrl()),

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryTableCredentialsService.java
@@ -1,5 +1,9 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.TABLE;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.AuthorizeExpressions;
@@ -14,23 +18,19 @@ import io.unitycatalog.server.persist.TableRepository.TableStorageLocationInfo;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.ServerProperties;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-
-import static io.unitycatalog.server.model.SecurableType.TABLE;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
 public class TemporaryTableCredentialsService implements UnityCatalogRestService {
   private final TableRepository tableRepository;
   private final StorageCredentialVendor storageCredentialVendor;
   private final ServerProperties serverProperties;
 
-  public TemporaryTableCredentialsService(StorageCredentialVendor storageCredentialVendor,
-                                          Repositories repositories,
-                                          ServerProperties serverProperties) {
+  public TemporaryTableCredentialsService(
+      StorageCredentialVendor storageCredentialVendor,
+      Repositories repositories,
+      ServerProperties serverProperties) {
     this.storageCredentialVendor = storageCredentialVendor;
     this.tableRepository = repositories.getTableRepository();
     this.serverProperties = serverProperties;
@@ -39,9 +39,8 @@ public class TemporaryTableCredentialsService implements UnityCatalogRestService
   @Post("")
   @AuthorizeExpression(AuthorizeExpressions.VEND_TABLE_CREDENTIAL)
   public HttpResponse generateTemporaryTableCredential(
-      @AuthorizeResourceKey(value = TABLE, key = "table_id")
-      @AuthorizeKey(key = "operation")
-      GenerateTemporaryTableCredential generateTemporaryTableCredential) {
+      @AuthorizeResourceKey(value = TABLE, key = "table_id") @AuthorizeKey(key = "operation")
+          GenerateTemporaryTableCredential generateTemporaryTableCredential) {
     String tableId = generateTemporaryTableCredential.getTableId();
     TableStorageLocationInfo info =
         tableRepository.getStorageLocationForTableOrStagingTable(UUID.fromString(tableId));
@@ -49,7 +48,9 @@ public class TemporaryTableCredentialsService implements UnityCatalogRestService
         info.tableType(),
         "GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials"
             + " (or /delta/v1/staging-tables/{table_id}/credentials for unfinalized staging)");
-    return HttpResponse.ofJson(storageCredentialVendor.vendCredential(info.url(),
+    return HttpResponse.ofJson(
+        storageCredentialVendor.vendCredential(
+            info.url(),
             tableOperationToPrivileges(generateTemporaryTableCredential.getOperation())));
   }
 

--- a/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/TemporaryVolumeCredentialsService.java
@@ -1,10 +1,14 @@
 package io.unitycatalog.server.service;
 
+import static io.unitycatalog.server.model.SecurableType.VOLUME;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
+import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
+
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
+import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.GenerateTemporaryVolumeCredential;
@@ -12,29 +16,25 @@ import io.unitycatalog.server.model.VolumeInfo;
 import io.unitycatalog.server.model.VolumeOperation;
 import io.unitycatalog.server.persist.Repositories;
 import io.unitycatalog.server.persist.VolumeRepository;
-import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.NormalizedURL;
-
 import java.util.Collections;
 import java.util.Set;
-
-import static io.unitycatalog.server.model.SecurableType.VOLUME;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.SELECT;
-import static io.unitycatalog.server.service.credential.CredentialContext.Privilege.UPDATE;
 
 public class TemporaryVolumeCredentialsService implements UnityCatalogRestService {
   private final VolumeRepository volumeRepository;
   private final StorageCredentialVendor storageCredentialVendor;
 
-  public TemporaryVolumeCredentialsService(StorageCredentialVendor storageCredentialVendor,
-                                           Repositories repositories) {
+  public TemporaryVolumeCredentialsService(
+      StorageCredentialVendor storageCredentialVendor, Repositories repositories) {
     this.storageCredentialVendor = storageCredentialVendor;
     this.volumeRepository = repositories.getVolumeRepository();
   }
 
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA) &&
       #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
       (#operation == 'READ_VOLUME'
@@ -42,9 +42,8 @@ public class TemporaryVolumeCredentialsService implements UnityCatalogRestServic
         : #authorize(#principal, #volume, OWNER))
       """)
   public HttpResponse generateTemporaryVolumeCredential(
-      @AuthorizeResourceKey(value = VOLUME, key = "volume_id")
-      @AuthorizeKey(key = "operation")
-      GenerateTemporaryVolumeCredential generateTemporaryVolumeCredential) {
+      @AuthorizeResourceKey(value = VOLUME, key = "volume_id") @AuthorizeKey(key = "operation")
+          GenerateTemporaryVolumeCredential generateTemporaryVolumeCredential) {
     String volumeId = generateTemporaryVolumeCredential.getVolumeId();
     if (volumeId.isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Volume ID is required.");
@@ -64,5 +63,4 @@ public class TemporaryVolumeCredentialsService implements UnityCatalogRestServic
       case UNKNOWN_VOLUME_OPERATION -> Collections.emptySet();
     };
   }
-
 }

--- a/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/VolumeService.java
@@ -6,12 +6,19 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.model.SecurableType.SCHEMA;
 import static io.unitycatalog.server.model.SecurableType.VOLUME;
 
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Patch;
+import com.linecorp.armeria.server.annotation.Post;
 import io.unitycatalog.server.auth.UnityCatalogAuthorizer;
 import io.unitycatalog.server.auth.annotation.AuthorizeExpression;
-import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.auth.annotation.AuthorizeKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKey;
 import io.unitycatalog.server.auth.annotation.AuthorizeResourceKeys;
+import io.unitycatalog.server.auth.annotation.ResponseAuthorizeFilter;
 import io.unitycatalog.server.model.CreateVolumeRequestContent;
 import io.unitycatalog.server.model.ListVolumesResponseContent;
 import io.unitycatalog.server.model.SchemaInfo;
@@ -25,13 +32,6 @@ import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.VolumeRepository;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.Optional;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.Get;
-import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Patch;
-import com.linecorp.armeria.server.annotation.Post;
 import lombok.SneakyThrows;
 
 public class VolumeService extends AuthorizedService implements UnityCatalogRestService {
@@ -65,10 +65,10 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
    *       <ul>
    *         <li>The storage location must not overlap with any existing table, volume, or
    *             registered model
-   *         <li>If the storage location falls within a registered external location, the user
-   *             must have OWNER or CREATE_EXTERNAL_VOLUME permission on that external location
-   *         <li>If the storage location does not fall within any registered external location,
-   *             the volume can be created without additional external location permissions
+   *         <li>If the storage location falls within a registered external location, the user must
+   *             have OWNER or CREATE_EXTERNAL_VOLUME permission on that external location
+   *         <li>If the storage location does not fall within any registered external location, the
+   *             volume can be created without additional external location permissions
    *       </ul>
    *   <li>MANAGED volume creation delegates to catalog and schema for permission. Once the catalog
    *       or schema is allowed to create under an external location with permission
@@ -80,7 +80,8 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
    * @return HTTP response containing the created VolumeInfo
    */
   @Post("")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
       (#authorize(#principal, #schema, OWNER) ||
         #authorizeAll(#principal, #schema, USE_SCHEMA, CREATE_VOLUME)) &&
@@ -91,12 +92,12 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
       """)
   public HttpResponse createVolume(
       @AuthorizeResourceKeys({
-        @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
-        @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
-        @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_location")
-      })
-      @AuthorizeKey(key = "volume_type")
-      CreateVolumeRequestContent createVolumeRequest) {
+            @AuthorizeResourceKey(value = SCHEMA, key = "schema_name"),
+            @AuthorizeResourceKey(value = CATALOG, key = "catalog_name"),
+            @AuthorizeResourceKey(value = EXTERNAL_LOCATION, key = "storage_location")
+          })
+          @AuthorizeKey(key = "volume_type")
+          CreateVolumeRequestContent createVolumeRequest) {
     // Throw error if catalog/schema does not exist
     VolumeInfo volumeInfo = volumeRepository.createVolume(createVolumeRequest);
 
@@ -107,7 +108,8 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
     return HttpResponse.ofJson(volumeInfo);
   }
 
-  private static final String LIST_AND_GET_AUTH_EXPRESSION = """
+  private static final String LIST_AND_GET_AUTH_EXPRESSION =
+      """
       #authorize(#principal, #metastore, OWNER) ||
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
@@ -126,8 +128,8 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
       @Param("max_results") Optional<Integer> maxResults,
       @Param("page_token") Optional<String> pageToken,
       @Param("include_browse") Optional<Boolean> includeBrowse) {
-    ListVolumesResponseContent listVolumesResponse = volumeRepository.listVolumes(
-        catalogName, schemaName, maxResults, pageToken, includeBrowse);
+    ListVolumesResponseContent listVolumesResponse =
+        volumeRepository.listVolumes(catalogName, schemaName, maxResults, pageToken, includeBrowse);
     applyResponseFilter(SecurableType.VOLUME, listVolumesResponse.getVolumes());
     return HttpResponse.ofJson(listVolumesResponse);
   }
@@ -142,7 +144,8 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Patch("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       (#authorize(#principal, #volume, OWNER) &&
           #authorizeAny(#principal, #catalog, OWNER, USE_CATALOG) &&
           #authorizeAny(#principal, #schema, OWNER, USE_SCHEMA))
@@ -155,7 +158,8 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
   }
 
   @Delete("/{full_name}")
-  @AuthorizeExpression("""
+  @AuthorizeExpression(
+      """
       #authorize(#principal, #catalog, OWNER) ||
       (#authorize(#principal, #schema, OWNER) && #authorize(#principal, #catalog, USE_CATALOG)) ||
       (#authorize(#principal, #volume, OWNER) &&
@@ -174,6 +178,4 @@ public class VolumeService extends AuthorizedService implements UnityCatalogRest
 
     return HttpResponse.of(HttpStatus.OK);
   }
-
 }
-

--- a/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/StorageCredentialVendor.java
@@ -48,7 +48,8 @@ public class StorageCredentialVendor {
     }
     ValidationUtils.checkArgument(
         !path.isCloudStorageRoot(),
-        "Storage location must include a non-empty path prefix before credentials can be vended: %s",
+        "Storage location must include a non-empty path prefix before credentials can be vended:"
+            + " %s",
         path);
     if (privileges == null || privileges.isEmpty()) {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "Privileges cannot be null or empty.");

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -7,15 +7,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
-import lombok.SneakyThrows;
-import org.apache.iceberg.exceptions.NotAuthorizedException;
-
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
@@ -25,8 +24,8 @@ public class AwsPolicyGenerator {
   static final String AWS_PARTITION = "aws";
 
   static final List<String> SELECT_ACTIONS = List.of("s3:GetO*");
-  static final List<String> UPDATE_ACTIONS = List.of(
-      "s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
+  static final List<String> UPDATE_ACTIONS =
+      List.of("s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
 
   // Reading an object encrypted with SSE-KMS requires kms:Decrypt, and writing one additionally
   // requires kms:GenerateDataKey*. Without these the vended session credentials can't touch a
@@ -34,12 +33,14 @@ public class AwsPolicyGenerator {
   static final List<String> SELECT_KMS_ACTIONS = List.of("kms:Decrypt");
   static final List<String> UPDATE_KMS_ACTIONS = List.of("kms:Decrypt", "kms:GenerateDataKey*");
 
-  static final String POLICY_STATEMENT = """
+  static final String POLICY_STATEMENT =
+      """
       Version: 2012-10-17
       Statement: []
       """;
 
-  static final String BUCKET_STATEMENT = """
+  static final String BUCKET_STATEMENT =
+      """
       Effect: Allow
       Action:
         - s3:ListBucket
@@ -49,7 +50,8 @@ public class AwsPolicyGenerator {
           "s3:prefix": []
       """;
 
-  static final String OPERATION_STATEMENT = """
+  static final String OPERATION_STATEMENT =
+      """
       Effect: Allow
       Action: []
       Resource: []
@@ -63,7 +65,8 @@ public class AwsPolicyGenerator {
   // ("Packed policy consumes 100% of allotted space"). S3 resource statements already constrain
   // which objects the session can Get/Put. GovCloud/China hit the limit sooner because those
   // ARN prefixes are longer, but commercial paths of the same length overflow too.
-  static final String KMS_STATEMENT = """
+  static final String KMS_STATEMENT =
+      """
       Effect: Allow
       Action: []
       Resource:
@@ -76,13 +79,12 @@ public class AwsPolicyGenerator {
   // This can support generating a policy across multiple buckets and paths, however, the assumed
   // role the policy is applied to for a scoped-session needs to have access across those buckets
   /**
-   * Test helper: commercial {@link #AWS_PARTITION} (no role ARN or region). Production always
-   * calls {@link #generatePolicy(Set, List, String, Region)}.
+   * Test helper: commercial {@link #AWS_PARTITION} (no role ARN or region). Production always calls
+   * {@link #generatePolicy(Set, List, String, Region)}.
    */
   @SneakyThrows
   static String generatePolicy(
-      Set<CredentialContext.Privilege> privileges,
-      List<NormalizedURL> locations) {
+      Set<CredentialContext.Privilege> privileges, List<NormalizedURL> locations) {
     return generatePolicy(privileges, locations, null, null);
   }
 
@@ -91,8 +93,8 @@ public class AwsPolicyGenerator {
    *
    * <p>IAM partition is taken from {@code roleArn} when that ARN is well-formed ({@code
    * arn:aws-us-gov:...} → {@code aws-us-gov}), then from the STS region catalog, then commercial
-   * {@code aws}. The same partition is used for S3 resources and {@code kms:ViaService}
-   * ({@code s3.*.amazonaws.com} vs {@code s3.*.amazonaws.com.cn}).
+   * {@code aws}. The same partition is used for S3 resources and {@code kms:ViaService} ({@code
+   * s3.*.amazonaws.com} vs {@code s3.*.amazonaws.com.cn}).
    */
   @SneakyThrows
   public static String generatePolicy(
@@ -122,39 +124,44 @@ public class AwsPolicyGenerator {
       SELECT_KMS_ACTIONS.forEach(kmsActions::add);
     } else {
       throw new NotAuthorizedException(
-          String.format("Can't generate policy for unknown privileges '%s' for locations: '%s'",
+          String.format(
+              "Can't generate policy for unknown privileges '%s' for locations: '%s'",
               privileges, locations));
     }
 
     // Group each location by s3 bucket it's located in, then for each
     // bucket, add the bucket arn for the listBucket and operations statements,
     // then add each path as a conditional prefix
-    getBucketToPathsMap(locations).forEach((bucketName, paths) -> {
-      JsonNode listStatement = loadYaml(BUCKET_STATEMENT);
-      policyStatement.add(listStatement);
+    getBucketToPathsMap(locations)
+        .forEach(
+            (bucketName, paths) -> {
+              JsonNode listStatement = loadYaml(BUCKET_STATEMENT);
+              policyStatement.add(listStatement);
 
-      ArrayNode bucketResource = (ArrayNode) listStatement.findPath("Resource");
-      ArrayNode operationsResource = (ArrayNode) operationsStatement.findPath("Resource");
-      bucketResource.add(s3Arn(partition, bucketName));
+              ArrayNode bucketResource = (ArrayNode) listStatement.findPath("Resource");
+              ArrayNode operationsResource = (ArrayNode) operationsStatement.findPath("Resource");
+              bucketResource.add(s3Arn(partition, bucketName));
 
-      ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
-      paths.forEach(path -> {
-        // remove any preceding forward slashes
-        String sanitizedPath = escapeIamSpecialCharacters(path.replaceAll("^/+", ""));
+              ArrayNode conditionalPrefixes = (ArrayNode) listStatement.findPath("s3:prefix");
+              paths.forEach(
+                  path -> {
+                    // remove any preceding forward slashes
+                    String sanitizedPath = escapeIamSpecialCharacters(path.replaceAll("^/+", ""));
 
-        if (sanitizedPath.isEmpty()) {
-          conditionalPrefixes.add("*");
-          operationsResource.add(s3Arn(partition, bucketName + "/*"));
-        } else {
-          conditionalPrefixes.add(sanitizedPath);
-          conditionalPrefixes.add(sanitizedPath + "/");
-          conditionalPrefixes.add(sanitizedPath + "/*");
+                    if (sanitizedPath.isEmpty()) {
+                      conditionalPrefixes.add("*");
+                      operationsResource.add(s3Arn(partition, bucketName + "/*"));
+                    } else {
+                      conditionalPrefixes.add(sanitizedPath);
+                      conditionalPrefixes.add(sanitizedPath + "/");
+                      conditionalPrefixes.add(sanitizedPath + "/*");
 
-          operationsResource.add(s3Arn(partition, bucketName + "/" + sanitizedPath + "/*"));
-          operationsResource.add(s3Arn(partition, bucketName + "/" + sanitizedPath));
-        }
-      });
-    });
+                      operationsResource.add(
+                          s3Arn(partition, bucketName + "/" + sanitizedPath + "/*"));
+                      operationsResource.add(s3Arn(partition, bucketName + "/" + sanitizedPath));
+                    }
+                  });
+            });
 
     // Appended after the per-bucket statements so that the position of the S3 statements
     // within the policy doesn't change
@@ -223,27 +230,27 @@ public class AwsPolicyGenerator {
   /**
    * Makes an S3 path safe to include in an IAM policy.
    *
-   * <p>S3 treats {@code *}, {@code ?}, and {@code $} as ordinary characters in object
-   * names. IAM gives them special meanings:
+   * <p>S3 treats {@code *}, {@code ?}, and {@code $} as ordinary characters in object names. IAM
+   * gives them special meanings:
    *
    * <ul>
-   *   <li>{@code *} matches any number of characters. For example, {@code reports/*}
-   *       matches every object under {@code reports/}.
-   *   <li>{@code ?} matches exactly one character. For example, {@code file?.txt}
-   *       matches {@code file1.txt}.
-   *   <li>{@code ${...}} is a policy variable whose value IAM fills in when it evaluates
-   *       the policy. For example, {@code ${aws:username}} is replaced with the caller's
-   *       IAM username.
+   *   <li>{@code *} matches any number of characters. For example, {@code reports/*} matches every
+   *       object under {@code reports/}.
+   *   <li>{@code ?} matches exactly one character. For example, {@code file?.txt} matches {@code
+   *       file1.txt}.
+   *   <li>{@code ${...}} is a policy variable whose value IAM fills in when it evaluates the
+   *       policy. For example, {@code ${aws:username}} is replaced with the caller's IAM username.
    * </ul>
    *
-   * <p>Therefore, copying an S3 path directly into a policy could grant access to more
-   * objects than the path names. AWS provides {@code ${*}}, {@code ${?}}, and {@code ${$}}
-   * to make IAM match the literal {@code *}, {@code ?}, and {@code $} characters instead.
+   * <p>Therefore, copying an S3 path directly into a policy could grant access to more objects than
+   * the path names. AWS provides {@code ${*}}, {@code ${?}}, and {@code ${$}} to make IAM match the
+   * literal {@code *}, {@code ?}, and {@code $} characters instead.
    *
-   * <p>We replace {@code $} first because the replacements for {@code *} and {@code ?}
-   * also contain a dollar sign.
+   * <p>We replace {@code $} first because the replacements for {@code *} and {@code ?} also contain
+   * a dollar sign.
    *
-   * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html">
+   * @see <a
+   *     href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html">
    *     AWS documentation for IAM policy variables</a>
    */
   private static String escapeIamSpecialCharacters(String keyPrefix) {
@@ -253,13 +260,14 @@ public class AwsPolicyGenerator {
   private static Map<String, List<String>> getBucketToPathsMap(List<NormalizedURL> locations) {
     return locations.stream()
         .map(NormalizedURL::toUri)
-        .collect(Collectors.toMap(
-            URI::getHost,
-            uri -> new LinkedList<>(List.of(uri.getPath())),
-            (map, newPaths) -> {
-              map.addAll(newPaths);
-              return map;
-            }));
+        .collect(
+            Collectors.toMap(
+                URI::getHost,
+                uri -> new LinkedList<>(List.of(uri.getPath())),
+                (map, newPaths) -> {
+                  map.addAll(newPaths);
+                  return map;
+                }));
   }
 
   @SneakyThrows

--- a/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/gcp/GcpCredentialVendor.java
@@ -148,7 +148,8 @@ public class GcpCredentialVendor {
               // for listing objects
               String objectListPrefixStartsWithExpr =
                   format(
-                      "api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith(%s)",
+                      "api.getAttribute('storage.googleapis.com/objectListPrefix',"
+                          + " '').startsWith(%s)",
                       celStringLiteral(path));
 
               String combinedExpr =

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -9,6 +9,7 @@ import static io.unitycatalog.server.model.SecurableType.TABLE;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
 import com.linecorp.armeria.server.annotation.Param;
@@ -31,7 +32,6 @@ import io.unitycatalog.server.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.server.delta.model.DeltaTableType;
 import io.unitycatalog.server.delta.model.DeltaUpdateTableRequest;
 import io.unitycatalog.server.exception.BaseException;
-import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import io.unitycatalog.server.exception.DeltaApiExceptionHandler;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.model.CreateStagingTable;
@@ -84,7 +84,6 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
   private final TableRepository tableRepository;
   private final StagingTableRepository stagingTableRepository;
   private final StorageCredentialVendor storageCredentialVendor;
-
 
   @Override
   public ExceptionHandlerFunction exceptionHandler() {
@@ -224,8 +223,8 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
    * TableService.createTable}. EXTERNAL wires it via the {@code
    * initializeHierarchicalAuthorization} call below. MANAGED reuses the staging-table UUID's auth
    * row (already wired by {@code createStagingTable} under the staging-creator); {@code
-   * commitStagingTable} additionally enforces {@code callerId == staging.createdBy}, so a
-   * different principal cannot finalize someone else's staging — the staging-creator and the
+   * commitStagingTable} additionally enforces {@code callerId == staging.createdBy}, so a different
+   * principal cannot finalize someone else's staging — the staging-creator and the
    * createTable-caller are always the same identity. The cross-principal rejection is pinned by
    * {@code SdkStagingTableAccessControlTest#testManagedTableCreationByDifferentUserShouldFail}.
    */
@@ -240,8 +239,8 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
           DeltaCreateTableRequest request) {
     DeltaCreateTableMapper.Result mapped =
         DeltaCreateTableMapper.toCreateTable(catalog, schema, request, serverProperties);
-    DeltaLoadTableResponse response = tableRepository.createTableForDelta(
-        mapped.createTable(), mapped.uniformIcebergFields());
+    DeltaLoadTableResponse response =
+        tableRepository.createTableForDelta(mapped.createTable(), mapped.uniformIcebergFields());
     // Wire the new table into the auth hierarchy under its schema (mirrors
     // TableService.createTable). MANAGED tables reuse the staging-table UUID, whose auth row
     // was already created in createStagingTable, so re-init is unnecessary there.
@@ -261,9 +260,9 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
    * partition-columns, set-table-comment, set-domain-metadata / remove-domain-metadata -- and the
    * CCv2 commit flow via add-commit (+ optional uniform for UniForm tables) and
    * set-latest-backfilled-version. External-table-only post-commit-hook updates go through
-   * update-metadata-snapshot-version. Authorization mirrors the UC REST commit endpoint
-   * ({@link io.unitycatalog.server.service.DeltaCommitsService#postCommit}) so a caller's
-   * privileges don't vary by URL.
+   * update-metadata-snapshot-version. Authorization mirrors the UC REST commit endpoint ({@link
+   * io.unitycatalog.server.service.DeltaCommitsService#postCommit}) so a caller's privileges don't
+   * vary by URL.
    */
   @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
   @ProducesJson
@@ -281,7 +280,6 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
   /**
    * Rename a table by three-part name, within the same catalog and schema. Cross-catalog and
    * cross-schema moves are not supported per {@code delta.yaml}.
-   *
    */
   @Post("/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename")
   @AuthorizeExpression(AuthorizeExpressions.RENAME_TABLE)

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaCreateTableMapper.java
@@ -15,14 +15,13 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Converts a {@link DeltaCreateTableRequest} (with typed Delta columns and kebab-case field
- * names) into the UC {@link CreateTable} (with UC {@link ColumnInfo}s and
- * partition-index-per-column). The server holds path params for catalog and schema; the rest
- * comes from the request body.
+ * Converts a {@link DeltaCreateTableRequest} (with typed Delta columns and kebab-case field names)
+ * into the UC {@link CreateTable} (with UC {@link ColumnInfo}s and partition-index-per-column). The
+ * server holds path params for catalog and schema; the rest comes from the request body.
  *
- * <p>Required-field checks (name, location, columns, protocol, table-type) apply to all tables.
- * The full UC catalog-managed contract ({@link UcManagedDeltaContract}) applies only to MANAGED
- * tables; EXTERNAL tables skip contract validation but still go through the same {@link
+ * <p>Required-field checks (name, location, columns, protocol, table-type) apply to all tables. The
+ * full UC catalog-managed contract ({@link UcManagedDeltaContract}) applies only to MANAGED tables;
+ * EXTERNAL tables skip contract validation but still go through the same {@link
  * DeltaPropertyMapper} projection, so derived {@code delta.feature.*} and {@code clusteringColumns}
  * entries override any client-supplied values under those keys.
  */
@@ -32,11 +31,10 @@ public final class DeltaCreateTableMapper {
 
   /**
    * Result of mapping a {@link DeltaCreateTableRequest}: the assembled UC {@link CreateTable}
-   * together
-   * with the validated, normalized UniForm Iceberg fields ({@code Optional.empty()} when no
-   * UniForm metadata was supplied). Callers thread the uniform fields straight to {@code
-   * TableRepository.createTableForDelta} so the metadata-location is normalized exactly once at
-   * the request boundary.
+   * together with the validated, normalized UniForm Iceberg fields ({@code Optional.empty()} when
+   * no UniForm metadata was supplied). Callers thread the uniform fields straight to {@code
+   * TableRepository.createTableForDelta} so the metadata-location is normalized exactly once at the
+   * request boundary.
    */
   public record Result(
       CreateTable createTable,
@@ -63,8 +61,7 @@ public final class DeltaCreateTableMapper {
       throw new BaseException(ErrorCode.INVALID_ARGUMENT, "protocol is required.");
     }
     if (req.getLastCommitTimestampMs() == null) {
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT, "last-commit-timestamp-ms is required.");
+      throw new BaseException(ErrorCode.INVALID_ARGUMENT, "last-commit-timestamp-ms is required.");
     }
 
     // MANAGED-only: full UC catalog-managed contract (protocol versions + features + reader-subset

--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaUpdateTableMapper.java
@@ -4,8 +4,8 @@ import io.unitycatalog.server.delta.model.DeltaAddCommitUpdate;
 import io.unitycatalog.server.delta.model.DeltaAssertEtag;
 import io.unitycatalog.server.delta.model.DeltaAssertTableUUID;
 import io.unitycatalog.server.delta.model.DeltaCommit;
-import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.DeltaDomainMetadataUpdates;
+import io.unitycatalog.server.delta.model.DeltaProtocol;
 import io.unitycatalog.server.delta.model.DeltaRemoveDomainMetadataUpdate;
 import io.unitycatalog.server.delta.model.DeltaRemovePropertiesUpdate;
 import io.unitycatalog.server.delta.model.DeltaSetDomainMetadataUpdate;
@@ -49,8 +49,7 @@ import java.util.stream.Collectors;
 import org.hibernate.Session;
 
 /**
- * Translates a {@link DeltaUpdateTableRequest} into in-memory mutations on a {@link
- * TableInfoDAO}
+ * Translates a {@link DeltaUpdateTableRequest} into in-memory mutations on a {@link TableInfoDAO}
  * and {@link MutablePropertyMap}. Three phases, each separately callable:
  *
  * <ol>
@@ -69,8 +68,7 @@ public final class DeltaUpdateTableMapper {
 
   // ---------------------------------------------------------------------- collection
 
-  public record CollectedRequest(
-      CollectedRequirements requirements, CollectedUpdates updates) {}
+  public record CollectedRequest(CollectedRequirements requirements, CollectedUpdates updates) {}
 
   /**
    * Classify and shape-check the request. {@code assert-table-uuid} is mandatory: without it a
@@ -183,9 +181,9 @@ public final class DeltaUpdateTableMapper {
 
     /**
      * True if this request carries at least one MANAGED-applicable metadata-changing action
-     * (properties, protocol, schema, partition columns, comment, domain metadata). Used to gate
-     * the auto-stamping of {@code delta.lastUpdateVersion} / {@code delta.lastCommitTimestamp} on
-     * a MANAGED {@code add-commit}. {@code update-metadata-snapshot-version} is intentionally
+     * (properties, protocol, schema, partition columns, comment, domain metadata). Used to gate the
+     * auto-stamping of {@code delta.lastUpdateVersion} / {@code delta.lastCommitTimestamp} on a
+     * MANAGED {@code add-commit}. {@code update-metadata-snapshot-version} is intentionally
      * omitted: it is EXTERNAL-only and so can never co-occur with {@code add-commit}.
      *
      * <p>A {@code set-domain-metadata} that touches only the {@code delta.rowTracking} domain does
@@ -220,10 +218,10 @@ public final class DeltaUpdateTableMapper {
     }
 
     /**
-     * True if this request changes catalog-visible table metadata: any MANAGED-applicable
-     * metadata action ({@link #hasManagedTableMetadataChange()}) or the EXTERNAL-only {@code
-     * update-metadata-snapshot-version}. Data-only {@code add-commit} and backfill-only
-     * requests carry no metadata change and return false.
+     * True if this request changes catalog-visible table metadata: any MANAGED-applicable metadata
+     * action ({@link #hasManagedTableMetadataChange()}) or the EXTERNAL-only {@code
+     * update-metadata-snapshot-version}. Data-only {@code add-commit} and backfill-only requests
+     * carry no metadata change and return false.
      */
     public boolean changesTableMetadata() {
       return hasManagedTableMetadataChange() || updateSnapshotVersion.isPresent();
@@ -310,8 +308,7 @@ public final class DeltaUpdateTableMapper {
    * would compare against post-mutation state.
    */
   public static void checkEtagRequirement(String preApplyEtag, CollectedRequest collected) {
-    Optional<String> assertEtag =
-        collected.requirements().assertEtag.map(DeltaAssertEtag::getEtag);
+    Optional<String> assertEtag = collected.requirements().assertEtag.map(DeltaAssertEtag::getEtag);
     if (assertEtag.isPresent() && !Objects.equals(preApplyEtag, assertEtag.get())) {
       throw new BaseException(
           ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
@@ -324,12 +321,11 @@ public final class DeltaUpdateTableMapper {
    *
    * <p>Known weakness: ms-precision {@code updated_at}. If a state-changing update lands in the
    * same wall-clock millisecond as the client's prior read, the etag doesn't advance and a
-   * follow-up {@code assert-etag} passes against state the client never observed. The Delta
-   * update path holds {@code PESSIMISTIC_WRITE} on the row, so two concurrent {@code
-   * updateTableForDelta} calls cannot both pass {@code assert-etag} against the same stale
-   * snapshot. {@code assert-etag} is an optional client-side optimization anyway; the
-   * authoritative serialization for CCv2 commits is the version conflict check in the commit
-   * endpoint.
+   * follow-up {@code assert-etag} passes against state the client never observed. The Delta update
+   * path holds {@code PESSIMISTIC_WRITE} on the row, so two concurrent {@code updateTableForDelta}
+   * calls cannot both pass {@code assert-etag} against the same stale snapshot. {@code assert-etag}
+   * is an optional client-side optimization anyway; the authoritative serialization for CCv2
+   * commits is the version conflict check in the commit endpoint.
    */
   public static String computeEtag(TableInfoDAO dao) {
     return dao.getUpdatedAt() != null
@@ -431,8 +427,8 @@ public final class DeltaUpdateTableMapper {
    * with {@code partition-columns references unknown column: ...}.
    *
    * <p>Swap semantics rely on the orphanRemoval mapping on {@link TableInfoDAO#getColumns()} to
-   * clean up the old rows; the intervening flush ensures the deletes hit the DB before the
-   * inserts, so the {@code (table_id, ordinal_position, name)} unique constraint doesn't trip.
+   * clean up the old rows; the intervening flush ensures the deletes hit the DB before the inserts,
+   * so the {@code (table_id, ordinal_position, name)} unique constraint doesn't trip.
    */
   private static void applySchemaAndPartitionColumns(
       Session session,
@@ -450,8 +446,7 @@ public final class DeltaUpdateTableMapper {
           ValidationUtils.checkNotNull(
               setSchema.get().getColumns(), "set-columns requires a columns block.");
       List<DeltaStructField> fields =
-          ValidationUtils.checkNotNull(
-              columns.getFields(), "set-columns requires columns.fields.");
+          ValidationUtils.checkNotNull(columns.getFields(), "set-columns requires columns.fields.");
       if (fields.isEmpty()) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT, "set-columns requires at least one column.");
@@ -537,10 +532,12 @@ public final class DeltaUpdateTableMapper {
           "update-metadata-snapshot-version is only supported for EXTERNAL Delta tables; "
               + "for MANAGED tables, use the Delta commit endpoint.");
     }
-    ValidationUtils.checkNotNull(update.getLastCommitVersion(),
-      "update-metadata-snapshot-version requires last-commit-version.");
-    ValidationUtils.checkNotNull(update.getLastCommitTimestampMs(),
-      "update-metadata-snapshot-version requires last-commit-timestamp-ms.");
+    ValidationUtils.checkNotNull(
+        update.getLastCommitVersion(),
+        "update-metadata-snapshot-version requires last-commit-version.");
+    ValidationUtils.checkNotNull(
+        update.getLastCommitTimestampMs(),
+        "update-metadata-snapshot-version requires last-commit-timestamp-ms.");
     properties.put(
         TableProperties.LAST_UPDATE_VERSION, String.valueOf(update.getLastCommitVersion()));
     properties.put(
@@ -551,8 +548,8 @@ public final class DeltaUpdateTableMapper {
 
   /**
    * Mapper-side preparation for the {@code add-commit} and {@code set-latest-backfilled-version}
-   * actions: cross-action validation plus snapshot-property bookkeeping. Returns the
-   * {@link CommitDispatch} the caller forwards to {@code
+   * actions: cross-action validation plus snapshot-property bookkeeping. Returns the {@link
+   * CommitDispatch} the caller forwards to {@code
    * DeltaCommitRepository.applyCommitAndBackfillInSession} so the mapper stays free of the
    * commit-repo dependency.
    *
@@ -561,11 +558,11 @@ public final class DeltaUpdateTableMapper {
    *       format is guaranteed by the caller's prior {@code requireDeltaTable});
    *   <li>extract and shape-validate uniform fields when {@code add-commit} carries them;
    *   <li>pin uniform.iceberg.converted-delta-version equal to commit.version (the commit-time
-   *       check that the create-time uniform validator can't run because there is no commit
-   *       version at create);
+   *       check that the create-time uniform validator can't run because there is no commit version
+   *       at create);
    *   <li>run the UniForm presence-consistency check against the post-update property map;
-   *   <li>stamp {@code delta.lastUpdateVersion} / {@code delta.lastCommitTimestamp} when the
-   *       commit is metadata-changing;
+   *   <li>stamp {@code delta.lastUpdateVersion} / {@code delta.lastCommitTimestamp} when the commit
+   *       is metadata-changing;
    *   <li>read {@code latest-published-version} off the backfill action and reject if it's null.
    * </ul>
    */
@@ -613,8 +610,8 @@ public final class DeltaUpdateTableMapper {
   }
 
   /**
-   * Convert a {@link DeltaCommit} into the UC {@link DeltaCommitInfo} shape so the Delta
-   * update path can flow through the shared commit-log helpers, which speak the UC wire shape.
+   * Convert a {@link DeltaCommit} into the UC {@link DeltaCommitInfo} shape so the Delta update
+   * path can flow through the shared commit-log helpers, which speak the UC wire shape.
    */
   private static DeltaCommitInfo toUcCommitInfo(DeltaCommit commit) {
     return new DeltaCommitInfo()

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/IcebergSchemaConverter.java
@@ -20,8 +20,8 @@ import org.apache.iceberg.types.Types;
  * Iceberg REST catalog are browsable through the UC API and UI. The Iceberg metadata file remains
  * the source of truth for Iceberg clients; this conversion only feeds UC's own column listing.
  *
- * <p>{@code type_json} is rendered in the Spark StructField JSON shape that UC stores for all
- * other formats (see {@code ColumnUtils.validateTypeJson}).
+ * <p>{@code type_json} is rendered in the Spark StructField JSON shape that UC stores for all other
+ * formats (see {@code ColumnUtils.validateTypeJson}).
  */
 public final class IcebergSchemaConverter {
 

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -132,7 +132,8 @@ public class MetadataService {
       NormalizedURL metadataLocation, NormalizedURL persistedTableLocation) {
     ValidationUtils.checkArgument(
         metadataLocation.toString().startsWith(persistedTableLocation.toString() + "/"),
-        "Iceberg metadata location ('%s') must be a subpath of the persisted table location ('%s').",
+        "Iceberg metadata location ('%s') must be a subpath of the persisted table location"
+            + " ('%s').",
         metadataLocation,
         persistedTableLocation);
   }

--- a/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ColumnUtils.java
@@ -155,10 +155,10 @@ public class ColumnUtils {
 
   /**
    * Validate that a UC column stores {@code typeJson} as Spark {@code StructField} JSON. Shape
-   * (deserializability) and name/nullable cross-match run for all formats. The
-   * Delta-protocol primitive-type closed-set check runs only for {@link DataSourceFormat#DELTA} --
-   * non-Delta tables (Parquet, CSV, ...) may legitimately carry Spark types that the closed set
-   * rejects (e.g. {@code char(N)} / {@code varchar(N)}).
+   * (deserializability) and name/nullable cross-match run for all formats. The Delta-protocol
+   * primitive-type closed-set check runs only for {@link DataSourceFormat#DELTA} -- non-Delta
+   * tables (Parquet, CSV, ...) may legitimately carry Spark types that the closed set rejects (e.g.
+   * {@code char(N)} / {@code varchar(N)}).
    */
   public static void validateTypeJson(ColumnInfo column, DataSourceFormat format) {
     if (column == null) {
@@ -210,9 +210,7 @@ public class ColumnUtils {
         cause);
   }
 
-  /**
-   * Serialize a DeltaStructField to Spark's camelCase typeJson format for UC database storage.
-   */
+  /** Serialize a DeltaStructField to Spark's camelCase typeJson format for UC database storage. */
   public static String toTypeJson(DeltaStructField field) {
     try {
       return TYPE_MAPPER.writeValueAsString(field);
@@ -228,8 +226,8 @@ public class ColumnUtils {
    * pre-checking nullness/emptiness.
    *
    * <p>Field-name uniqueness is enforced case-insensitively (per Delta's schema rule "All column
-   * names must be unique regardless of casing"). Names are stored case-preserving on
-   * {@link DeltaStructField#getName()}; only the duplicate check ignores case.
+   * names must be unique regardless of casing"). Names are stored case-preserving on {@link
+   * DeltaStructField#getName()}; only the duplicate check ignores case.
    */
   public static void validateStructType(DeltaStructType structType, String path) {
     requireNonNull(structType, path);
@@ -247,8 +245,8 @@ public class ColumnUtils {
       String name = fields.get(i).getName();
       if (!seenLower.add(name.toLowerCase(Locale.ROOT))) {
         throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "Duplicate field name (case-insensitive) in " + fieldPath + ": " + name);
+            ErrorCode.INVALID_ARGUMENT,
+            "Duplicate field name (case-insensitive) in " + fieldPath + ": " + name);
       }
     }
   }
@@ -332,30 +330,31 @@ public class ColumnUtils {
   }
 
   /**
-   * Convert a UC Delta API {@link DeltaStructField} into a UC {@link ColumnInfo}, mirroring
-   * {@code UCSingleCatalog.createTable}'s per-column projection so Delta-created tables render
-   * identically to Spark-created ones.
+   * Convert a UC Delta API {@link DeltaStructField} into a UC {@link ColumnInfo}, mirroring {@code
+   * UCSingleCatalog.createTable}'s per-column projection so Delta-created tables render identically
+   * to Spark-created ones.
    *
-   * <p>Caller contract: {@code field} must have already been validated by
-   * {@link #validateStructType}. This method does not re-check shape -- malformed input will
-   * surface as a downstream {@link IllegalStateException} from {@link #toTypeJson} or a
-   * {@link BaseException} from {@link #resolveColumnTypeName}, without the path-context that
-   * {@code validateStructType} provides.
+   * <p>Caller contract: {@code field} must have already been validated by {@link
+   * #validateStructType}. This method does not re-check shape -- malformed input will surface as a
+   * downstream {@link IllegalStateException} from {@link #toTypeJson} or a {@link BaseException}
+   * from {@link #resolveColumnTypeName}, without the path-context that {@code validateStructType}
+   * provides.
    *
    * <p>Fields populated (matching UCSingleCatalog exactly):
+   *
    * <ul>
    *   <li>{@code name}, {@code nullable}, {@code position}
-   *   <li>{@code comment} -- only when present in {@code metadata.comment} (UCSingleCatalog
-   *       skips the setter when {@code field.getComment().isEmpty}); when absent the field is
-   *       left at its default {@code null}, which produces the same wire shape
+   *   <li>{@code comment} -- only when present in {@code metadata.comment} (UCSingleCatalog skips
+   *       the setter when {@code field.getComment().isEmpty}); when absent the field is left at its
+   *       default {@code null}, which produces the same wire shape
    *   <li>{@code typeJson} -- {@code field.dataType.json}, the Spark-format column spec
    *   <li>{@code typeName} -- {@code convertDataTypeToTypeName(field.dataType)}
    *   <li>{@code typeText} -- {@code field.dataType.catalogString}
    * </ul>
    *
-   * <p>Fields intentionally not populated (matching UCSingleCatalog):
-   * {@code typePrecision}, {@code typeScale}, {@code typeIntervalType}, {@code partitionIndex}
-   * ({@code partitionIndex} is stamped separately by {@link #applyPartitionColumns}).
+   * <p>Fields intentionally not populated (matching UCSingleCatalog): {@code typePrecision}, {@code
+   * typeScale}, {@code typeIntervalType}, {@code partitionIndex} ({@code partitionIndex} is stamped
+   * separately by {@link #applyPartitionColumns}).
    */
   public static ColumnInfo toColumnInfo(DeltaStructField field, int position) {
     DeltaDataType type = field.getType();
@@ -375,9 +374,9 @@ public class ColumnUtils {
   }
 
   /**
-   * Project a list of {@link DeltaStructField}s into UC {@link ColumnInfo}s, stamping each
-   * column's {@code position} from its index in the list. Used by both the create and update paths
-   * of the UC Delta API so the wire-order-to-position mapping stays in one place.
+   * Project a list of {@link DeltaStructField}s into UC {@link ColumnInfo}s, stamping each column's
+   * {@code position} from its index in the list. Used by both the create and update paths of the UC
+   * Delta API so the wire-order-to-position mapping stays in one place.
    */
   public static List<ColumnInfo> toColumnInfos(List<DeltaStructField> fields) {
     List<ColumnInfo> columns = new ArrayList<>(fields.size());
@@ -405,7 +404,10 @@ public class ColumnUtils {
       return "array<" + toCatalogString(a.getElementType()) + ">";
     }
     if (type instanceof DeltaMapType m) {
-      return "map<" + toCatalogString(m.getKeyType()) + "," + toCatalogString(m.getValueType())
+      return "map<"
+          + toCatalogString(m.getKeyType())
+          + ","
+          + toCatalogString(m.getValueType())
           + ">";
     }
     if (type instanceof DeltaStructType s) {
@@ -474,14 +476,14 @@ public class ColumnUtils {
   }
 
   /**
-   * Stamp each {@link ColumnInfo} whose name appears in {@code partitionColumns} with its
-   * partition index (the position within {@code partitionColumns}). Throws {@code INVALID_ARGUMENT}
-   * at the first partition-column name that does not match any column in {@code columns}.
+   * Stamp each {@link ColumnInfo} whose name appears in {@code partitionColumns} with its partition
+   * index (the position within {@code partitionColumns}). Throws {@code INVALID_ARGUMENT} at the
+   * first partition-column name that does not match any column in {@code columns}.
    *
-   * <p>The input {@code columns} list is mutated in place. Designed to be shared between the
-   * UC Delta API create and update/commit paths -- both take a kebab-case {@code
-   * partition-columns} list of names from the wire and project it onto UC's
-   * partition-index-per-column representation (only create is wired up today).
+   * <p>The input {@code columns} list is mutated in place. Designed to be shared between the UC
+   * Delta API create and update/commit paths -- both take a kebab-case {@code partition-columns}
+   * list of names from the wire and project it onto UC's partition-index-per-column representation
+   * (only create is wired up today).
    *
    * <p>Runs in {@code O(|columns| + |partitionColumns|)}: builds a name → ColumnInfo lookup once,
    * then walks {@code partitionColumns} stamping indices and rejecting unknown names inline.
@@ -509,8 +511,7 @@ public class ColumnUtils {
       ColumnInfo match = columnsByLowerName.get(lowerPartName);
       if (match == null) {
         throw new BaseException(
-            ErrorCode.INVALID_ARGUMENT,
-            "partition-columns references unknown column: " + partName);
+            ErrorCode.INVALID_ARGUMENT, "partition-columns references unknown column: " + partName);
       }
       match.setPartitionIndex(i);
     }

--- a/server/src/main/java/io/unitycatalog/server/utils/JwksOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/JwksOperations.java
@@ -51,22 +51,27 @@ public class JwksOperations {
     String keyType = jwk.getType();
 
     return switch (keyType) {
-      case "RSA" -> switch (alg) {
-        case "RS256" -> Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
-        case "RS384" -> Algorithm.RSA384((RSAPublicKey) jwk.getPublicKey(), null);
-        case "RS512" -> Algorithm.RSA512((RSAPublicKey) jwk.getPublicKey(), null);
-        default -> throw new OAuthInvalidClientException(ErrorCode.ABORTED,
-                String.format("Unsupported RSA algorithm: %s", alg));
-      };
-      case "EC" -> switch (alg) {
-        case "ES256" -> Algorithm.ECDSA256((ECPublicKey) jwk.getPublicKey(), null);
-        case "ES384" -> Algorithm.ECDSA384((ECPublicKey) jwk.getPublicKey(), null);
-        case "ES512" -> Algorithm.ECDSA512((ECPublicKey) jwk.getPublicKey(), null);
-        default -> throw new OAuthInvalidClientException(ErrorCode.ABORTED,
-                String.format("Unsupported ECDSA algorithm: %s", alg));
-      };
-      default -> throw new OAuthInvalidClientException(ErrorCode.ABORTED,
-              String.format("Unsupported key type: %s", keyType));
+      case "RSA" ->
+          switch (alg) {
+            case "RS256" -> Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
+            case "RS384" -> Algorithm.RSA384((RSAPublicKey) jwk.getPublicKey(), null);
+            case "RS512" -> Algorithm.RSA512((RSAPublicKey) jwk.getPublicKey(), null);
+            default ->
+                throw new OAuthInvalidClientException(
+                    ErrorCode.ABORTED, String.format("Unsupported RSA algorithm: %s", alg));
+          };
+      case "EC" ->
+          switch (alg) {
+            case "ES256" -> Algorithm.ECDSA256((ECPublicKey) jwk.getPublicKey(), null);
+            case "ES384" -> Algorithm.ECDSA384((ECPublicKey) jwk.getPublicKey(), null);
+            case "ES512" -> Algorithm.ECDSA512((ECPublicKey) jwk.getPublicKey(), null);
+            default ->
+                throw new OAuthInvalidClientException(
+                    ErrorCode.ABORTED, String.format("Unsupported ECDSA algorithm: %s", alg));
+          };
+      default ->
+          throw new OAuthInvalidClientException(
+              ErrorCode.ABORTED, String.format("Unsupported key type: %s", keyType));
     };
   }
 
@@ -95,26 +100,22 @@ public class JwksOperations {
       var path = wellKnownConfigUrl + ".well-known/openid-configuration";
       LOGGER.debug("path: {}", path);
 
-      String response = webClient
-          .get(path)
-          .aggregate()
-          .join()
-          .contentUtf8();
+      String response = webClient.get(path).aggregate().join().contentUtf8();
 
       // TODO: We should cache this. No need to fetch it each time.
       Map<String, Object> configMap = mapper.readValue(response, new TypeReference<>() {});
 
       if (configMap == null || configMap.isEmpty()) {
-        throw new OAuthInvalidRequestException(ErrorCode.ABORTED,
-            "Could not get issuer configuration");
+        throw new OAuthInvalidRequestException(
+            ErrorCode.ABORTED, "Could not get issuer configuration");
       }
 
       String configIssuer = (String) configMap.get("issuer");
       String configJwksUri = (String) configMap.get("jwks_uri");
 
       if (!configIssuer.equals(issuer)) {
-        throw new OAuthInvalidRequestException(ErrorCode.ABORTED,
-            "Issuer doesn't match configuration");
+        throw new OAuthInvalidRequestException(
+            ErrorCode.ABORTED, "Issuer doesn't match configuration");
       }
 
       if (configJwksUri == null) {
@@ -126,4 +127,3 @@ public class JwksOperations {
     }
   }
 }
-

--- a/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
@@ -2,8 +2,8 @@ package io.unitycatalog.server.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,6 +35,10 @@ import io.unitycatalog.server.service.credential.gcp.TestingCredentialGenerator;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import io.unitycatalog.server.utils.UriScheme;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,11 +50,6 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
-
-import java.time.Instant;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Stream;
 
 public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
   @Mock AwsCredentialVendor awsCredentialVendor;
@@ -79,11 +78,12 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
     schemaOperations = createSchemaOperations(serverConfig);
 
     // Setup AWS external location + credential
-    awsCredentialInfo = credentialsApi.createCredential(
-        new CreateCredentialRequest()
-            .name(AWS_CREDENTIAL_NAME)
-            .purpose(CredentialPurpose.STORAGE)
-            .awsIamRole(new AwsIamRoleRequest().roleArn(TEST_AWS_STORAGE_CREDENTIAL_ROLE_ARN)));
+    awsCredentialInfo =
+        credentialsApi.createCredential(
+            new CreateCredentialRequest()
+                .name(AWS_CREDENTIAL_NAME)
+                .purpose(CredentialPurpose.STORAGE)
+                .awsIamRole(new AwsIamRoleRequest().roleArn(TEST_AWS_STORAGE_CREDENTIAL_ROLE_ARN)));
     externalLocationsApi.createExternalLocation(
         new CreateExternalLocation()
             .name(AWS_EXTERNAL_LOCATION_NAME)
@@ -102,8 +102,7 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
 
     // AWS S3 master role config
     serverProperties.put(
-        ServerProperties.Property.AWS_MASTER_ROLE_ARN.getKey(),
-        TestUtils.TEST_AWS_MASTER_ROLE_ARN);
+        ServerProperties.Property.AWS_MASTER_ROLE_ARN.getKey(), TestUtils.TEST_AWS_MASTER_ROLE_ARN);
     serverProperties.put(
         ServerProperties.Property.AWS_ACCESS_KEY.getKey(),
         TestUtils.TEST_AWS_MASTER_ROLE_ACCESS_KEY);
@@ -128,11 +127,8 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
     setupAzureCredentials();
     setupGcpCredentials();
 
-    cloudCredentialVendor = new CloudCredentialVendor(
-            awsCredentialVendor,
-            azureCredentialVendor,
-            gcpCredentialVendor
-    );
+    cloudCredentialVendor =
+        new CloudCredentialVendor(awsCredentialVendor, azureCredentialVendor, gcpCredentialVendor);
   }
 
   @SneakyThrows
@@ -164,38 +160,41 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
 
   private void setupAzureCredentials() {
     azureCredentialVendor = mock(AzureCredentialVendor.class);
-    AzureCredential azureCredential = AzureCredential.builder()
+    AzureCredential azureCredential =
+        AzureCredential.builder()
             .sasToken("test-sas-token")
             .expirationTimeInEpochMillis(System.currentTimeMillis() + 6000)
             .build();
     serverProperties.entrySet().stream()
-            .filter(e -> e.getKey().toString().startsWith("adls.storageAccountName"))
-            .map(e -> e.getValue().toString())
-            .forEach(path -> doReturn(azureCredential)
+        .filter(e -> e.getKey().toString().startsWith("adls.storageAccountName"))
+        .map(e -> e.getValue().toString())
+        .forEach(
+            path ->
+                doReturn(azureCredential)
                     .when(azureCredentialVendor)
                     .vendAzureCredential(
-                            argThat(isCredentialContextForCloudPath(UriScheme.ABFS, path))));
+                        argThat(isCredentialContextForCloudPath(UriScheme.ABFS, path))));
   }
 
   private void setupGcpCredentials() {
     gcpCredentialVendor = mock(GcpCredentialVendor.class);
-    AccessToken gcpCredential = new AccessToken(
-            "test-token",
-            Date.from(Instant.now().plusSeconds(10 * 60))
-    );
+    AccessToken gcpCredential =
+        new AccessToken("test-token", Date.from(Instant.now().plusSeconds(10 * 60)));
     serverProperties.entrySet().stream()
-            .filter(e -> e.getKey().toString().startsWith("gcs.bucketPath"))
-            .map(e -> e.getValue().toString())
-            .forEach(path -> doReturn(gcpCredential)
+        .filter(e -> e.getKey().toString().startsWith("gcs.bucketPath"))
+        .map(e -> e.getValue().toString())
+        .forEach(
+            path ->
+                doReturn(gcpCredential)
                     .when(gcpCredentialVendor)
                     .vendGcpCredential(
-                            argThat(isCredentialContextForCloudPath(UriScheme.GS, path))));
+                        argThat(isCredentialContextForCloudPath(UriScheme.GS, path))));
   }
 
   private ArgumentMatcher<CredentialContext> isCredentialContextForCloudPath(
       UriScheme scheme, String path) {
-    return arg -> arg.getStorageScheme().equals(scheme)
-        && arg.getStorageBase().toString().contains(path);
+    return arg ->
+        arg.getStorageScheme().equals(scheme) && arg.getStorageBase().toString().contains(path);
   }
 
   /**
@@ -254,17 +253,18 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
 
     // Cartesian product of clouds and isConfiguredPathFlags
     return clouds.stream()
-            .flatMap(cloud -> isConfiguredPathFlags.stream()
+        .flatMap(
+            cloud ->
+                isConfiguredPathFlags.stream()
                     .map(isConfiguredPath -> Arguments.of(cloud, isConfiguredPath)));
   }
 
   /**
    * A mock STS client for testing that examines input parameters and echos back some of them back
    * in the response. It can be useful to verify that the right ARN and external is being used, and
-   * test can further examine the content of session policy by checking its response.
-   * This directly replaces and mocks the real AWS so that in all the tests based on this file
-   * the entire AWS credential vending logic is exercised to the point of calling
-   * `stsClient.assumeRole()`.
+   * test can further examine the content of session policy by checking its response. This directly
+   * replaces and mocks the real AWS so that in all the tests based on this file the entire AWS
+   * credential vending logic is exercised to the point of calling `stsClient.assumeRole()`.
    */
   protected class EchoAwsStsClient implements StsClient {
     public static final String RETURN_ACCESS_KEY = "assumedRoleAccessKey";
@@ -277,8 +277,7 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
       AwsIamRoleResponse awsIamRole = awsCredentialInfo.getAwsIamRole();
       assertThat(request.roleArn()).isEqualTo(awsIamRole.getRoleArn());
       assertThat(request.externalId()).isEqualTo(awsIamRole.getExternalId());
-      String echoSessionToken =
-          generateSessionToken(request.roleSessionName(), request.policy());
+      String echoSessionToken = generateSessionToken(request.roleSessionName(), request.policy());
       return AssumeRoleResponse.builder()
           .credentials(
               Credentials.builder()

--- a/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
+++ b/server/src/test/java/io/unitycatalog/server/base/delta/DeltaBaseTableCRUDTestEnv.java
@@ -33,9 +33,7 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * Test scaffolding for integration tests that exercise the Delta APIs against a UC catalog.
- */
+/** Test scaffolding for integration tests that exercise the Delta APIs against a UC catalog. */
 public abstract class DeltaBaseTableCRUDTestEnv extends BaseTableCRUDTestEnv {
 
   /**
@@ -73,8 +71,9 @@ public abstract class DeltaBaseTableCRUDTestEnv extends BaseTableCRUDTestEnv {
   /** Stage a MANAGED Delta table via Delta REST. */
   protected DeltaStagingTableResponse createDeltaStaging(String name) throws ApiException {
     return deltaTablesApi.createStagingTable(
-        TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME,
-            new DeltaCreateStagingTableRequest().name(name));
+        TestUtils.CATALOG_NAME,
+        TestUtils.SCHEMA_NAME,
+        new DeltaCreateStagingTableRequest().name(name));
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/base/managedlocation/BaseManagedLocationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/managedlocation/BaseManagedLocationTest.java
@@ -237,7 +237,8 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> volumeOperations.createVolume(createManagedVolume),
           ErrorCode.FAILED_PRECONDITION,
-          "None of catalog, schema or storage-root.tables server property has managed location configured.");
+          "None of catalog, schema or storage-root.tables server property has managed location"
+              + " configured.");
     }
 
     // Managed volume must not specify a location
@@ -306,7 +307,8 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> tableOperations.createTable(createManagedTable),
           ErrorCode.FAILED_PRECONDITION,
-          "None of catalog, schema or storage-root.tables server property has managed location configured.");
+          "None of catalog, schema or storage-root.tables server property has managed location"
+              + " configured.");
     }
 
     // Testing failure cases of external table creation
@@ -384,7 +386,8 @@ public abstract class BaseManagedLocationTest extends BaseCRUDTest {
       TestUtils.assertApiException(
           () -> modelOperations.createRegisteredModel(createModel),
           ErrorCode.FAILED_PRECONDITION,
-          "None of catalog, schema or storage-root.tables server property has managed location configured.");
+          "None of catalog, schema or storage-root.tables server property has managed location"
+              + " configured.");
     }
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/base/table/TableOperations.java
+++ b/server/src/test/java/io/unitycatalog/server/base/table/TableOperations.java
@@ -14,6 +14,7 @@ public interface TableOperations {
       throws ApiException;
 
   TableInfo getTable(String tableFullName) throws ApiException;
+
   // TableInfo updateTable(UpdateTableRequestContent updateTableRequest) throws IOException;
   void deleteTable(String tableFullName) throws ApiException;
 }

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
@@ -190,7 +190,7 @@ public class TransactionManagerTest {
                         return null;
                       },
                       errorMessage,
-                      /* readOnly = */ true))
+                      /* readOnly= */ true))
           .isInstanceOf(BaseException.class)
           .hasMessageContaining(errorMessage)
           .hasMessageContaining(hibernateException.getMessage());

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/SdkExternalLocationAccessControlTest.java
@@ -450,10 +450,12 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
       // Grant test case specific permissions
       for (Privileges privilege : testCase.grantPermissions) {
         switch (privilege) {
-          case CREATE_TABLE, CREATE_VOLUME -> grantPermissions(
-              testCase.email, SecurableType.SCHEMA, TestUtils.SCHEMA_FULL_NAME, privilege);
-          case CREATE_EXTERNAL_TABLE, CREATE_EXTERNAL_VOLUME -> grantPermissions(
-              testCase.email, SecurableType.EXTERNAL_LOCATION, externalLocationName, privilege);
+          case CREATE_TABLE, CREATE_VOLUME ->
+              grantPermissions(
+                  testCase.email, SecurableType.SCHEMA, TestUtils.SCHEMA_FULL_NAME, privilege);
+          case CREATE_EXTERNAL_TABLE, CREATE_EXTERNAL_VOLUME ->
+              grantPermissions(
+                  testCase.email, SecurableType.EXTERNAL_LOCATION, externalLocationName, privilege);
           default -> throw new RuntimeException("Unknown privilege: " + privilege);
         }
       }
@@ -513,8 +515,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
   }
 
   /** Minimum valid DeltaCreateTableRequest for an EXTERNAL Delta table. */
-  private static DeltaCreateTableRequest
-      deltaExternalTableRequest(String name, String location) {
+  private static DeltaCreateTableRequest deltaExternalTableRequest(String name, String location) {
     return new DeltaCreateTableRequest()
         .name(name)
         .location(location)
@@ -532,9 +533,7 @@ public class SdkExternalLocationAccessControlTest extends SdkAccessControlBaseCR
                     List.of(
                         new DeltaStructField()
                             .name("id")
-                            .type(
-                                new DeltaPrimitiveType()
-                                    .type("long"))
+                            .type(new DeltaPrimitiveType().type("long"))
                             .nullable(true)
                             .metadata(new DeltaStructFieldMetadata()))))
         .properties(java.util.Map.of("delta.enableDeletionVectors", "true"))

--- a/server/src/test/java/io/unitycatalog/server/sdk/access/TemporaryPathCredentialAccessControlTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/access/TemporaryPathCredentialAccessControlTest.java
@@ -66,6 +66,7 @@ public class TemporaryPathCredentialAccessControlTest extends SdkAccessControlBa
   private static final String READWRITE_EMAIL = "readwrite@example.com";
   private static final String CREATE_TABLE_EMAIL = "createtable@example.com";
   private static final String UNAUTHORIZED_EMAIL = "unauthorized@example.com";
+
   /** User dedicated to creating external tables and volumes for testing. */
   private static final String TABLE_VOLUME_OWNER_EMAIL = "table_volume_owner@example.com";
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/RawCreateTableTest.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The auto-generated {@code unitycatalog-client} can't construct certain malformed payloads --
  * its DTOs reject them at compile time -- but a non-SDK client (Rust, Kernel) is not bound by the
- * SDK's typed shape. This test posts hand-crafted JSON straight at the endpoint to pin server-
- * side validation that the SDK tests cannot reach. Sister to {@link SdkCreateTableTest}, which
- * covers everything reachable through the typed client.
+ * SDK's typed shape. This test posts hand-crafted JSON straight at the endpoint to pin server- side
+ * validation that the SDK tests cannot reach. Sister to {@link SdkCreateTableTest}, which covers
+ * everything reachable through the typed client.
  */
 public class RawCreateTableTest extends BaseCRUDTest {
 
@@ -86,7 +86,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"type": "long", "nullable": false, "metadata": {}}""",
+        {"type": "long", "nullable": false, "metadata": {}}\
+        """,
         "columns.fields[0].name is required.");
 
     // -------- DeltaStructField missing 'type', second column in a multi-column request -------
@@ -97,7 +98,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
         staging,
         """
         {"name": "id", "type": "long", "nullable": false, "metadata": {}},
-        {"name": "amount", "nullable": true, "metadata": {}}""",
+        {"name": "amount", "nullable": true, "metadata": {}}\
+        """,
         "columns.fields[1].type is required.");
 
     // -------- a field element that is the bare string instead of a DeltaStructField object --
@@ -125,7 +127,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"name": "x", "type": "void", "nullable": false, "metadata": {}}""",
+        {"name": "x", "type": "void", "nullable": false, "metadata": {}}\
+        """,
         "columns.fields[0].type: Unsupported Delta primitive type: void");
 
     // -------- DeltaStructField with a blank name --------
@@ -134,7 +137,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"name": "   ", "type": "long", "nullable": false, "metadata": {}}""",
+        {"name": "   ", "type": "long", "nullable": false, "metadata": {}}\
+        """,
         "columns.fields[0].name is required.");
 
     // -------- DeltaStructField missing 'nullable' --------
@@ -142,7 +146,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"name": "id", "type": "long", "metadata": {}}""",
+        {"name": "id", "type": "long", "metadata": {}}\
+        """,
         "columns.fields[0].nullable is required.");
 
     // -------- DeltaStructField missing 'metadata' --------
@@ -152,7 +157,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"name": "id", "type": "long", "nullable": false}""",
+        {"name": "id", "type": "long", "nullable": false}\
+        """,
         "columns.fields[0].metadata is required.");
 
     // -------- DeltaArrayType missing 'contains-null' --------
@@ -167,7 +173,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "array", "element-type": "string"},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.contains-null is required.");
 
     // -------- DeltaMapType missing 'value-contains-null' --------
@@ -179,7 +186,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "map", "key-type": "string", "value-type": "string"},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.value-contains-null is required.");
 
     // -------- DeltaMapType missing 'key-type' --------
@@ -191,7 +199,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "map", "value-type": "string", "value-contains-null": false},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.key-type is required.");
 
     // -------- DeltaMapType missing 'value-type' --------
@@ -203,7 +212,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "map", "key-type": "string", "value-contains-null": false},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.value-type is required.");
 
     // -------- DeltaDecimalType: precision > 38 (string wire form) --------
@@ -212,7 +222,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
     assertRejected(
         staging,
         """
-        {"name": "price", "type": "decimal(50,2)", "nullable": true, "metadata": {}}""",
+        {"name": "price", "type": "decimal(50,2)", "nullable": true, "metadata": {}}\
+        """,
         "columns.fields[0].type.precision must be in [0, 38], got 50.");
 
     // -------- DeltaDecimalType: precision < 0 (object wire form) --------
@@ -227,14 +238,16 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "decimal", "precision": -1, "scale": 0},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.precision must be in [0, 38], got -1.");
 
     // -------- DeltaDecimalType: scale > precision (string wire form) --------
     assertRejected(
         staging,
         """
-        {"name": "price", "type": "decimal(5,10)", "nullable": true, "metadata": {}}""",
+        {"name": "price", "type": "decimal(5,10)", "nullable": true, "metadata": {}}\
+        """,
         "columns.fields[0].type.scale must be in [0, precision=5], got 10.");
 
     // -------- DeltaDecimalType: missing precision (object wire form) --------
@@ -247,7 +260,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           "type": {"type": "decimal", "scale": 0},
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.precision is required.");
 
     // -------- nested DeltaStructField inside an array of structs --------
@@ -268,7 +282,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
           },
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "columns.fields[0].type.element-type.fields[0].name is required.");
 
     // -------- columns.fields is an empty list --------
@@ -289,7 +304,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
         staging,
         """
         {"name": "id", "type": "long", "nullable": false, "metadata": {}},
-        {"name": "ID", "type": "string", "nullable": true, "metadata": {}}""",
+        {"name": "ID", "type": "string", "nullable": true, "metadata": {}}\
+        """,
         "Duplicate field name (case-insensitive) in columns.fields[1]: ID");
 
     // -------- duplicate field name inside a nested struct --------
@@ -313,9 +329,10 @@ public class RawCreateTableTest extends BaseCRUDTest {
           },
           "nullable": true,
           "metadata": {}
-        }""",
+        }\
+        """,
         "Duplicate field name (case-insensitive) in columns.fields[0].type.element-type"
-          + ".fields[1]: x");
+            + ".fields[1]: x");
   }
 
   // ---------- helpers ----------
@@ -325,8 +342,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
    * columnJson} (or no fields at all when {@code columnJson} is empty), and assert the server
    * rejects it with HTTP 400 and the exact {@code expectedMessage} in {@code error.message}. The
    * surrounding request body is a full UC-managed shape (location/table-type/protocol/properties)
-   * bound to the given staging response, so cases that pass the column
-   * gates land on a request the rest of the server would normally accept.
+   * bound to the given staging response, so cases that pass the column gates land on a request the
+   * rest of the server would normally accept.
    */
   @SneakyThrows
   private void assertRejected(
@@ -336,8 +353,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
   }
 
   /**
-   * Like {@link #assertRejected} but matches a substring of {@code error.message} -- used when
-   * the response message comes from Jackson + Armeria framework wrapping (e.g. a deserialization
+   * Like {@link #assertRejected} but matches a substring of {@code error.message} -- used when the
+   * response message comes from Jackson + Armeria framework wrapping (e.g. a deserialization
    * mismatch) and contains source-location / reference-chain noise we don't want to pin.
    */
   @SneakyThrows
@@ -395,8 +412,7 @@ public class RawCreateTableTest extends BaseCRUDTest {
             .path(CREATE_TABLE_PATH)
             .contentType(MediaType.JSON)
             .build();
-    AggregatedHttpResponse resp =
-        client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
+    AggregatedHttpResponse resp = client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
 
     String content = resp.contentUtf8();
     assertThat(resp.status().code()).as("body: %s", content).isEqualTo(400);
@@ -408,8 +424,8 @@ public class RawCreateTableTest extends BaseCRUDTest {
   /**
    * Posts a createTable request whose {@code columns.fields} contains {@code columnJson} and
    * asserts the envelope (HTTP 400, {@code error.code} 400, {@code error.type}
-   * "InvalidParameterValueException"). Returns {@code error} so the caller can additionally
-   * assert on {@code message}.
+   * "InvalidParameterValueException"). Returns {@code error} so the caller can additionally assert
+   * on {@code message}.
    */
   @SneakyThrows
   private JsonNode postAndAssertRejected(DeltaStagingTableResponse staging, String columnJson) {
@@ -454,8 +470,7 @@ public class RawCreateTableTest extends BaseCRUDTest {
             .path(CREATE_TABLE_PATH)
             .contentType(MediaType.JSON)
             .build();
-    AggregatedHttpResponse resp =
-        client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
+    AggregatedHttpResponse resp = client.execute(headers, HttpData.ofUtf8(body)).aggregate().join();
 
     String content = resp.contentUtf8();
     assertThat(resp.status().code()).as("body: %s", content).isEqualTo(400);

--- a/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/deltacommits/SdkDeltaCommitsCRUDTest.java
@@ -17,9 +17,9 @@ import io.unitycatalog.client.model.DeltaCommitMetadataProperties;
 import io.unitycatalog.client.model.DeltaGetCommits;
 import io.unitycatalog.client.model.DeltaGetCommitsResponse;
 import io.unitycatalog.client.model.DeltaMetadata;
+import io.unitycatalog.client.model.DeltaUniform;
 import io.unitycatalog.client.model.DeltaUniformIceberg;
 import io.unitycatalog.client.model.TableInfo;
-import io.unitycatalog.client.model.DeltaUniform;
 import io.unitycatalog.client.model.TableType;
 import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
@@ -86,8 +86,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   private DeltaMetadata deltaMetadataWithTableId(String tableId) {
-    Map<String, String> propertiesWithTableId =
-        Map.of(TableProperties.UC_TABLE_ID, tableId);
+    Map<String, String> propertiesWithTableId = Map.of(TableProperties.UC_TABLE_ID, tableId);
     return new DeltaMetadata()
         .properties(new DeltaCommitMetadataProperties().properties(propertiesWithTableId));
   }
@@ -136,14 +135,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
             .endVersion(endVersion.orElse(null)));
   }
 
-  /** Get all the commits of a table and verify that the response has the latest version as
-   * {@code expectedLatestTableVersion} and it contains all the {@code expectedCommits} in the
-   * exact order.
+  /**
+   * Get all the commits of a table and verify that the response has the latest version as {@code
+   * expectedLatestTableVersion} and it contains all the {@code expectedCommits} in the exact order.
    *
    * @param expectedLatestTableVersion the expected latestTableVersion in {@code response}
    * @param expectedCommits Can be either a list of {@code DeltaCommit}, or a list of Integer/Long
-   *                        representing the version numbers, or empty if it's not expected to
-   *                        return any commits.
+   *     representing the version numbers, or empty if it's not expected to return any commits.
    */
   private void verifyDeltaCommits(long expectedLatestTableVersion, Object... expectedCommits)
       throws ApiException {
@@ -152,14 +150,14 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaGetCommitsResponse(response, expectedLatestTableVersion, expectedCommits);
   }
 
-  /** Verify that the {@code response} has the latest version as {@code expectedLatestTableVersion}
+  /**
+   * Verify that the {@code response} has the latest version as {@code expectedLatestTableVersion}
    * and it contains all the {@code expectedCommits} in the exact order.
    *
    * @param response returned from {@code DeltaGetCommits} rpc
    * @param expectedLatestTableVersion the expected latestTableVersion in {@code response}
    * @param expectedCommits Can be either a list of {@code DeltaCommit}, or a list of Integer/Long
-   *                        representing the version numbers, or empty if it's not expected to
-   *                        return any commits.
+   *     representing the version numbers, or empty if it's not expected to return any commits.
    */
   private void verifyDeltaGetCommitsResponse(
       DeltaGetCommitsResponse response,
@@ -182,31 +180,29 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   /**
-   * Helper function to verify TableInfoDAO fields by opening a session, fetching the DAO,
-   * and executing custom assertions on it.
+   * Helper function to verify TableInfoDAO fields by opening a session, fetching the DAO, and
+   * executing custom assertions on it.
    *
    * @param assertions Consumer function that performs assertions on the TableInfoDAO
    */
   private void verifyTableInfoDAO(Consumer<TableInfoDAO> assertions) {
     try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
       TableInfoDAO tableInfoDAO =
-          session.get(
-              TableInfoDAO.class,
-              UUID.fromString(tableInfo.getTableId()));
+          session.get(TableInfoDAO.class, UUID.fromString(tableInfo.getTableId()));
       assertNotNull(tableInfoDAO);
       assertions.accept(tableInfoDAO);
     }
   }
 
   /**
-   * Helper function to verify the uniform iceberg fields on a TableInfoDAO.
-   * Handles timestamp truncation to milliseconds since DB only stores millisecond precision.
+   * Helper function to verify the uniform iceberg fields on a TableInfoDAO. Handles timestamp
+   * truncation to milliseconds since DB only stores millisecond precision.
    *
    * @param dao The TableInfoDAO to verify
    * @param expectedIcebergMetadataLocation Expected value for uniformIcebergMetadataLocation
    * @param expectedConvertedDeltaVersion Expected value for uniformIcebergConvertedDeltaVersion
    * @param expectedConvertedDeltaTimestamp Expected value for uniformIcebergConvertedDeltaTimestamp
-   *                          (ISO-8601 format)
+   *     (ISO-8601 format)
    */
   private void verifyUniformFields(
       TableInfoDAO dao,
@@ -224,22 +220,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   }
 
   private DeltaCommitMetadataProperties constructProperties(
-          String tableId,
-          Boolean isUniFormEnabled
-  ) {
+      String tableId, Boolean isUniFormEnabled) {
     return constructProperties(tableId, isUniFormEnabled, new HashMap<>());
   }
 
   private DeltaCommitMetadataProperties constructProperties(
-          String tableId,
-          Boolean isUniFormEnabled,
-          Map<String, String> additionalProperties
-  ) {
-    Map<String, String> properties = new HashMap<>(
-        Map.of(
-            TableProperties.UC_TABLE_ID, tableId
-        )
-    );
+      String tableId, Boolean isUniFormEnabled, Map<String, String> additionalProperties) {
+    Map<String, String> properties = new HashMap<>(Map.of(TableProperties.UC_TABLE_ID, tableId));
     properties.putAll(additionalProperties);
     if (isUniFormEnabled) {
       properties.put(
@@ -252,8 +239,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   @Test
   public void testBasicCoordinatedCommitsCRUD() throws ApiException, IOException {
     // Get commits on a table with no commits
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 0);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 0);
 
     DeltaCommit commit1 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation());
@@ -263,8 +249,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // no-op success, not a conflict, so a client that lost the response is not misled into
     // rebasing and duplicating the commit. The table state is unchanged.
     deltaCommitsApi.commit(commit1);
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 1, /* expectedCommits= */ commit1);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 1, /* expectedCommits= */ commit1);
 
     // Committing the same version with a DIFFERENT filename means another writer won it: conflict.
     DeltaCommit commit1_other_filename =
@@ -313,7 +298,9 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaGetCommitsResponse(
         response,
         /* expectedLatestTableVersion= */ 3,
-        /* expectedCommits= */ commit3, commit2, commit1);
+        /* expectedCommits= */ commit3,
+        commit2,
+        commit1);
 
     response =
         getAllCommits(tableInfo.getTableId(), tableInfo.getStorageLocation(), 2L, Optional.empty());
@@ -340,15 +327,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         /* expectedLatestTableVersion= */ 4, /* expectedCommits= */ commit4, commit3, commit2);
 
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(4L));
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 4);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 4);
 
     // The latest backfilled version (v4) is retained as a marker row that keeps its file name (it
     // is flagged, not purged), so an identical replay of that commit is still recognized as an
     // idempotent no-op success rather than a conflict.
     deltaCommitsApi.commit(commit4);
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 4);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 4);
 
     // Replay of a backfilled-and-purged version (v1/v2/v3 are purged; only the v4 marker remains)
     // can no longer be matched by file name, so it is settled by comparing the incoming staged file
@@ -380,8 +365,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaCommit commit5 =
         createCommitObject(tableInfo.getTableId(), 5L, tableInfo.getStorageLocation());
     deltaCommitsApi.commit(commit5);
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 5, /* expectedCommits= */ commit5);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 5, /* expectedCommits= */ commit5);
 
     // Verify commits are cleaned up upon table deletion
     tableOperations.deleteTable(TestUtils.TABLE_FULL_NAME);
@@ -499,8 +483,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     Map<String, String> properties1 = Map.of("customProperty", "customValue");
     DeltaMetadata metadata1 =
         new DeltaMetadata().properties(new DeltaCommitMetadataProperties().properties(properties1));
-    checkCommitInvalidParameter(
-        1L, c -> c.setMetadata(metadata1), TableProperties.UC_TABLE_ID);
+    checkCommitInvalidParameter(1L, c -> c.setMetadata(metadata1), TableProperties.UC_TABLE_ID);
     // Commit with metadata but with wrong io.unitycatalog.tableId
     checkCommitInvalidParameter(
         1L,
@@ -575,8 +558,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     }
 
     // Verify all 5 commits exist
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5, 4, 3, 2, 1);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5, 4, 3, 2, 1);
 
     // Backfill with metadata should fail
     DeltaCommit backfillCommit2WithMetadata =
@@ -591,8 +573,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(2L));
 
     // Verify versions 3, 4, 5 are present
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5, 4, 3);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5, 4, 3);
 
     // Try to backfill beyond the latest version
     assertApiException(
@@ -616,21 +597,18 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
 
     // Backfill up to version 4 (should keep only version 5)
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(4L));
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 5, /* expectedCommits= */ 5);
 
     // Backfill up to version 5 (the latest)
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(5L));
     // The commit should be marked as backfilled, so no commits should be returned
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 5);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 5);
 
     // Commit v6. Now we have [v5(backfilled), v6] in DB. Get commits only returns v6.
     DeltaCommit commit6 =
         createCommitObject(tableInfo.getTableId(), 6L, tableInfo.getStorageLocation());
     deltaCommitsApi.commit(commit6);
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 6, /* expectedCommits= */ 6);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 6, /* expectedCommits= */ 6);
   }
 
   @Test
@@ -659,8 +637,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(6L));
 
     // Verify we now have 4 commits (7~10)
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 10, /* expectedCommits= */ 10, 9, 8, 7);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 10, /* expectedCommits= */ 10, 9, 8, 7);
 
     // Now we should be able to add more commits
     for (long i = 11; i <= 14; i++) {
@@ -677,8 +654,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     deltaCommitsApi.commit(createBackfillOnlyCommitObject(14L));
 
     // Verify there's no unbackfilled commits
-    verifyDeltaCommits(
-        /* expectedLatestTableVersion= */ 14);
+    verifyDeltaCommits(/* expectedLatestTableVersion= */ 14);
 
     // Now we should be able to add another 10 commits
     for (long i = 15; i <= 24; i++) {
@@ -718,8 +694,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     response =
         getAllCommits(
             tableInfo.getTableId(), tableInfo.getStorageLocation(), 11L, Optional.empty());
-    verifyDeltaGetCommitsResponse(
-        response, /* expectedLatestTableVersion= */ 10);
+    verifyDeltaGetCommitsResponse(response, /* expectedLatestTableVersion= */ 10);
 
     // Get commits with start_version = end_version
     response =
@@ -749,8 +724,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     TableInfo updatedTable1 = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
     assertNotNull(updatedTable1.getProperties());
     assertEquals(
-        tableInfo.getTableId(),
-        updatedTable1.getProperties().get(TableProperties.UC_TABLE_ID));
+        tableInfo.getTableId(), updatedTable1.getProperties().get(TableProperties.UC_TABLE_ID));
     assertEquals("customValue", updatedTable1.getProperties().get("customProperty"));
     assertEquals("enabled", updatedTable1.getProperties().get("delta.feature.test"));
 
@@ -846,14 +820,14 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
   public void testCommitWithUniform() throws ApiException {
     // Enable uniform by setting the property
     DeltaMetadata metadata =
-        new DeltaMetadata().properties(
-            constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */));
+        new DeltaMetadata()
+            .properties(constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */));
     String timestamp1 = Instant.now().toString();
     DeltaUniform uniform = new DeltaUniform();
     DeltaUniformIceberg icebergMetadata =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
-            .convertedDeltaVersion(1L)  // Must match commit version
+            .convertedDeltaVersion(1L) // Must match commit version
             .convertedDeltaTimestamp(timestamp1);
     uniform.setIceberg(icebergMetadata);
 
@@ -868,15 +842,17 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     verifyDeltaCommits(1, 1);
 
     // Verify the table's uniform metadata was updated
-    verifyTableInfoDAO(dao ->
-        verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1));
+    verifyTableInfoDAO(
+        dao ->
+            verifyUniformFields(
+                dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1));
 
     // Update uniform metadata with a new commit
     String timestamp2 = Instant.now().toString();
     DeltaUniformIceberg icebergMetadata2 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
-            .convertedDeltaVersion(2L)  // Must match commit version
+            .convertedDeltaVersion(2L) // Must match commit version
             .convertedDeltaTimestamp(timestamp2);
     DeltaUniform uniform2 = new DeltaUniform();
     uniform2.setIceberg(icebergMetadata2);
@@ -888,8 +864,10 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     deltaCommitsApi.commit(commit2);
 
     // Verify the table's uniform metadata was updated to the latest
-    verifyTableInfoDAO(dao ->
-        verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2));
+    verifyTableInfoDAO(
+        dao ->
+            verifyUniformFields(
+                dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2));
   }
 
   @Test
@@ -899,7 +877,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaUniformIceberg icebergMetadata =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
-            .convertedDeltaVersion(1L)  // Must match commit version
+            .convertedDeltaVersion(1L) // Must match commit version
             .convertedDeltaTimestamp(timestamp1);
     uniform.setIceberg(icebergMetadata);
 
@@ -908,11 +886,9 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     metadata.setDescription("Test table with both metadata and uniform");
     metadata.setProperties(
         constructProperties(
-          tableInfo.getTableId(),
-          true /* isUniFormEnabled */,
-          Map.of("custom.property", "custom.value")  /* additionalProperties */
-        )
-    );
+            tableInfo.getTableId(),
+            true /* isUniFormEnabled */,
+            Map.of("custom.property", "custom.value") /* additionalProperties */));
 
     // Create a commit with BOTH metadata and uniform
     DeltaCommit commit1 =
@@ -931,29 +907,28 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertEquals("custom.value", updatedTable.getProperties().get("custom.property"));
 
     // Also verify metadata and uniform metadata was stored in the database
-    verifyTableInfoDAO(dao -> {
-      // Verify metadata fields
-      assertEquals("Test table with both metadata and uniform", dao.getComment());
-      // Verify uniform fields
-      verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1);
-    });
+    verifyTableInfoDAO(
+        dao -> {
+          // Verify metadata fields
+          assertEquals("Test table with both metadata and uniform", dao.getComment());
+          // Verify uniform fields
+          verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v1.json", 1L, timestamp1);
+        });
 
     // Now update with new metadata and uniform in a second commit
     DeltaMetadata metadata2 = new DeltaMetadata();
     metadata2.setDescription("Updated description");
     metadata2.setProperties(
-            constructProperties(
-                    tableInfo.getTableId(),
-                    true /* isUniFormEnabled */,
-                    Map.of("custom.property", "updated.value")  /* additionalProperties */
-            )
-    );
+        constructProperties(
+            tableInfo.getTableId(),
+            true /* isUniFormEnabled */,
+            Map.of("custom.property", "updated.value") /* additionalProperties */));
 
     String timestamp2 = Instant.now().toString();
     DeltaUniformIceberg icebergMetadata2 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
-            .convertedDeltaVersion(2L)  // Must match commit version
+            .convertedDeltaVersion(2L) // Must match commit version
             .convertedDeltaTimestamp(timestamp2);
     DeltaUniform uniform2 = new DeltaUniform();
     uniform2.setIceberg(icebergMetadata2);
@@ -970,11 +945,12 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertEquals("updated.value", updatedTable2.getProperties().get("custom.property"));
 
     // Also verify metadata and uniform metadata was stored in the databasemet
-    verifyTableInfoDAO(dao -> {
-      // Verify both metadata and uniform were updated to latest values
-      assertEquals("Updated description", dao.getComment());
-      verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2);
-    });
+    verifyTableInfoDAO(
+        dao -> {
+          // Verify both metadata and uniform were updated to latest values
+          assertEquals("Updated description", dao.getComment());
+          verifyUniformFields(dao, tableInfo.getStorageLocation() + "/_u/v2.json", 2L, timestamp2);
+        });
   }
 
   @Test
@@ -986,32 +962,26 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform0);
     assertApiException(
-        () -> deltaCommitsApi.commit(commit0),
-        ErrorCode.INVALID_ARGUMENT,
-        "iceberg");
+        () -> deltaCommitsApi.commit(commit0), ErrorCode.INVALID_ARGUMENT, "iceberg");
 
     // Test 1: Missing metadata-location
     DeltaUniformIceberg invalidIceberg1 =
         new DeltaUniformIceberg()
             .convertedDeltaVersion(100L)
             .convertedDeltaTimestamp(Instant.now().toString());
-    DeltaUniform invalidUniform1 =
-        new DeltaUniform().iceberg(invalidIceberg1);
+    DeltaUniform invalidUniform1 = new DeltaUniform().iceberg(invalidIceberg1);
     DeltaCommit commit1 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform1);
     assertApiException(
-        () -> deltaCommitsApi.commit(commit1),
-        ErrorCode.INVALID_ARGUMENT,
-        "metadata-location");
+        () -> deltaCommitsApi.commit(commit1), ErrorCode.INVALID_ARGUMENT, "metadata-location");
 
     // Test 2: Missing converted_delta_version
     DeltaUniformIceberg invalidIceberg2 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaTimestamp(Instant.now().toString());
-    DeltaUniform invalidUniform2 =
-        new DeltaUniform().iceberg(invalidIceberg2);
+    DeltaUniform invalidUniform2 = new DeltaUniform().iceberg(invalidIceberg2);
     DeltaCommit commit2 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform2);
@@ -1025,8 +995,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
             .convertedDeltaVersion(100L);
-    DeltaUniform invalidUniform3 =
-        new DeltaUniform().iceberg(invalidIceberg3);
+    DeltaUniform invalidUniform3 = new DeltaUniform().iceberg(invalidIceberg3);
     DeltaCommit commit3 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform3);
@@ -1038,15 +1007,15 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Test 4: Size exceeds limit
     // Create a very long metadata location that exceeds the maximum allowed size
     String longLocation =
-        tableInfo.getStorageLocation() + "/_u/"
+        tableInfo.getStorageLocation()
+            + "/_u/"
             + "x".repeat(DeltaUniformUtils.MAX_METADATA_LOCATION_CHARS);
     DeltaUniformIceberg invalidIceberg4 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(longLocation))
-            .convertedDeltaVersion(1L)  // Must match commit version
+            .convertedDeltaVersion(1L) // Must match commit version
             .convertedDeltaTimestamp(Instant.now().toString());
-    DeltaUniform invalidUniform4 =
-        new DeltaUniform().iceberg(invalidIceberg4);
+    DeltaUniform invalidUniform4 = new DeltaUniform().iceberg(invalidIceberg4);
     DeltaCommit commit4 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform4);
@@ -1059,10 +1028,9 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     DeltaUniformIceberg invalidIceberg5 =
         new DeltaUniformIceberg()
             .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v1.json"))
-            .convertedDeltaVersion(999L)  // Wrong version - commit is version 1
+            .convertedDeltaVersion(999L) // Wrong version - commit is version 1
             .convertedDeltaTimestamp(Instant.now().toString());
-    DeltaUniform invalidUniform5 =
-        new DeltaUniform().iceberg(invalidIceberg5);
+    DeltaUniform invalidUniform5 = new DeltaUniform().iceberg(invalidIceberg5);
     DeltaCommit commit5 =
         createCommitObject(tableInfo.getTableId(), 1L, tableInfo.getStorageLocation())
             .uniform(invalidUniform5);
@@ -1079,8 +1047,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // check) is reachable.
     DeltaMetadata uniformEnablingMetadata =
         new DeltaMetadata()
-            .properties(
-                constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */));
+            .properties(constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */));
     DeltaUniformIceberg invalidIceberg6 =
         new DeltaUniformIceberg()
             // Sibling location, not under tableInfo.getStorageLocation().
@@ -1093,9 +1060,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
             .metadata(uniformEnablingMetadata)
             .uniform(invalidUniform6);
     assertApiException(
-        () -> deltaCommitsApi.commit(commit6),
-        ErrorCode.INVALID_ARGUMENT,
-        "must be a subpath");
+        () -> deltaCommitsApi.commit(commit6), ErrorCode.INVALID_ARGUMENT, "must be a subpath");
   }
 
   @Test
@@ -1106,7 +1071,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Uniform metadata existence in commit: yes;
     // - should succeed
     DeltaCommitMetadataProperties uniformEnabledProperties =
-      constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */);
+        constructProperties(tableInfo.getTableId(), true /* isUniFormEnabled */);
     DeltaMetadata uniformEnabledMetadata = new DeltaMetadata().properties(uniformEnabledProperties);
 
     DeltaUniform uniform1 = new DeltaUniform();
@@ -1127,8 +1092,7 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // Property Change: no property change;
     // Uniform metadata existence in commit: no;
     // - should fail
-    DeltaMetadata unchangePropertyMetadata =
-        new DeltaMetadata().description("description");
+    DeltaMetadata unchangePropertyMetadata = new DeltaMetadata().description("description");
     DeltaCommit commit2 =
         createCommitObject(tableInfo.getTableId(), 2L, tableInfo.getStorageLocation())
             .metadata(unchangePropertyMetadata)
@@ -1136,7 +1100,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit2),
         ErrorCode.INVALID_ARGUMENT,
-        "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
+        "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes"
+            + " 'iceberg'.");
     // Test 3:
     // Existing Table: uniform enabled;
     // Property Change: disable uniform;
@@ -1144,14 +1109,13 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     // - should fail
     DeltaUniform uniform2 = new DeltaUniform();
     DeltaMetadata uniformDisabledMetadata =
-            new DeltaMetadata().properties(
-                constructProperties(tableInfo.getTableId(), false /* isUniFormEnabled */));
+        new DeltaMetadata()
+            .properties(constructProperties(tableInfo.getTableId(), false /* isUniFormEnabled */));
     DeltaUniformIceberg icebergMetadata2 =
-            new DeltaUniformIceberg()
-                    .metadataLocation(
-                            URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
-                    .convertedDeltaVersion(2L)
-                    .convertedDeltaTimestamp(Instant.now().toString());
+        new DeltaUniformIceberg()
+            .metadataLocation(URI.create(tableInfo.getStorageLocation() + "/_u/v2.json"))
+            .convertedDeltaVersion(2L)
+            .convertedDeltaTimestamp(Instant.now().toString());
     uniform2.setIceberg(icebergMetadata2);
     DeltaCommit commit3 =
         createCommitObject(tableInfo.getTableId(), 2L, tableInfo.getStorageLocation())
@@ -1160,7 +1124,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit3),
         ErrorCode.INVALID_ARGUMENT,
-        "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
+        "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes"
+            + " 'iceberg'.");
     // Test 4:
     // Existing Table: uniform enabled;
     // Property Change: disable uniform;
@@ -1190,7 +1155,8 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
     assertApiException(
         () -> deltaCommitsApi.commit(commit5),
         ErrorCode.INVALID_ARGUMENT,
-            "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
+        "Uniform metadata must not be set unless 'delta.universalFormat.enabledFormats' includes"
+            + " 'iceberg'.");
     // Test 6:
     // Existing Table: uniform disabled;
     // Property Change: enable uniform;
@@ -1201,8 +1167,9 @@ public class SdkDeltaCommitsCRUDTest extends BaseTableCRUDTestEnv {
             .metadata(uniformEnabledMetadata)
             .uniform(null);
     assertApiException(
-            () -> deltaCommitsApi.commit(commit6),
-            ErrorCode.INVALID_ARGUMENT,
-            "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes 'iceberg'.");
+        () -> deltaCommitsApi.commit(commit6),
+        ErrorCode.INVALID_ARGUMENT,
+        "Uniform metadata must be set when 'delta.universalFormat.enabledFormats' includes"
+            + " 'iceberg'.");
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableOperations.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableOperations.java
@@ -60,8 +60,8 @@ public class SdkTableOperations implements TableOperations {
   public TableInfo getTable(String tableFullName) throws ApiException {
     return tablesApi.getTable(
         tableFullName,
-        /* readStreamingTableAsManaged = */ true,
-        /* readMaterializedViewAsManaged = */ true);
+        /* readStreamingTableAsManaged= */ true,
+        /* readMaterializedViewAsManaged= */ true);
   }
 
   @Override

--- a/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/delta/DeltaModelSerializationTest.java
@@ -296,8 +296,7 @@ public class DeltaModelSerializationTest {
   public void testDeserMalformedDecimalString() throws Exception {
     // Malformed decimal string doesn't match decimal(N,N) regex,
     // so it falls through to DeltaPrimitiveType (same as any unrecognized type string)
-    String json =
-        "{\"name\":\"col\",\"type\":\"decimal(abc)\",\"nullable\":true,\"metadata\":{}}";
+    String json = "{\"name\":\"col\",\"type\":\"decimal(abc)\",\"nullable\":true,\"metadata\":{}}";
     DeltaStructField col = MAPPER.readValue(json, DeltaStructField.class);
     assertThat(col.getType()).isInstanceOf(DeltaPrimitiveType.class);
     assertThat(col.getType().getType()).isEqualTo("decimal(abc)");
@@ -383,8 +382,7 @@ public class DeltaModelSerializationTest {
                 meta(
                     null,
                     Map.of(
-                        "delta.columnMapping.id", 1,
-                        "delta.columnMapping.physicalName", "col-1")));
+                        "delta.columnMapping.id", 1, "delta.columnMapping.physicalName", "col-1")));
     DeltaStructField colPrice =
         new DeltaStructField()
             .name("price")
@@ -418,8 +416,10 @@ public class DeltaModelSerializationTest {
                                             meta(
                                                 "score value",
                                                 Map.of(
-                                                    "delta.columnMapping.id", 10,
-                                                    "delta.columnMapping.physicalName", "col-10"))),
+                                                    "delta.columnMapping.id",
+                                                    10,
+                                                    "delta.columnMapping.physicalName",
+                                                    "col-10"))),
                                     new DeltaStructField()
                                         .name("timestamp")
                                         .type(new DeltaPrimitiveType().type("long"))
@@ -527,8 +527,7 @@ public class DeltaModelSerializationTest {
   @Test
   public void testCreateTableRequestRoundTrip() throws Exception {
     String json = readFixture("/delta-model-test/create-table-request.json");
-    DeltaCreateTableRequest req =
-        MAPPER.readValue(json, DeltaCreateTableRequest.class);
+    DeltaCreateTableRequest req = MAPPER.readValue(json, DeltaCreateTableRequest.class);
 
     // Verify DeltaDataType serde works on nested DeltaStructType fields
     DeltaStructField idField = req.getColumns().getFields().get(0);
@@ -557,8 +556,7 @@ public class DeltaModelSerializationTest {
   @Test
   public void testLoadTableResponseRoundTrip() throws Exception {
     String json = readFixture("/delta-model-test/load-table-response.json");
-    DeltaLoadTableResponse resp =
-        MAPPER.readValue(json, DeltaLoadTableResponse.class);
+    DeltaLoadTableResponse resp = MAPPER.readValue(json, DeltaLoadTableResponse.class);
 
     // Verify DeltaDataType serde works in DeltaTableMetadata.columns
     DeltaStructField priceField = resp.getMetadata().getColumns().getFields().get(1);
@@ -589,8 +587,8 @@ public class DeltaModelSerializationTest {
    * Build a {@link DeltaStructFieldMetadata} with the optional {@code comment} plus a bag of
    * additional properties for the spec's dotted Delta keys (e.g. {@code delta.columnMapping.id}).
    * The schema models {@code DeltaStructFieldMetadata} as a bare additionalProperties wrapper, so
-   * the generated class extends {@code HashMap<String, Object>}; all keys (including
-   * {@code comment}) go through the map view.
+   * the generated class extends {@code HashMap<String, Object>}; all keys (including {@code
+   * comment}) go through the map view.
    */
   private static DeltaStructFieldMetadata meta(String comment, Map<String, Object> additional) {
     DeltaStructFieldMetadata m = new DeltaStructFieldMetadata();

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -391,9 +391,7 @@ public class TestUtils {
       String contentType)
       throws Exception {
     HttpRequest.Builder reqBuilder =
-        HttpRequest.newBuilder()
-            .uri(URI.create(config.getServerUrl() + path))
-            .method(method, body);
+        HttpRequest.newBuilder().uri(URI.create(config.getServerUrl() + path)).method(method, body);
     if (contentType != null) {
       reqBuilder.header("Content-Type", contentType);
     }


### PR DESCRIPTION
## Summary

We maintain a private fork that has to use a separate build (Maven / Spotless) alongside this sbt tree. The current formatter is **google-java-format 1.7** via `sbt-java-formatter` 0.8.0. That release cannot parse text blocks or switch expressions, so `javafmtCheck` silently skips those files, and GJF 1.7 cannot be run at all on JDK 17 by modern format plugins (Spotless requires ≥ 1.10.0). The two builds therefore cannot share a formatter.

This PR bumps to the oldest GJF the current `sbt-java-formatter` will actually run on the JDK 17 CI image: **1.28.0** (`sbt-java-formatter` 0.13.1, `javafmtFormatterCompatibleJavaVersion := 17`). That is a version a Maven/Spotless build can pin as well, so both trees can stay format-identical. 0.13.1 only changes the Java 21 formatter line (GJF 1.36.1); this tree stays on 17 / 1.28.0.

- Plugin + Checkstyle + README in the first commit. Checkstyle `Indentation` / `CommentsIndentation` are dropped, not retuned. They are Spark wrap-2; google-java-format is Google wrap-4. They only coexisted because GJF 1.7 never parsed switch expressions or text blocks. Checkstyle 10/11 still reject that layout, so indent stays owned by GJF.
- Mechanical `javafmtAll` in the second commit (review with `git show -w`).
- Plugin bump 0.12.0 → 0.13.1 in a follow-up commit; no extra reformat.

## Test plan
- [x] `build/sbt javafmtCheck` (same command as `.github/workflows/lint-check.yml`)
- [x] `build/sbt javafmtCheckAll`
- [ ] Confirm the `java-fmt` GitHub Actions job is green