### PR TITLE
[Server] Answer unrouted Iceberg requests with an Iceberg error document

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -18,6 +18,7 @@ import com.linecorp.armeria.server.docs.DocService;
 import io.unitycatalog.server.auth.decorator.AuthorizationGateConverter;
 import io.unitycatalog.server.exception.GlobalExceptionHandlingDecorator;
 import io.unitycatalog.server.exception.ServiceExceptionHandlingDecorator;
+import io.unitycatalog.server.exception.UnroutedIcebergRequestHandler;
 import io.unitycatalog.server.service.AuthService;
 import io.unitycatalog.server.service.IcebergRestCatalogService;
 import io.unitycatalog.server.service.RegisteredService;
@@ -47,6 +48,12 @@ import java.util.Objects;
  * properties or security context.
  */
 public class ArmeriaServerBuilder {
+
+  /**
+   * Relative path the Iceberg REST API is mounted at. Shared with the error handler that renders
+   * unrouted Iceberg requests, so the mount point and that handler's prefix cannot drift apart.
+   */
+  static final String ICEBERG_RELATIVE_PATH = "iceberg";
 
   private final ServerBuilder armeriaServerBuilder;
   private final String basePath;
@@ -78,6 +85,10 @@ public class ArmeriaServerBuilder {
     this.armeriaServerBuilder.service("/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
     this.basePath = basePath;
     this.controlPath = controlPath;
+    // Renders the 404s and 405s Armeria answers before a service is reached as Iceberg error
+    // documents, for the Iceberg API's paths only.
+    this.armeriaServerBuilder.errorHandler(
+        new UnroutedIcebergRequestHandler(basePath + ICEBERG_RELATIVE_PATH + "/"));
     this.authorizationEnabled = serverProperties.isAuthorizationEnabled();
     this.ucMapper =
         JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -265,7 +265,7 @@ public class UnityCatalogServer implements AutoCloseable {
     TableConfigService tableConfigService = new TableConfigService(fileOperations);
 
     armeriaServerBuilder.annotate(
-        "iceberg",
+        ArmeriaServerBuilder.ICEBERG_RELATIVE_PATH,
         new IcebergRestCatalogService(
             authorizer, tableConfigService, metadataService, repositories, serverProperties));
   }

--- a/server/src/main/java/io/unitycatalog/server/exception/UnroutedIcebergRequestHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/UnroutedIcebergRequestHandler.java
@@ -1,0 +1,99 @@
+package io.unitycatalog.server.exception;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServerErrorHandler;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.unitycatalog.server.service.iceberg.IcebergObjectMapper;
+import lombok.SneakyThrows;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+
+/**
+ * Renders the status-only responses Armeria produces when no route matched -- 404 for a path the
+ * server does not serve, 405 for a method that path does not accept -- as an Iceberg {@link
+ * ErrorResponse}, for the paths that belong to the Iceberg REST API.
+ *
+ * <p>{@link IcebergRestExceptionHandler} can only speak for a request that reached the Iceberg
+ * service. A request to an endpoint the service does not implement never gets that far, and Armeria
+ * answers it with a plain-text body ("Status: 405") that an Iceberg client cannot parse. Clients
+ * that consult the {@code endpoints} list this server advertises never make such a request, but the
+ * ones that predate that field, or that skip it, get an unreadable response where the REST spec
+ * says an error document belongs.
+ *
+ * <p>Paths outside the Iceberg API are left to Armeria: this handler returns null for them, and for
+ * service exceptions, which the per-service handlers already render.
+ */
+public final class UnroutedIcebergRequestHandler implements ServerErrorHandler {
+
+  private final String icebergPathPrefix;
+
+  /**
+   * @param icebergPathPrefix the path prefix the Iceberg REST API is served under, e.g. {@code
+   *     /api/2.1/unity-catalog/iceberg/}. A trailing slash is added if it is missing, so that the
+   *     prefix cannot match a sibling path that merely starts with the same characters.
+   */
+  public UnroutedIcebergRequestHandler(String icebergPathPrefix) {
+    this.icebergPathPrefix =
+        icebergPathPrefix.endsWith("/") ? icebergPathPrefix : icebergPathPrefix + "/";
+  }
+
+  /**
+   * Whether the path belongs to the Iceberg REST API: one under the prefix, or the mount point
+   * itself, which is the Iceberg API's own root even though nothing is served there.
+   */
+  private boolean isIcebergPath(String path) {
+    return path.startsWith(icebergPathPrefix)
+        || path.equals(icebergPathPrefix.substring(0, icebergPathPrefix.length() - 1));
+  }
+
+  @Nullable
+  @Override
+  public HttpResponse onServiceException(ServiceRequestContext ctx, Throwable cause) {
+    // An exception thrown by a service is rendered by that service's own handler.
+    return null;
+  }
+
+  @SneakyThrows
+  @Nullable
+  @Override
+  public AggregatedHttpResponse renderStatus(
+      @Nullable ServiceConfig config,
+      RequestHeaders headers,
+      HttpStatus status,
+      @Nullable String description,
+      @Nullable Throwable cause) {
+    if (!isIcebergPath(headers.path())) {
+      return null;
+    }
+    String message =
+        description != null && !description.isEmpty() ? description : status.reasonPhrase();
+    return AggregatedHttpResponse.of(
+        status,
+        MediaType.JSON,
+        IcebergObjectMapper.mapper()
+            .writeValueAsString(
+                ErrorResponse.builder()
+                    .responseCode(status.code())
+                    .withType(errorType(status))
+                    .withMessage(message)
+                    .build()));
+  }
+
+  /**
+   * The Iceberg exception to name for a status raised before any service was reached. A path the
+   * server does not serve is reported as not found; Iceberg has no exception of its own for the
+   * remaining statuses and raises a plain {@code RESTException} for them.
+   */
+  private static String errorType(HttpStatus status) {
+    return status.code() == HttpStatus.NOT_FOUND.code()
+        ? NotFoundException.class.getSimpleName()
+        : RESTException.class.getSimpleName();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -62,6 +62,8 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.metrics.CommitMetrics;
 import org.apache.iceberg.metrics.CommitMetricsResult;
@@ -951,6 +953,65 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
+  }
+
+  @Test
+  public void testUnroutedIcebergRequestsAnswerWithAnIcebergError() throws Exception {
+    createUniformIcebergTable();
+
+    // A path the Iceberg API does not serve is answered before any service is reached, so the
+    // service's own handler never sees it. The response still has to be an error document Iceberg's
+    // parser can read.
+    AggregatedHttpResponse resp =
+        client
+            .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/views")
+            .aggregate()
+            .join();
+    assertIcebergStatusDocument(resp, 404, NotFoundException.class, "Not Found");
+
+    // Same for a method a served path does not accept, such as the namespace drop Iceberg's client
+    // sends to a path this server only serves GET on. Iceberg has no exception of its own for 405.
+    resp =
+        client.delete(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
+    assertIcebergStatusDocument(resp, 405, RESTException.class, "Method Not Allowed");
+
+    // The mount point itself belongs to the Iceberg API too, even though nothing is served there,
+    // so the prefix has to match it as well as the paths under it.
+    WebClient rootClient =
+        WebClient.builder(serverConfig.getServerUrl())
+            .auth(AuthToken.ofOAuth2(serverConfig.getAuthToken()))
+            .build();
+    resp = rootClient.get("/api/2.1/unity-catalog/iceberg").aggregate().join();
+    assertIcebergStatusDocument(resp, 404, NotFoundException.class, "Not Found");
+
+    // Paths outside the Iceberg API keep Armeria's own rendering, whether they are another UC API
+    // or the server root.
+    AggregatedHttpResponse outside =
+        rootClient.get("/api/2.1/unity-catalog/no_such_endpoint").aggregate().join();
+    assertThat(outside.status().code()).isEqualTo(404);
+    assertThat(outside.contentType()).isNotEqualTo(MediaType.JSON);
+
+    outside = rootClient.get("/").aggregate().join();
+    assertThat(outside.status().code()).isEqualTo(200);
+    assertThat(outside.contentUtf8()).isEqualTo("Hello, Unity Catalog!");
+  }
+
+  /**
+   * Asserts the response is the Iceberg error document a status raised before any service was
+   * reached has to be rendered as: Iceberg's own media type, the status in the body as well as on
+   * the response, and a type Iceberg's client knows.
+   */
+  private static void assertIcebergStatusDocument(
+      AggregatedHttpResponse resp,
+      int expectedCode,
+      Class<?> expectedType,
+      String expectedMessage) {
+    assertThat(resp.status().code()).isEqualTo(expectedCode);
+    assertThat(resp.contentType()).isEqualTo(MediaType.JSON);
+    ErrorResponse error = ErrorResponseParser.fromJson(resp.contentUtf8());
+    assertThat(error.code()).isEqualTo(expectedCode);
+    assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
+    assertThat(error.message()).isEqualTo(expectedMessage);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -956,8 +956,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   }
 
   @Test
-  public void testUnroutedIcebergRequestsAnswerWithAnIcebergError() throws Exception {
-    createUniformIcebergTable();
+  public void testUnroutedIcebergRequestsAnswerWithAnIcebergError() {
+    // These paths are answered before any service is reached, so nothing here needs a catalog, a
+    // schema or a table to exist.
 
     // A path the Iceberg API does not serve is answered before any service is reached, so the
     // service's own handler never sees it. The response still has to be an error document Iceberg's


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1835.

A request to an Iceberg REST path this server does not implement never reaches
`IcebergRestCatalogService`, so `IcebergRestExceptionHandler` never sees it and Armeria renders the
status itself as `text/plain` -- `Status: 404` and a `Description:` line. Iceberg's
`ErrorResponseParser` cannot read that, so a client that does not consult the advertised `endpoints`
list gets an unparsable body where the REST spec puts an error document.

This registers a `ServerErrorHandler` on the Armeria server that renders those status-only responses
as an Iceberg `ErrorResponse`, and only for paths under the Iceberg API:

- `onServiceException` returns null, so an exception raised by a service is still rendered by that
  service's own handler; nothing about the existing error paths changes.
- `renderStatus` returns null unless the request path starts with the Iceberg API prefix, so
  non-Iceberg paths and `/` keep Armeria's rendering.
- The prefix is built from the same `ICEBERG_RELATIVE_PATH` constant `UnityCatalogServer` mounts the
  service with, so the mount point and the handler cannot drift apart. It matches on a slash
  boundary, and matches the mount point itself as well as the paths under it, so
  `GET /api/2.1/unity-catalog/iceberg` is covered while a sibling path that merely starts with the
  same characters is not.
- 404 is named `NotFoundException`; the remaining statuses have no Iceberg exception of their own and
  are named `RESTException`, which is what Iceberg's client raises for them.

For users: an Iceberg client that calls an endpoint this catalog does not implement now fails with
the exception the status means, instead of a parse error. Responses from implemented endpoints are
byte-for-byte unchanged.

Verified on `main` at 58d5c7b. Before, `GET .../namespaces/{ns}/views` answered
`text/plain` `Status: 404\nDescription: Not Found\n` and `DELETE .../namespaces/{ns}` answered
`Status: 405\nDescription: Method Not Allowed\n`; after, they answer
`{"error":{"message":"Not Found","type":"NotFoundException","code":404}}` and
`{"error":{"message":"Method Not Allowed","type":"RESTException","code":405}}` as
`application/json`. `testUnroutedIcebergRequestsAnswerWithAnIcebergError` fails on an unfixed tree
(`expected: application/json but was: text/plain; charset=utf-8`) and passes with the fix. It pins the
error `type` and `message` as well as the status -- `NotFoundException` for the 404 and
`RESTException` for the 405 -- the mount point itself, and two paths outside the Iceberg API: another
UC endpoint, and `/`, which still answers `Hello, Unity Catalog!`.
`IcebergRestCatalogTest` (10/10) and `ArmeriaServerBuilderTest` are green, and the full
`server/test` suite shows no failure attributable to this change.
