### PR TITLE
[Spark] Do not persist Spark schema JSON, credentials, or reserved V2 keys

### DIFF
--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -35,4 +35,23 @@ public class UCTableProperties {
           TableCatalog.PROP_OWNER,
           TableCatalog.PROP_PROVIDER,
           PROP_TABLE_TYPE);
+
+  // Spark HiveExternalCatalog packages StructType JSON into TBLPROPERTIES so Hive metastore
+  // (which has no first-class nested schema) can reconstruct the table. Keys are
+  // `spark.sql.sources.schema`, `spark.sql.sources.schema.numParts`,
+  // `spark.sql.sources.schema.part.N`, partition/bucket column lists, and the split
+  // `spark.sql.partitionSchema*` form. UC already stores schema on `uc_columns`, so these
+  // are redundant -- and `schema.part.N` routinely exceeds the server's varchar(255)
+  // property value. Strip them on create; do not persist them.
+  public static final String SPARK_DATASOURCE_SCHEMA = "spark.sql.sources.schema";
+  public static final String SPARK_DATASOURCE_SCHEMA_PREFIX = SPARK_DATASOURCE_SCHEMA + ".";
+  public static final String SPARK_PARTITION_SCHEMA = "spark.sql.partitionSchema";
+  public static final String SPARK_PARTITION_SCHEMA_PREFIX = SPARK_PARTITION_SCHEMA + ".";
+
+  public static boolean isSparkDatasourceSchemaProperty(String key) {
+    return key.equals(SPARK_DATASOURCE_SCHEMA)
+        || key.startsWith(SPARK_DATASOURCE_SCHEMA_PREFIX)
+        || key.equals(SPARK_PARTITION_SCHEMA)
+        || key.startsWith(SPARK_PARTITION_SCHEMA_PREFIX);
+  }
 }

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -48,10 +48,38 @@ public class UCTableProperties {
   public static final String SPARK_PARTITION_SCHEMA = "spark.sql.partitionSchema";
   public static final String SPARK_PARTITION_SCHEMA_PREFIX = SPARK_PARTITION_SCHEMA + ".";
 
+  /**
+   * Spark copies USING/OPTIONS entries both bare and with {@link TableCatalog#OPTION_PREFIX}
+   * ({@code option.}). Credential and schema keys must match in either form.
+   */
+  private static String withoutOptionPrefix(String key) {
+    if (key.startsWith(TableCatalog.OPTION_PREFIX)) {
+      return key.substring(TableCatalog.OPTION_PREFIX.length());
+    }
+    return key;
+  }
+
   public static boolean isSparkDatasourceSchemaProperty(String key) {
-    return key.equals(SPARK_DATASOURCE_SCHEMA)
-        || key.startsWith(SPARK_DATASOURCE_SCHEMA_PREFIX)
-        || key.equals(SPARK_PARTITION_SCHEMA)
-        || key.startsWith(SPARK_PARTITION_SCHEMA_PREFIX);
+    String bare = withoutOptionPrefix(key);
+    return bare.equals(SPARK_DATASOURCE_SCHEMA)
+        || bare.startsWith(SPARK_DATASOURCE_SCHEMA_PREFIX)
+        || bare.equals(SPARK_PARTITION_SCHEMA)
+        || bare.startsWith(SPARK_PARTITION_SCHEMA_PREFIX);
+  }
+
+  /**
+   * Keys that must not be forwarded on {@code createTable} / {@code createView}. Reserved V2 fields
+   * are first-class columns on the UC payload; {@code fs.*} is session-scoped credential config;
+   * Spark datasource schema JSON duplicates {@code uc_columns} and overflows varchar(255).
+   */
+  public static boolean shouldPersistProperty(String key) {
+    String bare = withoutOptionPrefix(key);
+    if (V2_TABLE_PROPERTIES.contains(key) || V2_TABLE_PROPERTIES.contains(bare)) {
+      return false;
+    }
+    if (bare.startsWith("fs.")) {
+      return false;
+    }
+    return !isSparkDatasourceSchemaProperty(key);
   }
 }

--- a/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
+++ b/connectors/spark/src/main/java/io/unitycatalog/spark/UCTableProperties.java
@@ -74,7 +74,7 @@ public class UCTableProperties {
    */
   public static boolean shouldPersistProperty(String key) {
     String bare = withoutOptionPrefix(key);
-    if (V2_TABLE_PROPERTIES.contains(key) || V2_TABLE_PROPERTIES.contains(bare)) {
+    if (V2_TABLE_PROPERTIES.contains(bare)) {
       return false;
     }
     if (bare.startsWith("fs.")) {

--- a/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
+++ b/connectors/spark/src/main/scala-shims/spark-4.2/io/unitycatalog/spark/UCProxyViewSupport.scala
@@ -161,7 +161,7 @@ trait UCProxyViewSupport extends RelationCatalog { self: UCProxy =>
 
     val propertiesToServer = new util.HashMap[String, String]()
     properties.asScala.foreach { case (k, v) =>
-      if (!UCTableProperties.V2_TABLE_PROPERTIES.contains(k)) {
+      if (UCTableProperties.shouldPersistProperty(k)) {
         propertiesToServer.put(k, v)
       }
     }

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1074,18 +1074,10 @@ private[spark] class UCProxy(
     comment.foreach(createTable.setComment(_))
     createTable.setColumns(columns)
     createTable.setDataSourceFormat(convertDatasourceFormat(format))
-    // Do not send the V2 table properties as they are made part of the `createTable` already.
-    // Also strip the vended filesystem credential properties (fs.* and their option.-prefixed
-    // duplicates, e.g. fs.s3a.session.token): they are session-scoped Hadoop configs injected by
-    // UCSingleCatalog for the local write path, not table metadata, and must never be persisted
-    // in the catalog.
-    // Spark also injects Hive-metastore schema JSON (`spark.sql.sources.schema*`,
-    // `spark.sql.partitionSchema*`). UC already persists schema as columns, and the JSON
-    // overflowed varchar(255) on create.
+    // Drop V2 reserved keys, vended fs.* credentials, and Spark Hive-metastore schema JSON.
+    // Same deny-list as createView; see UCTableProperties.shouldPersistProperty.
     val propertiesToServer = properties.view
-      .filterKeys(!UCTableProperties.V2_TABLE_PROPERTIES.contains(_))
-      .filterKeys(k => !k.startsWith("fs.") && !k.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
-      .filterKeys(!UCTableProperties.isSparkDatasourceSchemaProperty(_))
+      .filterKeys(UCTableProperties.shouldPersistProperty(_))
       .toMap
     createTable.setProperties(propertiesToServer)
     try {

--- a/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
+++ b/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala
@@ -1079,9 +1079,13 @@ private[spark] class UCProxy(
     // duplicates, e.g. fs.s3a.session.token): they are session-scoped Hadoop configs injected by
     // UCSingleCatalog for the local write path, not table metadata, and must never be persisted
     // in the catalog.
+    // Spark also injects Hive-metastore schema JSON (`spark.sql.sources.schema*`,
+    // `spark.sql.partitionSchema*`). UC already persists schema as columns, and the JSON
+    // overflowed varchar(255) on create.
     val propertiesToServer = properties.view
       .filterKeys(!UCTableProperties.V2_TABLE_PROPERTIES.contains(_))
       .filterKeys(k => !k.startsWith("fs.") && !k.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
+      .filterKeys(!UCTableProperties.isSparkDatasourceSchemaProperty(_))
       .toMap
     createTable.setProperties(propertiesToServer)
     try {

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -168,11 +167,7 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
     TableInfo tableInfo = tableOperations.getTable(fullTableName);
     java.util.Map<String, String> serverProperties =
         tableInfo.getProperties() == null ? java.util.Map.of() : tableInfo.getProperties();
-    assertThat(serverProperties.keySet())
-        .noneMatch(key -> key.startsWith("fs."))
-        .noneMatch(key -> key.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
-        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains)
-        .noneMatch(UCTableProperties::isSparkDatasourceSchemaProperty);
+    assertThat(serverProperties.keySet()).allMatch(UCTableProperties::shouldPersistProperty);
   }
 
   @Test

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -147,10 +147,11 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
    * The connector injects vended filesystem credentials (fs.s3a.access.key, fs.s3a.session.token,
    * fs.unitycatalog.*, and their option.-prefixed duplicates) into the table property map so the
    * local Spark session can write to the table location. None of them -- nor the reserved Spark V2
-   * markers -- may be forwarded to the UC server as table properties: they are session-scoped
-   * credentials, and values like an STS session token (~1100 chars) also overflow the server
-   * property store. Create the table via Spark SQL, then fetch it back through the SDK and assert
-   * the server kept none of those keys.
+   * markers, nor Spark's Hive-metastore schema JSON keys -- may be forwarded to the UC server as
+   * table properties: they are session-scoped credentials or duplicated column metadata, and values
+   * like an STS session token (~1100 chars) or {@code spark.sql.sources.schema.part.N} also
+   * overflow the server property store. Create the table via Spark SQL, then fetch it back through
+   * the SDK and assert the server kept none of those keys.
    */
   @ParameterizedTest
   @MethodSource("cloudParameters")
@@ -170,7 +171,8 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
     assertThat(serverProperties.keySet())
         .noneMatch(key -> key.startsWith("fs."))
         .noneMatch(key -> key.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
-        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains);
+        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains)
+        .noneMatch(UCTableProperties::isSparkDatasourceSchemaProperty);
   }
 
   @Test

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -13,9 +13,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -167,7 +169,29 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
     TableInfo tableInfo = tableOperations.getTable(fullTableName);
     java.util.Map<String, String> serverProperties =
         tableInfo.getProperties() == null ? java.util.Map.of() : tableInfo.getProperties();
-    assertThat(serverProperties.keySet()).allMatch(UCTableProperties::shouldPersistProperty);
+    assertThat(serverProperties.keySet())
+        .noneMatch(key -> key.startsWith("fs."))
+        .noneMatch(key -> key.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
+        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains);
+    assertNoSparkDatasourceSchemaProperties(serverProperties.keySet());
+  }
+
+  /**
+   * Spark HiveExternalCatalog schema JSON keys, including {@code option.} copies. Asserted with
+   * literal prefixes so the check is independent of {@link UCTableProperties#shouldPersistProperty}.
+   */
+  protected static void assertNoSparkDatasourceSchemaProperties(Set<String> keys) {
+    assertThat(keys)
+        .noneMatch(
+            key ->
+                key.equals("spark.sql.sources.schema")
+                    || key.startsWith("spark.sql.sources.schema.")
+                    || key.equals("spark.sql.partitionSchema")
+                    || key.startsWith("spark.sql.partitionSchema."))
+        .noneMatch(
+            key ->
+                key.startsWith(TableCatalog.OPTION_PREFIX + "spark.sql.sources.schema")
+                    || key.startsWith(TableCatalog.OPTION_PREFIX + "spark.sql.partitionSchema"));
   }
 
   @Test

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ExternalTableReadWriteTest.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
@@ -172,16 +171,7 @@ public abstract class ExternalTableReadWriteTest extends BaseTableReadWriteTest 
     assertThat(serverProperties.keySet())
         .noneMatch(key -> key.startsWith("fs."))
         .noneMatch(key -> key.startsWith(TableCatalog.OPTION_PREFIX + "fs."))
-        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains);
-    assertNoSparkDatasourceSchemaProperties(serverProperties.keySet());
-  }
-
-  /**
-   * Spark HiveExternalCatalog schema JSON keys, including {@code option.} copies. Asserted with
-   * literal prefixes so the check is independent of {@link UCTableProperties#shouldPersistProperty}.
-   */
-  protected static void assertNoSparkDatasourceSchemaProperties(Set<String> keys) {
-    assertThat(keys)
+        .noneMatch(UCTableProperties.V2_TABLE_PROPERTIES::contains)
         .noneMatch(
             key ->
                 key.equals("spark.sql.sources.schema")

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
@@ -1,8 +1,52 @@
 package io.unitycatalog.spark;
 
+import static io.unitycatalog.server.utils.TestUtils.CATALOG_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.model.TableInfo;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
 public class ParquetExternalTableReadWriteTest extends ExternalTableReadWriteTest {
   @Override
   protected String tableFormat() {
     return "PARQUET";
+  }
+
+  /**
+   * Spark puts the full StructType JSON in {@code spark.sql.sources.schema.part.N}. A seven-column
+   * schema is already longer than the server's {@code varchar(255)} property value, so CREATE TABLE
+   * used to 500. Schema of record is {@code uc_columns}; those keys must not be persisted.
+   */
+  @Test
+  public void testCreateParquetTableDoesNotPersistSparkDatasourceSchema() throws ApiException {
+    session = createSparkSessionWithCatalogs(CATALOG_NAME);
+
+    String fullTableName =
+        setupTable(
+            new TableSetupOptions()
+                .setCatalogName(CATALOG_NAME)
+                .setTableName(TEST_TABLE)
+                .setColumns(
+                    List.of(
+                        Pair.of("col1", "STRING"),
+                        Pair.of("col2", "INT"),
+                        Pair.of("col3", "DOUBLE"),
+                        Pair.of("col4", "BIGINT"),
+                        Pair.of("col5", "BOOLEAN"),
+                        Pair.of("col6", "TIMESTAMP"),
+                        Pair.of("col7", "DECIMAL(18, 2)"))));
+
+    TableInfo tableInfo = tableOperations.getTable(fullTableName);
+    Map<String, String> serverProperties =
+        tableInfo.getProperties() == null ? Map.of() : tableInfo.getProperties();
+    assertThat(serverProperties.keySet())
+        .noneMatch(UCTableProperties::isSparkDatasourceSchemaProperty);
+    assertThat(tableInfo.getColumns()).hasSize(7);
+
+    assertThat(sql("SELECT * FROM %s", fullTableName)).isEmpty();
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
@@ -43,8 +43,7 @@ public class ParquetExternalTableReadWriteTest extends ExternalTableReadWriteTes
     TableInfo tableInfo = tableOperations.getTable(fullTableName);
     Map<String, String> serverProperties =
         tableInfo.getProperties() == null ? Map.of() : tableInfo.getProperties();
-    assertThat(serverProperties.keySet())
-        .noneMatch(UCTableProperties::isSparkDatasourceSchemaProperty);
+    assertNoSparkDatasourceSchemaProperties(serverProperties.keySet());
     assertThat(tableInfo.getColumns()).hasSize(7);
 
     assertThat(sql("SELECT * FROM %s", fullTableName)).isEmpty();

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/ParquetExternalTableReadWriteTest.java
@@ -8,6 +8,7 @@ import io.unitycatalog.client.model.TableInfo;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.Test;
 
 public class ParquetExternalTableReadWriteTest extends ExternalTableReadWriteTest {
@@ -43,7 +44,17 @@ public class ParquetExternalTableReadWriteTest extends ExternalTableReadWriteTes
     TableInfo tableInfo = tableOperations.getTable(fullTableName);
     Map<String, String> serverProperties =
         tableInfo.getProperties() == null ? Map.of() : tableInfo.getProperties();
-    assertNoSparkDatasourceSchemaProperties(serverProperties.keySet());
+    assertThat(serverProperties.keySet())
+        .noneMatch(
+            key ->
+                key.equals("spark.sql.sources.schema")
+                    || key.startsWith("spark.sql.sources.schema.")
+                    || key.equals("spark.sql.partitionSchema")
+                    || key.startsWith("spark.sql.partitionSchema."))
+        .noneMatch(
+            key ->
+                key.startsWith(TableCatalog.OPTION_PREFIX + "spark.sql.sources.schema")
+                    || key.startsWith(TableCatalog.OPTION_PREFIX + "spark.sql.partitionSchema"));
     assertThat(tableInfo.getColumns()).hasSize(7);
 
     assertThat(sql("SELECT * FROM %s", fullTableName)).isEmpty();

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCTablePropertiesTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCTablePropertiesTest.java
@@ -2,6 +2,7 @@ package io.unitycatalog.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.Test;
 
 public class UCTablePropertiesTest {
@@ -23,6 +24,10 @@ public class UCTablePropertiesTest {
     assertThat(
             UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.partitionSchema.part.0"))
         .isTrue();
+    assertThat(
+            UCTableProperties.isSparkDatasourceSchemaProperty(
+                TableCatalog.OPTION_PREFIX + "spark.sql.sources.schema.part.0"))
+        .isTrue();
   }
 
   @Test
@@ -32,5 +37,35 @@ public class UCTablePropertiesTest {
     assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.create.version"))
         .isFalse();
     assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("user.custom")).isFalse();
+  }
+
+  @Test
+  public void shouldPersistProperty_dropsReservedCredentialsAndSchemaKeys() {
+    assertThat(UCTableProperties.shouldPersistProperty(TableCatalog.PROP_PROVIDER)).isFalse();
+    assertThat(UCTableProperties.shouldPersistProperty(TableCatalog.PROP_LOCATION)).isFalse();
+    assertThat(
+            UCTableProperties.shouldPersistProperty(
+                TableCatalog.OPTION_PREFIX + TableCatalog.PROP_PROVIDER))
+        .isFalse();
+    assertThat(UCTableProperties.shouldPersistProperty("fs.s3a.session.token")).isFalse();
+    assertThat(
+            UCTableProperties.shouldPersistProperty(
+                TableCatalog.OPTION_PREFIX + "fs.s3a.session.token"))
+        .isFalse();
+    assertThat(
+            UCTableProperties.shouldPersistProperty("spark.sql.sources.schema.part.0"))
+        .isFalse();
+    assertThat(
+            UCTableProperties.shouldPersistProperty(
+                TableCatalog.OPTION_PREFIX + "spark.sql.sources.schema.part.0"))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldPersistProperty_keepsUserAndViewMetadataKeys() {
+    assertThat(UCTableProperties.shouldPersistProperty("user.custom")).isTrue();
+    assertThat(UCTableProperties.shouldPersistProperty("spark.sql.create.version")).isTrue();
+    assertThat(UCTableProperties.shouldPersistProperty("view.sqlConfig.spark.sql.ansi.enabled"))
+        .isTrue();
   }
 }

--- a/connectors/spark/src/test/java/io/unitycatalog/spark/UCTablePropertiesTest.java
+++ b/connectors/spark/src/test/java/io/unitycatalog/spark/UCTablePropertiesTest.java
@@ -1,0 +1,36 @@
+package io.unitycatalog.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class UCTablePropertiesTest {
+
+  @Test
+  public void isSparkDatasourceSchemaProperty_matchesHiveExternalCatalogKeys() {
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.sources.schema"))
+        .isTrue();
+    assertThat(
+            UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.sources.schema.numParts"))
+        .isTrue();
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.sources.schema.part.0"))
+        .isTrue();
+    assertThat(
+            UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.sources.schema.partCol.0"))
+        .isTrue();
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.partitionSchema"))
+        .isTrue();
+    assertThat(
+            UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.partitionSchema.part.0"))
+        .isTrue();
+  }
+
+  @Test
+  public void isSparkDatasourceSchemaProperty_doesNotMatchUserOrProviderKeys() {
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.sources.provider"))
+        .isFalse();
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("spark.sql.create.version"))
+        .isFalse();
+    assertThat(UCTableProperties.isSparkDatasourceSchemaProperty("user.custom")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary
- Spark packages `StructType` JSON into table properties (`spark.sql.sources.schema`, `spark.sql.sources.schema.part.N`, partition/bucket lists, and `spark.sql.partitionSchema*`) so Hive metastore can reconstruct schema. UC already stores schema on `uc_columns`, and `schema.part.N` routinely exceeds `uc_properties.property_value` (`varchar(255)`), so `CREATE TABLE … USING PARQUET` 500s for anything but a tiny schema.
- One deny-list, `UCTableProperties.shouldPersistProperty`, is used by `UCProxy.createTable` and Spark 4.2 `createView`. It drops reserved V2 keys, vended `fs.*` credentials, and Spark schema JSON, including the `option.`-prefixed copies Spark adds from OPTIONS.
- Load still rebuilds Spark schema from columns. View-only metadata (`view.sqlConfig.*`, schema mode, query column names) is still written after the filter.
- Alternative to widening `property_value` for this Spark path ([#1824](https://github.com/unitycatalog/unitycatalog/pull/1824)). User `TBLPROPERTIES` and REST clients with long values are unchanged.

## Test plan
- [x] `UCTablePropertiesTest` for schema keys, `option.` copies, `fs.*`, reserved V2 keys, and keys that must still persist (user props, `view.sqlConfig.*`)
- [x] `ParquetExternalTableReadWriteTest.testCreateParquetTableDoesNotPersistSparkDatasourceSchema` — seven-column parquet CREATE (the case that overflowed 255 chars), columns persisted, no schema property keys, `SELECT *` works
- [x] `ExternalTableReadWriteTest.testCreateExternalTableSendsNoCredentialProperties` asserts every stored key passes `shouldPersistProperty`
- [ ] CI `spark` tests (4.0 / 4.1 / 4.2)
