### PR TITLE
[Python] Remove OpenAI upper version bound

### DIFF
--- a/ai/integrations/openai/pyproject.toml
+++ b/ai/integrations/openai/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "openai>=1.46.1,<=2.24.0",
+    "openai>=1.46.1",
     "unitycatalog-ai>=0.4.0,<0.5.0",
     "pydantic<3,>=2",
 ]

--- a/ai/integrations/openai/pyproject.toml
+++ b/ai/integrations/openai/pyproject.toml
@@ -74,7 +74,7 @@ docstring-code-line-length = 88
 convention = "google"
 
 [tool.uv]
-exclude-newer = "2026-03-10T00:00:00Z"
+exclude-newer = "30d"
 
 [tool.uv.sources]
 unitycatalog-ai = { path = "../../core", editable = true }

--- a/ai/integrations/openai/uv.lock
+++ b/ai/integrations/openai/uv.lock
@@ -3937,7 +3937,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mlflow", marker = "extra == 'dev'", specifier = ">=3.3.0,<=3.10.0" },
-    { name = "openai", specifier = ">=1.46.1,<=2.24.0" },
+    { name = "openai", specifier = ">=1.46.1" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "unitycatalog-ai", editable = "../../core" },
     { name = "unitycatalog-ai", extras = ["databricks"], marker = "extra == 'databricks'", editable = "../../core" },

--- a/ai/integrations/openai/uv.lock
+++ b/ai/integrations/openai/uv.lock
@@ -8,7 +8,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-10T00:00:00Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P30D"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -2371,7 +2372,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.24.0"
+version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2383,9 +2384,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR. (No related issue.)
- [x] If you've fixed a bug or added code that should be tested, add tests! (Dependency metadata only; lockfile validation is listed below.)
- [x] If you've added or modified a feature, documentation in `docs` is updated. (No feature change.)

**Description of changes**

Remove the `openai<=2.24.0` upper bound from `unitycatalog-openai` while retaining the existing minimum supported version. The upper bound reflected a point-in-time dependency cutoff rather than a known compatibility constraint, and now prevents consumers from using newer OpenAI SDK releases.

The existing `exclude-newer` setting and lockfile continue to provide reproducible development and CI resolution.

Validation:

- `UV_DEFAULT_INDEX=https://pypi.org/simple UV_SYSTEM_CERTS=true uv lock --check`
- `git diff --check`
