### PR TITLE
[Server] Enforce unique table names

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/TableRepository.java
@@ -53,12 +53,14 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TableRepository {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableRepository.class);
+  private static final String TABLE_NAME_UNIQUE_CONSTRAINT = "uc_tables_schema_id_name_unique";
   private final SessionFactory sessionFactory;
   private final Repositories repositories;
   private final ServerProperties serverProperties;
@@ -912,6 +914,7 @@ public class TableRepository {
             tableInfo.setViewDependencies(
                 new DependencyList().dependencies(DependencyDAO.toDependencyList(depDAOs)));
           }
+          flushTableNameChange(session, fullName);
           return mapper.apply(session, tableInfoDAO, tableInfo);
         },
         "Error creating table: " + fullName,
@@ -1175,9 +1178,24 @@ public class TableRepository {
           tableInfoDAO.setUpdatedAt(new Date());
           tableInfoDAO.setUpdatedBy(callerId);
           session.merge(tableInfoDAO);
+          flushTableNameChange(session, catalog + "." + schema + "." + newName);
           return null;
         },
         "Failed to rename table " + catalog + "." + schema + "." + table,
         /* readOnly = */ false);
+  }
+
+  private static void flushTableNameChange(Session session, String fullName) {
+    try {
+      session.flush();
+    } catch (ConstraintViolationException e) {
+      String constraintName = e.getConstraintName();
+      if (constraintName != null
+          && constraintName.toLowerCase(Locale.ROOT).contains(TABLE_NAME_UNIQUE_CONSTRAINT)) {
+        throw new BaseException(
+            ErrorCode.TABLE_ALREADY_EXISTS, "Table already exists: " + fullName);
+      }
+      throw e;
+    }
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/DroppableIdentifiableDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/DroppableIdentifiableDAO.java
@@ -1,0 +1,42 @@
+package io.unitycatalog.server.persist.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class DroppableIdentifiableDAO extends IdentifiableDAO {
+  @Column(name = "dropped_name")
+  private String droppedName;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "dropped_at")
+  private Date droppedAt;
+
+  @ColumnDefault("0")
+  @Column(name = "purge_state", nullable = false)
+  private short purgeState;
+
+  @ColumnDefault("0")
+  @Column(name = "num_cleanup_retries", nullable = false)
+  private short numCleanupRetries;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "last_cleanup_at")
+  private Date lastCleanupAt;
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/ModelVersionInfoDAO.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -14,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
 
 // Hibernate annotations
 @Entity
@@ -68,6 +71,22 @@ public class ModelVersionInfoDAO {
 
   @Column(name = "url", length = 4096)
   private String url;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "dropped_at")
+  private Date droppedAt;
+
+  @ColumnDefault("0")
+  @Column(name = "purge_state", nullable = false)
+  private short purgeState;
+
+  @ColumnDefault("0")
+  @Column(name = "num_cleanup_retries", nullable = false)
+  private short numCleanupRetries;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "last_cleanup_at")
+  private Date lastCleanupAt;
 
   public static ModelVersionInfoDAO from(ModelVersionInfo modelVersionInfo) {
     return ModelVersionInfoDAO.builder()

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/RegisteredModelInfoDAO.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class RegisteredModelInfoDAO extends IdentifiableDAO {
+public class RegisteredModelInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/StagingTableDAO.java
@@ -1,12 +1,11 @@
 package io.unitycatalog.server.persist.dao;
 
 import io.unitycatalog.server.model.StagingTableInfo;
+import io.unitycatalog.server.persist.model.PurgeState;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -30,7 +29,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class StagingTableDAO extends IdentifiableDAO {
+public class StagingTableDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 
@@ -52,16 +51,6 @@ public class StagingTableDAO extends IdentifiableDAO {
   @Column(name = "stage_committed_at")
   private Date stageCommittedAt;
 
-  @Column(name = "purge_state", nullable = false)
-  private short purgeState;
-
-  @Column(name = "num_cleanup_retries", nullable = false)
-  private short numCleanupRetries;
-
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "last_cleanup_at")
-  private Date lastCleanupAt;
-
   public StagingTableInfo toStagingTableInfo(String catalogName, String schemaName) {
     return new StagingTableInfo()
         .id(getId().toString())
@@ -77,7 +66,7 @@ public class StagingTableDAO extends IdentifiableDAO {
     setAccessedAt(now); // Assuming current date for last access
     setStageCommitted(false);
     setStageCommittedAt(null);
-    setPurgeState((short) 0);
+    setPurgeState(PurgeState.ACTIVE.getValue());
     setNumCleanupRetries((short) 0);
     setLastCleanupAt(null);
   }

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -36,7 +36,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class TableInfoDAO extends IdentifiableDAO {
+public class TableInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/TableInfoDAO.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +27,11 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Table(
     name = "uc_tables",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uc_tables_schema_id_name_unique",
+          columnNames = {"schema_id", "name"})
+    },
     indexes = {
       @Index(name = "idx_name", columnList = "name"),
     })

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/VolumeInfoDAO.java
@@ -24,7 +24,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
-public class VolumeInfoDAO extends IdentifiableDAO {
+public class VolumeInfoDAO extends DroppableIdentifiableDAO {
   @Column(name = "schema_id")
   private UUID schemaId;
 

--- a/server/src/main/java/io/unitycatalog/server/persist/model/PurgeState.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/model/PurgeState.java
@@ -1,0 +1,18 @@
+package io.unitycatalog.server.persist.model;
+
+/** Persistent states for deferred resource cleanup. */
+public enum PurgeState {
+  ACTIVE((short) 0),
+  PENDING((short) 1),
+  RUNNING((short) 2);
+
+  private final short value;
+
+  PurgeState(short value) {
+    this.value = value;
+  }
+
+  public short getValue() {
+    return value;
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -24,7 +24,16 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import lombok.Getter;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -42,6 +51,8 @@ import org.slf4j.LoggerFactory;
 public class HibernateConfigurator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HibernateConfigurator.class);
+  private static final String TABLE_NAME_UNIQUE_CONSTRAINT = "uc_tables_schema_id_name_unique";
+  private static final Set<String> TABLE_NAME_UNIQUE_COLUMNS = Set.of("schema_id", "name");
 
   private final SessionFactory sessionFactory;
   private final Properties hibernateProperties;
@@ -85,11 +96,84 @@ public class HibernateConfigurator {
       ServiceRegistry serviceRegistry =
           new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();
 
-      return configuration.buildSessionFactory(serviceRegistry);
+      SessionFactory sessionFactory = configuration.buildSessionFactory(serviceRegistry);
+      try {
+        validateTableNameUniqueness(sessionFactory);
+        return sessionFactory;
+      } catch (RuntimeException e) {
+        sessionFactory.close();
+        throw e;
+      }
     } catch (Exception e) {
       throw new RuntimeException("Exception during creation of SessionFactory", e);
     }
   }
+
+  private static void validateTableNameUniqueness(SessionFactory sessionFactory) {
+    try (var session = sessionFactory.openSession()) {
+      if (session.doReturningWork(HibernateConfigurator::hasTableNameUniqueConstraint)) {
+        return;
+      }
+      boolean hasDuplicates =
+          !session
+              .createQuery(
+                  "SELECT t.schemaId, t.name FROM TableInfoDAO t "
+                      + "GROUP BY t.schemaId, t.name HAVING COUNT(t) > 1",
+                  Object[].class)
+              .setMaxResults(1)
+              .getResultList()
+              .isEmpty();
+      if (hasDuplicates) {
+        throw new IllegalStateException(
+            "Cannot enforce unique table names because a schema contains duplicate names.");
+      }
+      throw new IllegalStateException(
+          "Cannot enforce unique table names because the database did not create constraint "
+              + TABLE_NAME_UNIQUE_CONSTRAINT
+              + ".");
+    }
+  }
+
+  private static boolean hasTableNameUniqueConstraint(Connection connection) throws SQLException {
+    DatabaseMetaData metadata = connection.getMetaData();
+    TableReference table = findTable(metadata, connection.getCatalog(), connection.getSchema());
+    if (table == null) {
+      return false;
+    }
+
+    Map<String, Set<String>> indexes = new HashMap<>();
+    try (ResultSet rows =
+        metadata.getIndexInfo(table.catalog(), table.schema(), table.name(), true, false)) {
+      while (rows.next()) {
+        String indexName = rows.getString("INDEX_NAME");
+        String columnName = rows.getString("COLUMN_NAME");
+        if (indexName != null && columnName != null && !rows.getBoolean("NON_UNIQUE")) {
+          indexes
+              .computeIfAbsent(indexName, ignored -> new HashSet<>())
+              .add(columnName.toLowerCase(Locale.ROOT));
+        }
+      }
+    }
+
+    return indexes.values().stream().anyMatch(TABLE_NAME_UNIQUE_COLUMNS::equals);
+  }
+
+  private static TableReference findTable(DatabaseMetaData metadata, String catalog, String schema)
+      throws SQLException {
+    try (ResultSet rows = metadata.getTables(catalog, schema, null, new String[] {"TABLE"})) {
+      while (rows.next()) {
+        if ("uc_tables".equalsIgnoreCase(rows.getString("TABLE_NAME"))) {
+          return new TableReference(
+              rows.getString("TABLE_CAT"),
+              rows.getString("TABLE_SCHEM"),
+              rows.getString("TABLE_NAME"));
+        }
+      }
+    }
+    return null;
+  }
+
+  private record TableReference(String catalog, String schema, String name) {}
 
   public static Properties setupHibernateProperties(ServerProperties serverProperties) {
     Path hibernatePropertiesPath = Paths.get("etc/conf/hibernate.properties");

--- a/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
@@ -1,0 +1,229 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.server.persist.dao.DroppableIdentifiableDAO;
+import io.unitycatalog.server.persist.dao.ModelVersionInfoDAO;
+import io.unitycatalog.server.persist.dao.RegisteredModelInfoDAO;
+import io.unitycatalog.server.persist.dao.StagingTableDAO;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.dao.VolumeInfoDAO;
+import io.unitycatalog.server.persist.model.PurgeState;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.util.Date;
+import java.util.Properties;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.jupiter.api.Test;
+
+abstract class AbstractLifecycleSchemaMigrationTest {
+  private static final UUID SCHEMA_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID MODEL_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+  private static final UUID TABLE_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+  private static final UUID VOLUME_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
+  private static final UUID STAGING_ID = UUID.fromString("00000000-0000-0000-0000-000000000005");
+  private static final UUID VERSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000006");
+  private static final Date LAST_CLEANUP_AT = new Date(1_700_000_000_000L);
+
+  protected abstract Properties databaseProperties();
+
+  @Test
+  void migrationPreservesExistingRowsAndStagingCleanupState() {
+    Properties properties = databaseProperties();
+    properties.setProperty("hibernate.hbm2ddl.auto", "create");
+    createLegacySchema(properties);
+
+    properties.setProperty("hibernate.hbm2ddl.auto", "update");
+    HibernateConfigurator configurator = new HibernateConfigurator(properties);
+    try (Session session = configurator.getSessionFactory().openSession()) {
+      assertActive(session.get(TableInfoDAO.class, TABLE_ID), "table");
+      assertActive(session.get(VolumeInfoDAO.class, VOLUME_ID), "volume");
+      assertActive(session.get(RegisteredModelInfoDAO.class, MODEL_ID), "model");
+
+      ModelVersionInfoDAO version = session.get(ModelVersionInfoDAO.class, VERSION_ID);
+      assertThat(version).isNotNull();
+      assertThat(version.getDroppedAt()).isNull();
+      assertThat(version.getPurgeState()).isEqualTo(PurgeState.ACTIVE.getValue());
+      assertThat(version.getNumCleanupRetries()).isZero();
+      assertThat(version.getLastCleanupAt()).isNull();
+
+      StagingTableDAO staging = session.get(StagingTableDAO.class, STAGING_ID);
+      assertThat(staging).isNotNull();
+      assertThat(staging.getName()).isEqualTo("staging");
+      assertThat(staging.getDroppedName()).isNull();
+      assertThat(staging.getDroppedAt()).isNull();
+      assertThat(staging.getPurgeState()).isEqualTo(PurgeState.RUNNING.getValue());
+      assertThat(staging.getNumCleanupRetries()).isEqualTo((short) 3);
+      assertThat(staging.getLastCleanupAt().getTime()).isEqualTo(LAST_CLEANUP_AT.getTime());
+
+      assertLifecycleStateRoundTrip(session);
+    } finally {
+      configurator.getSessionFactory().close();
+    }
+  }
+
+  private static void assertActive(DroppableIdentifiableDAO resource, String name) {
+    assertThat(resource).isNotNull();
+    assertThat(resource.getName()).isEqualTo(name);
+    assertThat(resource.getDroppedName()).isNull();
+    assertThat(resource.getDroppedAt()).isNull();
+    assertThat(resource.getPurgeState()).isEqualTo(PurgeState.ACTIVE.getValue());
+    assertThat(resource.getNumCleanupRetries()).isZero();
+    assertThat(resource.getLastCleanupAt()).isNull();
+  }
+
+  private static void assertLifecycleStateRoundTrip(Session session) {
+    Date droppedAt = new Date(1_710_000_000_000L);
+    Date cleanupAt = new Date(1_720_000_000_000L);
+    session.beginTransaction();
+    TableInfoDAO table = session.get(TableInfoDAO.class, TABLE_ID);
+    table.setDroppedName("table_before_drop");
+    table.setDroppedAt(droppedAt);
+    table.setPurgeState(PurgeState.RUNNING.getValue());
+    table.setNumCleanupRetries((short) 4);
+    table.setLastCleanupAt(cleanupAt);
+    session.getTransaction().commit();
+
+    session.clear();
+    TableInfoDAO reloaded = session.get(TableInfoDAO.class, TABLE_ID);
+    assertThat(reloaded.getDroppedName()).isEqualTo("table_before_drop");
+    assertThat(reloaded.getDroppedAt().getTime()).isEqualTo(droppedAt.getTime());
+    assertThat(reloaded.getPurgeState()).isEqualTo(PurgeState.RUNNING.getValue());
+    assertThat(reloaded.getNumCleanupRetries()).isEqualTo((short) 4);
+    assertThat(reloaded.getLastCleanupAt().getTime()).isEqualTo(cleanupAt.getTime());
+  }
+
+  private static void createLegacySchema(Properties properties) {
+    Configuration configuration = new Configuration().setProperties(properties);
+    configuration.addAnnotatedClass(LegacyTable.class);
+    configuration.addAnnotatedClass(LegacyVolume.class);
+    configuration.addAnnotatedClass(LegacyRegisteredModel.class);
+    configuration.addAnnotatedClass(LegacyStagingTable.class);
+    configuration.addAnnotatedClass(LegacyModelVersion.class);
+    ServiceRegistry registry =
+        new StandardServiceRegistryBuilder().applySettings(properties).build();
+
+    try (SessionFactory sessionFactory = configuration.buildSessionFactory(registry);
+        Session session = sessionFactory.openSession()) {
+      session.beginTransaction();
+      session.persist(new LegacyTable(TABLE_ID, "table", SCHEMA_ID));
+      session.persist(new LegacyVolume(VOLUME_ID, "volume", SCHEMA_ID));
+      session.persist(new LegacyRegisteredModel(MODEL_ID, "model", SCHEMA_ID));
+      session.persist(new LegacyStagingTable(STAGING_ID, "staging", SCHEMA_ID));
+      session.persist(new LegacyModelVersion(VERSION_ID, MODEL_ID));
+      session.getTransaction().commit();
+    }
+  }
+
+  @MappedSuperclass
+  static class LegacyNamedResource {
+    @Id
+    @Column(name = "id")
+    UUID id;
+
+    @Column(name = "name", nullable = false)
+    String name;
+
+    @Column(name = "schema_id")
+    UUID schemaId;
+
+    LegacyNamedResource() {}
+
+    LegacyNamedResource(UUID id, String name, UUID schemaId) {
+      this.id = id;
+      this.name = name;
+      this.schemaId = schemaId;
+    }
+  }
+
+  @Entity(name = "LegacyTable")
+  @Table(name = "uc_tables")
+  static class LegacyTable extends LegacyNamedResource {
+    LegacyTable() {}
+
+    LegacyTable(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyVolume")
+  @Table(name = "uc_volumes")
+  static class LegacyVolume extends LegacyNamedResource {
+    LegacyVolume() {}
+
+    LegacyVolume(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyRegisteredModel")
+  @Table(name = "uc_registered_models")
+  static class LegacyRegisteredModel extends LegacyNamedResource {
+    LegacyRegisteredModel() {}
+
+    LegacyRegisteredModel(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyStagingTable")
+  @Table(name = "uc_staging_tables")
+  static class LegacyStagingTable extends LegacyNamedResource {
+    @Column(name = "staging_location", length = 2048, nullable = false)
+    String stagingLocation = "file:/staging";
+
+    @Column(name = "created_at", nullable = false)
+    Date createdAt = LAST_CLEANUP_AT;
+
+    @Column(name = "accessed_at", nullable = false)
+    Date accessedAt = LAST_CLEANUP_AT;
+
+    @Column(name = "stage_committed", nullable = false)
+    boolean stageCommitted;
+
+    @Column(name = "purge_state", nullable = false)
+    short purgeState = PurgeState.RUNNING.getValue();
+
+    @Column(name = "num_cleanup_retries", nullable = false)
+    short numCleanupRetries = 3;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_cleanup_at")
+    Date lastCleanupAt = LAST_CLEANUP_AT;
+
+    LegacyStagingTable() {}
+
+    LegacyStagingTable(UUID id, String name, UUID schemaId) {
+      super(id, name, schemaId);
+    }
+  }
+
+  @Entity(name = "LegacyModelVersion")
+  @Table(name = "uc_model_versions")
+  static class LegacyModelVersion {
+    @Id
+    @Column(name = "id")
+    UUID id;
+
+    @Column(name = "registered_model_id")
+    UUID registeredModelId;
+
+    LegacyModelVersion() {}
+
+    LegacyModelVersion(UUID id, UUID registeredModelId) {
+      this.id = id;
+      this.registeredModelId = registeredModelId;
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/AbstractLifecycleSchemaMigrationTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.persist;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.unitycatalog.server.persist.dao.DroppableIdentifiableDAO;
 import io.unitycatalog.server.persist.dao.ModelVersionInfoDAO;
@@ -22,6 +23,7 @@ import java.util.Properties;
 import java.util.UUID;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.service.ServiceRegistry;
@@ -42,7 +44,7 @@ abstract class AbstractLifecycleSchemaMigrationTest {
   void migrationPreservesExistingRowsAndStagingCleanupState() {
     Properties properties = databaseProperties();
     properties.setProperty("hibernate.hbm2ddl.auto", "create");
-    createLegacySchema(properties);
+    createLegacySchema(properties, false);
 
     properties.setProperty("hibernate.hbm2ddl.auto", "update");
     HibernateConfigurator configurator = new HibernateConfigurator(properties);
@@ -68,9 +70,35 @@ abstract class AbstractLifecycleSchemaMigrationTest {
       assertThat(staging.getLastCleanupAt().getTime()).isEqualTo(LAST_CLEANUP_AT.getTime());
 
       assertLifecycleStateRoundTrip(session);
+      assertTableNameIsUnique(configurator.getSessionFactory());
     } finally {
       configurator.getSessionFactory().close();
     }
+  }
+
+  @Test
+  void migrationRejectsExistingDuplicateTableNames() {
+    Properties properties = databaseProperties();
+    properties.setProperty("hibernate.hbm2ddl.auto", "create");
+    createLegacySchema(properties, true);
+
+    properties.setProperty("hibernate.hbm2ddl.auto", "update");
+    assertThatThrownBy(() -> updateSchema(properties))
+        .hasRootCauseMessage(
+            "Cannot enforce unique table names because a schema contains duplicate names.");
+  }
+
+  @Test
+  void startupRejectsMissingTableNameConstraint() {
+    Properties properties = databaseProperties();
+    properties.setProperty("hibernate.hbm2ddl.auto", "create");
+    createLegacySchema(properties, false);
+
+    properties.setProperty("hibernate.hbm2ddl.auto", "none");
+    assertThatThrownBy(() -> updateSchema(properties))
+        .hasRootCauseMessage(
+            "Cannot enforce unique table names because the database did not create constraint "
+                + "uc_tables_schema_id_name_unique.");
   }
 
   private static void assertActive(DroppableIdentifiableDAO resource, String name) {
@@ -104,7 +132,28 @@ abstract class AbstractLifecycleSchemaMigrationTest {
     assertThat(reloaded.getLastCleanupAt().getTime()).isEqualTo(cleanupAt.getTime());
   }
 
-  private static void createLegacySchema(Properties properties) {
+  private static void assertTableNameIsUnique(SessionFactory sessionFactory) {
+    try (Session session = sessionFactory.openSession()) {
+      Transaction transaction = session.beginTransaction();
+      session.persist(
+          TableInfoDAO.builder()
+              .id(UUID.fromString("00000000-0000-0000-0000-000000000007"))
+              .schemaId(SCHEMA_ID)
+              .name("table")
+              .build());
+      assertThatThrownBy(transaction::commit).isInstanceOf(RuntimeException.class);
+      if (transaction.isActive()) {
+        transaction.rollback();
+      }
+    }
+  }
+
+  private static void updateSchema(Properties properties) {
+    HibernateConfigurator configurator = new HibernateConfigurator(properties);
+    configurator.getSessionFactory().close();
+  }
+
+  private static void createLegacySchema(Properties properties, boolean addDuplicateTable) {
     Configuration configuration = new Configuration().setProperties(properties);
     configuration.addAnnotatedClass(LegacyTable.class);
     configuration.addAnnotatedClass(LegacyVolume.class);
@@ -122,6 +171,11 @@ abstract class AbstractLifecycleSchemaMigrationTest {
       session.persist(new LegacyRegisteredModel(MODEL_ID, "model", SCHEMA_ID));
       session.persist(new LegacyStagingTable(STAGING_ID, "staging", SCHEMA_ID));
       session.persist(new LegacyModelVersion(VERSION_ID, MODEL_ID));
+      if (addDuplicateTable) {
+        session.persist(
+            new LegacyTable(
+                UUID.fromString("00000000-0000-0000-0000-000000000008"), "table", SCHEMA_ID));
+      }
       session.getTransaction().commit();
     }
   }

--- a/server/src/test/java/io/unitycatalog/server/persist/H2LifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/H2LifecycleSchemaMigrationTest.java
@@ -1,0 +1,14 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+
+class H2LifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:lifecycle_migration;DB_CLOSE_DELAY=-1");
+    return properties;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
@@ -1,0 +1,26 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class MySqlLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Container
+  private static final MySQLContainer<?> MYSQL =
+      new MySQLContainer<>("mysql:8.4")
+          .withDatabaseName("unitycatalog_test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "com.mysql.cj.jdbc.Driver");
+    properties.setProperty("hibernate.connection.url", MYSQL.getJdbcUrl());
+    properties.setProperty("hibernate.connection.username", MYSQL.getUsername());
+    properties.setProperty("hibernate.connection.password", MYSQL.getPassword());
+    return properties;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/MySqlLifecycleSchemaMigrationTest.java
@@ -8,7 +8,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class MySqlLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
   @Container
-  private static final MySQLContainer<?> MYSQL =
+  private final MySQLContainer<?> mysql =
       new MySQLContainer<>("mysql:8.4")
           .withDatabaseName("unitycatalog_test")
           .withUsername("test")
@@ -18,9 +18,9 @@ class MySqlLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigration
   protected Properties databaseProperties() {
     Properties properties = new Properties();
     properties.setProperty("hibernate.connection.driver_class", "com.mysql.cj.jdbc.Driver");
-    properties.setProperty("hibernate.connection.url", MYSQL.getJdbcUrl());
-    properties.setProperty("hibernate.connection.username", MYSQL.getUsername());
-    properties.setProperty("hibernate.connection.password", MYSQL.getPassword());
+    properties.setProperty("hibernate.connection.url", mysql.getJdbcUrl());
+    properties.setProperty("hibernate.connection.username", mysql.getUsername());
+    properties.setProperty("hibernate.connection.password", mysql.getPassword());
     return properties;
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/persist/PostgresLifecycleSchemaMigrationTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/PostgresLifecycleSchemaMigrationTest.java
@@ -1,0 +1,26 @@
+package io.unitycatalog.server.persist;
+
+import java.util.Properties;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class PostgresLifecycleSchemaMigrationTest extends AbstractLifecycleSchemaMigrationTest {
+  @Container
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("unitycatalog_test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @Override
+  protected Properties databaseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.postgresql.Driver");
+    properties.setProperty("hibernate.connection.url", POSTGRES.getJdbcUrl());
+    properties.setProperty("hibernate.connection.username", POSTGRES.getUsername());
+    properties.setProperty("hibernate.connection.password", POSTGRES.getPassword());
+    return properties;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/TableNameUniquenessTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/TableNameUniquenessTest.java
@@ -1,0 +1,171 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.linecorp.armeria.common.HttpStatus;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaRenameTableRequest;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableType;
+import io.unitycatalog.server.base.ServerConfig;
+import io.unitycatalog.server.base.catalog.CatalogOperations;
+import io.unitycatalog.server.base.schema.SchemaOperations;
+import io.unitycatalog.server.base.table.BaseTableCRUDTestEnv;
+import io.unitycatalog.server.base.table.TableOperations;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.sdk.catalog.SdkCatalogOperations;
+import io.unitycatalog.server.sdk.schema.SdkSchemaOperations;
+import io.unitycatalog.server.sdk.tables.SdkTableOperations;
+import io.unitycatalog.server.utils.TestUtils;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TableNameUniquenessTest extends BaseTableCRUDTestEnv {
+  private static final int CREATE_ATTEMPTS = 8;
+  private static final int RENAME_ATTEMPTS = 2;
+  private static final int RESULT_TIMEOUT_SECONDS = 30;
+  private static final int SHUTDOWN_TIMEOUT_SECONDS = 10;
+
+  private DeltaTablesApi deltaTablesApi;
+
+  @Override
+  protected CatalogOperations createCatalogOperations(ServerConfig config) {
+    return new SdkCatalogOperations(TestUtils.createApiClient(config));
+  }
+
+  @Override
+  protected SchemaOperations createSchemaOperations(ServerConfig config) {
+    return new SdkSchemaOperations(TestUtils.createApiClient(config));
+  }
+
+  @Override
+  protected TableOperations createTableOperations(ServerConfig config) {
+    return new SdkTableOperations(TestUtils.createApiClient(config));
+  }
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    deltaTablesApi = new DeltaTablesApi(TestUtils.createApiClient(serverConfig));
+  }
+
+  @Test
+  void concurrentCreatesHaveOneWinner() throws Exception {
+    List<Path> locations = new ArrayList<>();
+    for (int i = 0; i < CREATE_ATTEMPTS; i++) {
+      locations.add(Files.createDirectory(testDirectoryRoot.resolve("create-" + i)));
+    }
+
+    CyclicBarrier barrier = new CyclicBarrier(CREATE_ATTEMPTS);
+    ExecutorService pool = Executors.newFixedThreadPool(CREATE_ATTEMPTS);
+    List<Future<Integer>> results = new ArrayList<>();
+    try {
+      for (Path location : locations) {
+        results.add(
+            pool.submit(
+                () -> {
+                  TableOperations operations =
+                      new SdkTableOperations(TestUtils.createApiClient(serverConfig));
+                  barrier.await();
+                  try {
+                    operations.createTable(
+                        new CreateTable()
+                            .name("create_race")
+                            .catalogName(catalog())
+                            .schemaName(schema())
+                            .columns(COLUMNS)
+                            .tableType(TableType.EXTERNAL)
+                            .dataSourceFormat(DataSourceFormat.DELTA)
+                            .storageLocation(location.toString()));
+                    return HttpStatus.OK.code();
+                  } catch (ApiException e) {
+                    return e.getCode();
+                  }
+                }));
+      }
+
+      List<Integer> statuses = getResults(results);
+      assertThat(statuses)
+          .containsOnly(
+              HttpStatus.OK.code(), ErrorCode.TABLE_ALREADY_EXISTS.getHttpStatus().code());
+      assertThat(statuses).filteredOn(status -> status == HttpStatus.OK.code()).hasSize(1);
+    } finally {
+      shutdown(pool);
+    }
+  }
+
+  @Test
+  void concurrentRenamesToOneNameHaveOneWinner() throws Exception {
+    createExternalTable("source_a");
+    createExternalTable("source_b");
+
+    CyclicBarrier barrier = new CyclicBarrier(RENAME_ATTEMPTS);
+    ExecutorService pool = Executors.newFixedThreadPool(RENAME_ATTEMPTS);
+    try {
+      List<Future<Integer>> results =
+          List.of(
+              renameAfterBarrier(pool, barrier, "source_a", "target"),
+              renameAfterBarrier(pool, barrier, "source_b", "target"));
+      assertThat(getResults(results)).containsExactlyInAnyOrder(null, HttpStatus.CONFLICT.code());
+    } finally {
+      shutdown(pool);
+    }
+  }
+
+  private Future<Integer> renameAfterBarrier(
+      ExecutorService pool, CyclicBarrier barrier, String source, String target) {
+    return pool.submit(
+        () -> {
+          barrier.await();
+          try {
+            deltaTablesApi.renameTable(
+                catalog(), schema(), source, new DeltaRenameTableRequest().newName(target));
+            return null;
+          } catch (ApiException e) {
+            return e.getCode();
+          }
+        });
+  }
+
+  private void createExternalTable(String name) throws Exception {
+    createTestingTable(
+        name,
+        TableType.EXTERNAL,
+        Optional.of(Files.createDirectory(testDirectoryRoot.resolve(name)).toString()),
+        tableOperations);
+  }
+
+  private static <T> List<T> getResults(List<Future<T>> futures) throws Exception {
+    List<T> results = new ArrayList<>();
+    for (Future<T> future : futures) {
+      results.add(future.get(RESULT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+    return results;
+  }
+
+  private static void shutdown(ExecutorService pool) throws InterruptedException {
+    pool.shutdown();
+    assertThat(pool.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private static String catalog() {
+    return TestUtils.CATALOG_NAME;
+  }
+
+  private static String schema() {
+    return TestUtils.SCHEMA_NAME;
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1822/files/659994160bca99bceb8107415cb4d48ca45b7e8d..51c69f8a227aa9ee0277edd5c2d83dd2a8a9eb1a) to review incremental changes.
- [stack/managed-storage-lifecycle-schema](https://github.com/unitycatalog/unitycatalog/pull/1819) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1819/files)]
  - [**stack/managed-storage-lifecycle-unique-names**](https://github.com/unitycatalog/unitycatalog/pull/1822) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1822/files/659994160bca99bceb8107415cb4d48ca45b7e8d..51c69f8a227aa9ee0277edd5c2d83dd2a8a9eb1a)] ← _this PR_
    - [stack/managed-storage-lifecycle-soft-drop](https://github.com/unitycatalog/unitycatalog/pull/1820) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1820/files/51c69f8a227aa9ee0277edd5c2d83dd2a8a9eb1a..f7152233b460810ba24ed9e89b30f0c955adde90)]

---------
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This three-PR stack builds managed-table soft drop in small steps:

```text
PR 1    Add lifecycle state
  |
  v
PR 1.5  Enforce unique table names  <-- this PR protects table names
  |
  v
PR 2    Soft-drop managed tables
```

Before soft drop can free a table name, the database must guarantee that only one table owns that name. The existing application check is not enough because two create or rename requests can run at the same time.

- A unique constraint covers `(schema_id, name)`.
- Create and rename convert constraint conflicts to `TABLE_ALREADY_EXISTS`.
- Startup verifies that the database installed the constraint. It stops if duplicate rows or a missing constraint make this unsafe.
- Concurrent create and rename tests verify that only one request wins.

This PR does not change drop behavior or any public API. Tests cover H2, PostgreSQL, and MySQL.

Related: #1067
