### PR TITLE
[AI] [#1816] Add service credentials and secrets support to UC Python UDFs

### DIFF
--- a/ai/core/README.md
+++ b/ai/core/README.md
@@ -372,6 +372,130 @@ def dep_check(x: str) -> str:
 client.create_python_function(func=dep_check, catalog=CATALOG, schema=SCHEMA, replace=True, dependencies=["scrapy==2.10.1"])
 ```
 
+Dependencies can also be wheels stored in a Unity Catalog volume, referenced by their full volume path:
+
+```python
+client.create_python_function(
+    func=dep_check,
+    catalog=CATALOG,
+    schema=SCHEMA,
+    replace=True,
+    dependencies=["/Volumes/my_catalog/my_schema/my_volume/internal_sdk-1.2.0-py3-none-any.whl"],
+)
+```
+
+> [!NOTE]
+> Dependencies are installed by the Unity Catalog execution environment. They are not installed into the
+> local sandbox used by the `"local"` execution mode, so a function that imports an external dependency
+> must be executed with the `"serverless"` execution mode.
+
+#### Service Credentials and Secrets
+
+A function can declare Unity Catalog **service credentials** and **secrets** that its body reads at execution
+time. The declaration grants the function access; the body reads the values through the Databricks runtime
+modules. This requires a runtime that supports these clauses for scalar Python UDFs.
+
+To declare a service credential, pass either its name or a `ServiceCredential`. The alias is the name the
+credential is referred to by inside the function body, and the credential marked as the default is the one
+`CredentialRetriever` returns when called with no arguments:
+
+```python
+from unitycatalog.ai.core.utils.callable_utils import ServiceCredential
+
+
+def list_bucket(prefix: str) -> str:
+    """
+    List objects in an S3 bucket.
+
+    Args:
+        prefix: The key prefix to list.
+
+    Returns:
+        A newline-delimited list of object keys.
+    """
+    import boto3
+    from databricks.service_credentials.credential_retriever import CredentialRetriever
+
+    creds = CredentialRetriever().get_aws_credential("prod-s3")
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=creds.access_key_id,
+        aws_secret_access_key=creds.secret_access_key,
+        aws_session_token=creds.session_token,
+    )
+    response = s3.list_objects_v2(Bucket="my-bucket", Prefix=prefix)
+    return "\n".join(obj["Key"] for obj in response.get("Contents", []))
+
+
+client.create_python_function(
+    func=list_bucket,
+    catalog=CATALOG,
+    schema=SCHEMA,
+    replace=True,
+    dependencies=["boto3"],
+    credentials=[ServiceCredential(name="prod-s3", is_default=True)],
+)
+```
+
+Secrets are declared as three-part `catalog.schema.key` names and read with `databricks.secrets.secrets.get`:
+
+```python
+def call_api(query: str) -> str:
+    """
+    Call an external API using a stored API key.
+
+    Args:
+        query: The query to send.
+
+    Returns:
+        The API response body.
+    """
+    import requests
+    from databricks.secrets.secrets import get
+
+    api_key = get("main", "default", "api_key")
+    return requests.get(
+        "https://api.example.com/search",
+        params={"q": query},
+        headers={"Authorization": f"Bearer {api_key}"},
+    ).text
+
+
+client.create_python_function(
+    func=call_api,
+    catalog=CATALOG,
+    schema=SCHEMA,
+    replace=True,
+    dependencies=["requests"],
+    environment_version="6",
+    secrets=["main.default.api_key"],
+)
+```
+
+> [!IMPORTANT]
+> Declaring secrets requires an explicit `environment_version` of `"6"` or higher. The version that Unity
+> Catalog selects implicitly does not include the `databricks.secrets` module, so omitting it will fail.
+
+Functions that declare credentials or secrets cannot be executed with the `"local"` execution mode, which has
+no access to the Unity Catalog credential and secret services. Use the `"serverless"` execution mode.
+
+To read the declarations back off an existing function, use the helpers in `function_processing_utils`. Unity
+Catalog returns these in the JSON-encoded `FunctionInfo.properties` field rather than as typed fields:
+
+```python
+from unitycatalog.ai.core.utils.function_processing_utils import (
+    get_function_credentials,
+    get_function_environment,
+    get_function_secrets,
+)
+
+function_info = client.get_function(f"{CATALOG}.{SCHEMA}.call_api")
+
+get_function_environment(function_info)  # FunctionEnvironment(dependencies=['requests'], environment_version='6')
+get_function_credentials(function_info)  # [ServiceCredential(name='prod-s3', alias=None, is_default=True)]
+get_function_secrets(function_info)      # ['main.default.api_key']
+```
+
 #### Retrieve a UC function
 
 The client also provides API to get the UC function information details. Note that the function name passed in must be the full name in the format of `<catalog>.<schema>.<function_name>`.

--- a/ai/core/src/unitycatalog/ai/core/databricks.py
+++ b/ai/core/src/unitycatalog/ai/core/databricks.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass
 from decimal import Decimal
 from io import StringIO
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from typing_extensions import override
 
@@ -21,6 +21,7 @@ from unitycatalog.ai.core.executor.local_subprocess import run_in_sandbox_subpro
 from unitycatalog.ai.core.paged_list import PagedList
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
+    ServiceCredential,
     dynamically_construct_python_function,
     generate_sql_function_body,
     generate_wrapped_sql_function_body,
@@ -32,6 +33,8 @@ from unitycatalog.ai.core.utils.execution_utils import (
 )
 from unitycatalog.ai.core.utils.function_processing_utils import (
     extract_function_name,
+    get_function_credentials,
+    get_function_secrets,
     process_function_parameter_defaults,
 )
 from unitycatalog.ai.core.utils.retry_utils import retry_on_session_expiration
@@ -90,6 +93,25 @@ def _validate_databricks_connect_available() -> bool:
             raise Exception(DATABRICKS_CONNECT_VERSION_NOT_SUPPORTED_ERROR_MESSAGE)
     except ImportError as e:
         raise Exception(DATABRICKS_CONNECT_IMPORT_ERROR_MESSAGE) from e
+
+
+def _declared_securables(function_info: "FunctionInfo") -> str:
+    """
+    Describe the credentials and secrets a function declares, for use in error messages.
+
+    Args:
+        function_info: The FunctionInfo to inspect.
+
+    Returns:
+        A human-readable description such as "service credentials and secrets", or an empty
+        string when the function declares neither.
+    """
+    declared = []
+    if get_function_credentials(function_info):
+        declared.append("service credentials")
+    if get_function_secrets(function_info):
+        declared.append("secrets")
+    return " and ".join(declared)
 
 
 def _is_in_databricks_notebook_environment() -> bool:
@@ -229,6 +251,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
         replace: bool = False,
         dependencies: Optional[list[str]] = None,
         environment_version: str = "None",
+        credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+        secrets: Optional[list[str]] = None,
     ) -> "FunctionInfo":
         """
         Create a Unity Catalog (UC) function directly from a Python function.
@@ -324,6 +348,46 @@ class DatabricksFunctionClient(BaseFunctionClient):
             - It is strongly recommended to test the created function by executing it before integrating it into
             GenAI or other tools.
 
+        4. **Service Credentials and Secrets**:
+            - A function can declare Unity Catalog service credentials and secrets that its body may read at
+            execution time. The declaration is made here; the function body reads them through the Databricks
+            runtime modules:
+
+            ```python
+            from unitycatalog.ai.core.utils.callable_utils import ServiceCredential
+
+            def read_bucket(key: str) -> str:
+                \"\"\"
+                Read an object from S3.
+
+                Args:
+                    key (str): The object key to read.
+
+                Returns:
+                    str: The object contents.
+                \"\"\"
+                from databricks.service_credentials.credential_retriever import CredentialRetriever
+                from databricks.secrets.secrets import get
+
+                token = CredentialRetriever().get_aws_credential("prod-s3").access_key_id
+                api_key = get("main", "default", "api_key")
+                ...
+
+            client.create_python_function(
+                func=read_bucket,
+                catalog="main",
+                schema="ai",
+                environment_version="6",
+                credentials=[ServiceCredential(name="prod-s3", is_default=True)],
+                secrets=["main.default.api_key"],
+            )
+            ```
+
+            - Declaring secrets requires an explicit `environment_version` of '6' or higher; the version Unity
+            Catalog selects implicitly does not include the `databricks.secrets` module.
+            - Functions that declare credentials or secrets cannot be run in 'local' execution mode, which has no
+            access to the Unity Catalog credential and secret services. Use 'serverless' execution mode instead.
+
         **Function Metadata**:
         - Docstrings (if provided and Google-style) will automatically be included as detailed descriptions for
         function parameters as well as for the function itself, enhancing the discoverability of the utility of your
@@ -367,6 +431,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
             environment_version: The version of the environment in which the function will be executed. Defaults to 'None'. Note
                 that the `environment_version` parameter is not supported in all runtimes. Ensure that you are using a runtime that
                 supports environment and dependency declaration prior to creating a function that declares an environment verison.
+            credentials: An optional list of Unity Catalog service credentials to make available to the function body. Each entry is
+                either a credential name or a `ServiceCredential`, which additionally supports an alias to refer to the credential by
+                and marking it as the function's default credential. At most one credential can be the default.
+            secrets: An optional list of Unity Catalog secrets to make available to the function body, each a three-part name of the
+                form 'catalog.schema.key'. Declaring secrets requires `environment_version` to be '6' or higher.
 
         Returns:
             FunctionInfo: Metadata about the created function, including its name and signature.
@@ -376,7 +445,14 @@ class DatabricksFunctionClient(BaseFunctionClient):
             raise ValueError("The provided function is not callable.")
 
         sql_function_body = generate_sql_function_body(
-            func, catalog, schema, replace, dependencies, environment_version
+            func=func,
+            catalog=catalog,
+            schema=schema,
+            replace=replace,
+            dependencies=dependencies,
+            environment_version=environment_version,
+            credentials=credentials,
+            secrets=secrets,
         )
 
         try:
@@ -404,6 +480,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
         replace=False,
         dependencies: Optional[list[str]] = None,
         environment_version: str = "None",
+        credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+        secrets: Optional[list[str]] = None,
     ) -> "FunctionInfo":
         """
         Create a wrapped function comprised of a `primary_func` function and in-lined wrapped `functions` within the `primary_func` body.
@@ -424,6 +502,11 @@ class DatabricksFunctionClient(BaseFunctionClient):
             environment_version: The version of the environment in which the function will be executed. Defaults to 'None'. Note
                 that the `environment_version` parameter is not supported in all runtimes. Ensure that you are using a runtime that
                 supports environment and dependency declaration prior to creating a function that declares an environment verison.
+            credentials: An optional list of Unity Catalog service credentials to make available to the function body. Each entry is
+                either a credential name or a `ServiceCredential`, which additionally supports an alias to refer to the credential by
+                and marking it as the function's default credential. At most one credential can be the default.
+            secrets: An optional list of Unity Catalog secrets to make available to the function body, each a three-part name of the
+                form 'catalog.schema.key'. Declaring secrets requires `environment_version` to be '6' or higher.
 
         Returns:
             FunctionInfo: Metadata about the created function, including its name and signature.
@@ -439,6 +522,8 @@ class DatabricksFunctionClient(BaseFunctionClient):
             replace=replace,
             dependencies=dependencies,
             environment_version=environment_version,
+            credentials=credentials,
+            secrets=secrets,
         )
 
         return self.create_function(sql_function_body=sql_function_body)
@@ -728,6 +813,13 @@ class DatabricksFunctionClient(BaseFunctionClient):
             raise ValueError(
                 "Local sandbox execution is only supported for scalar Python functions. "
                 "Use 'serverless' execution mode for table functions."
+            )
+        # The sandbox subprocess has no Unity Catalog securable service, so a body that reads a
+        # credential or a secret dies with an opaque signal instead of a usable error.
+        if declared := _declared_securables(function_info):
+            raise ValueError(
+                f"Function {function_info.full_name} declares {declared}, which are not available "
+                "in local sandbox execution. Use 'serverless' execution mode to execute it."
             )
         _logger.info("Using local sandbox to execute functions.")
 

--- a/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/callable_utils.py
@@ -26,6 +26,10 @@ from unitycatalog.ai.core.utils.type_utils import (
 FORBIDDEN_PARAMS = ["self", "cls"]
 PRIMARY_INDENT = " " * 4
 WRAPPED_INDENT = " " * 6
+# Mirrors the server-side minimum environment version that ships the `databricks.secrets`
+# module. Unity Catalog is the authority on this value; it is duplicated here only to fail
+# fast with an actionable message instead of after a round trip.
+SECRETS_MIN_ENVIRONMENT_VERSION = 6
 
 
 class FunctionBodyExtractor(ast.NodeVisitor):
@@ -124,6 +128,28 @@ class SQLMetadata:
     sql_params: List[str]
     func_comment: str
     indented_body: str
+
+
+@dataclass(frozen=True)
+class ServiceCredential:
+    """
+    Dataclass to declare a Unity Catalog service credential on a function.
+
+    A credential is exposed to the function body through
+    `databricks.service_credentials.credential_retriever.CredentialRetriever`, keyed by
+    `alias` when one is given and by `name` otherwise. The credential marked as the default
+    is the one `CredentialRetriever` returns when called without a name.
+
+    Attributes:
+        name: The name of the service credential in Unity Catalog.
+        alias: An optional alias to refer to the credential by within the function body.
+        is_default: Whether this is the default credential for the function. At most one
+            credential in a function may be the default.
+    """
+
+    name: str
+    alias: Optional[str] = None
+    is_default: bool = False
 
 
 def extract_function_body(func: Callable[..., Any]) -> tuple[str, int]:
@@ -389,6 +415,84 @@ def process_parameter(
         return f"{param_name} {sql_type} COMMENT '{param_comment}'"
 
 
+def _quote_identifier(identifier: str, context: str) -> str:
+    """
+    Backtick-quote a SQL identifier so that names containing hyphens or reserved words parse.
+
+    Args:
+        identifier: The identifier to quote.
+        context: A description of what the identifier is, used in error messages.
+
+    Returns:
+        str: The backtick-quoted identifier.
+
+    Raises:
+        ValueError: If the identifier is empty or contains a backtick.
+    """
+    if not identifier or not identifier.strip():
+        raise ValueError(f"{context} cannot be empty.")
+    if "`" in identifier:
+        raise ValueError(f"{context} cannot contain a backtick: {identifier!r}.")
+    return f"`{identifier}`"
+
+
+def _validate_dependencies(dependencies: list[str]) -> None:
+    """
+    Validate function dependencies before they are embedded in the ENVIRONMENT clause.
+
+    The dependency list is emitted as a single-quoted SQL string literal, so a dependency
+    containing a single quote or a backslash would corrupt the statement. Volume paths are
+    checked for the `/Volumes/<catalog>/<schema>/<volume>` shape that Unity Catalog resolves
+    to a volume securable.
+
+    Args:
+        dependencies: The list of dependencies to validate.
+
+    Raises:
+        ValueError: If a dependency is empty, contains a single quote or a backslash, or is a
+            malformed volume path.
+    """
+    for dependency in dependencies:
+        stripped = dependency.strip() if dependency else ""
+        if not stripped:
+            raise ValueError("Dependencies cannot contain empty entries.")
+        for character, name in (("'", "a single quote"), ("\\", "a backslash")):
+            if character in dependency:
+                raise ValueError(
+                    f"Dependency cannot contain {name}: {dependency!r}. The dependency list is "
+                    "carried in a SQL string literal that such a character would corrupt."
+                )
+        if stripped.lower().startswith("/volumes/"):
+            segments = [segment for segment in stripped.split("/") if segment]
+            if len(segments) < 4:
+                raise ValueError(
+                    f"Volume dependency {dependency!r} is not a valid volume path. Expected at "
+                    "least '/Volumes/<catalog>/<schema>/<volume>'."
+                )
+
+
+def _validate_environment_version(environment_version: str) -> None:
+    """
+    Validate the environment version before it is embedded in the ENVIRONMENT clause.
+
+    The version is emitted inside a single-quoted SQL string literal. A single quote would close
+    that literal, and a trailing backslash would escape the closing quote so that the rest of the
+    statement is absorbed into the string and the text after it is reparsed as SQL.
+
+    Args:
+        environment_version: The environment version to validate.
+
+    Raises:
+        ValueError: If the version contains a single quote or a backslash.
+    """
+    for character, name in (("'", "a single quote"), ("\\", "a backslash")):
+        if character in environment_version:
+            raise ValueError(
+                f"environment_version cannot contain {name}: {environment_version!r}. It is "
+                "emitted inside a single-quoted SQL string literal."
+            )
+
+
 def construct_dependency_statement(
     dependencies: Optional[list[str]] = None, environment_version: str = "None"
 ) -> str:
@@ -402,13 +506,136 @@ def construct_dependency_statement(
     Returns:
         str: The constructed dependency statement.
     """
+    _validate_environment_version(environment_version)
     if dependencies:
+        _validate_dependencies(dependencies)
         dependencies_json = json.dumps(dependencies)
         return f"\nENVIRONMENT (dependencies = '{dependencies_json}', environment_version = '{environment_version}')"
     elif environment_version != "None":
         return f"\nENVIRONMENT (environment_version = '{environment_version}')"
     else:
         return ""
+
+
+def construct_credentials_statement(
+    credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+) -> str:
+    """
+    Constructs the CREDENTIALS clause for the SQL function.
+
+    Args:
+        credentials: An optional list of service credentials to make available to the function.
+            A plain string is shorthand for `ServiceCredential(name=...)`.
+
+    Returns:
+        str: The constructed CREDENTIALS clause, or an empty string if no credentials are given.
+
+    Raises:
+        ValueError: If more than one credential is marked as the default, or if two credentials
+            resolve to the same name within the function body.
+    """
+    if not credentials:
+        return ""
+
+    specs = []
+    referenced_names = set()
+    default_names = []
+    for credential in credentials:
+        if isinstance(credential, str):
+            credential = ServiceCredential(name=credential)
+
+        spec = _quote_identifier(credential.name, "Service credential name")
+        if credential.alias is not None:
+            spec += f" AS {_quote_identifier(credential.alias, 'Service credential alias')}"
+        if credential.is_default:
+            spec += " DEFAULT"
+            default_names.append(credential.name)
+
+        # The name a credential is reachable by inside the function body, which is what must
+        # be unique; two different credentials aliased to the same thing are ambiguous.
+        referenced_name = credential.alias or credential.name
+        if referenced_name in referenced_names:
+            raise ValueError(
+                f"Duplicate service credential reference: {referenced_name!r}. Each credential "
+                "must have a distinct name or alias within a function."
+            )
+        referenced_names.add(referenced_name)
+        specs.append(spec)
+
+    if len(default_names) > 1:
+        raise ValueError(
+            "Only one service credential can be marked as the default, but "
+            f"{len(default_names)} were: {default_names}."
+        )
+
+    return f"\nCREDENTIALS ({', '.join(specs)})"
+
+
+def _validate_secrets_environment_version(environment_version: str) -> None:
+    """
+    Validate that the environment version supports secrets.
+
+    Unity Catalog rejects a function that declares secrets on an environment version below
+    `SECRETS_MIN_ENVIRONMENT_VERSION`, and the version the server picks implicitly is currently
+    below that minimum, so an explicit version is required. A version that does not parse as a
+    number (a named channel, for example) is left to the server to judge rather than rejected
+    here.
+
+    Args:
+        environment_version: The environment version declared for the function.
+
+    Raises:
+        ValueError: If the version is absent or is a number below the minimum.
+    """
+    if environment_version == "None":
+        raise ValueError(
+            "Declaring secrets requires an explicit environment_version of at least "
+            f"'{SECRETS_MIN_ENVIRONMENT_VERSION}'. Pass "
+            f"environment_version='{SECRETS_MIN_ENVIRONMENT_VERSION}' when creating the function."
+        )
+
+    major_version = environment_version.split("-", 1)[0]
+    if major_version.isdigit() and int(major_version) < SECRETS_MIN_ENVIRONMENT_VERSION:
+        raise ValueError(
+            f"Declaring secrets requires an environment_version of at least "
+            f"'{SECRETS_MIN_ENVIRONMENT_VERSION}', but {environment_version!r} was given."
+        )
+
+
+def construct_secrets_statement(
+    secrets: Optional[list[str]] = None, environment_version: str = "None"
+) -> str:
+    """
+    Constructs the SECRETS clause for the SQL function.
+
+    Args:
+        secrets: An optional list of Unity Catalog secrets to make available to the function,
+            each a three-part name of the form "catalog.schema.key".
+        environment_version: The environment version declared for the function. Secrets require
+            an explicit version of at least `SECRETS_MIN_ENVIRONMENT_VERSION`.
+
+    Returns:
+        str: The constructed SECRETS clause, or an empty string if no secrets are given.
+
+    Raises:
+        ValueError: If a secret is not a three-part name, or if the environment version is
+            absent or below the minimum that supports secrets.
+    """
+    if not secrets:
+        return ""
+
+    _validate_secrets_environment_version(environment_version)
+
+    specs = []
+    for secret in secrets:
+        parts = secret.split(".")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Secret {secret!r} must be a three-part name of the form 'catalog.schema.key'."
+            )
+        specs.append(".".join(_quote_identifier(part, "Secret identifier part") for part in parts))
+
+    return f"\nSECRETS ({', '.join(specs)})"
 
 
 def assemble_sql_body(
@@ -422,6 +649,8 @@ def assemble_sql_body(
     replace: bool,
     dependencies: Optional[list[str]] = None,
     environment_version: str = "None",
+    credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+    secrets: Optional[list[str]] = None,
 ) -> str:
     """
     Assembles the final SQL function body.
@@ -439,6 +668,8 @@ def assemble_sql_body(
         replace: Whether to include the 'OR REPLACE' clause.
         dependencies: An optional list of PyPI dependencies for the function to utilize in the execution environment
         environment_version: The version of the environment to use for the function. Defaults to "None".
+        credentials: An optional list of service credentials to make available to the function.
+        secrets: An optional list of Unity Catalog secrets to make available to the function.
 
     Returns:
         The assembled SQL function creation statement.
@@ -448,10 +679,12 @@ def assemble_sql_body(
     """Assembles the final SQL function body."""
     sql_params_str = ", ".join(sql_params)
     environment_str = construct_dependency_statement(dependencies, environment_version)
+    credentials_str = construct_credentials_statement(credentials)
+    secrets_str = construct_secrets_statement(secrets, environment_version)
     sql_body = f"""
 {replace_command} FUNCTION `{catalog}`.`{schema}`.`{func_name}`({sql_params_str})
 RETURNS {sql_return_type}
-LANGUAGE PYTHON{environment_str}
+LANGUAGE PYTHON{environment_str}{credentials_str}{secrets_str}
 COMMENT '{func_comment}'
 AS $$
 {indented_body}
@@ -570,6 +803,8 @@ def generate_sql_function_body(
     replace: bool = False,
     dependencies: Optional[list[str]] = None,
     environment_version: str = "None",
+    credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+    secrets: Optional[list[str]] = None,
 ) -> str:
     """
     Generate SQL body for creating the function in Unity Catalog.
@@ -581,6 +816,8 @@ def generate_sql_function_body(
         replace: Whether to replace the function if it already exists. Defaults to False.
         dependencies: An optional list of PyPI dependencies for the function to utilize in the execution environment
         environment_version: The version of the environment to use for the function. Defaults to "None".
+        credentials: An optional list of service credentials to make available to the function.
+        secrets: An optional list of Unity Catalog secrets to make available to the function.
 
     Returns:
         SQL statement for creating the UDF.
@@ -601,6 +838,8 @@ def generate_sql_function_body(
         replace,
         dependencies,
         environment_version,
+        credentials,
+        secrets,
     )
 
     return sql_body
@@ -614,6 +853,8 @@ def generate_wrapped_sql_function_body(
     replace: bool = False,
     dependencies: Optional[list[str]] = None,
     environment_version: str = "None",
+    credentials: Optional[list[Union[str, ServiceCredential]]] = None,
+    secrets: Optional[list[str]] = None,
 ) -> str:
     """
     Generate SQL body for creating the function in Unity Catalog.
@@ -626,6 +867,8 @@ def generate_wrapped_sql_function_body(
         replace: Whether to include the 'OR REPLACE' clause.
         dependencies: An optional list of PyPI dependencies for the function to utilize in the execution environment
         environment_version: The version of the environment to use for the function. Defaults to "None".
+        credentials: An optional list of service credentials to make available to the function.
+        secrets: An optional list of Unity Catalog secrets to make available to the function.
 
     Returns:
         SQL statement for creating the UDF.
@@ -653,6 +896,8 @@ def generate_wrapped_sql_function_body(
         replace,
         dependencies,
         environment_version,
+        credentials,
+        secrets,
     )
 
     return sql_body

--- a/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
+++ b/ai/core/src/unitycatalog/ai/core/utils/function_processing_utils.py
@@ -5,12 +5,14 @@ import json
 import logging
 import os
 import re
+from dataclasses import dataclass
 from hashlib import md5
 from io import StringIO
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pydantic import Field, create_model
 
+from unitycatalog.ai.core.utils.callable_utils import ServiceCredential
 from unitycatalog.ai.core.utils.config import JSON_SCHEMA_TYPE, UC_LIST_FUNCTIONS_MAX_RESULTS
 from unitycatalog.ai.core.utils.pydantic_utils import (
     PydanticField,
@@ -469,3 +471,133 @@ def extract_function_name(sql_body: str) -> str:
         "statement in Databricks: "
         "https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-sql-function.html#syntax."
     )
+
+
+@dataclass(frozen=True)
+class FunctionEnvironment:
+    """
+    Dataclass to store the execution environment declared on a Unity Catalog function.
+
+    Attributes:
+        dependencies: The dependencies declared for the function, empty when none were declared.
+        environment_version: The environment version declared for the function, or None when the
+            function did not declare one and Unity Catalog selected it implicitly.
+    """
+
+    dependencies: List[str]
+    environment_version: Optional[str]
+
+
+def _function_properties(function_info: Any) -> Dict[str, Any]:
+    """
+    Decode the `properties` field of a FunctionInfo into a dictionary.
+
+    Unity Catalog returns function properties as a JSON-encoded string rather than a typed field,
+    and the values within it are themselves JSON-encoded.
+
+    Args:
+        function_info: The FunctionInfo to read from.
+
+    Returns:
+        The decoded properties, or an empty dictionary if the function has none or they are not
+        decodable.
+    """
+    properties = getattr(function_info, "properties", None)
+    if not properties:
+        return {}
+    try:
+        decoded = json.loads(properties)
+    except (TypeError, ValueError):
+        _logger.warning("Unable to decode the properties of function %s.", function_info.name)
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _decode_property(properties: Dict[str, Any], key: str) -> Any:
+    """
+    Decode a single JSON-encoded property value.
+
+    Args:
+        properties: The decoded function properties.
+        key: The property key to read.
+
+    Returns:
+        The decoded value, or None when the key is absent or its value is not decodable.
+    """
+    raw = properties.get(key)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        _logger.warning("Unable to decode the %s property of a function.", key)
+        return None
+
+
+def get_function_environment(function_info: Any) -> FunctionEnvironment:
+    """
+    Read the execution environment declared on a Unity Catalog function.
+
+    Args:
+        function_info: The FunctionInfo to read from.
+
+    Returns:
+        FunctionEnvironment: The declared dependencies and environment version.
+    """
+    properties = _function_properties(function_info)
+    dependencies = _decode_property(properties, "environment.dependencies")
+    return FunctionEnvironment(
+        dependencies=dependencies if isinstance(dependencies, list) else [],
+        environment_version=properties.get("environment.environment_version"),
+    )
+
+
+def get_function_credentials(function_info: Any) -> List[ServiceCredential]:
+    """
+    Read the service credentials declared on a Unity Catalog function.
+
+    Note that a credential declared without an alias is stored as an alias equal to its name, so
+    it is indistinguishable from one explicitly aliased to its own name; both are reported with
+    `alias` set to None.
+
+    Args:
+        function_info: The FunctionInfo to read from.
+
+    Returns:
+        The declared service credentials, ordered by the name they are referenced by.
+    """
+    properties = _function_properties(function_info)
+    mappings = _decode_property(properties, "routine_credential.credentials_mappings")
+    if not isinstance(mappings, dict):
+        return []
+
+    default_credential = _decode_property(properties, "routine_credential.default_credential")
+    return [
+        ServiceCredential(
+            name=name,
+            alias=alias if alias != name else None,
+            is_default=name == default_credential,
+        )
+        for alias, name in sorted(mappings.items())
+    ]
+
+
+def get_function_secrets(function_info: Any) -> List[str]:
+    """
+    Read the Unity Catalog secrets declared on a function.
+
+    Args:
+        function_info: The FunctionInfo to read from.
+
+    Returns:
+        The declared secrets as three-part 'catalog.schema.key' names.
+    """
+    properties = _function_properties(function_info)
+    secrets = _decode_property(properties, "routine_secrets.secrets")
+    if not isinstance(secrets, dict):
+        return []
+    return [
+        f"{secret['catalog']}.{secret['schema']}.{secret['key']}"
+        for secret in secrets.get("secrets", [])
+        if isinstance(secret, dict) and {"catalog", "schema", "key"} <= secret.keys()
+    ]

--- a/ai/core/tests/core/databricks/test_databricks_unit_tests.py
+++ b/ai/core/tests/core/databricks/test_databricks_unit_tests.py
@@ -26,6 +26,13 @@ from unitycatalog.ai.core.databricks import (
     extract_function_name,
 )
 from unitycatalog.ai.core.envs.databricks_env_vars import UCAI_DATABRICKS_SESSION_RETRY_MAX_ATTEMPTS
+from unitycatalog.ai.core.utils.callable_utils import ServiceCredential
+from unitycatalog.ai.core.utils.function_processing_utils import (
+    FunctionEnvironment,
+    get_function_credentials,
+    get_function_environment,
+    get_function_secrets,
+)
 from unitycatalog.ai.core.utils.retry_utils import (
     SESSION_CHANGED_MESSAGE,
     SESSION_EXPIRED_MESSAGE,
@@ -1017,12 +1024,14 @@ def test_create_python_function_with_dependencies(client: DatabricksFunctionClie
         )
 
         mock_generate_sql.assert_called_once_with(
-            sample_func,
-            "catalog",
-            "schema",
-            False,
-            dependencies,
-            "None",
+            func=sample_func,
+            catalog="catalog",
+            schema="schema",
+            replace=False,
+            dependencies=dependencies,
+            environment_version="None",
+            credentials=None,
+            secrets=None,
         )
 
         client.create_function.assert_called_once_with(sql_function_body=expected_sql_body)
@@ -1072,12 +1081,14 @@ def test_create_python_function_with_environment_version(client: DatabricksFunct
         )
 
         mock_generate_sql.assert_called_once_with(
-            another_sample_func,
-            "catalog",
-            "schema",
-            False,
-            None,
-            environment_version,
+            func=another_sample_func,
+            catalog="catalog",
+            schema="schema",
+            replace=False,
+            dependencies=None,
+            environment_version=environment_version,
+            credentials=None,
+            secrets=None,
         )
 
         client.create_function.assert_called_once_with(sql_function_body=expected_sql_body)
@@ -1245,6 +1256,8 @@ def test_create_wrapped_function_databricks(mock_workspace_client, mock_spark_se
                 replace=True,
                 dependencies=None,
                 environment_version="None",
+                credentials=None,
+                secrets=None,
             )
             mock_create_func.assert_called_once_with(sql_function_body=dummy_sql_body)
             assert result == "dummy_func_info"
@@ -1282,6 +1295,8 @@ def test_create_wrapped_function_with_dependencies(mock_workspace_client, mock_s
                 replace=True,
                 dependencies=["scipy==1.15.0"],
                 environment_version="1",
+                credentials=None,
+                secrets=None,
             )
             mock_create_func.assert_called_once_with(sql_function_body=dummy_sql_body)
             assert result == "dummy_func_info"
@@ -1730,3 +1745,168 @@ def test_no_spark_session_created_for_local_execution_mode():
     ):
         client = DatabricksFunctionClient(execution_mode="local")
         assert client.spark is None
+
+
+# The property payloads below were captured from a live `get_function` response for a scalar
+# UDF created with dependencies, credentials, and secrets.
+_LIVE_PROPERTIES = {
+    "environment.dependencies": '["requests>=2.31"]',
+    "environment.environment_version": "6",
+    "featureTags.dependencies": "",
+    "isolation.strict": "false",
+    "routine_credential.credentials_mappings": '{"bedrock":"bedrock_sandbox"}',
+    "routine_credential.default_credential": '"bedrock_sandbox"',
+    "routine_secrets.secrets": (
+        '{"secrets":[{"catalog":"magrund","schema":"ucai_probe","key":"probe_key"}]}'
+    ),
+    "sqlConfig.spark.databricks.ai.adaptiveBatch.initialSize": "4",
+}
+
+
+def _function_info_with_properties(properties):
+    return FunctionInfo(
+        catalog_name="catalog",
+        schema_name="schema",
+        name="fn",
+        full_name="catalog.schema.fn",
+        data_type=ColumnTypeName.STRING,
+        properties=None if properties is None else json.dumps(properties),
+    )
+
+
+def test_get_function_environment_reads_live_payload():
+    env = get_function_environment(_function_info_with_properties(_LIVE_PROPERTIES))
+
+    assert env.dependencies == ["requests>=2.31"]
+    assert env.environment_version == "6"
+
+
+def test_get_function_credentials_reads_live_payload():
+    credentials = get_function_credentials(_function_info_with_properties(_LIVE_PROPERTIES))
+
+    assert credentials == [
+        ServiceCredential(name="bedrock_sandbox", alias="bedrock", is_default=True)
+    ]
+
+
+def test_get_function_secrets_reads_live_payload():
+    secrets = get_function_secrets(_function_info_with_properties(_LIVE_PROPERTIES))
+
+    assert secrets == ["magrund.ucai_probe.probe_key"]
+
+
+def test_get_function_credentials_without_alias():
+    # An omitted alias is stored as an alias equal to the credential name, so it must not be
+    # reported back as an explicit alias.
+    info = _function_info_with_properties(
+        {
+            "routine_credential.credentials_mappings": '{"cred":"cred"}',
+            "routine_credential.default_credential": "null",
+        }
+    )
+
+    assert get_function_credentials(info) == [ServiceCredential(name="cred", alias=None)]
+
+
+def test_get_function_credentials_multiple_are_sorted_and_only_one_is_default():
+    info = _function_info_with_properties(
+        {
+            "routine_credential.credentials_mappings": '{"z":"z_cred","a":"a_cred"}',
+            "routine_credential.default_credential": '"z_cred"',
+        }
+    )
+
+    assert get_function_credentials(info) == [
+        ServiceCredential(name="a_cred", alias="a", is_default=False),
+        ServiceCredential(name="z_cred", alias="z", is_default=True),
+    ]
+
+
+def test_get_function_secrets_multiple():
+    info = _function_info_with_properties(
+        {
+            "routine_secrets.secrets": (
+                '{"secrets":[{"catalog":"c1","schema":"s1","key":"k1"},'
+                '{"catalog":"c2","schema":"s2","key":"k2"}]}'
+            )
+        }
+    )
+
+    assert get_function_secrets(info) == ["c1.s1.k1", "c2.s2.k2"]
+
+
+@pytest.mark.parametrize("properties", [None, {}, {"sqlConfig.spark.foo": "bar"}])
+def test_readback_helpers_on_functions_without_declarations(properties):
+    info = _function_info_with_properties(properties)
+
+    assert get_function_environment(info) == FunctionEnvironment(
+        dependencies=[], environment_version=None
+    )
+    assert get_function_credentials(info) == []
+    assert get_function_secrets(info) == []
+
+
+@pytest.mark.parametrize(
+    "properties",
+    [
+        {"routine_credential.credentials_mappings": "not json"},
+        {"routine_credential.credentials_mappings": '"a string"'},
+        {"routine_secrets.secrets": "not json"},
+        {"routine_secrets.secrets": '{"secrets":[{"catalog":"c"}]}'},
+        {"environment.dependencies": "not json"},
+    ],
+)
+def test_readback_helpers_tolerate_malformed_properties(properties):
+    info = _function_info_with_properties(properties)
+
+    assert get_function_environment(info).dependencies == []
+    assert get_function_credentials(info) == []
+    assert get_function_secrets(info) == []
+
+
+def test_readback_helpers_tolerate_undecodable_properties():
+    info = FunctionInfo(
+        catalog_name="catalog", schema_name="schema", name="fn", properties="{not json"
+    )
+
+    assert get_function_credentials(info) == []
+
+
+@pytest.mark.parametrize(
+    ("properties", "expected_message"),
+    [
+        (
+            {"routine_credential.credentials_mappings": '{"c":"c"}'},
+            "declares service credentials",
+        ),
+        (
+            {"routine_secrets.secrets": '{"secrets":[{"catalog":"c","schema":"s","key":"k"}]}'},
+            "declares secrets",
+        ),
+        (_LIVE_PROPERTIES, "declares service credentials and secrets"),
+    ],
+)
+def test_local_execution_rejects_declared_securables(properties, expected_message):
+    client = DatabricksFunctionClient(client=MagicMock(), execution_mode="local")
+    info = FunctionInfo(
+        catalog_name="catalog",
+        schema_name="schema",
+        name="fn",
+        full_name="catalog.schema.fn",
+        data_type=ColumnTypeName.STRING,
+        routine_body=CreateFunctionRoutineBody.EXTERNAL,
+        routine_definition="return 'x'",
+        input_params=FunctionParameterInfos(parameters=[]),
+        properties=json.dumps(properties),
+    )
+
+    with pytest.raises(ValueError, match=expected_message):
+        client._execute_uc_functions_with_local(info, {})
+
+
+def test_get_function_secrets_ignores_non_dict_entries():
+    info = _function_info_with_properties(
+        {"routine_secrets.secrets": '{"secrets":["oops",{"catalog":"c","schema":"s","key":"k"}]}'}
+    )
+
+    assert get_function_secrets(info) == ["c.s.k"]

--- a/ai/core/tests/core/test_callable_utils.py
+++ b/ai/core/tests/core/test_callable_utils.py
@@ -7,10 +7,15 @@ import pytest
 
 from unitycatalog.ai.core.types import Variant
 from unitycatalog.ai.core.utils.callable_utils import (
+    ServiceCredential,
     _parse_routine_definition,
     _parse_sql_data_type,
+    construct_credentials_statement,
+    construct_dependency_statement,
+    construct_secrets_statement,
     dynamically_construct_python_function,
     generate_sql_function_body,
+    generate_wrapped_sql_function_body,
 )
 from unitycatalog.ai.core.utils.type_utils import SQL_TYPE_TO_PYTHON_TYPE_MAPPING
 
@@ -1903,3 +1908,307 @@ def test_dynamically_construct_python_function_indentation(input_body, expected_
     reconstructed = dynamically_construct_python_function(dummy)
     expected_def = build_expected_definition("test_func", input_body, "Test function")
     assert reconstructed == expected_def, f"Expected:\n{expected_def}\nGot:\n{reconstructed}"
+
+
+# ---------------------------
+# Tests for Credentials, Secrets, and Dependency Validation
+# ---------------------------
+
+
+def _env_deps_func(a: int) -> str:
+    """
+    A function that declares credentials or secrets.
+
+    Args:
+        a: An integer
+
+    Returns:
+        str: A string representation of the integer
+    """
+    return str(a)
+
+
+@pytest.mark.parametrize(
+    ("credentials", "expected"),
+    [
+        (None, ""),
+        ([], ""),
+        (["cred"], "\nCREDENTIALS (`cred`)"),
+        (["my-cred"], "\nCREDENTIALS (`my-cred`)"),
+        ([ServiceCredential(name="cred")], "\nCREDENTIALS (`cred`)"),
+        ([ServiceCredential(name="cred", alias="c")], "\nCREDENTIALS (`cred` AS `c`)"),
+        ([ServiceCredential(name="cred", is_default=True)], "\nCREDENTIALS (`cred` DEFAULT)"),
+        (
+            [ServiceCredential(name="cred", alias="c", is_default=True)],
+            "\nCREDENTIALS (`cred` AS `c` DEFAULT)",
+        ),
+        (
+            [ServiceCredential(name="a", is_default=True), ServiceCredential(name="b", alias="z")],
+            "\nCREDENTIALS (`a` DEFAULT, `b` AS `z`)",
+        ),
+        (["a", ServiceCredential(name="b")], "\nCREDENTIALS (`a`, `b`)"),
+    ],
+)
+def test_construct_credentials_statement(credentials, expected):
+    assert construct_credentials_statement(credentials) == expected
+
+
+@pytest.mark.parametrize(
+    ("credentials", "match"),
+    [
+        (
+            [
+                ServiceCredential(name="a", is_default=True),
+                ServiceCredential(name="b", is_default=True),
+            ],
+            "Only one service credential can be marked as the default",
+        ),
+        (
+            [ServiceCredential(name="a"), ServiceCredential(name="b", alias="a")],
+            "Duplicate service credential reference: 'a'",
+        ),
+        (
+            [ServiceCredential(name="a"), ServiceCredential(name="a")],
+            "Duplicate service credential",
+        ),
+        ([ServiceCredential(name="")], "Service credential name cannot be empty"),
+        ([ServiceCredential(name="a", alias="")], "Service credential alias cannot be empty"),
+        ([ServiceCredential(name="a`b")], "Service credential name cannot contain a backtick"),
+        (
+            [ServiceCredential(name="a", alias="x`y")],
+            "Service credential alias cannot contain a backtick",
+        ),
+    ],
+)
+def test_construct_credentials_statement_invalid(credentials, match):
+    with pytest.raises(ValueError, match=match):
+        construct_credentials_statement(credentials)
+
+
+@pytest.mark.parametrize(
+    ("secrets", "expected"),
+    [
+        (None, ""),
+        ([], ""),
+        (["cat.sch.key"], "\nSECRETS (`cat`.`sch`.`key`)"),
+        (["my-cat.my sch.key-1"], "\nSECRETS (`my-cat`.`my sch`.`key-1`)"),
+        (
+            ["a.b.c", "d.e.f"],
+            "\nSECRETS (`a`.`b`.`c`, `d`.`e`.`f`)",
+        ),
+    ],
+)
+def test_construct_secrets_statement(secrets, expected):
+    assert construct_secrets_statement(secrets, environment_version="6") == expected
+
+
+@pytest.mark.parametrize(
+    ("secrets", "match"),
+    [
+        (["cat.sch"], "must be a three-part name"),
+        (["cat.sch.key.extra"], "must be a three-part name"),
+        (["key"], "must be a three-part name"),
+        (["cat..key"], "Secret identifier part cannot be empty"),
+        (["cat.sch.ke`y"], "Secret identifier part cannot contain a backtick"),
+    ],
+)
+def test_construct_secrets_statement_invalid(secrets, match):
+    with pytest.raises(ValueError, match=match):
+        construct_secrets_statement(secrets, environment_version="6")
+
+
+@pytest.mark.parametrize("environment_version", ["6", "7", "10", "6-AIRGAPPED", "custom-channel"])
+def test_secrets_environment_version_accepted(environment_version):
+    assert construct_secrets_statement(["a.b.c"], environment_version) == "\nSECRETS (`a`.`b`.`c`)"
+
+
+@pytest.mark.parametrize("environment_version", ["None", "1", "5", "5-AIRGAPPED"])
+def test_secrets_environment_version_rejected(environment_version):
+    with pytest.raises(ValueError, match="environment_version"):
+        construct_secrets_statement(["a.b.c"], environment_version)
+
+
+def test_secrets_without_environment_version_names_the_fix():
+    with pytest.raises(ValueError, match="environment_version='6'"):
+        construct_secrets_statement(["a.b.c"], "None")
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "match"),
+    [
+        (["pandas'; DROP"], "cannot contain a single quote"),
+        ([""], "cannot contain empty entries"),
+        (["   "], "cannot contain empty entries"),
+        (["/Volumes/cat/sch"], "not a valid volume path"),
+        (["/volumes/cat"], "not a valid volume path"),
+    ],
+)
+def test_validate_dependencies_invalid(dependencies, match):
+    with pytest.raises(ValueError, match=match):
+        construct_dependency_statement(dependencies)
+
+
+@pytest.mark.parametrize(
+    "dependency",
+    [
+        "requests>=2.31",
+        "/Volumes/cat/sch/vol/pkg.whl",
+        "/volumes/cat/sch/vol",
+        "git+https://example.invalid/pkg.git",
+    ],
+)
+def test_validate_dependencies_valid(dependency):
+    assert dependency in construct_dependency_statement([dependency])
+
+
+def test_credentials_and_secrets_in_generated_sql():
+    sql_body = generate_sql_function_body(
+        _env_deps_func,
+        "test_catalog",
+        "test_schema",
+        True,
+        ["numpy"],
+        "6",
+        [ServiceCredential(name="my-cred", alias="c", is_default=True)],
+        ["cat.sch.key"],
+    )
+
+    expected_sql = """
+CREATE OR REPLACE FUNCTION `test_catalog`.`test_schema`.`_env_deps_func`(a LONG COMMENT 'An integer')
+RETURNS STRING
+LANGUAGE PYTHON
+ENVIRONMENT (dependencies = '["numpy"]', environment_version = '6')
+CREDENTIALS (`my-cred` AS `c` DEFAULT)
+SECRETS (`cat`.`sch`.`key`)
+COMMENT 'A function that declares credentials or secrets.'
+AS $$
+    return str(a)
+$$;
+    """
+
+    assert sql_body.strip() == expected_sql.strip()
+
+
+def test_credentials_only_in_generated_sql():
+    sql_body = generate_sql_function_body(
+        _env_deps_func, "test_catalog", "test_schema", True, credentials=["my-cred"]
+    )
+
+    expected_sql = """
+CREATE OR REPLACE FUNCTION `test_catalog`.`test_schema`.`_env_deps_func`(a LONG COMMENT 'An integer')
+RETURNS STRING
+LANGUAGE PYTHON
+CREDENTIALS (`my-cred`)
+COMMENT 'A function that declares credentials or secrets.'
+AS $$
+    return str(a)
+$$;
+    """
+
+    assert sql_body.strip() == expected_sql.strip()
+
+
+def test_secrets_only_in_generated_sql():
+    sql_body = generate_sql_function_body(
+        _env_deps_func,
+        "test_catalog",
+        "test_schema",
+        True,
+        environment_version="6",
+        secrets=["cat.sch.key"],
+    )
+
+    expected_sql = """
+CREATE OR REPLACE FUNCTION `test_catalog`.`test_schema`.`_env_deps_func`(a LONG COMMENT 'An integer')
+RETURNS STRING
+LANGUAGE PYTHON
+ENVIRONMENT (environment_version = '6')
+SECRETS (`cat`.`sch`.`key`)
+COMMENT 'A function that declares credentials or secrets.'
+AS $$
+    return str(a)
+$$;
+    """
+
+    assert sql_body.strip() == expected_sql.strip()
+
+
+def test_no_credentials_or_secrets_leaves_sql_unchanged():
+    sql_body = generate_sql_function_body(_env_deps_func, "test_catalog", "test_schema", True)
+
+    assert "CREDENTIALS" not in sql_body
+    assert "SECRETS" not in sql_body
+
+
+def test_wrapped_function_carries_credentials_and_secrets():
+    def helper(x: int) -> int:
+        """
+        Double a number.
+
+        Args:
+            x: A number
+
+        Returns:
+            int: The doubled number
+        """
+        return x * 2
+
+    def primary(a: int) -> str:
+        """
+        A wrapper function.
+
+        Args:
+            a: An integer
+
+        Returns:
+            str: A string
+        """
+        return str(helper(a))
+
+    sql_body = generate_wrapped_sql_function_body(
+        primary_func=primary,
+        functions=[helper],
+        catalog="test_catalog",
+        schema="test_schema",
+        replace=True,
+        environment_version="6",
+        credentials=["my-cred"],
+        secrets=["cat.sch.key"],
+    )
+
+    assert "CREDENTIALS (`my-cred`)" in sql_body
+    assert "SECRETS (`cat`.`sch`.`key`)" in sql_body
+
+
+@pytest.mark.parametrize("environment_version", ["6' OR '1'='1", "'"])
+def test_environment_version_rejects_single_quote(environment_version):
+    with pytest.raises(ValueError, match="environment_version cannot contain a single quote"):
+        construct_dependency_statement(["numpy"], environment_version)
+
+
+@pytest.mark.parametrize("environment_version", ["6\\", "\\", "6\\\\"])
+def test_environment_version_rejects_backslash(environment_version):
+    # A trailing backslash escapes the closing quote of the SQL string literal the version is
+    # emitted into, so the rest of the statement is absorbed and the text after it is reparsed
+    # as SQL.
+    with pytest.raises(ValueError, match="environment_version cannot contain a backslash"):
+        construct_dependency_statement(["numpy"], environment_version)
+
+
+@pytest.mark.parametrize("dependency", ["numpy\\", "\\", "/Volumes/c/s/v/a\\b.whl"])
+def test_dependencies_reject_backslash(dependency):
+    with pytest.raises(ValueError, match="Dependency cannot contain a backslash"):
+        construct_dependency_statement([dependency])
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("plain", "`plain`"),
+        ("with-hyphen", "`with-hyphen`"),
+        ("with space", "`with space`"),
+        ("SELECT", "`SELECT`"),
+    ],
+)
+def test_identifiers_are_quoted_verbatim(identifier, expected):
+    assert construct_credentials_statement([identifier]) == f"\nCREDENTIALS ({expected})"


### PR DESCRIPTION
Unity Catalog Python UDFs can declare service credentials and secrets that their body reads at execution time, but `DatabricksFunctionClient` had no way to emit either clause. Functions needing an external credential or an API key could not be created through this library at all.

Changes:

- Add `credentials` and `secrets` to `create_python_function` and `create_wrapped_function`. Credentials are declared as a credential name or a `ServiceCredential`, which also carries an alias and a default marker; secrets are three-part `catalog.schema.key` names.
- Validate both client-side, mirroring the server's own rules: at most one default credential, no duplicate references, three-part secret names, and an `environment_version` of at least 6 for secrets. The version Unity Catalog picks implicitly is below that minimum, so an explicit version is required.
- Backtick-quote every emitted identifier, so hyphenated credential names and secret keys parse.
- Validate dependencies, which are interpolated into a single-quoted SQL string literal: reject embedded single quotes, and check the shape of `/Volumes/` paths so a malformed one fails locally rather than at create time. The same quoting check now covers `environment_version`.
- Add `get_function_environment`, `get_function_credentials`, and `get_function_secrets`, which read these declarations back out of the JSON-encoded `FunctionInfo.properties` field. Unity Catalog exposes no typed field for them, and the values are themselves JSON-encoded.
- Reject local sandbox execution of a function that declares credentials or secrets. The sandbox has no Unity Catalog securable service, so the body otherwise dies with an opaque signal rather than a usable error.

`generate_sql_function_body` is now called with keyword arguments, as its sibling already was.

Verified end to end against a workspace: a function declaring a dependency, an aliased default credential, and a secret was created, read back with all three declarations intact, and executed on serverless.

Tests: `pytest tests/core` (352 passed; `test_local_executor.py` fails identically on an unmodified tree in this environment, and `tests/core/oss` needs a local server).

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
