### PR TITLE
[Server] Widen uc_properties.property_value beyond varchar(255)

### DIFF
--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -107,3 +107,32 @@ This guide outlines how to deploy the Unity Catalog server.
     ```
 
 - Modify the `jars/classpath` file and add path to your jdbc driver.
+
+### Existing deployments and column type changes
+
+The server uses `hibernate.hbm2ddl.auto=update`. Hibernate can create missing tables and
+columns, but **it does not change the type or length of a column that already exists**.
+
+`uc_properties.property_value` used to be created as `varchar(255)`. Spark stores datasource
+schema JSON in table properties (`spark.sql.sources.schema.part.N`), which is often longer than
+255 characters (for example `CREATE TABLE … USING PARQUET` with more than a couple of columns).
+New installs get a wider column from Hibernate. **Existing databases keep `varchar(255)` until
+you run one of the statements below**; upgrading the server JAR alone has no effect.
+
+PostgreSQL:
+
+```sql
+ALTER TABLE uc_properties ALTER COLUMN property_value TYPE text;
+```
+
+MySQL:
+
+```sql
+ALTER TABLE uc_properties MODIFY property_value MEDIUMTEXT NOT NULL;
+```
+
+H2:
+
+```sql
+ALTER TABLE uc_properties ALTER COLUMN property_value SET DATA TYPE VARCHAR(16777215);
+```

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
@@ -49,7 +49,18 @@ public class PropertyDAO {
   @Column(name = "property_key", nullable = false)
   private String key;
 
-  @Column(name = "property_value", nullable = false)
+  /**
+   * Entity property values, including Spark datasource schema JSON ({@code
+   * spark.sql.sources.schema.part.N}).
+   *
+   * <p>An unannotated {@code String} is mapped as {@code varchar(255)}. That is too small for Spark
+   * table properties, so the length matches {@code ColumnInfoDAO.typeJson}.
+   *
+   * <p>{@code hibernate.hbm2ddl.auto=update} does not change the type of an existing column. Fresh
+   * databases pick up this mapping; existing deployments must {@code ALTER} {@code
+   * uc_properties.property_value} as described in {@code docs/server/deployment.md}.
+   */
+  @Column(name = "property_value", nullable = false, length = 16777215)
   private String value;
 
   public static List<PropertyDAO> from(

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/PropertyDAO.java
@@ -49,17 +49,6 @@ public class PropertyDAO {
   @Column(name = "property_key", nullable = false)
   private String key;
 
-  /**
-   * Entity property values, including Spark datasource schema JSON ({@code
-   * spark.sql.sources.schema.part.N}).
-   *
-   * <p>An unannotated {@code String} is mapped as {@code varchar(255)}. That is too small for Spark
-   * table properties, so the length matches {@code ColumnInfoDAO.typeJson}.
-   *
-   * <p>{@code hibernate.hbm2ddl.auto=update} does not change the type of an existing column. Fresh
-   * databases pick up this mapping; existing deployments must {@code ALTER} {@code
-   * uc_properties.property_value} as described in {@code docs/server/deployment.md}.
-   */
   @Column(name = "property_value", nullable = false, length = 16777215)
   private String value;
 

--- a/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/tables/SdkTableCRUDTest.java
@@ -99,6 +99,49 @@ public class SdkTableCRUDTest extends BaseTableCRUDTest {
         .withMessageContaining("s3://bucket/");
   }
 
+  /**
+   * Spark stores datasource schema JSON in {@code spark.sql.sources.schema.part.N}. That value is
+   * larger than Hibernate's default {@code varchar(255)} as soon as the table has more than a
+   * couple of columns.
+   */
+  @Test
+  public void testCreateTableAcceptsPropertyValueLongerThanDefaultVarchar() throws Exception {
+    String schemaJson =
+        "{\"type\":\"struct\",\"fields\":["
+            + "{\"name\":\"col1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col2\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col3\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col4\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col5\",\"type\":\"boolean\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col6\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},"
+            + "{\"name\":\"col7\",\"type\":\"decimal(18,2)\",\"nullable\":true,\"metadata\":{}}"
+            + "]}";
+    assertThat(schemaJson.length()).isGreaterThan(255);
+
+    String tableName = "long_property_table";
+    TableInfo created =
+        tableOperations.createTable(
+            new CreateTable()
+                .name(tableName)
+                .catalogName(TestUtils.CATALOG_NAME)
+                .schemaName(TestUtils.SCHEMA_NAME)
+                .columns(COLUMNS)
+                .properties(Map.of("spark.sql.sources.schema.part.0", schemaJson))
+                .comment(TestUtils.COMMENT)
+                .storageLocation(
+                    Files.createTempDirectory(testDirectoryRoot, "long-props").toString())
+                .tableType(TableType.EXTERNAL)
+                .dataSourceFormat(DataSourceFormat.PARQUET));
+
+    TableInfo retrieved =
+        tableOperations.getTable(
+            TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + tableName);
+    assertThat(retrieved.getProperties())
+        .containsEntry("spark.sql.sources.schema.part.0", schemaJson);
+    tableOperations.deleteTable(
+        created.getCatalogName() + "." + created.getSchemaName() + "." + created.getName());
+  }
+
   @Test
   public void testListTablesWithNoNextPageTokenShouldReturnNull() throws Exception {
     TableInfo testingTable =


### PR DESCRIPTION
## Summary
- Hibernate maps an unannotated `String` as `varchar(255)`. Any `uc_properties.property_value` longer than that fails with `ERROR: value too long for type character varying(255)` on `PropertyDAO` insert.
- [#1830](https://github.com/unitycatalog/unitycatalog/pull/1830) stopped Spark from persisting Hive-style schema JSON (`spark.sql.sources.schema.part.N`) on `createTable` / `createView`. That does **not** cover every long value: Spark still forwards `view.sqlConfig.*` and other user `TBLPROPERTIES`. Those still hit `varchar(255)`.
- Map `property_value` with the same `length = 16777215` used for `ColumnInfoDAO.typeJson`.
- **Existing deployments are not updated by this change.** The server uses `hibernate.hbm2ddl.auto=update`, which creates missing tables/columns but does **not** change the type or length of a column that already exists. Upgrading the server JAR alone leaves `varchar(255)` in place. Operators must `ALTER` `uc_properties.property_value` (statements in `docs/server/deployment.md`).

## Example that fails today

Delta `CREATE TABLE` with a wide schema succeeds: table schema is stored on `uc_columns` (`type_json`), not as a table property.

`CREATE VIEW` then calls `TablesApi.createTable` with Spark view properties (including `view.sqlConfig.*` and user `TBLPROPERTIES`). A value longer than 255 characters 500s the insert even though the view SQL itself is stored on `uc_tables.view_definition` (already a wide column).

```text
io.unitycatalog.client.ApiException: createTable call failed with: 500
{"error_code":"INTERNAL","message":"Error creating table: cat.sch.activity_union: could not execute statement [ERROR: value too long for type character varying(255)] [/* insert for io.unitycatalog.server.persist.dao.PropertyDAO */ insert into uc_properties (entity_id,entity_type,property_key,property_value,id) values (?,?,?,?,?)]"}
```

The same 255-char limit still applies to any REST client that sends a long table/view property.

## Test plan
- [ ] `SdkViewCRUDTest` / `BaseViewCRUDTest.testCreateViewAcceptsPropertyValueLongerThanDefaultVarchar` persists a user property longer than 255 characters
- [ ] Confirm a **new** database gets the wider column from Hibernate
- [ ] Confirm an **existing** database still has `varchar(255)` until the documented `ALTER` is run, then `CREATE VIEW` with a long property succeeds
