### PR TITLE
[Server] Add managed storage lifecycle schema

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DroppableIdentifiableDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DroppableIdentifiableDAO.java
@@ -1,0 +1,42 @@
+package io.unitycatalog.server.persist.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DroppableIdentifiableDAO extends IdentifiableDAO {
+  @Column(name = "dropped_name")
+  private String droppedName;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "dropped_at")
+  private Date droppedAt;
+
+  @ColumnDefault("0")
+  @Column(name = "purge_state", nullable = false)
+  private short purgeState;
+
+  @ColumnDefault("0")
+  @Column(name = "num_cleanup_retries", nullable = false)
+  private short numCleanupRetries;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "last_cleanup_at")
+  private Date lastCleanupAt;
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -14,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
 
 // Hibernate annotations
 @Entity
@@ -68,6 +71,22 @@ public class ModelVersionInfoDAO {
 
   @Column(name = "url", length = 4096)
   private String url;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "dropped_at")
+  private Date droppedAt;
+
+  @ColumnDefault("0")
+  @Column(name = "purge_state", nullable = false)
+  private short purgeState;
+
+  @ColumnDefault("0")
+  @Column(name = "num_cleanup_retries", nullable = false)
+  private short numCleanupRetries;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "last_cleanup_at")
+  private Date lastCleanupAt;
 
   public static ModelVersionInfoDAO from(ModelVersionInfo modelVersionInfo) {
     return ModelVersionInfoDAO.builder()

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class RegisteredModelInfoDAO extends IdentifiableDAO {
+public class RegisteredModelInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
@@ -1,12 +1,11 @@
 package io.unitycatalog.server.persist.dao;
 
 import io.unitycatalog.server.model.StagingTableInfo;
+import io.unitycatalog.server.persist.model.PurgeState;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -30,7 +29,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class StagingTableDAO extends IdentifiableDAO {
+public class StagingTableDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 
@@ -52,16 +51,6 @@ public class StagingTableDAO extends IdentifiableDAO {
   @Column(name = "stage_committed_at")
   private Date stageCommittedAt;
 
-  @Column(name = "purge_state", nullable = false)
-  private short purgeState;
-
-  @Column(name = "num_cleanup_retries", nullable = false)
-  private short numCleanupRetries;
-
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "last_cleanup_at")
-  private Date lastCleanupAt;
-
   public StagingTableInfo toStagingTableInfo(String catalogName, String schemaName) {
     return new StagingTableInfo()
         .id(getId().toString())
@@ -77,7 +66,7 @@ public class StagingTableDAO extends IdentifiableDAO {
     setAccessedAt(now); // Assuming current date for last access
     setStageCommitted(false);
     setStageCommittedAt(null);
-    setPurgeState((short) 0);
+    setPurgeState(PurgeState.ACTIVE.getValue());
     setNumCleanupRetries((short) 0);
     setLastCleanupAt(null);
   }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -36,7 +36,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class TableInfoDAO extends IdentifiableDAO {
+public class TableInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
@@ -24,7 +24,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
-public class VolumeInfoDAO extends IdentifiableDAO {
+public class VolumeInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/model/PurgeState.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/model/PurgeState.java
@@ -1,0 +1,18 @@
+package io.unitycatalog.server.persist.model;
+
+/** Persistent states for deferred resource cleanup. */
+public enum PurgeState {
+  ACTIVE((short) 0),
+  PENDING((short) 1),
+  RUNNING((short) 2);
+
+  private final short value;
+
+  PurgeState(short value) {
+    this.value = value;
+  }
+
+  public short getValue() {
+    return value;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
@@ -1,0 +1,229 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.server.persist.dao.DroppableIdentifiableDAO;
+import io.unitycatalog.server.persist.dao.ModelVersionInfoDAO;
+import io.unitycatalog.server.persist.dao.RegisteredModelInfoDAO;
+import io.unitycatalog.server.persist.dao.StagingTableDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.dao.VolumeInfoDAO;
+import io.unitycatalog.server.persist.model.PurgeState;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.util.Date;
+import java.util.Properties;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.jupiter.api.Test;
+
+abstract class AbstractLifecycleSchemaMigrationTest {
+  private static final UUID SCHEMA_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID MODEL_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+  private static final UUID TABLE_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+  private static final UUID VOLUME_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
+  private static final UUID STAGING_ID = UUID.fromString("00000000-0000-0000-0000-000000000005");
+  private static final UUID VERSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000006");
+  private static final Date LAST_CLEANUP_AT = new Date(1_700_000_000_000L);
+
+  protected abstract Properties databaseProperties();
+
+  @Test
+  void migrationPreservesExistingRowsAndStagingCleanupState() {
+    Properties properties = databaseProperties();
+    properties.setProperty("hibernate.hbm2ddl.auto", "create");
+    createLegacySchema(properties);
+
+    properties.setProperty("hibernate.hbm2ddl.auto", "update");
+    HibernateConfigurator configurator = new HibernateConfigurator(properties);
+    try (Session session = configurator.getSessionFactory().openSession()) {
+      assertActive(session.get(TableInfoDAO.class, TABLE_ID), "table");
+      assertActive(session.get(VolumeInfoDAO.class, VOLUME_ID), "volume");
+      assertActive(session.get(RegisteredModelInfoDAO.class, MODEL_ID), "model");
+
+      ModelVersionInfoDAO version = session.get(ModelVersionInfoDAO.class, VERSION_ID);
+      assertThat(version).isNotNull();
+      assertThat(version.getDroppedAt()).isNull();
+      assertThat(version.getPurgeState()).isEqualTo(PurgeState.ACTIVE.getValue());
+      assertThat(version.getNumCleanupRetries()).isZero();
+      assertThat(version.getLastCleanupAt()).isNull();
+
+      StagingTableDAO staging = session.get(StagingTableDAO.class, STAGING_ID);
+      assertThat(staging).isNotNull();
+      assertThat(staging.getName()).isEqualTo("staging");
+      assertThat(staging.getDroppedName()).isNull();
+      assertThat(staging.getDroppedAt()).isNull();
+      assertThat(staging.getPurgeState()).isEqualTo(PurgeState.RUNNING.getValue());
+      assertThat(staging.getNumCleanupRetries()).isEqualTo((short) 3);
+      assertThat(staging.getLastCleanupAt().getTime()).isEqualTo(LAST_CLEANUP_AT.getTime());
+
+      assertLifecycleStateRoundTrip(session);
+    } finally {
+      configurator.getSessionFactory().close();
+    }
+  }
+
+  private static void assertActive(DroppableIdentifiableDAO resource, String name) {
+    assertThat(resource).isNotNull();
+    assertThat(resource.getName()).isEqualTo(name);
+    assertThat(resource.getDroppedName()).isNull();
+    assertThat(resource.getDroppedAt()).isNull();
+    assertThat(resource.getPurgeState()).isEqualTo(PurgeState.ACTIVE.getValue());
+    assertThat(resource.getNumCleanupRetries()).isZero();
+    assertThat(resource.getLastCleanupAt()).isNull();
+  }
+
+  private static void assertLifecycleStateRoundTrip(Session session) {
+    Date droppedAt = new Date(1_710_000_000_000L);
+    Date cleanupAt = new Date(1_720_000_000_000L);
+    session.beginTransaction();
+    TableInfoDAO table = session.get(TableInfoDAO.class, TABLE_ID);
+    table.setDroppedName("table_before_drop");
+    table.setDroppedAt(droppedAt);
+    table.setPurgeState(PurgeState.RUNNING.getValue());
+    table.setNumCleanupRetries((short) 4);
+    table.setLastCleanupAt(cleanupAt);
+    session.getTransaction().commit();
+
+    session.clear();
+    TableInfoDAO reloaded = session.get(TableInfoDAO.class, TABLE_ID);
+    assertThat(reloaded.getDroppedName()).isEqualTo("table_before_drop");
+    assertThat(reloaded.getDroppedAt().getTime()).isEqualTo(droppedAt.getTime());
+    assertThat(reloaded.getPurgeState()).isEqualTo(PurgeState.RUNNING.getValue());
+    assertThat(reloaded.getNumCleanupRetries()).isEqualTo((short) 4);
+    assertThat(reloaded.getLastCleanupAt().getTime()).isEqualTo(cleanupAt.getTime());
+  }
+
+  private static void createLegacySchema(Properties properties) {
+    Configuration configuration = new Configuration().setProperties(properties);
+    configuration.addAnnotatedClass(LegacyTable.class);
+    configuration.addAnnotatedClass(LegacyVolume.class);
+    configuration.addAnnotatedClass(LegacyRegisteredModel.class);
+    configuration.addAnnotatedClass(LegacyStagingTable.class);
+    configuration.addAnnotatedClass(LegacyModelVersion.class);
+    ServiceRegistry registry =
+        new StandardServiceRegistryBuilder().applySettings(properties).build();
+
+    try (SessionFactory sessionFactory = configuration.buildSessionFactory(registry);
+        Session session = sessionFactory.openSession()) {
+      session.beginTransaction();
+      session.persist(new LegacyTable(TABLE_ID, "table", SCHEMA_ID));
+      session.persist(new LegacyVolume(VOLUME_ID, "volume", SCHEMA_ID));
+      session.persist(new LegacyRegisteredModel(MODEL_ID, "model", SCHEMA_ID));
+      session.persist(new LegacyStagingTable(STAGING_ID, "staging", SCHEMA_ID));
+      session.persist(new LegacyModelVersion(VERSION_ID, MODEL_ID));
+      session.getTransaction().commit();
+    }
+  }
+
+  @MappedSuperclass
+  static class LegacyNamedResource {
+    @Id
+    @Column(name = "id")
+    UUID id;
+
+    @Column(name = "name", nullable = false)
+    String name;
+
+    @Column(name = "schema_id")
+    UUID schemaId;
+
+    LegacyNamedResource() {}
+
+    LegacyNamedResource(UUID id, String name, UUID schemaId) {
+      this.id = id;
+      this.name = name;
+      this.schemaId = schemaId;
+    }
+  }
+
+  @Entity(name = "LegacyTable")
+  @Table(name = "uc_tables")
+  static class LegacyTable extends LegacyNamedResource {
+    LegacyTable() {}
+
+    LegacyTable(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyVolume")
+  @Table(name = "uc_volumes")
+  static class LegacyVolume extends LegacyNamedResource {
+    LegacyVolume() {}
+
+    LegacyVolume(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyRegisteredModel")
+  @Table(name = "uc_registered_models")
+  static class LegacyRegisteredModel extends LegacyNamedResource {
+    LegacyRegisteredModel() {}
+
+    LegacyRegisteredModel(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyStagingTable")
+  @Table(name = "uc_staging_tables")
+  static class LegacyStagingTable extends LegacyNamedResource {
+    @Column(name = "staging_location", length = 2048, nullable = false)
+    String stagingLocation = "file:/staging";
+
+    @Column(name = "created_at", nullable = false)
+    Date createdAt = LAST_CLEANUP_AT;
+
+    @Column(name = "accessed_at", nullable = false)
+    Date accessedAt = LAST_CLEANUP_AT;
+
+    @Column(name = "stage_committed", nullable = false)
+    boolean stageCommitted;
+
+    @Column(name = "purge_state", nullable = false)
+    short purgeState = PurgeState.RUNNING.getValue();
+
+    @Column(name = "num_cleanup_retries", nullable = false)
+    short numCleanupRetries = 3;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_cleanup_at")
+    Date lastCleanupAt = LAST_CLEANUP_AT;
+
+    LegacyStagingTable() {}
+
+    LegacyStagingTable(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyModelVersion")
+  @Table(name = "uc_model_versions")
+  static class LegacyModelVersion {
+    @Id
+    @Column(name = "id")
+    UUID id;
+
+    @Column(name = "registered_model_id")
+    UUID registeredModelId;
+
+    LegacyModelVersion() {}
+
+    LegacyModelVersion(UUID id, UUID registeredModelId) {
+      this.id = id;
+      this.registeredModelId = registeredModelId;
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/H2LifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/H2LifecycleSchemaMigrationTest.java
@@ -1,0 +1,14 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+
+class H2LifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:lifecycle_migration;DB_CLOSE_DELAY=-1");
+    return properties;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
@@ -1,0 +1,26 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class MySqlLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Container
+  private static final MySQLContainer<?> MYSQL =
+      new MySQLContainer<>("mysql:8.4")
+          .withDatabaseName("unitycatalog_test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "com.mysql.cj.jdbc.Driver");
+    properties.setProperty("hibernate.connection.url", MYSQL.getJdbcUrl());
+    properties.setProperty("hibernate.connection.username", MYSQL.getUsername());
+    properties.setProperty("hibernate.connection.password", MYSQL.getPassword());
+    return properties;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/PostgresLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/PostgresLifecycleSchemaMigrationTest.java
@@ -1,0 +1,26 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class PostgresLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Container
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("unitycatalog_test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.postgresql.Driver");
+    properties.setProperty("hibernate.connection.url", POSTGRES.getJdbcUrl());
+    properties.setProperty("hibernate.connection.username", POSTGRES.getUsername());
+    properties.setProperty("hibernate.connection.password", POSTGRES.getPassword());
+    return properties;
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1819/files) to review incremental changes.
- [**stack/managed-storage-lifecycle-schema**](https://github.com/unitycatalog/unitycatalog/pull/1819) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1819/files)] ← _this PR_
  - [stack/managed-storage-lifecycle-unique-names](https://github.com/unitycatalog/unitycatalog/pull/1822) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1822/files/659994160bca99bceb8107415cb4d48ca45b7e8d..51c69f8a227aa9ee0277edd5c2d83dd2a8a9eb1a)]
    - [stack/managed-storage-lifecycle-soft-drop](https://github.com/unitycatalog/unitycatalog/pull/1820) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1820/files/51c69f8a227aa9ee0277edd5c2d83dd2a8a9eb1a..f7152233b460810ba24ed9e89b30f0c955adde90)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This three-PR stack builds managed-table soft drop in small steps:

```text
PR 1    Add lifecycle state  <-- this PR adds lifecycle state
  |
  v
PR 1.5  Enforce unique table names
  |
  v
PR 2    Soft-drop managed tables
```

This PR adds the database fields needed to retain a dropped resource and track later cleanup. It does not change drop or read behavior.

- Named resources get `dropped_name`, `dropped_at`, `purge_state`, `num_cleanup_retries`, and `last_cleanup_at`.
- Model versions get the same lifecycle state, except `dropped_name`, because they have no name.
- Existing staging-table fields keep their current columns and values.
- Existing rows remain active.

Migration tests cover H2, PostgreSQL, and MySQL.

Related: #1067
