### PR TITLE
[Server] Add more CRUD tests for the Iceberg REST catalog

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -48,6 +48,7 @@ import io.unitycatalog.server.utils.VersionUtils;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
+import java.util.function.UnaryOperator;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +151,8 @@ public class UnityCatalogServer implements AutoCloseable {
         new Repositories(
             hibernateConfigurator.getSessionFactory(),
             unityCatalogServerBuilder.serverProperties,
-            unityCatalogServerBuilder.cloudCredentialVendor);
+            unityCatalogServerBuilder.cloudCredentialVendor,
+            unityCatalogServerBuilder.fileOperationsDecorator);
     // Init metastore
     repositories.getMetastoreRepository().initMetastoreIfNeeded();
     // Init authorizer
@@ -368,6 +370,7 @@ public class UnityCatalogServer implements AutoCloseable {
     private ServerProperties serverProperties;
     private HibernateConfigurator hibernateConfigurator;
     private CloudCredentialVendor cloudCredentialVendor;
+    private UnaryOperator<FileOperations> fileOperationsDecorator = UnaryOperator.identity();
 
     private Builder() {}
 
@@ -396,6 +399,17 @@ public class UnityCatalogServer implements AutoCloseable {
     public UnityCatalogServer.Builder credentialOperations(
         CloudCredentialVendor cloudCredentialVendor) {
       this.cloudCredentialVendor = cloudCredentialVendor;
+      return this;
+    }
+
+    /**
+     * Decorates the {@link FileOperations} the server builds, e.g. to wrap file IO in tests. Treats
+     * {@code null} as {@link UnaryOperator#identity()}.
+     */
+    public UnityCatalogServer.Builder fileOperations(
+        UnaryOperator<FileOperations> fileOperationsDecorator) {
+      this.fileOperationsDecorator =
+          fileOperationsDecorator != null ? fileOperationsDecorator : UnaryOperator.identity();
       return this;
     }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -3,9 +3,11 @@ package io.unitycatalog.server.persist;
 import io.unitycatalog.server.auth.decorator.KeyMapper;
 import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
 import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.persist.utils.FileOperationsImpl;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import io.unitycatalog.server.utils.ServerProperties;
+import java.util.function.UnaryOperator;
 import lombok.Getter;
 import org.hibernate.SessionFactory;
 
@@ -40,16 +42,26 @@ public class Repositories {
     this(sessionFactory, serverProperties, null);
   }
 
+  public Repositories(
+      SessionFactory sessionFactory,
+      ServerProperties serverProperties,
+      CloudCredentialVendor cloudCredentialVendor) {
+    this(sessionFactory, serverProperties, cloudCredentialVendor, UnaryOperator.identity());
+  }
+
   /**
    * @param cloudCredentialVendor an injected cloud credential vendor (e.g. a test mock), or {@code
    *     null} to build the default from {@code serverProperties}. Owning the credential/file-IO
    *     chain here lets repositories read table storage (e.g. Delta commit files) without
    *     late-binding.
+   * @param fileOperationsDecorator wraps the default {@link FileOperations} before use ({@link
+   *     UnaryOperator#identity()} leaves it unchanged); lets tests map cloud IO to local storage.
    */
   public Repositories(
       SessionFactory sessionFactory,
       ServerProperties serverProperties,
-      CloudCredentialVendor cloudCredentialVendor) {
+      CloudCredentialVendor cloudCredentialVendor,
+      UnaryOperator<FileOperations> fileOperationsDecorator) {
     this.sessionFactory = sessionFactory;
     this.externalLocationUtils = new ExternalLocationUtils(sessionFactory);
     CloudCredentialVendor resolvedCloudCredentialVendor =
@@ -58,7 +70,9 @@ public class Repositories {
             : new CloudCredentialVendor(serverProperties);
     this.storageCredentialVendor =
         new StorageCredentialVendor(resolvedCloudCredentialVendor, externalLocationUtils);
-    this.fileOperations = new FileOperations(storageCredentialVendor, serverProperties);
+    this.fileOperations =
+        fileOperationsDecorator.apply(
+            new FileOperationsImpl(storageCredentialVendor, serverProperties));
 
     this.catalogRepository = new CatalogRepository(this, sessionFactory);
     this.schemaRepository = new SchemaRepository(this, sessionFactory);

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperations.java
@@ -2,15 +2,8 @@ package io.unitycatalog.server.persist.utils;
 
 import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
-import io.unitycatalog.server.model.AwsCredentials;
-import io.unitycatalog.server.model.AzureUserDelegationSAS;
-import io.unitycatalog.server.model.GcpOauthToken;
-import io.unitycatalog.server.model.TemporaryCredentials;
 import io.unitycatalog.server.service.credential.CredentialContext;
-import io.unitycatalog.server.service.credential.StorageCredentialVendor;
-import io.unitycatalog.server.service.credential.azure.ADLSLocationUtils;
 import io.unitycatalog.server.utils.NormalizedURL;
-import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.UriScheme;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,35 +11,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
-import org.apache.iceberg.azure.AzureProperties;
-import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
 
 /**
  * Single entry point for all storage/file access in the server. Covers both directory lifecycle
  * management for managed storage locations (create/delete) and credential-vended Iceberg {@link
- * FileIO} construction used by the Iceberg REST catalog.
+ * FileIO} construction used by the Iceberg REST catalog. The default implementation is {@link
+ * FileOperationsImpl}; tests may wrap it to redirect cloud storage to the local filesystem.
  */
-public class FileOperations {
-
-  private final StorageCredentialVendor storageCredentialVendor;
-  private final Map<NormalizedURL, String> s3BucketRegionMap;
-
-  public FileOperations(
-      StorageCredentialVendor storageCredentialVendor, ServerProperties serverProperties) {
-    this.storageCredentialVendor = storageCredentialVendor;
-    this.s3BucketRegionMap =
-        serverProperties.getS3Configurations().entrySet().stream()
-            .filter(entry -> entry.getValue().getRegion() != null)
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRegion()));
-  }
+public interface FileOperations {
 
   /** Delete entire directory recursively. Note that currently it does nothing for cloud FS */
-  public static void deleteDirectory(NormalizedURL url) {
+  static void deleteDirectory(NormalizedURL url) {
     switch (UriScheme.fromURI(url.toUri())) {
       // Directory deletion for local paths is handled by SimpleLocalFileIO.
       case FILE, NULL -> SimpleLocalFileIO.deleteDirectory(url.toString());
@@ -59,7 +36,7 @@ public class FileOperations {
   }
 
   /** Create a directory for storage location. Note that currently it does nothing for cloud FS */
-  public static void createStorageLocationDir(NormalizedURL url) {
+  static void createStorageLocationDir(NormalizedURL url) {
     switch (UriScheme.fromURI(url.toUri())) {
       case FILE, NULL -> createLocalDirectory(url);
       // Currently we can NOT create the directory in cloud storage. We will update this in future
@@ -88,28 +65,12 @@ public class FileOperations {
    * Returns an Iceberg {@link FileIO} for reading the given location. Local paths use {@link
    * SimpleLocalFileIO}; cloud paths use a credential-vended {@link ResolvingFileIO}.
    */
-  // TODO: Cache fileIOs
-  public FileIO getFileIO(NormalizedURL path) {
+  default FileIO getFileIO(NormalizedURL path) {
     return getFileIO(path, CredentialContext.READ_ONLY);
   }
 
   /** Returns a FileIO configured for the requested storage privileges. */
-  public FileIO getFileIO(
-      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
-    return switch (UriScheme.fromURI(path.toUri())) {
-      // Local paths are served by SimpleLocalFileIO (backed by java.nio + iceberg-core). We
-      // deliberately do NOT route these through ResolvingFileIO: it resolves the file:// scheme to
-      // Iceberg's HadoopFileIO, which requires hadoop-client-runtime on the classpath. The server
-      // only depends on hadoop-client-api, and SimpleLocalFileIO covers the local read and
-      // directory operations we need without that heavy runtime dependency.
-      case FILE, NULL -> new SimpleLocalFileIO();
-      case S3, GS, ABFS, ABFSS -> {
-        ResolvingFileIO fileio = new ResolvingFileIO();
-        fileio.initialize(getFileIOConfig(path, privileges));
-        yield fileio;
-      }
-    };
-  }
+  FileIO getFileIO(NormalizedURL path, Set<CredentialContext.Privilege> privileges);
 
   /**
    * Builds the Iceberg FileIO configuration (credentials, region, token expiry) for the given
@@ -118,74 +79,11 @@ public class FileOperations {
    *
    * @param path the normalized storage location to vend credentials and build config for
    */
-  public Map<String, String> getFileIOConfig(NormalizedURL path) {
+  default Map<String, String> getFileIOConfig(NormalizedURL path) {
     return getFileIOConfig(path, CredentialContext.READ_ONLY);
   }
 
   /** Builds FileIO configuration using the requested storage privileges. */
-  public Map<String, String> getFileIOConfig(
-      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
-    UriScheme scheme = UriScheme.fromURI(path.toUri());
-    if (scheme == UriScheme.FILE || scheme == UriScheme.NULL) {
-      // Local (file://) paths need no cloud credentials, so short-circuit before vending: the
-      // scheme is known here and vending would do a needless external-location lookup for local
-      // tables.
-      return Map.of();
-    }
-
-    TemporaryCredentials cred = storageCredentialVendor.vendCredential(path, privileges);
-    if (cred.getAzureUserDelegationSas() != null) {
-      return getADLSConfig(path, cred.getAzureUserDelegationSas());
-    } else if (cred.getGcpOauthToken() != null) {
-      return getGCSConfig(cred.getGcpOauthToken(), cred.getExpirationTime());
-    } else if (cred.getAwsTempCredentials() != null) {
-      return getS3Config(path, cred.getAwsTempCredentials());
-    } else {
-      // Cloud vend returned no recognized credential type. This should not happen for a cloud
-      // scheme, so fail loudly rather than silently returning an empty (credential-less) config
-      // that would later surface as an opaque access-denied error.
-      throw new BaseException(
-          ErrorCode.INTERNAL,
-          "No recognized storage credential was vended for location: " + path);
-    }
-  }
-
-  private Map<String, String> getADLSConfig(
-      NormalizedURL path, AzureUserDelegationSAS azureUserDelegationSAS) {
-    ADLSLocationUtils.ADLSLocationParts locationParts = ADLSLocationUtils.parseLocation(path);
-    // NOTE: when fileio caching is implemented, need to set/deal with expiry here
-    return Map.of(
-        AzureProperties.ADLS_SAS_TOKEN_PREFIX + locationParts.account(),
-        azureUserDelegationSAS.getSasToken());
-  }
-
-  private Map<String, String> getGCSConfig(GcpOauthToken gcpOauthToken, Long expirationTime) {
-    if (expirationTime != null) {
-      return Map.of(
-          GCPProperties.GCS_OAUTH2_TOKEN,
-          gcpOauthToken.getOauthToken(),
-          GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT,
-          Long.toString(expirationTime));
-    } else {
-      return Map.of(GCPProperties.GCS_OAUTH2_TOKEN, gcpOauthToken.getOauthToken());
-    }
-  }
-
-  private Map<String, String> getS3Config(NormalizedURL path, AwsCredentials awsCredentials) {
-    // TODO: if region isn't configured, use HEAD bucket to figure out
-    String s3Region = s3BucketRegionMap.get(path.getStorageBase());
-    if (s3Region == null) {
-      // s3BucketRegionMap has no entry for this bucket (Map.get returns null on a miss). Guard
-      // here with a clear message rather than letting Map.of throw an opaque NullPointerException
-      // below.
-      throw new BaseException(
-          ErrorCode.INVALID_ARGUMENT,
-          "No S3 region configured for bucket: " + path.getStorageBase());
-    }
-    return Map.of(
-        S3FileIOProperties.ACCESS_KEY_ID, awsCredentials.getAccessKeyId(),
-        S3FileIOProperties.SECRET_ACCESS_KEY, awsCredentials.getSecretAccessKey(),
-        S3FileIOProperties.SESSION_TOKEN, awsCredentials.getSessionToken(),
-        AwsClientProperties.CLIENT_REGION, s3Region);
-  }
+  Map<String, String> getFileIOConfig(
+      NormalizedURL path, Set<CredentialContext.Privilege> privileges);
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperationsImpl.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/FileOperationsImpl.java
@@ -1,0 +1,124 @@
+package io.unitycatalog.server.persist.utils;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.model.AwsCredentials;
+import io.unitycatalog.server.model.AzureUserDelegationSAS;
+import io.unitycatalog.server.model.GcpOauthToken;
+import io.unitycatalog.server.model.TemporaryCredentials;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import io.unitycatalog.server.service.credential.StorageCredentialVendor;
+import io.unitycatalog.server.service.credential.azure.ADLSLocationUtils;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ServerProperties;
+import io.unitycatalog.server.utils.UriScheme;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.ResolvingFileIO;
+
+/** Default {@link FileOperations}: builds credential-vended Iceberg {@link FileIO}s. */
+public class FileOperationsImpl implements FileOperations {
+
+  private final StorageCredentialVendor storageCredentialVendor;
+  private final Map<NormalizedURL, String> s3BucketRegionMap;
+
+  public FileOperationsImpl(
+      StorageCredentialVendor storageCredentialVendor, ServerProperties serverProperties) {
+    this.storageCredentialVendor = storageCredentialVendor;
+    this.s3BucketRegionMap =
+        serverProperties.getS3Configurations().entrySet().stream()
+            .filter(entry -> entry.getValue().getRegion() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRegion()));
+  }
+
+  // TODO: Cache fileIOs
+  @Override
+  public FileIO getFileIO(NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
+    return switch (UriScheme.fromURI(path.toUri())) {
+      // Local paths are served by SimpleLocalFileIO (backed by java.nio + iceberg-core). We
+      // deliberately do NOT route these through ResolvingFileIO: it resolves the file:// scheme to
+      // Iceberg's HadoopFileIO, which requires hadoop-client-runtime on the classpath. The server
+      // only depends on hadoop-client-api, and SimpleLocalFileIO covers the local read and
+      // directory operations we need without that heavy runtime dependency.
+      case FILE, NULL -> new SimpleLocalFileIO();
+      case S3, GS, ABFS, ABFSS -> {
+        ResolvingFileIO fileio = new ResolvingFileIO();
+        fileio.initialize(getFileIOConfig(path, privileges));
+        yield fileio;
+      }
+    };
+  }
+
+  @Override
+  public Map<String, String> getFileIOConfig(
+      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
+    UriScheme scheme = UriScheme.fromURI(path.toUri());
+    if (scheme == UriScheme.FILE || scheme == UriScheme.NULL) {
+      // Local (file://) paths need no cloud credentials, so short-circuit before vending: the
+      // scheme is known here and vending would do a needless external-location lookup for local
+      // tables.
+      return Map.of();
+    }
+
+    TemporaryCredentials cred = storageCredentialVendor.vendCredential(path, privileges);
+    if (cred.getAzureUserDelegationSas() != null) {
+      return getADLSConfig(path, cred.getAzureUserDelegationSas());
+    } else if (cred.getGcpOauthToken() != null) {
+      return getGCSConfig(cred.getGcpOauthToken(), cred.getExpirationTime());
+    } else if (cred.getAwsTempCredentials() != null) {
+      return getS3Config(path, cred.getAwsTempCredentials());
+    } else {
+      // Cloud vend returned no recognized credential type. This should not happen for a cloud
+      // scheme, so fail loudly rather than silently returning an empty (credential-less) config
+      // that would later surface as an opaque access-denied error.
+      throw new BaseException(
+          ErrorCode.INTERNAL,
+          "No recognized storage credential was vended for location: " + path);
+    }
+  }
+
+  private Map<String, String> getADLSConfig(
+      NormalizedURL path, AzureUserDelegationSAS azureUserDelegationSAS) {
+    ADLSLocationUtils.ADLSLocationParts locationParts = ADLSLocationUtils.parseLocation(path);
+    // NOTE: when fileio caching is implemented, need to set/deal with expiry here
+    return Map.of(
+        AzureProperties.ADLS_SAS_TOKEN_PREFIX + locationParts.account(),
+        azureUserDelegationSAS.getSasToken());
+  }
+
+  private Map<String, String> getGCSConfig(GcpOauthToken gcpOauthToken, Long expirationTime) {
+    if (expirationTime != null) {
+      return Map.of(
+          GCPProperties.GCS_OAUTH2_TOKEN,
+          gcpOauthToken.getOauthToken(),
+          GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT,
+          Long.toString(expirationTime));
+    } else {
+      return Map.of(GCPProperties.GCS_OAUTH2_TOKEN, gcpOauthToken.getOauthToken());
+    }
+  }
+
+  private Map<String, String> getS3Config(NormalizedURL path, AwsCredentials awsCredentials) {
+    // TODO: if region isn't configured, use HEAD bucket to figure out
+    String s3Region = s3BucketRegionMap.get(path.getStorageBase());
+    if (s3Region == null) {
+      // s3BucketRegionMap has no entry for this bucket (Map.get returns null on a miss). Guard
+      // here with a clear message rather than letting Map.of throw an opaque NullPointerException
+      // below.
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "No S3 region configured for bucket: " + path.getStorageBase());
+    }
+    return Map.of(
+        S3FileIOProperties.ACCESS_KEY_ID, awsCredentials.getAccessKeyId(),
+        S3FileIOProperties.SECRET_ACCESS_KEY, awsCredentials.getSecretAccessKey(),
+        S3FileIOProperties.SESSION_TOKEN, awsCredentials.getSessionToken(),
+        AwsClientProperties.CLIENT_REGION, s3Region);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseCRUDTestWithMockCredentials.java
@@ -36,6 +36,7 @@ import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.TestUtils;
 import io.unitycatalog.server.utils.UriScheme;
 import lombok.SneakyThrows;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.ArgumentMatcher;
@@ -50,6 +51,7 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
@@ -67,6 +69,26 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
   protected static final String TEST_AWS_STORAGE_CREDENTIAL_ROLE_ARN =
       "arn:aws:iam::987654321:role/UCDbRole-EXAMPLE";
   protected CredentialInfo awsCredentialInfo;
+
+  // The bucket/account configured (index 0) for every cloud scheme in setUpProperties;
+  // getTestCloudPath contrasts it with an unconfigured bucket.
+  protected static final String CONFIGURED_BUCKET = "test-bucket0";
+
+  // Credential values the mock vendor produces, named once so the vendor setup and the assertions
+  // on vended credentials cannot drift apart.
+  protected static final String S3_ACCESS_KEY = "accessKey0";
+  protected static final String S3_SECRET_KEY = "secretKey0";
+  protected static final String S3_SESSION_TOKEN = "sessionToken0";
+  protected static final String GCS_OAUTH_TOKEN = "test-token";
+
+  // Expected S3 credentials in a vended Iceberg FileIO config, keyed by FileIO property. Only S3 is
+  // pinned: it flows through a real AwsCredentialVendor, so the values are meaningful; GCS/Azure
+  // vendors are fully mocked. Checked by the fake FileIO (see LocalMappingFileOperations).
+  protected static final Map<String, String> EXPECTED_VENDED_S3_CREDENTIALS =
+      Map.of(
+          S3FileIOProperties.ACCESS_KEY_ID, S3_ACCESS_KEY,
+          S3FileIOProperties.SECRET_ACCESS_KEY, S3_SECRET_KEY,
+          S3FileIOProperties.SESSION_TOKEN, S3_SESSION_TOKEN);
 
   @SneakyThrows
   @BeforeEach
@@ -95,10 +117,13 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
   @Override
   protected void setUpProperties() {
     super.setUpProperties();
-    serverProperties.put("s3.bucketPath.0", "s3://test-bucket0");
-    serverProperties.put("s3.accessKey.0", "accessKey0");
-    serverProperties.put("s3.secretKey.0", "secretKey0");
-    serverProperties.put("s3.sessionToken.0", "sessionToken0");
+    serverProperties.put("s3.bucketPath.0", "s3://" + CONFIGURED_BUCKET);
+    serverProperties.put("s3.accessKey.0", S3_ACCESS_KEY);
+    serverProperties.put("s3.secretKey.0", S3_SECRET_KEY);
+    serverProperties.put("s3.sessionToken.0", S3_SESSION_TOKEN);
+    // Per-bucket region completes the S3 config; getFileIOConfig (the Iceberg FileIO path) requires
+    // it, while the Delta/temporary-credential paths vend credentials without it.
+    serverProperties.put("s3.region.0", TestUtils.TEST_AWS_REGION);
 
     // AWS S3 master role config
     serverProperties.put(
@@ -112,11 +137,11 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
         TestUtils.TEST_AWS_MASTER_ROLE_SECRET_KEY);
     serverProperties.put(ServerProperties.Property.AWS_REGION.getKey(), TestUtils.TEST_AWS_REGION);
 
-    serverProperties.put("gcs.bucketPath.0", "gs://test-bucket0");
+    serverProperties.put("gcs.bucketPath.0", "gs://" + CONFIGURED_BUCKET);
     serverProperties.put("gcs.jsonKeyFilePath.0", "testing://0");
     serverProperties.put("gcs.credentialGenerator.0", TestingCredentialGenerator.class.getName());
 
-    serverProperties.put("adls.storageAccountName.0", "test-bucket0");
+    serverProperties.put("adls.storageAccountName.0", CONFIGURED_BUCKET);
     serverProperties.put("adls.tenantId.0", "tenantId0");
     serverProperties.put("adls.clientId.0", "clientId0");
     serverProperties.put("adls.clientSecret.0", "clientSecret0");
@@ -180,7 +205,7 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
   private void setupGcpCredentials() {
     gcpCredentialVendor = mock(GcpCredentialVendor.class);
     AccessToken gcpCredential = new AccessToken(
-            "test-token",
+            GCS_OAUTH_TOKEN,
             Date.from(Instant.now().plusSeconds(10 * 60))
     );
     serverProperties.entrySet().stream()
@@ -204,8 +229,8 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
    * @return Cloud path for testing
    */
   protected String getTestCloudPath(String scheme, boolean isConfiguredPath) {
-    // test-bucket0 is configured in the properties
-    String bucket = isConfiguredPath ? "test-bucket0" : "test-bucket1";
+    // CONFIGURED_BUCKET is configured in the properties; the unconfigured bucket is not.
+    String bucket = isConfiguredPath ? CONFIGURED_BUCKET : "test-bucket1";
     return switch (scheme) {
       case "s3" -> "s3://" + bucket + "/test";
       case "abfs", "abfss" -> "abfs://test-container@" + bucket + ".dfs.core.windows.net/test";
@@ -222,9 +247,9 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
       case "s3":
         AwsCredentials awsCredentials = tempCredentials.getAwsTempCredentials();
         assertThat(awsCredentials).isNotNull();
-        assertThat(awsCredentials.getSessionToken()).isEqualTo("sessionToken0");
-        assertThat(awsCredentials.getAccessKeyId()).isEqualTo("accessKey0");
-        assertThat(awsCredentials.getSecretAccessKey()).isEqualTo("secretKey0");
+        assertThat(awsCredentials.getSessionToken()).isEqualTo(S3_SESSION_TOKEN);
+        assertThat(awsCredentials.getAccessKeyId()).isEqualTo(S3_ACCESS_KEY);
+        assertThat(awsCredentials.getSecretAccessKey()).isEqualTo(S3_SECRET_KEY);
         break;
       case "abfs":
       case "abfss":
@@ -235,7 +260,7 @@ public abstract class BaseCRUDTestWithMockCredentials extends BaseCRUDTest {
       case "gs":
         GcpOauthToken gcpOauthToken = tempCredentials.getGcpOauthToken();
         assertThat(gcpOauthToken).isNotNull();
-        assertThat(gcpOauthToken.getOauthToken()).isEqualTo("test-token");
+        assertThat(gcpOauthToken.getOauthToken()).isEqualTo(GCS_OAUTH_TOKEN);
         break;
       default:
         fail("Invalid scheme");

--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.base;
 
 import io.unitycatalog.server.UnityCatalogServer;
+import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.HibernateConfigurator;
 import io.unitycatalog.server.service.credential.CloudCredentialVendor;
 import io.unitycatalog.server.utils.ServerProperties;
@@ -64,6 +65,14 @@ public abstract class BaseServerTest {
   protected void setUpCredentialOperations(ServerProperties serverProperties) {}
 
   /**
+   * Subclasses can override this to decorate the server's {@link FileOperations}, e.g. to map cloud
+   * storage to local files for Iceberg tests. Returns the instance unchanged by default.
+   */
+  protected FileOperations decorateFileOperations(FileOperations fileOperations) {
+    return fileOperations;
+  }
+
+  /**
    * Subclasses can override this to customize the hibernate properties before the session factory
    * is created, e.g. to point the server at an external database such as PostgreSQL via
    * Testcontainers. Defaults to the H2 in-memory test configuration.
@@ -101,6 +110,7 @@ public abstract class BaseServerTest {
               .serverProperties(initServerProperties)
               .hibernateConfigurator(hibernateConfigurator)
               .credentialOperations(cloudCredentialVendor)
+              .fileOperations(this::decorateFileOperations)
               .build();
       unityCatalogServer.start();
       serverConfig.setServerUrl("http://localhost:" + port);

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkCreateStagingTableTest.java
@@ -73,7 +73,7 @@ public class SdkCreateStagingTableTest extends BaseCRUDTestWithMockCredentials {
     DeltaStorageCredential sc = resp.getStorageCredentials().get(0);
     assertThat(sc.getOperation()).isEqualTo(DeltaCredentialOperation.READ_WRITE);
     assertThat(sc.getPrefix()).isEqualTo(resp.getLocation());
-    assertThat(sc.getConfig().getS3AccessKeyId()).isEqualTo("accessKey0");
+    assertThat(sc.getConfig().getS3AccessKeyId()).isEqualTo(S3_ACCESS_KEY);
     assertThat(sc.getConfig().getS3SecretAccessKey()).isNotBlank();
 
     // Required / suggested protocol + properties reflect UC's catalog-managed Delta contract.

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaCredentialsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaCredentialsTest.java
@@ -85,7 +85,7 @@ public class SdkDeltaCredentialsTest extends BaseCRUDTestWithMockCredentials {
       DeltaStorageCredential sc = resp.getStorageCredentials().get(0);
       assertThat(sc.getOperation()).isEqualTo(DeltaCredentialOperation.READ);
       assertThat(sc.getPrefix()).startsWith("s3://");
-      assertThat(sc.getConfig().getS3AccessKeyId()).isEqualTo("accessKey0");
+      assertThat(sc.getConfig().getS3AccessKeyId()).isEqualTo(S3_ACCESS_KEY);
       assertThat(sc.getConfig().getS3SecretAccessKey()).isNotBlank();
     }
 

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogDisabledTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogDisabledTest.java
@@ -1,0 +1,111 @@
+package io.unitycatalog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.server.base.BaseCRUDTestWithMockCredentials;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.utils.IcebergRestClient;
+import io.unitycatalog.server.utils.TestUtils;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Iceberg REST catalog behavior when native Iceberg table writes are disabled (the production
+ * default: {@code server.iceberg-table.enabled=false}). This class deliberately does not enable the
+ * flag, unlike {@link IcebergRestCatalogTest}. The write endpoints all call {@code
+ * checkIcebergTableEnabled()} before touching any resource, so they are rejected regardless of
+ * whether the target catalog/schema/table exists.
+ */
+public class IcebergRestCatalogDisabledTest extends BaseCRUDTestWithMockCredentials {
+
+  private IcebergRestClient icebergClient;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig serverConfig) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    icebergClient = new IcebergRestClient(serverConfig);
+  }
+
+  @Test
+  public void testConfigAdvertisesOnlyReadEndpoints() throws Exception {
+    ConfigResponse resp = icebergClient.config(TestUtils.CATALOG_NAME);
+    assertThat(resp.overrides()).containsEntry("prefix", "catalogs/" + TestUtils.CATALOG_NAME);
+    assertThat(resp.endpoints())
+        .containsExactlyInAnyOrder(
+            Endpoint.V1_LIST_NAMESPACES,
+            Endpoint.V1_LOAD_NAMESPACE,
+            Endpoint.V1_TABLE_EXISTS,
+            Endpoint.V1_LOAD_TABLE,
+            Endpoint.V1_LOAD_VIEW,
+            Endpoint.V1_REPORT_METRICS,
+            Endpoint.V1_LIST_TABLES);
+  }
+
+  @Test
+  public void testWriteEndpointsRejectedWhenDisabled() {
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+
+    // createNamespace
+    TestUtils.assertIcebergApiException(
+        () -> icebergClient.createNamespace(TestUtils.CATALOG_NAME, "iceberg_disabled_ns"),
+        400,
+        "currently disabled");
+
+    // createTable
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.createTable(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                CreateTableRequest.builder()
+                    .withName(TestUtils.TABLE_NAME)
+                    .withSchema(schema)
+                    .build()),
+        400,
+        "currently disabled");
+
+    // updateTable
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.updateTable(
+                TestUtils.CATALOG_NAME,
+                TestUtils.SCHEMA_NAME,
+                TestUtils.TABLE_NAME,
+                new UpdateTableRequest(
+                    List.of(), List.of(new MetadataUpdate.SetProperties(Map.of("a", "b"))))),
+        400,
+        "currently disabled");
+
+    // dropTable
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.dropTable(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME),
+        400,
+        "currently disabled");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -2,40 +2,35 @@ package io.unitycatalog.server.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.auth.AuthToken;
 import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.model.CatalogInfo;
 import io.unitycatalog.client.model.ColumnInfo;
 import io.unitycatalog.client.model.ColumnTypeName;
 import io.unitycatalog.client.model.CreateCatalog;
-import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.DataSourceFormat;
-import io.unitycatalog.client.model.SchemaInfo;
 import io.unitycatalog.client.model.TableInfo;
 import io.unitycatalog.client.model.TableType;
-import io.unitycatalog.server.base.BaseServerTest;
+import io.unitycatalog.server.base.BaseCRUDTestWithMockCredentials;
+import io.unitycatalog.server.base.ServerConfig;
 import io.unitycatalog.server.base.catalog.CatalogOperations;
 import io.unitycatalog.server.base.schema.SchemaOperations;
 import io.unitycatalog.server.base.table.TableOperations;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.utils.FileOperations;
 import io.unitycatalog.server.persist.utils.PagedListingHelper;
 import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
 import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
 import io.unitycatalog.server.sdk.tables.SdkTableOperations;
-import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import io.unitycatalog.server.utils.IcebergRestClient;
+import io.unitycatalog.server.utils.LocalMappingFileOperations;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties.Property;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,28 +47,29 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import lombok.SneakyThrows;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
-import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.metrics.CommitMetrics;
 import org.apache.iceberg.metrics.CommitMetricsResult;
 import org.apache.iceberg.metrics.ImmutableCommitReport;
 import org.apache.iceberg.metrics.ImmutableScanReport;
 import org.apache.iceberg.metrics.ScanMetrics;
 import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
-import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
@@ -88,18 +84,38 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class IcebergRestCatalogTest extends BaseServerTest {
+/**
+ * Integration tests for the Iceberg REST catalog service, driven through the hand-rolled {@link
+ * IcebergRestClient}. Extends {@link BaseCRUDTestWithMockCredentials} so the server is wired with
+ * mock cloud-credential vendors and a default catalog + schema ({@link TestUtils#CATALOG_NAME} /
+ * {@link TestUtils#SCHEMA_NAME}) already exist; tests use those directly and create additional
+ * namespaces only where the scenario is about namespace creation itself.
+ */
+public class IcebergRestCatalogTest extends BaseCRUDTestWithMockCredentials {
 
-  private static final String TEST_BASE_PREFIX = "/v1/catalogs/" + TestUtils.CATALOG_NAME;
-  private static final String TEST_BASE_NON_PREFIX = "/v1";
+  // Base path the Iceberg REST catalog is mounted at; used by the two raw probes for HTTP-level
+  // checks the typed client can't express: a missing warehouse param and a body that isn't a valid
+  // request. Every other call goes through IcebergRestClient.
+  private static final String ICEBERG_PREFIX = "/api/2.1/unity-catalog/iceberg";
   private static final int PAGE_SIZE = PagedListingHelper.DEFAULT_PAGE_SIZE;
 
   @TempDir private Path icebergTableLocation;
 
-  protected CatalogOperations catalogOperations;
-  protected SchemaOperations schemaOperations;
-  protected TableOperations tableOperations;
-  private WebClient client;
+  private TableOperations tableOperations;
+  private IcebergRestClient icebergClient;
+  // The decorator that maps a registered cloud prefix to a local dir; kept so a test can register
+  // its catalog root and resolve cloud locations back to local paths.
+  private LocalMappingFileOperations mappingFileOperations;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig serverConfig) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig serverConfig) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
+  }
 
   @Override
   protected void setUpProperties() {
@@ -108,133 +124,108 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     serverProperties.setProperty(Property.ICEBERG_TABLE_ENABLED.getKey(), "true");
   }
 
+  @Override
+  protected FileOperations decorateFileOperations(FileOperations fileOperations) {
+    // Map registered cloud prefixes to local files so the cloud file-IO path can run without a real
+    // backend, validating UC vended the expected credentials before any access. Roots are
+    // registered after the server starts (setUp / the per-cloud test), so keep the instance.
+    mappingFileOperations =
+        new LocalMappingFileOperations(fileOperations, EXPECTED_VENDED_S3_CREDENTIALS);
+    return mappingFileOperations;
+  }
+
   @BeforeEach
+  @Override
   public void setUp() {
+    // Creates the default (file://) catalog + schema and the mock cloud-credential vendors.
     super.setUp();
-    String uri = serverConfig.getServerUrl() + "/api/2.1/unity-catalog/iceberg";
-    String token = serverConfig.getAuthToken();
-    catalogOperations = new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
-    schemaOperations = new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
     tableOperations = new SdkTableOperations(TestUtils.createApiClient(serverConfig));
-    client = WebClient.builder(uri).auth(AuthToken.ofOAuth2(token)).build();
-    cleanUp();
+    icebergClient = new IcebergRestClient(serverConfig);
   }
 
-  protected void cleanUp() {
-    try {
-      if (catalogOperations.getCatalog(TestUtils.CATALOG_NAME) != null) {
-        catalogOperations.deleteCatalog(TestUtils.CATALOG_NAME, Optional.of(true));
-      }
-    } catch (Exception e) {
-      // Ignore
-    }
-  }
-
-  @Test
-  public void testConfig() {
-    // successful test of getting client config with prefix when passing in warehouse param
-    AggregatedHttpResponse resp =
-        client.get("/v1/config?warehouse=" + TestUtils.CATALOG_NAME).aggregate().join();
-    assertThat(resp.contentUtf8())
-        .isEqualTo(
-            "{\"defaults\":{},\"overrides\":{\"prefix\":\"catalogs/"
-                + TestUtils.CATALOG_NAME
-                + "\"}"
-                + ",\"endpoints\":["
-                + "\"GET /v1/{prefix}/namespaces\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}\""
-                + ",\"HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}/views/{view}\","
-                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\","
-                + "\"POST /v1/{prefix}/namespaces\","
-                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
-                + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
-                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
-                + "]}");
-
-    // not setting warehouse param should result in 400 BadRequestException
-    resp = client.get("/v1/config").aggregate().join();
-    assertThat(resp.status().code()).isEqualTo(400);
-    ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
-    assertThat(errorResponse.type()).isEqualTo(BadRequestException.class.getSimpleName());
+  /**
+   * Registers a cloud-storage mapping and creates a catalog rooted there with the {@code
+   * SCHEMA_NAME} namespace the table tests use. Namespace create/conflict coverage lives in
+   * testNamespaces.
+   */
+  @SneakyThrows
+  private void createCloudCatalog(String catalog, String cloudRoot, Path localDir) {
+    mappingFileOperations.mapLocation(NormalizedURL.from(cloudRoot), localDir);
+    catalogOperations.createCatalog(new CreateCatalog().name(catalog).storageRoot(cloudRoot));
+    icebergClient.createNamespace(catalog, TestUtils.SCHEMA_NAME);
   }
 
   @Test
-  public void testNamespaces() throws ApiException, IOException {
-    CreateCatalog createCatalog =
-        new CreateCatalog()
-            .name(TestUtils.CATALOG_NAME)
-            .comment(TestUtils.COMMENT)
-            .properties(TestUtils.PROPERTIES);
-    CatalogInfo catalogInfo = catalogOperations.createCatalog(createCatalog);
-    assertThat(catalogInfo.getName()).isEqualTo(createCatalog.getName());
-    assertThat(catalogInfo.getComment()).isEqualTo(createCatalog.getComment());
-    assertThat(catalogInfo.getProperties()).isEqualTo(createCatalog.getProperties());
+  public void testConfig() throws Exception {
+    // Successful config with the warehouse param carries the catalog prefix override and the full
+    // endpoint list (writes included, since ICEBERG_TABLE_ENABLED is on for this suite).
+    ConfigResponse resp = icebergClient.config(TestUtils.CATALOG_NAME);
+    assertThat(resp.overrides()).containsEntry("prefix", "catalogs/" + TestUtils.CATALOG_NAME);
+    assertThat(resp.endpoints())
+        .containsExactlyInAnyOrder(
+            Endpoint.V1_LIST_NAMESPACES,
+            Endpoint.V1_LOAD_NAMESPACE,
+            Endpoint.V1_TABLE_EXISTS,
+            Endpoint.V1_LOAD_TABLE,
+            Endpoint.V1_LOAD_VIEW,
+            Endpoint.V1_REPORT_METRICS,
+            Endpoint.V1_LIST_TABLES,
+            Endpoint.V1_CREATE_NAMESPACE,
+            Endpoint.V1_CREATE_TABLE,
+            Endpoint.V1_UPDATE_TABLE,
+            Endpoint.V1_DELETE_TABLE);
 
-    CreateSchema createSchema =
-        new CreateSchema()
-            .catalogName(TestUtils.CATALOG_NAME)
-            .name(TestUtils.SCHEMA_NAME)
-            .properties(TestUtils.PROPERTIES);
-    SchemaInfo schemaInfo = schemaOperations.createSchema(createSchema);
-    assertThat(schemaInfo.getName()).isEqualTo(createSchema.getName());
-    assertThat(schemaInfo.getCatalogName()).isEqualTo(createSchema.getCatalogName());
-    assertThat(schemaInfo.getFullName()).isEqualTo(TestUtils.SCHEMA_FULL_NAME);
-    assertThat(schemaInfo.getProperties()).isEqualTo(createSchema.getProperties());
+    // Not setting the warehouse param should result in a 400 BadRequestException.
+    HttpResponse<String> missingWarehouse =
+        TestUtils.sendRaw(serverConfig, "GET", ICEBERG_PREFIX + "/v1/config", Optional.empty());
+    assertThat(missingWarehouse.statusCode()).isEqualTo(400);
+    assertThat(ErrorResponseParser.fromJson(missingWarehouse.body()).type())
+        .isEqualTo(BadRequestException.class.getSimpleName());
+  }
+
+  @Test
+  public void testNamespaces() throws Exception {
+    // The default SCHEMA_NAME namespace has no properties; create a second one with properties to
+    // verify that schema properties flow through create and getNamespace.
+    CreateNamespaceRequest createRequest =
+        CreateNamespaceRequest.builder()
+            .withNamespace(Namespace.of(TestUtils.SCHEMA_NAME2))
+            .setProperties(TestUtils.PROPERTIES)
+            .build();
+    CreateNamespaceResponse created =
+        icebergClient.createNamespace(TestUtils.CATALOG_NAME, createRequest);
+    assertThat(created.namespace()).isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME2));
+    assertThat(created.properties()).isEqualTo(TestUtils.PROPERTIES);
+
+    // creating it again is a 409 conflict
+    TestUtils.assertIcebergApiException(
+        () -> icebergClient.createNamespace(TestUtils.CATALOG_NAME, createRequest),
+        409,
+        "already exists");
+
     // GetNamespace
     {
-      AggregatedHttpResponse resp =
-          client.get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      assertThat(
-              IcebergObjectMapper.mapper()
-                  .readValue(resp.contentUtf8(), GetNamespaceResponse.class))
-          .asString()
-          .isEqualTo(
-              GetNamespaceResponse.builder()
-                  .withNamespace(Namespace.of(TestUtils.SCHEMA_NAME))
-                  .setProperties(TestUtils.PROPERTIES)
-                  .build()
-                  .toString());
+      GetNamespaceResponse namespace =
+          icebergClient.loadNamespace(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME2);
+      assertThat(namespace.namespace()).isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME2));
+      assertThat(namespace.properties()).isEqualTo(TestUtils.PROPERTIES);
 
-      // non-prefixed URL should result in 404
-      resp =
-          client
-              .get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(404);
+      // loading a namespace that doesn't exist is a 404
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.loadNamespace(TestUtils.CATALOG_NAME, "nonexistent_namespace"), 404);
     }
 
     // ListNamespaces
     {
-      AggregatedHttpResponse resp = client.get(TEST_BASE_PREFIX + "/namespaces").aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      assertThat(
-              IcebergObjectMapper.mapper()
-                  .readValue(resp.contentUtf8(), ListNamespacesResponse.class))
-          .asString()
-          .isEqualTo(
-              ListNamespacesResponse.builder()
-                  .add(Namespace.of(TestUtils.SCHEMA_NAME))
-                  .build()
-                  .toString());
-
-      // non-prefixed URL should result in 404
-      resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces").aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(404);
+      ListNamespacesResponse namespaces = icebergClient.listNamespaces(TestUtils.CATALOG_NAME);
+      assertThat(namespaces.namespaces())
+          .containsExactlyInAnyOrder(
+              Namespace.of(TestUtils.SCHEMA_NAME), Namespace.of(TestUtils.SCHEMA_NAME2));
     }
   }
 
   @Test
-  public void testTable() throws ApiException, IOException {
-    CreateCatalog createCatalog =
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT);
-    catalogOperations.createCatalog(createCatalog);
-    schemaOperations.createSchema(
-        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+  public void testTable() throws Exception {
     ColumnInfo columnInfo1 =
         new ColumnInfo()
             .name("as_int")
@@ -272,34 +263,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     TableInfo tableInfo = tableOperations.createTable(createTableRequest);
 
     // Uniform table doesn't exist at this point
-    {
-      AggregatedHttpResponse resp =
-          client
-              .head(
-                  TEST_BASE_PREFIX
-                      + "/namespaces/"
-                      + TestUtils.SCHEMA_NAME
-                      + "/tables/"
-                      + TestUtils.TABLE_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(404);
-    }
-    {
-      AggregatedHttpResponse resp =
-          client
-              .get(
-                  TEST_BASE_PREFIX
-                      + "/namespaces/"
-                      + TestUtils.SCHEMA_NAME
-                      + "/tables/"
-                      + TestUtils.TABLE_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(404);
-      ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
-      assertThat(errorResponse.type()).isEqualTo(NoSuchTableException.class.getSimpleName());
-    }
+    assertThat(
+            icebergClient.tableExists(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME))
+        .isFalse();
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.loadTable(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME),
+        404,
+        "does not exist");
 
     // Register UniForm-derived Iceberg metadata for the table. The fixture's baked table root is
     // rewritten onto a hermetic temp directory and the metadata file is written under it, modeling
@@ -329,91 +302,47 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     }
 
     // Now the uniform table exists
-    {
-      AggregatedHttpResponse resp =
-          client
-              .head(
-                  TEST_BASE_PREFIX
-                      + "/namespaces/"
-                      + TestUtils.SCHEMA_NAME
-                      + "/tables/"
-                      + TestUtils.TABLE_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(200);
-    }
+    assertThat(
+            icebergClient.tableExists(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME))
+        .isTrue();
+
     // metadata is valid metadata content and metadata location matches
     {
-      AggregatedHttpResponse resp =
-          client
-              .get(
-                  TEST_BASE_PREFIX
-                      + "/namespaces/"
-                      + TestUtils.SCHEMA_NAME
-                      + "/tables/"
-                      + TestUtils.TABLE_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.loadTable(
+              TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .isEqualTo(metadataFile.toString());
-
-      // non-prefixed URL should result in 404
-      resp =
-          client
-              .get(
-                  TEST_BASE_NON_PREFIX
-                      + "/namespaces/"
-                      + TestUtils.SCHEMA_NAME
-                      + "/tables/"
-                      + TestUtils.TABLE_NAME)
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(404);
     }
 
     // List uniform tables
     {
-      AggregatedHttpResponse resp =
-          client
-              .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables")
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      ListTablesResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
-      assertThat(loadTableResponse.identifiers())
+      ListTablesResponse listTablesResponse =
+          icebergClient.listTables(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME);
+      assertThat(listTablesResponse.identifiers())
           .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
-
-      // non-prefixed URL should result in 404
-      resp =
-          client
-              .get(TEST_BASE_NON_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables")
-              .aggregate()
-              .join();
-      assertThat(resp.status().code()).isEqualTo(404);
     }
 
     // UniForm-derived Iceberg metadata is read-only: commits and drops through the Iceberg REST
     // catalog must be rejected.
     {
-      String tablePath =
-          TEST_BASE_PREFIX
-              + "/namespaces/"
-              + TestUtils.SCHEMA_NAME
-              + "/tables/"
-              + TestUtils.TABLE_NAME;
       UpdateTableRequest commitRequest =
           new UpdateTableRequest(
               List.of(), List.of(new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
-      AggregatedHttpResponse resp =
-          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(commitRequest));
-      assertThat(resp.status().code()).isEqualTo(400);
-
-      resp = client.delete(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(400);
+      TestUtils.assertIcebergApiException(
+          () ->
+              icebergClient.updateTable(
+                  TestUtils.CATALOG_NAME,
+                  TestUtils.SCHEMA_NAME,
+                  TestUtils.TABLE_NAME,
+                  commitRequest),
+          400);
+      TestUtils.assertIcebergApiException(
+          () ->
+              icebergClient.dropTable(
+                  TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME),
+          400);
     }
 
     // Credentials must never be scoped by a conflicting location in the metadata payload. Repoint
@@ -427,57 +356,32 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       conflicting.setUrl(icebergTableLocation.resolve("other_table").toString());
       tx.commit();
     }
-    AggregatedHttpResponse conflictResp =
-        client
-            .get(
-                TEST_BASE_PREFIX
-                    + "/namespaces/"
-                    + TestUtils.SCHEMA_NAME
-                    + "/tables/"
-                    + TestUtils.TABLE_NAME)
-            .aggregate()
-            .join();
-    assertThat(conflictResp.status().code()).isEqualTo(400);
-    assertThat(ErrorResponseParser.fromJson(conflictResp.contentUtf8()).message())
-        .contains("persisted table location");
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.loadTable(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME),
+        400,
+        "persisted table location");
   }
 
   @Test
-  public void testIcebergTableWriteLifecycle() throws ApiException, IOException {
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-
-    String namespacesPath = TEST_BASE_PREFIX + "/namespaces";
-    String tablesPath = namespacesPath + "/" + TestUtils.SCHEMA_NAME + "/tables";
-    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
-
-    // Create the namespace through the Iceberg REST catalog
-    {
-      CreateNamespaceRequest request =
-          CreateNamespaceRequest.builder()
-              .withNamespace(Namespace.of(TestUtils.SCHEMA_NAME))
-              .setProperties(TestUtils.PROPERTIES)
-              .build();
-      AggregatedHttpResponse resp =
-          postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
-      CreateNamespaceResponse createNamespaceResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), CreateNamespaceResponse.class);
-      assertThat(createNamespaceResponse.namespace())
-          .isEqualTo(Namespace.of(TestUtils.SCHEMA_NAME));
-
-      // creating it again is a conflict
-      resp = postJson(namespacesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(AlreadyExistsException.class.getSimpleName());
-    }
+  public void testIcebergTableWriteLifecycle() throws Exception {
+    // Runs the full create/commit/load/drop lifecycle against an s3:// mock-storage catalog, so
+    // this single test exercises the cloud file-IO path and credential vending as well as the CRUD
+    // semantics. The s3:// key is the absolute temp dir, which maps back onto that local dir.
+    String catalog = TestUtils.CATALOG_NAME2;
+    String namespace = TestUtils.SCHEMA_NAME;
+    String tableFullName = catalog + "." + namespace + "." + TestUtils.TABLE_NAME;
+    String s3CatalogRoot =
+        "s3://" + CONFIGURED_BUCKET + testDirectoryRoot.toAbsolutePath() + "/s3catalog";
+    createCloudCatalog(
+        catalog, s3CatalogRoot, testDirectoryRoot.toAbsolutePath().resolve("s3catalog"));
 
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
             Types.NestedField.optional(2, "data", Types.StringType.get()));
-    String location = Files.createTempDirectory("iceberg-rest-table").toUri().toString();
+    String location = s3CatalogRoot + "/ext_table";
 
     // Staged creation is stateless: it returns metadata without a metadata-location and
     // registers nothing, so the direct create below still succeeds.
@@ -489,13 +393,10 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .withLocation(location)
               .stageCreate()
               .build();
-      AggregatedHttpResponse resp =
-          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).as(resp.contentUtf8()).isEqualTo(200);
-      LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      LoadTableResponse loadTableResponse = icebergClient.createTable(catalog, namespace, request);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation()).isNull();
-      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.loadTable(catalog, namespace, TestUtils.TABLE_NAME), 404);
     }
 
     // Create the table
@@ -508,13 +409,17 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .withLocation(location)
               .setProperty("created-by", "iceberg-rest-test")
               .build();
-      AggregatedHttpResponse resp =
-          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).as(resp.contentUtf8()).isEqualTo(200);
-      LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+      LoadTableResponse loadTableResponse = icebergClient.createTable(catalog, namespace, request);
       initialMetadataLocation = loadTableResponse.tableMetadata().metadataFileLocation();
-      assertThat(initialMetadataLocation).contains("/metadata/00000-");
+      // The metadata "commit" file was written to the cloud location, i.e. the mapped local path.
+      assertThat(initialMetadataLocation)
+          .startsWith("s3://" + CONFIGURED_BUCKET)
+          .contains("/metadata/00000-");
+      assertThat(Files.exists(localPathOf(initialMetadataLocation))).isTrue();
+      // Credential vending is real: the vended mock S3 credentials appear in the load config.
+      assertThat(loadTableResponse.config())
+          .containsEntry(S3FileIOProperties.ACCESS_KEY_ID, S3_ACCESS_KEY)
+          .containsEntry(S3FileIOProperties.SESSION_TOKEN, S3_SESSION_TOKEN);
       assertThat(loadTableResponse.tableMetadata().schema().columns()).hasSize(2);
       assertThat(loadTableResponse.tableMetadata().properties())
           .containsEntry("created-by", "iceberg-rest-test");
@@ -525,15 +430,13 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       }
 
       // creating it again is a conflict
-      resp = postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.createTable(catalog, namespace, request), 409, "already exists");
     }
 
     // The table is registered in UC as a native Iceberg table with converted columns
     {
-      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      TableInfo tableInfo = tableOperations.getTable(tableFullName);
       assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
       assertThat(tableInfo.getTableType()).isEqualTo(TableType.EXTERNAL);
       assertThat(tableInfo.getColumns())
@@ -545,23 +448,17 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     // The table is loadable and listable through the Iceberg REST catalog
     String tableUuid;
     {
-      AggregatedHttpResponse resp = client.head(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
+      assertThat(icebergClient.tableExists(catalog, namespace, TestUtils.TABLE_NAME)).isTrue();
 
-      resp = client.get(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.loadTable(catalog, namespace, TestUtils.TABLE_NAME);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .isEqualTo(initialMetadataLocation);
       tableUuid = loadTableResponse.tableMetadata().uuid();
 
-      resp = client.get(tablesPath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
-      ListTablesResponse listTablesResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+      ListTablesResponse listTablesResponse = icebergClient.listTables(catalog, namespace);
       assertThat(listTablesResponse.identifiers())
-          .containsExactly(TableIdentifier.of(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME));
+          .containsExactly(TableIdentifier.of(namespace, TestUtils.TABLE_NAME));
     }
 
     // Commit an update against the table
@@ -578,29 +475,28 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   new MetadataUpdate.AddSchema(updatedSchema),
                   new MetadataUpdate.SetCurrentSchema(-1),
                   new MetadataUpdate.SetProperties(Map.of("foo", "bar"))));
-      AggregatedHttpResponse resp =
-          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.updateTable(catalog, namespace, TestUtils.TABLE_NAME, request);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .contains("/metadata/00001-");
+      // The new metadata version was written to the cloud location too.
+      assertThat(
+              Files.exists(localPathOf(loadTableResponse.tableMetadata().metadataFileLocation())))
+          .isTrue();
       assertThat(loadTableResponse.tableMetadata().properties()).containsEntry("foo", "bar");
       assertThat(loadTableResponse.tableMetadata().schema().columns())
           .extracting(Types.NestedField::name)
           .containsExactly("id", "data", "category");
 
-      TableInfo tableInfo = tableOperations.getTable(TestUtils.TABLE_FULL_NAME);
+      TableInfo tableInfo = tableOperations.getTable(tableFullName);
       assertThat(tableInfo.getColumns())
           .extracting(ColumnInfo::getName)
           .containsExactly("id", "data", "category");
       assertThat(tableInfo.getProperties()).containsEntry("foo", "bar");
 
       // the new metadata location is what loadTable now returns
-      resp = client.get(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse reloaded =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.loadTable(catalog, namespace, TestUtils.TABLE_NAME);
       assertThat(reloaded.tableMetadata().metadataFileLocation())
           .isEqualTo(loadTableResponse.tableMetadata().metadataFileLocation());
       assertThat(reloaded.tableMetadata().properties()).containsEntry("foo", "bar");
@@ -612,63 +508,76 @@ public class IcebergRestCatalogTest extends BaseServerTest {
           new UpdateTableRequest(
               List.of(new UpdateRequirement.AssertTableUUID(UUID.randomUUID().toString())),
               List.of(new MetadataUpdate.SetProperties(Map.of("should", "fail"))));
-      AggregatedHttpResponse resp =
-          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(CommitFailedException.class.getSimpleName());
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.updateTable(catalog, namespace, TestUtils.TABLE_NAME, request),
+          409,
+          "Requirement failed");
     }
 
     // Drop the table
     {
-      AggregatedHttpResponse resp = client.delete(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(204);
-
-      resp = client.head(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(404);
-
-      resp = client.get(tablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(404);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(NoSuchTableException.class.getSimpleName());
+      icebergClient.dropTable(catalog, namespace, TestUtils.TABLE_NAME);
+      assertThat(icebergClient.tableExists(catalog, namespace, TestUtils.TABLE_NAME)).isFalse();
+      // The UC row is gone after the drop, so the load surfaces the repository's TABLE_NOT_FOUND
+      // ("Table not found: ..."), not the service-level "does not exist" used when a row exists
+      // without Iceberg metadata.
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.loadTable(catalog, namespace, TestUtils.TABLE_NAME),
+          404,
+          "not found");
     }
 
-    // A create request without a location gets a server-assigned managed location
+    // A create request without a location gets a server-assigned managed location under the catalog
     {
-      String managedTablePath = tablesPath + "/managed_iceberg_table";
       CreateTableRequest request =
           CreateTableRequest.builder().withName("managed_iceberg_table").withSchema(schema).build();
-      AggregatedHttpResponse resp =
-          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
-      LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
-      assertThat(loadTableResponse.tableMetadata().location()).contains("/tables/");
+      LoadTableResponse loadTableResponse = icebergClient.createTable(catalog, namespace, request);
+      assertThat(loadTableResponse.tableMetadata().location())
+          .startsWith("s3://" + CONFIGURED_BUCKET);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .contains("/metadata/00000-");
+      assertThat(
+              Files.exists(localPathOf(loadTableResponse.tableMetadata().metadataFileLocation())))
+          .isTrue();
 
       TableInfo tableInfo =
-          tableOperations.getTable(
-              TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".managed_iceberg_table");
+          tableOperations.getTable(catalog + "." + namespace + ".managed_iceberg_table");
       assertThat(tableInfo.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
       assertThat(tableInfo.getTableType()).isEqualTo(TableType.MANAGED);
       assertThat(tableInfo.getStorageLocation())
           .isEqualTo(loadTableResponse.tableMetadata().location());
 
-      resp = client.delete(managedTablePath).aggregate().join();
-      assertThat(resp.status().code()).isEqualTo(204);
+      icebergClient.dropTable(catalog, namespace, "managed_iceberg_table");
     }
   }
 
   @Test
-  public void testStagedCreateAndCommit() throws ApiException, IOException {
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    schemaOperations.createSchema(
-        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+  public void testCreateOnGcsValidatesVendedToken() throws Exception {
+    // A gs://-rooted catalog exercises the GCS branch of credential vending/validation: the fake
+    // FileIO requires the vended GCS OAuth token before it will touch storage.
+    String gcsRoot =
+        "gs://" + CONFIGURED_BUCKET + testDirectoryRoot.toAbsolutePath() + "/gcscatalog";
+    createCloudCatalog(
+        "uc_iceberg_gcs", gcsRoot, testDirectoryRoot.toAbsolutePath().resolve("gcscatalog"));
 
-    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
-    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    LoadTableResponse created =
+        icebergClient.createTable(
+            "uc_iceberg_gcs",
+            TestUtils.SCHEMA_NAME,
+            CreateTableRequest.builder()
+                .withName(TestUtils.TABLE_NAME)
+                .withSchema(schema)
+                .withLocation(gcsRoot + "/ext_iceberg")
+                .build());
+    String metadata = created.tableMetadata().metadataFileLocation();
+    assertThat(metadata).startsWith("gs://" + CONFIGURED_BUCKET).contains("/metadata/00000-");
+    assertThat(Files.exists(localPathOf(metadata))).isTrue();
+    assertThat(created.config()).containsEntry(GCPProperties.GCS_OAUTH2_TOKEN, GCS_OAUTH_TOKEN);
+  }
+
+  @Test
+  public void testStagedCreateAndCommit() throws Exception {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -685,11 +594,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .withSchema(schema)
               .stageCreate()
               .build();
-      AggregatedHttpResponse resp =
-          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.createTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, request);
       staged = loadTableResponse.tableMetadata();
       assertThat(staged.metadataFileLocation()).isNull();
       assertThat(staged.location()).contains("/tables/");
@@ -700,7 +606,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       stagingTableId = stagingTable.getId();
 
       // the staged table is not yet a permanent UC table, so it is not loadable or listable
-      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
+      TestUtils.assertIcebergApiException(
+          () ->
+              icebergClient.loadTable(
+                  TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME),
+          404);
     }
 
     // Commit the staged create: assert-create requirement + updates rebuilding the metadata
@@ -719,11 +629,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                   new MetadataUpdate.SetDefaultSortOrder(-1),
                   new MetadataUpdate.SetLocation(staged.location()),
                   new MetadataUpdate.SetProperties(Map.of("staged", "true"))));
-      AggregatedHttpResponse resp =
-          postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(200);
       LoadTableResponse loadTableResponse =
-          IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+          icebergClient.updateTable(
+              TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, request);
       assertThat(loadTableResponse.tableMetadata().metadataFileLocation())
           .contains("/metadata/00000-");
       assertThat(loadTableResponse.tableMetadata().uuid()).isEqualTo(staged.uuid());
@@ -737,13 +645,18 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       try (Session session = hibernateConfigurator.getSessionFactory().openSession()) {
         assertThat(session.get(StagingTableDAO.class, stagingTableId).isStageCommitted()).isTrue();
       }
-      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(200);
+      assertThat(
+              icebergClient.tableExists(
+                  TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME))
+          .isTrue();
 
       // replaying the create commit loses the race: 409 CommitFailedException
-      resp = postJson(tablePath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(CommitFailedException.class.getSimpleName());
+      TestUtils.assertIcebergApiException(
+          () ->
+              icebergClient.updateTable(
+                  TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, request),
+          409,
+          "Requirement failed");
     }
 
     // staging a create for an existing table is a conflict
@@ -754,24 +667,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
               .withSchema(schema)
               .stageCreate()
               .build();
-      AggregatedHttpResponse resp =
-          postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(request));
-      assertThat(resp.status().code()).isEqualTo(409);
-      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-          .isEqualTo(AlreadyExistsException.class.getSimpleName());
+      TestUtils.assertIcebergApiException(
+          () -> icebergClient.createTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, request),
+          409,
+          "already exists");
     }
   }
 
   @Test
   public void testConcurrentCommitsSerializeWithCompareAndSwap()
       throws ApiException, IOException, InterruptedException, ExecutionException, TimeoutException {
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    schemaOperations.createSchema(
-        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
-
-    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
-    String tablePath = tablesPath + "/" + TestUtils.TABLE_NAME;
     Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
     String location = Files.createTempDirectory("iceberg-rest-concurrent").toUri().toString();
 
@@ -782,11 +687,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             .withSchema(schema)
             .withLocation(location)
             .build();
-    AggregatedHttpResponse createResp =
-        postJson(tablesPath, IcebergObjectMapper.mapper().writeValueAsString(createRequest));
-    assertThat(createResp.status().code()).isEqualTo(200);
     LoadTableResponse created =
-        IcebergObjectMapper.mapper().readValue(createResp.contentUtf8(), LoadTableResponse.class);
+        icebergClient.createTable(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, createRequest);
     assertThat(created.tableMetadata().metadataFileLocation()).contains("/metadata/00000-");
 
     // Fire N commits at once. Each asserts the original current-schema-id (0) and bumps the schema
@@ -803,7 +705,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             Types.NestedField.optional(2, "added", Types.StringType.get()));
     CyclicBarrier barrier = new CyclicBarrier(concurrency);
     ExecutorService pool = Executors.newFixedThreadPool(concurrency);
-    List<Future<Integer>> futures = new ArrayList<>();
+    List<Future<ErrorResponse>> futures = new ArrayList<>();
     for (int i = 0; i < concurrency; i++) {
       futures.add(
           pool.submit(
@@ -814,22 +716,28 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                         List.of(
                             new MetadataUpdate.AddSchema(bumpedSchema),
                             new MetadataUpdate.SetCurrentSchema(-1)));
-                String body = IcebergObjectMapper.mapper().writeValueAsString(request);
                 barrier.await();
-                return postJson(tablePath, body).status().code();
+                try {
+                  icebergClient.updateTable(
+                      TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, request);
+                  return null;
+                } catch (ApiException e) {
+                  return ErrorResponseParser.fromJson(e.getResponseBody());
+                }
               }));
     }
 
     int successes = 0;
     int conflicts = 0;
-    for (Future<Integer> future : futures) {
-      int code = future.get(30, TimeUnit.SECONDS);
-      // A commit either wins (200) or loses cleanly (409 CommitFailedException); any other status
-      // would mean the contention surfaced as a server error.
-      assertThat(code).isIn(200, 409);
-      if (code == 200) {
+    for (Future<ErrorResponse> future : futures) {
+      ErrorResponse error = future.get(30, TimeUnit.SECONDS);
+      if (error == null) {
         successes++;
       } else {
+        // A commit either wins (null error) or loses cleanly as a 409 CommitFailedException; any
+        // other status or error type would mean the contention surfaced as a server error.
+        assertThat(error.code()).isEqualTo(409);
+        assertThat(error.type()).isEqualTo("CommitFailedException");
         conflicts++;
       }
     }
@@ -842,97 +750,79 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
     // The single winner advanced the table to version 1 with the bumped schema; losers left no
     // trace (their metadata files were rolled back), so the table is loadable and consistent.
-    AggregatedHttpResponse loadResp = client.get(tablePath).aggregate().join();
-    assertThat(loadResp.status().code()).isEqualTo(200);
     LoadTableResponse loaded =
-        IcebergObjectMapper.mapper().readValue(loadResp.contentUtf8(), LoadTableResponse.class);
+        icebergClient.loadTable(
+            TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME);
     assertThat(loaded.tableMetadata().metadataFileLocation()).contains("/metadata/00001-");
     assertThat(loaded.tableMetadata().schema().columns()).hasSize(2);
   }
 
   @Test
   public void testReportMetrics() throws Exception {
-    createUniformIcebergTable();
-    String metricsPath =
-        TEST_BASE_PREFIX
-            + "/namespaces/"
-            + TestUtils.SCHEMA_NAME
-            + "/tables/"
-            + TestUtils.TABLE_NAME
-            + "/metrics";
+    setUniformMetadata(createTable(TestUtils.TABLE_NAME), writeIcebergMetadata());
 
     // Per the REST spec, a report is acknowledged with 204 No Content.
-    assertThat(postJson(metricsPath, scanReportJson()).status().code()).isEqualTo(204);
-    assertThat(postJson(metricsPath, commitReportJson()).status().code()).isEqualTo(204);
+    icebergClient.reportMetrics(
+        TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, scanReport());
+    icebergClient.reportMetrics(
+        TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, commitReport());
 
     // A body that isn't a metrics report is rejected rather than silently accepted.
-    assertThat(postJson(metricsPath, "{\"foo\":\"bar\"}").status().code()).isEqualTo(400);
-
-    // A table UC knows about but doesn't serve as an Iceberg table is a 404, like loadTable.
-    createTable("plainTable");
-    AggregatedHttpResponse resp =
-        postJson(
-            TEST_BASE_PREFIX
-                + "/namespaces/"
-                + TestUtils.SCHEMA_NAME
-                + "/tables/plainTable/metrics",
-            scanReportJson());
-    assertThat(resp.status().code()).isEqualTo(404);
-    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-        .isEqualTo(NoSuchTableException.class.getSimpleName());
-
-    // A table that doesn't exist at all is a 404 too.
-    resp =
-        postJson(
-            TEST_BASE_PREFIX
-                + "/namespaces/"
-                + TestUtils.SCHEMA_NAME
-                + "/tables/missingTable/metrics",
-            scanReportJson());
-    assertThat(resp.status().code()).isEqualTo(404);
-
-    // The non-prefixed URL isn't routed, matching the other Iceberg endpoints.
-    resp =
-        postJson(
-            TEST_BASE_NON_PREFIX
+    HttpResponse<String> badBody =
+        TestUtils.sendRaw(
+            serverConfig,
+            "POST",
+            ICEBERG_PREFIX
+                + "/v1/catalogs/"
+                + TestUtils.CATALOG_NAME
                 + "/namespaces/"
                 + TestUtils.SCHEMA_NAME
                 + "/tables/"
                 + TestUtils.TABLE_NAME
                 + "/metrics",
-            scanReportJson());
-    assertThat(resp.status().code()).isEqualTo(404);
+            Optional.of("{\"foo\":\"bar\"}"));
+    assertThat(badBody.statusCode()).isEqualTo(400);
+
+    // A table UC knows about but doesn't serve as an Iceberg table is a 404, like loadTable.
+    createTable("plainTable");
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.reportMetrics(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "plainTable", scanReport()),
+        404,
+        "does not exist");
+
+    // A table that doesn't exist at all is a 404 too.
+    TestUtils.assertIcebergApiException(
+        () ->
+            icebergClient.reportMetrics(
+                TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME, "missingTable", scanReport()),
+        404);
   }
 
   @Test
   public void testListNamespacesReturnsEveryNamespace() throws ApiException, IOException {
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    // One namespace more than the repository returns in a single page
-    List<String> created = new ArrayList<>();
+    // One namespace more than the repository returns in a single page (on top of the default
+    // SCHEMA_NAME the base class created).
+    List<String> expected = new ArrayList<>();
     for (int i = 0; i <= PAGE_SIZE; i++) {
       String name = "schema_%03d".formatted(i);
-      schemaOperations.createSchema(
-          new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(name));
-      created.add(name);
+      icebergClient.createNamespace(TestUtils.CATALOG_NAME, name);
+      expected.add(name);
     }
+    // The base class's default SCHEMA_NAME ("uc_testschema") sorts after every "schema_NNN", so it
+    // comes last in the sorted listing.
+    expected.add(TestUtils.SCHEMA_NAME);
 
-    AggregatedHttpResponse resp = client.get(TEST_BASE_PREFIX + "/namespaces").aggregate().join();
-
-    assertThat(resp.status().code()).isEqualTo(200);
-    ListNamespacesResponse listed =
-        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListNamespacesResponse.class);
-    assertThat(listed.namespaces()).map(Namespace::toString).containsExactlyElementsOf(created);
+    ListNamespacesResponse listed = icebergClient.listNamespaces(TestUtils.CATALOG_NAME);
+    // The listing pages to the end and returns exactly the expected namespaces, in order -- so a
+    // paging regression that dropped, duplicated, or reordered entries beyond the first page fails.
+    assertThat(listed.namespaces()).map(Namespace::toString).containsExactlyElementsOf(expected);
   }
 
   @Test
   public void testListTablesReturnsTablesBeyondTheFirstPage()
       throws ApiException, IOException, URISyntaxException {
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    schemaOperations.createSchema(
-        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
-
     // Fill the first page with tables the Iceberg endpoints don't serve, so that the only uniform
     // table sorts onto the second page
     for (int i = 0; i < PAGE_SIZE; i++) {
@@ -940,25 +830,15 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     }
     setUniformMetadata(createTable("uniform_table"), writeIcebergMetadata());
 
-    AggregatedHttpResponse resp =
-        client
-            .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables")
-            .aggregate()
-            .join();
-
-    assertThat(resp.status().code()).isEqualTo(200);
     ListTablesResponse listed =
-        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
+        icebergClient.listTables(TestUtils.CATALOG_NAME, TestUtils.SCHEMA_NAME);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
   }
 
-  private AggregatedHttpResponse postJson(String path, String body) {
-    return client
-        .execute(
-            RequestHeaders.builder(HttpMethod.POST, path).contentType(MediaType.JSON).build(), body)
-        .aggregate()
-        .join();
+  /** Maps a cloud location back to the local path the fake FileIO wrote it to. */
+  private Path localPathOf(String cloudLocation) {
+    return mappingFileOperations.localPathOf(NormalizedURL.from(cloudLocation));
   }
 
   private StagingTableDAO getStagingTableByLocation(String location) {
@@ -978,40 +858,28 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         .getSingleResult();
   }
 
-  private static String scanReportJson() {
-    return ReportMetricsRequestParser.toJson(
-        ReportMetricsRequest.of(
-            ImmutableScanReport.builder()
-                .tableName(TestUtils.TABLE_NAME)
-                .schemaId(0)
-                .addProjectedFieldIds(1)
-                .addProjectedFieldNames("as_int")
-                .snapshotId(23L)
-                .filter(Expressions.alwaysTrue())
-                .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
-                .build()));
+  private static ReportMetricsRequest scanReport() {
+    return ReportMetricsRequest.of(
+        ImmutableScanReport.builder()
+            .tableName(TestUtils.TABLE_NAME)
+            .schemaId(0)
+            .addProjectedFieldIds(1)
+            .addProjectedFieldNames("as_int")
+            .snapshotId(23L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+            .build());
   }
 
-  private static String commitReportJson() {
-    return ReportMetricsRequestParser.toJson(
-        ReportMetricsRequest.of(
-            ImmutableCommitReport.builder()
-                .tableName(TestUtils.TABLE_NAME)
-                .snapshotId(23L)
-                .sequenceNumber(4L)
-                .operation("append")
-                .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
-                .build()));
-  }
-
-  /** Creates a table that the Iceberg endpoints see, i.e. one with uniform Iceberg metadata. */
-  private void createUniformIcebergTable() throws IOException, URISyntaxException, ApiException {
-    Path metadataFile = writeIcebergMetadata();
-    catalogOperations.createCatalog(
-        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
-    schemaOperations.createSchema(
-        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
-    setUniformMetadata(createTable(TestUtils.TABLE_NAME), metadataFile);
+  private static ReportMetricsRequest commitReport() {
+    return ReportMetricsRequest.of(
+        ImmutableCommitReport.builder()
+            .tableName(TestUtils.TABLE_NAME)
+            .snapshotId(23L)
+            .sequenceNumber(4L)
+            .operation("append")
+            .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
+            .build());
   }
 
   /** Makes a table visible to the Iceberg endpoints by giving it uniform Iceberg metadata. */

--- a/server/src/test/java/io/unitycatalog/server/utils/FileOperationsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/FileOperationsTest.java
@@ -15,6 +15,7 @@ import io.unitycatalog.server.model.GcpOauthToken;
 import io.unitycatalog.server.model.TemporaryCredentials;
 import io.unitycatalog.server.persist.utils.ExternalLocationUtils;
 import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.persist.utils.FileOperationsImpl;
 import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
 import io.unitycatalog.server.service.credential.StorageCredentialVendor;
 import java.io.FileNotFoundException;
@@ -175,7 +176,7 @@ public class FileOperationsTest {
   public void testGetFileIOConfigLocalPathSkipsVending() {
     // Local paths must short-circuit to an empty config WITHOUT vending credentials.
     StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     Map<String, String> config =
         fileOps.getFileIOConfig(NormalizedURL.from("file:///tmp/some/table"));
@@ -200,7 +201,7 @@ public class FileOperationsTest {
                         .accessKeyId("AKIA")
                         .secretAccessKey("secret")
                         .sessionToken("token")));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(props));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(props));
 
     Map<String, String> config =
         fileOps.getFileIOConfig(NormalizedURL.from("s3://my-bucket/table"));
@@ -220,7 +221,7 @@ public class FileOperationsTest {
             new TemporaryCredentials()
                 .gcpOauthToken(new GcpOauthToken().oauthToken("gcs-token"))
                 .expirationTime(12345L));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     Map<String, String> config =
         fileOps.getFileIOConfig(NormalizedURL.from("gs://my-bucket/table"));
@@ -236,7 +237,7 @@ public class FileOperationsTest {
     when(vendor.vendCredential(any(), any()))
         .thenReturn(
             new TemporaryCredentials().gcpOauthToken(new GcpOauthToken().oauthToken("gcs-token")));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     Map<String, String> config =
         fileOps.getFileIOConfig(NormalizedURL.from("gs://my-bucket/table"));
@@ -252,7 +253,7 @@ public class FileOperationsTest {
         .thenReturn(
             new TemporaryCredentials()
                 .azureUserDelegationSas(new AzureUserDelegationSAS().sasToken("sas-token")));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     Map<String, String> config =
         fileOps.getFileIOConfig(
@@ -269,7 +270,7 @@ public class FileOperationsTest {
     // silently returning a credential-less config.
     StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
     when(vendor.vendCredential(any(), any())).thenReturn(new TemporaryCredentials());
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     assertThatThrownBy(() -> fileOps.getFileIOConfig(NormalizedURL.from("gs://my-bucket/table")))
         .isInstanceOf(BaseException.class)
@@ -288,7 +289,7 @@ public class FileOperationsTest {
                         .accessKeyId("AKIA")
                         .secretAccessKey("secret")
                         .sessionToken("token")));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     assertThatThrownBy(() -> fileOps.getFileIOConfig(NormalizedURL.from("s3://my-bucket/table")))
         .isInstanceOf(BaseException.class)
@@ -300,7 +301,7 @@ public class FileOperationsTest {
     // Local paths must not be vended and must resolve to SimpleLocalFileIO (no ResolvingFileIO,
     // which would require hadoop-client-runtime for the file:// scheme).
     StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     try (FileIO fileIO = fileOps.getFileIO(NormalizedURL.from("file:///tmp/some/table"))) {
       assertThat(fileIO).isInstanceOf(SimpleLocalFileIO.class);
@@ -316,7 +317,7 @@ public class FileOperationsTest {
     Files.writeString(file, "hello world");
 
     StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     try (FileIO fileIO = fileOps.getFileIO(NormalizedURL.from(file.toUri().toString()))) {
       InputFile input = fileIO.newInputFile(file.toUri().toString());
@@ -329,7 +330,7 @@ public class FileOperationsTest {
   public void testGetFileIOForLocalPathWritesThroughReturnedFileIO() {
     Path file = rootBase.resolve("metadata-" + UUID.randomUUID() + ".json");
     StorageCredentialVendor vendor = mock(StorageCredentialVendor.class);
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(new Properties()));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(new Properties()));
 
     try (FileIO fileIO = fileOps.getFileIO(NormalizedURL.from(file.toUri().toString()))) {
       OutputFile output = fileIO.newOutputFile(file.toUri().toString());
@@ -356,7 +357,7 @@ public class FileOperationsTest {
                         .accessKeyId("AKIA")
                         .secretAccessKey("secret")
                         .sessionToken("token")));
-    FileOperations fileOps = new FileOperations(vendor, new ServerProperties(props));
+    FileOperations fileOps = new FileOperationsImpl(vendor, new ServerProperties(props));
 
     try (FileIO fileIO = fileOps.getFileIO(NormalizedURL.from("s3://my-bucket/table"))) {
       assertThat(fileIO).isInstanceOf(ResolvingFileIO.class);

--- a/server/src/test/java/io/unitycatalog/server/utils/IcebergRestClient.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/IcebergRestClient.java
@@ -1,0 +1,177 @@
+package io.unitycatalog.server.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+/**
+ * Minimal Iceberg REST catalog client for tests.
+ *
+ * <p>The UC REST and Delta APIs have generated SDK clients; the Iceberg REST catalog does not, so
+ * tests drive it over raw HTTP. This builds on {@link TestUtils#sendRaw} (the shared raw-HTTP
+ * sender used across the test suite) for transport -- base path, bearer auth from the {@link
+ * ServerConfig}, request execution -- and adds Iceberg path building and {@link
+ * IcebergObjectMapper} (de)serialization. Construct one instance per authenticated principal, from
+ * that principal's {@link ServerConfig}.
+ *
+ * <p>Each method returns the native Iceberg response type (or {@code void}/{@code boolean}) and, on
+ * a non-2xx response, throws the SDK's {@link ApiException} -- the same exception the UC/Delta
+ * clients throw -- carrying the HTTP status ({@link ApiException#getCode()}) and the Iceberg error
+ * body. CRUD tests read typed results directly; access-control tests assert on the status.
+ */
+public class IcebergRestClient {
+
+  private static final ObjectMapper MAPPER = IcebergObjectMapper.mapper();
+  private static final String BASE_PATH = "/api/2.1/unity-catalog/iceberg";
+
+  private final ServerConfig config;
+
+  public IcebergRestClient(ServerConfig config) {
+    this.config = config;
+  }
+
+  // --- endpoints ------------------------------------------------------------------------------
+
+  public ConfigResponse config(String warehouse) throws ApiException {
+    return parse(get("/v1/config?warehouse=" + warehouse), ConfigResponse.class);
+  }
+
+  public ListNamespacesResponse listNamespaces(String catalog) throws ApiException {
+    return parse(get(namespacesPath(catalog)), ListNamespacesResponse.class);
+  }
+
+  public GetNamespaceResponse loadNamespace(String catalog, String namespace) throws ApiException {
+    return parse(get(namespacePath(catalog, namespace)), GetNamespaceResponse.class);
+  }
+
+  public CreateNamespaceResponse createNamespace(String catalog, String namespace)
+      throws ApiException {
+    return createNamespace(
+        catalog, CreateNamespaceRequest.builder().withNamespace(Namespace.of(namespace)).build());
+  }
+
+  public CreateNamespaceResponse createNamespace(String catalog, CreateNamespaceRequest request)
+      throws ApiException {
+    return parse(post(namespacesPath(catalog), toJson(request)), CreateNamespaceResponse.class);
+  }
+
+  public ListTablesResponse listTables(String catalog, String namespace) throws ApiException {
+    return parse(get(tablesPath(catalog, namespace)), ListTablesResponse.class);
+  }
+
+  public LoadTableResponse loadTable(String catalog, String namespace, String table)
+      throws ApiException {
+    return parse(get(tablePath(catalog, namespace, table)), LoadTableResponse.class);
+  }
+
+  public boolean tableExists(String catalog, String namespace, String table) throws ApiException {
+    HttpResponse<String> response = head(tablePath(catalog, namespace, table));
+    int code = response.statusCode();
+    // The Iceberg REST spec returns 204 on existence; the UC server currently returns 200. Accept
+    // any 2xx so this is robust to either. 404 means "does not exist"; anything else is an error.
+    if (code >= 200 && code < 300) {
+      return true;
+    }
+    if (code == 404) {
+      return false;
+    }
+    throw new ApiException(code, "Iceberg REST request failed", null, response.body());
+  }
+
+  public LoadTableResponse createTable(String catalog, String namespace, CreateTableRequest request)
+      throws ApiException {
+    return parse(post(tablesPath(catalog, namespace), toJson(request)), LoadTableResponse.class);
+  }
+
+  public LoadTableResponse updateTable(
+      String catalog, String namespace, String table, UpdateTableRequest request)
+      throws ApiException {
+    return parse(
+        post(tablePath(catalog, namespace, table), toJson(request)), LoadTableResponse.class);
+  }
+
+  public void dropTable(String catalog, String namespace, String table) throws ApiException {
+    checkSuccess(delete(tablePath(catalog, namespace, table)));
+  }
+
+  public void reportMetrics(
+      String catalog, String namespace, String table, ReportMetricsRequest report)
+      throws ApiException {
+    checkSuccess(
+        post(
+            tablePath(catalog, namespace, table) + "/metrics",
+            ReportMetricsRequestParser.toJson(report)));
+  }
+
+  // --- plumbing -------------------------------------------------------------------------------
+
+  @SneakyThrows
+  private static <T> T parse(HttpResponse<String> response, Class<T> type) throws ApiException {
+    checkSuccess(response);
+    return MAPPER.readValue(response.body(), type);
+  }
+
+  private static void checkSuccess(HttpResponse<String> response) throws ApiException {
+    int code = response.statusCode();
+    if (code < 200 || code >= 300) {
+      throw new ApiException(code, "Iceberg REST request failed", null, response.body());
+    }
+  }
+
+  @SneakyThrows
+  private static String toJson(Object body) {
+    return MAPPER.writeValueAsString(body);
+  }
+
+  @SneakyThrows
+  private HttpResponse<String> get(String path) {
+    return TestUtils.sendRaw(config, "GET", BASE_PATH + path, Optional.empty());
+  }
+
+  @SneakyThrows
+  private HttpResponse<String> head(String path) {
+    return TestUtils.sendRaw(config, "HEAD", BASE_PATH + path, Optional.empty());
+  }
+
+  @SneakyThrows
+  private HttpResponse<String> delete(String path) {
+    return TestUtils.sendRaw(config, "DELETE", BASE_PATH + path, Optional.empty());
+  }
+
+  @SneakyThrows
+  private HttpResponse<String> post(String path, String jsonBody) {
+    return TestUtils.sendRaw(config, "POST", BASE_PATH + path, Optional.of(jsonBody));
+  }
+
+  private static String namespacesPath(String catalog) {
+    return "/v1/catalogs/" + catalog + "/namespaces";
+  }
+
+  private static String namespacePath(String catalog, String namespace) {
+    return namespacesPath(catalog) + "/" + namespace;
+  }
+
+  private static String tablesPath(String catalog, String namespace) {
+    return namespacePath(catalog, namespace) + "/tables";
+  }
+
+  private static String tablePath(String catalog, String namespace, String table) {
+    return tablesPath(catalog, namespace) + "/" + table;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/LocalMappingFileIO.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/LocalMappingFileIO.java
@@ -1,0 +1,227 @@
+package io.unitycatalog.server.utils;
+
+import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import lombok.experimental.Delegate;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+
+/**
+ * Test {@link FileIO} that maps one registered cloud prefix onto a local directory, so the server's
+ * Iceberg create/commit/load path can run end-to-end without a real cloud backend. A location under
+ * {@code cloudPrefix} has that prefix rewritten to {@code localDir} (e.g. prefix {@code
+ * s3://bucket/root} + {@code localDir} {@code /tmp/root} maps {@code s3://bucket/root/t/v.json} →
+ * {@code /tmp/root/t/v.json}); a location outside the prefix is rejected, so a stray access fails
+ * loudly. IO is delegated to {@link SimpleLocalFileIO}.
+ *
+ * <p>Before any read/write it asserts the vended config carries the scheme's credential keys (see
+ * the constructor), so a credential-less cloud FileIO fails loudly. This is lighter than the Spark
+ * fakes, which also validate the credential provider wiring and vary credentials per bucket.
+ *
+ * <p>The returned {@link InputFile}/{@link OutputFile} report the original cloud location, not the
+ * mapped local path, so metadata Iceberg reads back keeps its {@code s3://} location.
+ */
+public class LocalMappingFileIO implements FileIO {
+
+  private final SimpleLocalFileIO delegate = new SimpleLocalFileIO();
+  private final NormalizedURL cloudPrefix;
+  private final Path localDir;
+  private final Map<String, String> config;
+  private final boolean writable;
+
+  /**
+   * @param cloudPrefix the cloud location prefix this FileIO serves (e.g. {@code s3://bucket/root})
+   * @param localDir the local directory {@code cloudPrefix} is rewritten to
+   * @param config the config the server vended for the location (from {@code
+   *     FileOperations#getFileIOConfig})
+   * @param expectedCredentials config-key → expected value; each key the scheme requires must be
+   *     present in {@code config}, and where an expected value is given must match it exactly.
+   * @param privileges the privileges the server vended for; without {@code UPDATE} this FileIO
+   *     rejects writes, mimicking read-only cloud credentials.
+   */
+  public LocalMappingFileIO(
+      NormalizedURL cloudPrefix,
+      Path localDir,
+      Map<String, String> config,
+      Map<String, String> expectedCredentials,
+      Set<CredentialContext.Privilege> privileges) {
+    this.cloudPrefix = cloudPrefix;
+    this.localDir = localDir;
+    this.config = config;
+    this.writable = privileges.contains(CredentialContext.Privilege.UPDATE);
+    validateVendedCredentials(UriScheme.fromURI(cloudPrefix.toUri()), config, expectedCredentials);
+  }
+
+  private static void validateVendedCredentials(
+      UriScheme scheme, Map<String, String> config, Map<String, String> expected) {
+    switch (scheme) {
+      case S3 -> {
+        requireVendedKey(scheme, config, expected, S3FileIOProperties.ACCESS_KEY_ID);
+        requireVendedKey(scheme, config, expected, S3FileIOProperties.SECRET_ACCESS_KEY);
+        requireVendedKey(scheme, config, expected, S3FileIOProperties.SESSION_TOKEN);
+      }
+      case GS -> requireVendedKey(scheme, config, expected, GCPProperties.GCS_OAUTH2_TOKEN);
+      case ABFS, ABFSS ->
+          requireVendedKeyPrefix(scheme, config, AzureProperties.ADLS_SAS_TOKEN_PREFIX);
+      default -> throw new IllegalStateException("Not a cloud scheme: " + scheme);
+    }
+  }
+
+  /**
+   * Requires {@code key} to be present and non-blank, and -- when {@code expected} supplies a value
+   * for it -- to equal that value, so the credential is provably the one UC's test vendor produced.
+   */
+  private static void requireVendedKey(
+      UriScheme scheme, Map<String, String> config, Map<String, String> expected, String key) {
+    String value = config.get(key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException(
+          String.format(
+              "No vended credential for %s FileIO: missing/blank '%s' (config keys: %s)",
+              scheme, key, config.keySet()));
+    }
+    String expectedValue = expected.get(key);
+    if (expectedValue != null && !expectedValue.equals(value)) {
+      throw new IllegalStateException(
+          String.format(
+              "Credential '%s' for %s FileIO did not match the value vended by UC's test credential"
+                  + " vendor (expected '%s'); a present-but-unexpected value suggests it was not"
+                  + " produced by UC vending",
+              key, scheme, expectedValue));
+    }
+  }
+
+  private static void requireVendedKeyPrefix(
+      UriScheme scheme, Map<String, String> config, String keyPrefix) {
+    boolean present =
+        config.entrySet().stream()
+            .anyMatch(
+                e ->
+                    e.getKey().startsWith(keyPrefix)
+                        && e.getValue() != null
+                        && !e.getValue().isBlank());
+    if (!present) {
+      throw new IllegalStateException(
+          String.format(
+              "No vended credential for %s FileIO: no non-blank key starting with '%s' (config"
+                  + " keys: %s)",
+              scheme, keyPrefix, config.keySet()));
+    }
+  }
+
+  /**
+   * Maps a cloud {@code location} under {@code cloudPrefix} to the local file it stands in for,
+   * rejecting any location outside the prefix.
+   */
+  public static Path toLocalPath(String location, NormalizedURL cloudPrefix, Path localDir) {
+    String prefix = cloudPrefix.toString();
+    if (location.equals(prefix)) {
+      return localDir;
+    }
+    // Match on a path boundary so a sibling (e.g. ".../root2") isn't mistaken for a child of
+    // ".../root".
+    String base = prefix.endsWith("/") ? prefix : prefix + "/";
+    if (!location.startsWith(base)) {
+      throw new IllegalStateException(
+          String.format("Location %s is not under mapped prefix %s", location, prefix));
+    }
+    return localDir.resolve(location.substring(base.length()));
+  }
+
+  private String toLocalUri(String location) {
+    return toLocalPath(location, cloudPrefix, localDir).toUri().toString();
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    return new LocalMappingInputFile(delegate.newInputFile(toLocalUri(path)), path);
+  }
+
+  @Override
+  public InputFile newInputFile(String path, long length) {
+    return new LocalMappingInputFile(delegate.newInputFile(toLocalUri(path), length), path);
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    requireWritable("write");
+    return new LocalMappingOutputFile(delegate.newOutputFile(toLocalUri(path)), path);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    requireWritable("delete");
+    delegate.deleteFile(toLocalUri(path));
+  }
+
+  /** Fails a mutating op when the FileIO was vended read-only, as read-only cloud creds would. */
+  private void requireWritable(String operation) {
+    if (!writable) {
+      throw new IllegalStateException(
+          String.format(
+              "Cannot %s through a read-only (SELECT-only) FileIO for %s", operation, cloudPrefix));
+    }
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return config;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {}
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  // @Delegate forwards every FileIO method to the wrapped local file; the methods defined below
+  // (location, and toInputFile for output) are not generated, since lombok skips a method the class
+  // already declares. That lets each wrapper report the original cloud location while doing IO
+  // locally.
+
+  /** Delegates all IO to a local {@link InputFile} but reports the original cloud location. */
+  private static final class LocalMappingInputFile implements InputFile {
+    @Delegate private final InputFile local;
+    private final String reportedLocation;
+
+    LocalMappingInputFile(InputFile local, String reportedLocation) {
+      this.local = local;
+      this.reportedLocation = reportedLocation;
+    }
+
+    @Override
+    public String location() {
+      return reportedLocation;
+    }
+  }
+
+  /** Delegates all IO to a local {@link OutputFile} but reports the original cloud location. */
+  private static final class LocalMappingOutputFile implements OutputFile {
+    @Delegate private final OutputFile local;
+    private final String reportedLocation;
+
+    LocalMappingOutputFile(OutputFile local, String reportedLocation) {
+      this.local = local;
+      this.reportedLocation = reportedLocation;
+    }
+
+    @Override
+    public String location() {
+      return reportedLocation;
+    }
+
+    @Override
+    public InputFile toInputFile() {
+      return new LocalMappingInputFile(local.toInputFile(), reportedLocation);
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/LocalMappingFileOperations.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/LocalMappingFileOperations.java
@@ -1,0 +1,78 @@
+package io.unitycatalog.server.utils;
+
+import io.unitycatalog.server.persist.utils.FileOperations;
+import io.unitycatalog.server.service.credential.CredentialContext;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.io.FileIO;
+
+/**
+ * Decorating {@link FileOperations} for tests: serves cloud locations under a single registered
+ * prefix from a local directory (via {@link LocalMappingFileIO}) while delegating local paths and
+ * all credential vending to the wrapped real instance. Register the mapping with {@link
+ * #mapLocation} after the server starts; a cloud access outside the prefix fails. Wire it via
+ * {@code UnityCatalogServer.Builder#fileOperations} / {@code
+ * BaseServerTest#decorateFileOperations}.
+ */
+public class LocalMappingFileOperations implements FileOperations {
+
+  private final FileOperations delegate;
+  private final Map<String, String> expectedCredentials;
+  private NormalizedURL cloudPrefix;
+  private Path localDir;
+
+  /**
+   * @param expectedCredentials config-key → expected value that UC's test credential vendor should
+   *     have produced; passed through to {@link LocalMappingFileIO} for exact-match validation.
+   */
+  public LocalMappingFileOperations(
+      FileOperations delegate, Map<String, String> expectedCredentials) {
+    this.delegate = delegate;
+    this.expectedCredentials = expectedCredentials;
+  }
+
+  /**
+   * Serves cloud locations under {@code cloudPrefix} from {@code localDir}. May be called only
+   * once: a single test maps a single cloud root.
+   */
+  public void mapLocation(NormalizedURL cloudPrefix, Path localDir) {
+    if (this.cloudPrefix != null) {
+      throw new IllegalStateException(
+          "A location mapping is already registered: " + this.cloudPrefix);
+    }
+    this.cloudPrefix = cloudPrefix;
+    this.localDir = localDir;
+  }
+
+  /** The local path a mapped cloud location resolves to (for test assertions). */
+  public Path localPathOf(NormalizedURL cloudLocation) {
+    return LocalMappingFileIO.toLocalPath(cloudLocation.toString(), cloudPrefix, localDir);
+  }
+
+  @Override
+  public FileIO getFileIO(NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
+    UriScheme scheme = UriScheme.fromURI(path.toUri());
+    if (scheme == UriScheme.FILE || scheme == UriScheme.NULL) {
+      return delegate.getFileIO(path, privileges);
+    }
+    if (cloudPrefix == null) {
+      throw new IllegalStateException("No local mapping registered for cloud location: " + path);
+    }
+    // Vend real credentials (as production getFileIO does) and hand them to the fake, which
+    // validates them before mapping IO to the registered local dir. The privileges are passed
+    // through so a read-only FileIO refuses writes, as read-only cloud credentials would.
+    return new LocalMappingFileIO(
+        cloudPrefix,
+        localDir,
+        delegate.getFileIOConfig(path, privileges),
+        expectedCredentials,
+        privileges);
+  }
+
+  @Override
+  public Map<String, String> getFileIOConfig(
+      NormalizedURL path, Set<CredentialContext.Privilege> privileges) {
+    return delegate.getFileIOConfig(path, privileges);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/TestUtils.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Flow;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.junit.jupiter.api.function.Executable;
 
 public class TestUtils {
@@ -160,6 +163,52 @@ public class TestUtils {
         .isTrue();
   }
 
+  public static void assertIcebergApiException(Executable executable, int expectedStatus) {
+    assertIcebergApiExceptionImpl(executable, expectedStatus, Optional.empty());
+  }
+
+  /**
+   * As {@link #assertIcebergApiException(Executable, int)}, additionally asserting the error
+   * message contains {@code containsMessage}.
+   */
+  public static void assertIcebergApiException(
+      Executable executable, int expectedStatus, String containsMessage) {
+    assertIcebergApiExceptionImpl(executable, expectedStatus, Optional.of(containsMessage));
+  }
+
+  /**
+   * Asserts the call fails with {@code expectedStatus} and an Iceberg REST {@code ErrorResponse}
+   * body. The Iceberg endpoints use Iceberg's own error format ({@code {"error": {"code", "type",
+   * "message"}}}), distinct from the UC envelope ({@link #assertApiException}) and the Delta
+   * envelope ({@link #assertDeltaApiException}). Mirroring {@link #assertDeltaApiException}, this
+   * parses the body into an {@link ErrorResponse} and checks that both the HTTP status and the code
+   * echoed in the body equal {@code expectedStatus} (and, when present, that the message contains
+   * {@code containsMessage}).
+   */
+  private static void assertIcebergApiExceptionImpl(
+      Executable executable, int expectedStatus, Optional<String> containsMessage) {
+    ApiException ex = assertThrows(ApiException.class, executable);
+    assertThat(ex.getCode()).isEqualTo(expectedStatus);
+    ErrorResponse error = parseIcebergErrorBody(ex.getResponseBody());
+    assertThat(error.code())
+        .as("Iceberg ErrorResponse code in: %s", ex.getResponseBody())
+        .isEqualTo(expectedStatus);
+    containsMessage.ifPresent(
+        m ->
+            assertThat(error.message())
+                .as("Iceberg error message in: %s", ex.getResponseBody())
+                .contains(m));
+  }
+
+  private static ErrorResponse parseIcebergErrorBody(String bodyText) {
+    try {
+      return ErrorResponseParser.fromJson(bodyText);
+    } catch (Exception e) {
+      return fail(
+          "Error response was not a valid Iceberg ErrorResponse: " + bodyText, e);
+    }
+  }
+
   public static void assertDeltaApiException(
       Executable executable, DeltaErrorType expectedType, String expectedMessageSubstring) {
     int expectedCode = ErrorCode.getDeltaHttpStatus(expectedType.getValue()).code();
@@ -278,7 +327,7 @@ public class TestUtils {
     try {
       return new ObjectMapper().readTree(bodyText);
     } catch (Exception e) {
-      return org.assertj.core.api.Assertions.fail(
+      return fail(
           "Error response was not valid JSON: " + bodyText, e);
     }
   }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1814/files) to review incremental changes.
- [stack/irc_crud](https://github.com/unitycatalog/unitycatalog/pull/1814) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1814/files)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Rewrite the existing `IcebergRestCatalogTest` onto the hand-rolled `IcebergRestClient` and `BaseCRUDTestWithMockCredentials`, and expand its coverage of the endpoints served by `IcebergRestCatalogService` (native Iceberg writes enabled):
  - `config`, namespace create/get/list
  - table create / staged-create / commit / load / drop / list
  - metrics reporting and concurrent commits
  - end-to-end write lifecycle against emulated `s3://` / `gs://` storage
- Add `IcebergRestCatalogDisabledTest`: with `iceberg-table.enabled=false`, `config` advertises only read endpoints and write endpoints are rejected
- Split `FileOperations` into an interface + `FileOperationsImpl`; add a `UnaryOperator<FileOperations>` decorator seam via `Repositories` and `UnityCatalogServer.Builder`:
  - existing constructors retained; no public method signatures change
- Add test infrastructure:
  - `IcebergRestClient` - hand-rolled Iceberg REST client (no generated SDK for that surface)
  - `LocalMappingFileIO` / `LocalMappingFileOperations` - map a registered cloud prefix to a local dir, validating vended credentials and privileges
  - `TestUtils.assertIcebergApiException`
- Hoist mock credential-vendor fixtures (`CONFIGURED_BUCKET`, `S3_ACCESS_KEY`, `GCS_OAUTH_TOKEN`, `EXPECTED_VENDED_S3_CREDENTIALS`) into `BaseCRUDTestWithMockCredentials` as a single source of truth
- No API, wire-format, property, or generated-code changes

Tested: build/sbt "server/testOnly io.unitycatalog.server.service.IcebergRestCatalog* io.unitycatalog.server.utils.FileOperationsTest"
