### PR TITLE
[Server] Answer an unknown Iceberg warehouse with a 404

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -144,7 +144,10 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
         catalogOpt.orElseThrow(
             () -> new BadRequestException("Must supply a proper catalog in warehouse property."));
 
-    // TODO: check catalog exists
+    // The prefix below only leads anywhere if the catalog exists. Per the REST spec a warehouse
+    // that does not is a 404 here, rather than a config whose every later request fails.
+    catalogRepository.getCatalog(catalog);
+
     // set catalog prefix
     return ConfigResponse.builder()
         .withOverride("prefix", PREFIX_BASE + catalog)

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -131,7 +131,10 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   }
 
   @Test
-  public void testConfig() {
+  public void testConfig() throws ApiException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+
     // successful test of getting client config with prefix when passing in warehouse param
     AggregatedHttpResponse resp =
         client.get("/v1/config?warehouse=" + TestUtils.CATALOG_NAME).aggregate().join();
@@ -159,6 +162,13 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(resp.status().code()).isEqualTo(400);
     ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
     assertThat(errorResponse.type()).isEqualTo(BadRequestException.class.getSimpleName());
+
+    // A warehouse that does not exist is a 404, which is what the client reads as no such
+    // warehouse. Answering 200 would hand back a prefix whose every request fails instead.
+    resp = client.get("/v1/config?warehouse=noSuchCatalog").aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(404);
+    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).message())
+        .contains("noSuchCatalog");
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1838.

`GET /v1/config` built its prefix from the `warehouse` it was given without looking whether that
catalog exists, as its own `// TODO: check catalog exists` said. A client configured with a misspelled
warehouse initialized successfully and then failed every request against a catalog that was never
there.

The catalog is now resolved before the prefix is built, so an unknown warehouse answers 404 -- the
status the REST spec gives this endpoint for a warehouse that is not found, and the one Iceberg's
`ConfigErrorHandler` turns into `NoSuchWarehouseException` where the catalog is created.

For users: a client pointed at a catalog that does not exist now fails at `initialize`, naming the
warehouse, instead of on its first table operation with a 404 about a namespace. A client pointed at a
catalog that exists sees no change.

`testConfig` now creates the catalog it asks about -- previously it asked for a catalog that was never
created and expected a config back -- and asserts the 404 for one that does not exist. It fails on an
unfixed tree and passes with the fix; the full `server/test` suite shows no failure attributable to
this change.
