### PR TITLE
[Server] Map commit lock contention to `COMMIT_STATE_UNKNOWN`, not a conflict

### DIFF
--- a/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/PathCredentialReadWriteTest.java
@@ -78,7 +78,9 @@ public class PathCredentialReadWriteTest extends BaseSparkIntegrationTest {
     return createPathCredSession(false, false, true, ucCatalogs);
   }
 
-  /** Same layout as {@link #createPathCredSession} but omits {@code vendPathCredentials.enabled}. */
+  /**
+   * Same layout as {@link #createPathCredSession} but omits {@code vendPathCredentials.enabled}.
+   */
   private SparkSession createPathCredSessionLeavingVendFlagUnset(String... ucCatalogs) {
     SparkSession.Builder builder =
         SparkSession.builder()

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/RepositoryUtils.java
@@ -30,7 +30,16 @@ public class RepositoryUtils {
 
   /**
    * Acquires the table row lock shared by Delta and Iceberg commit paths. Lock waits and deadlock
-   * victims are reported as retryable requirement conflicts instead of leaking ORM exceptions.
+   * victims are reported as {@code COMMIT_STATE_UNKNOWN} (a retryable, unknown-outcome error)
+   * instead of leaking ORM exceptions.
+   *
+   * <p>The failure is deliberately not surfaced as a conflict. Failing to acquire the lock rolls
+   * back only this transaction; it does not reveal whether the logical commit landed. The lock
+   * holder is another commit still in progress on this table, and it may be this same commit's own
+   * earlier attempt (a slow client retry carrying the same UUID) that goes on to succeed. Reporting
+   * a conflict would let the client conclude the commit did not land and rebase, committing the
+   * same change twice. The client must instead resend the identical request, which deduplication
+   * resolves to the true outcome.
    */
   public static void lockTableForCommit(
       Session session, TableInfoDAO dao, UUID tableId, Optional<String> tableFullNameForLogging) {
@@ -38,11 +47,12 @@ public class RepositoryUtils {
       session.refresh(dao, LockMode.PESSIMISTIC_WRITE);
     } catch (RuntimeException e) {
       if (!(e instanceof org.hibernate.PessimisticLockException)
-          && !(e instanceof jakarta.persistence.PessimisticLockException)) {
+          && !(e instanceof jakarta.persistence.PessimisticLockException)
+          && !(e instanceof jakarta.persistence.LockTimeoutException)) {
         throw e;
       }
       throw new BaseException(
-          ErrorCode.UPDATE_REQUIREMENT_CONFLICT,
+          ErrorCode.COMMIT_STATE_UNKNOWN,
           "Concurrent commit in progress on table "
               + tableFullNameForLogging.orElseGet(tableId::toString)
               + "; retry the request.");

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/RepositoryUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/RepositoryUtilsTest.java
@@ -1,0 +1,67 @@
+package io.unitycatalog.server.persist.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import org.hibernate.LockMode;
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class RepositoryUtilsTest {
+
+  private static final UUID TABLE_ID = UUID.randomUUID();
+
+  /**
+   * A failed pessimistic lock acquisition means a concurrent commit is in progress and this
+   * request's outcome is unknown (the in-flight attempt may still land). It must surface as the
+   * retryable {@code COMMIT_STATE_UNKNOWN}, never as a conflict that would invite a rebase. Both
+   * the Hibernate and Jakarta {@code PessimisticLockException}, and the Jakarta {@code
+   * LockTimeoutException} a lock-wait can raise instead, are covered.
+   */
+  static RuntimeException[] lockAcquisitionFailures() {
+    return new RuntimeException[] {
+      new org.hibernate.PessimisticLockException("locked", new SQLException("locked"), "sql"),
+      new jakarta.persistence.PessimisticLockException("locked"),
+      new jakarta.persistence.LockTimeoutException("timed out"),
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("lockAcquisitionFailures")
+  public void lockFailureMapsToCommitStateUnknown(RuntimeException lockFailure) {
+    Session session = mock();
+    TableInfoDAO dao = mock();
+    doThrow(lockFailure).when(session).refresh(any(Object.class), any(LockMode.class));
+
+    assertThatThrownBy(
+            () ->
+                RepositoryUtils.lockTableForCommit(
+                    session, dao, TABLE_ID, Optional.of("cat.sch.tbl")))
+        .isInstanceOf(BaseException.class)
+        .extracting(e -> ((BaseException) e).getErrorCode())
+        .isEqualTo(ErrorCode.COMMIT_STATE_UNKNOWN);
+  }
+
+  /** Any non-lock failure must propagate unchanged rather than be masked as an unknown outcome. */
+  @Test
+  public void nonLockFailurePropagatesUnchanged() {
+    Session session = mock();
+    TableInfoDAO dao = mock();
+    IllegalStateException unexpected = new IllegalStateException("boom");
+    doThrow(unexpected).when(session).refresh(any(Object.class), any(LockMode.class));
+
+    assertThatThrownBy(
+            () -> RepositoryUtils.lockTableForCommit(session, dao, TABLE_ID, Optional.empty()))
+        .isSameAs(unexpected);
+  }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- `RepositoryUtils.lockTableForCommit` now throws `COMMIT_STATE_UNKNOWN` (retryable 500) instead of `UPDATE_REQUIREMENT_CONFLICT` (409) when the row lock can't be acquired.
  - The failed request rolls back, but the lock holder may be this same commit's own earlier attempt (a slow client retry) that goes on to land, so the commit's outcome is unknown.
  - A 409 would let the client rebase and re-commit the same change; instead it resends the identical request, which dedup resolves to the true outcome.
- Also catch `jakarta.persistence.LockTimeoutException`, which a lock-wait can raise instead of `PessimisticLockException`.
- Keeps a 409 meaning the commit definitely did not land.
- Add `RepositoryUtilsTest` covering the lock-failure mapping and non-lock passthrough.
