### PR TITLE
[Server] Answer namespaceExists with the spec's 204

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -91,6 +91,7 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
       List.of(
           Endpoint.V1_LIST_NAMESPACES,
           Endpoint.V1_LOAD_NAMESPACE,
+          Endpoint.V1_NAMESPACE_EXISTS,
           Endpoint.V1_TABLE_EXISTS,
           Endpoint.V1_LOAD_TABLE,
           Endpoint.V1_LOAD_VIEW,
@@ -178,6 +179,17 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     }
 
     return ListNamespacesResponse.builder().addAll(namespaces).build();
+  }
+
+  @Head("/v1/catalogs/{catalog}/namespaces/{namespace}")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse namespaceExists(
+      @Param("catalog") String catalog, @Param("namespace") String namespace) {
+    // Without a route of its own, this HEAD was served by the GET below, which answered 200 and
+    // described a body a HEAD response must not carry. The REST spec answers it with 204.
+    schemaRepository.getSchema(String.join(".", catalog, namespace));
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}")

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -142,7 +142,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"}"
                 + ",\"endpoints\":["
                 + "\"GET /v1/{prefix}/namespaces\","
-                + "\"GET /v1/{prefix}/namespaces/{namespace}\""
+                + "\"GET /v1/{prefix}/namespaces/{namespace}\","
+                + "\"HEAD /v1/{prefix}/namespaces/{namespace}\""
                 + ",\"HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/views/{view}\","
@@ -159,6 +160,27 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(resp.status().code()).isEqualTo(400);
     ErrorResponse errorResponse = ErrorResponseParser.fromJson(resp.contentUtf8());
     assertThat(errorResponse.type()).isEqualTo(BadRequestException.class.getSimpleName());
+  }
+
+  @Test
+  public void testNamespaceExists() throws ApiException {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+
+    // The REST spec answers this HEAD with 204 and no content. Served by the GET route it answered
+    // 200 and described the body of the namespace response, which a HEAD must not carry.
+    AggregatedHttpResponse resp =
+        client.head(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(204);
+    assertThat(resp.contentUtf8()).isEmpty();
+    assertThat(resp.headers().contentLength()).isLessThanOrEqualTo(0);
+
+    // A namespace that does not exist is a 404, which is what the client reads as "no such
+    // namespace" without a body to parse.
+    resp = client.head(TEST_BASE_PREFIX + "/namespaces/noSuchSchema").aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(404);
   }
 
   @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1839.

The HEAD on a namespace had no route of its own, so Armeria served it from the `@Get` beside it: the
response came back 200, with the content type and length of the body `getNamespace` would have
returned, which a HEAD response must not describe. The REST spec answers `namespaceExists` with 204
and no content.

This adds a `@Head` route that resolves the namespace and answers 204, and advertises
`V1_NAMESPACE_EXISTS` in the config `endpoints`. The server was already answering the request; the
list is what tells a client it can, and Iceberg's client only sends the HEAD when it is advertised,
falling back to the GET otherwise.

For users: `namespaceExists` answers the status the spec defines, and a client that reads `endpoints`
now uses the HEAD instead of loading the whole namespace to find out whether it exists.

`testNamespaceExists` pins the 204, the empty body and the 404 for a namespace that does not exist;
`testConfig`'s advertised list is updated. Both fail on an unfixed tree and pass with the fix; the
full `server/test` suite shows no failure attributable to this change.
