### PR TITLE
[Server] Use explicit S3 actions in AssumeRole session policies

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -23,9 +23,17 @@ public class AwsPolicyGenerator {
 
   static final String AWS_PARTITION = "aws";
 
-  static final List<String> SELECT_ACTIONS = List.of("s3:GetO*");
+  // Exact action names: some S3-compatible STS implementations reject partial
+  // wildcards such as s3:GetO*. On AWS, multipart initiate/upload/complete are
+  // authorized by s3:PutObject; abort and list-parts are separate actions.
+  static final List<String> SELECT_ACTIONS = List.of("s3:GetObject");
   static final List<String> UPDATE_ACTIONS =
-      List.of("s3:GetO*", "s3:PutO*", "s3:DeleteO*", "s3:*Multipart*");
+      List.of(
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListMultipartUploadParts");
 
   // Reading an object encrypted with SSE-KMS requires kms:Decrypt, and writing one additionally
   // requires kms:GenerateDataKey*. Without these the vended session credentials can't touch a

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -148,9 +148,15 @@ public class AwsPolicyGeneratorTest {
                 .toList());
 
     assertThat(updatePolicy)
-        .contains("s3:PutO*")
-        .contains("s3:GetO*")
-        .contains("s3:DeleteO*")
+        .contains("s3:PutObject")
+        .contains("s3:GetObject")
+        .contains("s3:DeleteObject")
+        .contains("s3:AbortMultipartUpload")
+        .contains("s3:ListMultipartUploadParts")
+        .doesNotContain("s3:PutO*")
+        .doesNotContain("s3:GetO*")
+        .doesNotContain("s3:DeleteO*")
+        .doesNotContain("s3:*Multipart*")
         .contains("arn:aws:s3:::profile-bucket2/*")
         .contains("arn:aws:s3:::profile-bucket3/*");
 
@@ -165,9 +171,12 @@ public class AwsPolicyGeneratorTest {
                 .toList());
 
     assertThat(selectPolicy)
+        .doesNotContain("s3:PutObject")
+        .doesNotContain("s3:DeleteObject")
         .doesNotContain("s3:PutO*")
         .doesNotContain("s3:DeleteO*")
-        .contains("s3:GetO*");
+        .contains("s3:GetObject")
+        .doesNotContain("s3:GetO*");
   }
 
   @Test
@@ -239,10 +248,29 @@ public class AwsPolicyGeneratorTest {
             Set.of(SELECT), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
 
     JsonNode statements = JSON_MAPPER.readTree(policy).get("Statement");
-    assertThat(statements.get(0).path("Action")).map(JsonNode::asText).containsExactly("s3:GetO*");
+    assertThat(statements.get(0).path("Action"))
+        .map(JsonNode::asText)
+        .containsExactly("s3:GetObject");
     assertThat(statements.get(1).path("Action"))
         .map(JsonNode::asText)
         .containsExactly("s3:ListBucket");
+  }
+
+  @Test
+  public void testUpdatePolicyEmitsExactMultipartActions() throws Exception {
+    String policy =
+        AwsPolicyGenerator.generatePolicy(
+            Set.of(UPDATE), List.of(NormalizedURL.from("s3://my-bucket/path1/table1")));
+
+    JsonNode actions = JSON_MAPPER.readTree(policy).get("Statement").get(0).path("Action");
+    assertThat(actions)
+        .map(JsonNode::asText)
+        .containsExactlyInAnyOrder(
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:AbortMultipartUpload",
+            "s3:ListMultipartUploadParts");
   }
 
   @ParameterizedTest(name = "{index}: region {0} -> partition {1}")


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

AssumeRole session policies currently emit partial IAM action wildcards (`s3:GetO*`, `s3:PutO*`, `s3:DeleteO*`, `s3:*Multipart*`). Some S3-compatible STS implementations reject those patterns, so credential vending fails even when the rest of the AWS config is valid.

This PR lists the concrete S3 actions needed for table I/O:

- SELECT: `s3:GetObject`
- UPDATE: `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:AbortMultipartUpload`, `s3:ListMultipartUploadParts`

`s3:ListBucket` and the KMS statements are unchanged. On AWS, CreateMultipartUpload / UploadPart / CompleteMultipartUpload are authorized by `s3:PutObject`; abort and list-parts remain explicit.

On AWS this is also a least-privilege tightening. `s3:GetO*` / `s3:PutO*` / `s3:DeleteO*` / `s3:*Multipart*` match extra APIs the session does not need for table reads and writes (for example object ACL, torrent, and version variants). Exact actions grant only the operations UC intends to vend. Functional AWS I/O is unchanged for the normal Spark/Delta/Iceberg path.

The action array grows by 4 characters (SELECT) or 51 (UPDATE). The existing long GovCloud managed-table fixture stays under the 1600-character packed-policy budget.

Related: https://github.com/unitycatalog/unitycatalog/issues/43 (S3-compatible endpoints; this is the session-policy piece only)

**Testing**

- [x] `AwsPolicyGeneratorTest` assertions updated for exact actions
- [x] `testUpdatePolicyEmitsExactMultipartActions`
- [x] `build/sbt javafmtCheck`
- [ ] `build/sbt "server/testOnly io.unitycatalog.server.service.credential.aws.AwsPolicyGeneratorTest"` — local Test compile failed on unrelated files (`S3Client` / `IOUtils` missing from the test classpath in this worktree)
