### PR TITLE
Fix DeltaApiService returning {catalog} placeholder instead of actual catalog name

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -126,7 +126,12 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
     catalogRepository.getCatalog(catalog);
 
     // For now, we only have 1.0 as the first protocol version. Input protocolVersions is ignored.
-    return new DeltaCatalogConfig().endpoints(ENDPOINTS).protocolVersion("1.0");
+    // Replace {catalog} placeholder in endpoint templates with the actual catalog name.
+    // The static ENDPOINTS list uses {catalog} as a template placeholder;
+    // clients expect the resolved catalog name in the config response.
+    List<String> resolvedEndpoints =
+        ENDPOINTS.stream().map(e -> e.replace("{catalog}", catalog)).toList();
+    return new DeltaCatalogConfig().endpoints(resolvedEndpoints).protocolVersion("1.0");
   }
 
   // ==================== Load Table API ====================

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
@@ -52,6 +52,10 @@ public class SdkDeltaConfigTest extends BaseServerTest {
     DeltaCatalogConfig config = configApi.getConfig(TestUtils.CATALOG_NAME, "1.0");
     assertThat(config.getEndpoints()).isNotEmpty();
     assertThat(config.getProtocolVersion()).isEqualTo("1.0");
+    // Verify that the {catalog} placeholder has been resolved to the actual catalog name
+    assertThat(config.getEndpoints())
+        .anySatisfy(endpoint -> assertThat(endpoint).contains(TestUtils.CATALOG_NAME))
+        .noneSatisfy(endpoint -> assertThat(endpoint).contains("{catalog}"));
 
     // Error: missing catalog returns 400 with InvalidParameterValueException
     TestUtils.assertDeltaApiException(


### PR DESCRIPTION
## What

Fix `GET /delta/v1/config` endpoint returning literal `{catalog}` placeholder in endpoint URLs instead of the resolved catalog name.

## Problem

When a client calls `GET /delta/v1/config?catalog=main`, the response contains endpoint URLs like:

```json
{
  "endpoints": ["POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables", ...]
}
```

The `{catalog}` placeholder should be replaced with the actual catalog name (`main` in this example).

## Fix

In `DeltaApiService.getConfig()`, replace the `{catalog}` placeholder in each endpoint template string with the actual catalog parameter value before returning the response.

## Testing

Existing `SdkDeltaConfigTest` should continue to pass. The fix is a simple string replacement of the resolved catalog name.

Closes #1628