### PR TITLE
[Server] Negotiate Delta API protocol version

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/delta/DeltaApiService.java
@@ -64,6 +64,10 @@ import java.util.UUID;
  */
 public class DeltaApiService extends AuthorizedService implements RegisteredService {
 
+  private static final int SUPPORTED_PROTOCOL_MAJOR_VERSION = 1;
+  private static final int SUPPORTED_PROTOCOL_MINOR_VERSION = 0;
+  private static final String SUPPORTED_PROTOCOL_VERSION = "1.0";
+
   private static final List<String> ENDPOINTS =
       List.of(
           "POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables",
@@ -124,8 +128,49 @@ public class DeltaApiService extends AuthorizedService implements RegisteredServ
     // Verify catalog exists
     catalogRepository.getCatalog(catalog);
 
-    // For now, we only have 1.0 as the first protocol version. Input protocolVersions is ignored.
-    return new DeltaCatalogConfig().endpoints(ENDPOINTS).protocolVersion("1.0");
+    return new DeltaCatalogConfig()
+        .endpoints(ENDPOINTS)
+        .protocolVersion(negotiateProtocolVersion(protocolVersions));
+  }
+
+  private static String negotiateProtocolVersion(String protocolVersions) {
+    if (protocolVersions == null || protocolVersions.isBlank()) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT, "Must supply at least one protocol version.");
+    }
+
+    boolean isSupported = false;
+    for (String version : protocolVersions.split(",", -1)) {
+      String[] parts = version.trim().split("\\.", -1);
+      if (parts.length != 2) {
+        throw invalidProtocolVersion(version);
+      }
+
+      try {
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        if (major < 1 || minor < 0) {
+          throw invalidProtocolVersion(version);
+        }
+        if (major == SUPPORTED_PROTOCOL_MAJOR_VERSION
+            && minor >= SUPPORTED_PROTOCOL_MINOR_VERSION) {
+          isSupported = true;
+        }
+      } catch (NumberFormatException e) {
+        throw invalidProtocolVersion(version);
+      }
+    }
+
+    if (!isSupported) {
+      throw new BaseException(
+          ErrorCode.INVALID_ARGUMENT,
+          "No compatible protocol version found for: " + protocolVersions);
+    }
+    return SUPPORTED_PROTOCOL_VERSION;
+  }
+
+  private static BaseException invalidProtocolVersion(String version) {
+    return new BaseException(ErrorCode.INVALID_ARGUMENT, "Invalid protocol version: " + version);
   }
 
   // ==================== Load Table API ====================

--- a/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
+++ b/server/src/test/java/io/unitycatalog/server/sdk/delta/SdkDeltaConfigTest.java
@@ -48,9 +48,13 @@ public class SdkDeltaConfigTest extends BaseServerTest {
 
   @Test
   public void testGetConfig() throws Exception {
-    // Success: valid catalog returns endpoints and protocol version
+    // Success: exact protocol version returns endpoints and the selected version
     DeltaCatalogConfig config = configApi.getConfig(TestUtils.CATALOG_NAME, "1.0");
     assertThat(config.getEndpoints()).isNotEmpty();
+    assertThat(config.getProtocolVersion()).isEqualTo("1.0");
+
+    // Success: a higher compatible minor version selects the server's highest version
+    config = configApi.getConfig(TestUtils.CATALOG_NAME, "1.1");
     assertThat(config.getProtocolVersion()).isEqualTo("1.0");
 
     // Error: missing catalog returns 400 with InvalidParameterValueException
@@ -64,5 +68,23 @@ public class SdkDeltaConfigTest extends BaseServerTest {
         () -> configApi.getConfig("nonexistent", "1.0"),
         DeltaErrorType.NO_SUCH_CATALOG_EXCEPTION,
         "nonexistent");
+
+    // Error: malformed protocol version returns 400 with InvalidParameterValueException
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, "invalid"),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "protocol version");
+
+    // Error: missing protocol versions return 400 with InvalidParameterValueException
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, ""),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "protocol version");
+
+    // Error: a protocol version with no compatible major version returns 400
+    TestUtils.assertDeltaApiException(
+        () -> configApi.getConfig(TestUtils.CATALOG_NAME, "2.0"),
+        DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION,
+        "protocol version");
   }
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [x] If you have added or modified a feature, documentation in docs is updated.

**Description of changes**

The Delta configuration endpoint ignored the client protocol versions and always returned version 1.0. For example, a client that supported only major version 2 still received version 1.0.

This change validates the client input and selects the highest version that both sides support. The server currently supports only version 1.0. A client value of 1.0 or 1.1 selects 1.0. Missing, malformed, or incompatible values return the existing invalid-parameter error.

The API shape and documented negotiation rule do not change.

Tested with:

- build/sbt javafmtAll
- build/sbt "server/testOnly io.unitycatalog.server.sdk.delta.SdkDeltaConfigTest"