### PR TITLE
[Server] Honour the Iceberg snapshots parameter on loadTable

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -85,6 +85,9 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
 
   private static final String PREFIX_BASE = "catalogs/";
 
+  private static final String SNAPSHOTS_ALL = "all";
+  private static final String SNAPSHOTS_REFS = "refs";
+
   private static final List<Endpoint> READ_ENDPOINTS =
       List.of(
           Endpoint.V1_LIST_NAMESPACES,
@@ -276,7 +279,8 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   public LoadTableResponse loadTable(
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
-      @Param("table") String table) {
+      @Param("table") String table,
+      @Param("snapshots") Optional<String> snapshots) {
     TableRepository.IcebergTableState state =
         tableRepository.getIcebergTableState(catalog, namespace, table);
     if (state.metadataLocation() == null) {
@@ -287,6 +291,13 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     TableMetadata tableMetadata =
         metadataService.readTableMetadata(
             NormalizedURL.from(state.metadataLocation()), tableLocation);
+    if (refsOnly(snapshots)) {
+      tableMetadata =
+          TableMetadata.buildFrom(tableMetadata)
+              .withMetadataLocation(tableMetadata.metadataFileLocation())
+              .suppressHistoricalSnapshots()
+              .build();
+    }
     Map<String, String> config =
         tableConfigService.getTableConfig(tableLocation, getLoadCredentialPrivileges(state));
 
@@ -639,6 +650,27 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     } while (pageToken.isPresent());
 
     return listed.build();
+  }
+
+  /**
+   * Whether the request asked for only the snapshots the table's refs point at. The REST spec's
+   * {@code snapshots} parameter takes "all", which is also the default, or "refs"; anything else is
+   * a bad request rather than a silently full response.
+   */
+  private static boolean refsOnly(Optional<String> snapshots) {
+    if (snapshots.isEmpty()) {
+      return false;
+    }
+    String mode = snapshots.get();
+    if (SNAPSHOTS_REFS.equalsIgnoreCase(mode)) {
+      return true;
+    }
+    if (SNAPSHOTS_ALL.equalsIgnoreCase(mode)) {
+      return false;
+    }
+    throw new BadRequestException(
+        "Invalid snapshots parameter: %s. Valid values are %s and %s.",
+        mode, SNAPSHOTS_ALL, SNAPSHOTS_REFS);
   }
 
   /**

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -47,6 +47,7 @@ import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -66,6 +67,8 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.RESTCatalogProperties;
+import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
@@ -84,9 +87,6 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergRestCatalogService.class);
 
   private static final String PREFIX_BASE = "catalogs/";
-
-  private static final String SNAPSHOTS_ALL = "all";
-  private static final String SNAPSHOTS_REFS = "refs";
 
   private static final List<Endpoint> READ_ENDPOINTS =
       List.of(
@@ -280,7 +280,7 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       @Param("table") String table,
-      @Param("snapshots") Optional<String> snapshots) {
+      @Param(RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER) Optional<String> snapshots) {
     TableRepository.IcebergTableState state =
         tableRepository.getIcebergTableState(catalog, namespace, table);
     if (state.metadataLocation() == null) {
@@ -658,19 +658,24 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
    * a bad request rather than a silently full response.
    */
   private static boolean refsOnly(Optional<String> snapshots) {
-    if (snapshots.isEmpty()) {
-      return false;
+    return snapshots.map(IcebergRestCatalogService::snapshotMode).orElse(SnapshotMode.ALL)
+        == SnapshotMode.REFS;
+  }
+
+  /** Reads the parameter as the mode Iceberg's client names it with, rejecting anything else. */
+  private static SnapshotMode snapshotMode(String snapshots) {
+    try {
+      return SnapshotMode.valueOf(snapshots.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(
+          "Invalid snapshots parameter: %s. Valid values are %s and %s.",
+          snapshots, modeName(SnapshotMode.ALL), modeName(SnapshotMode.REFS));
     }
-    String mode = snapshots.get();
-    if (SNAPSHOTS_REFS.equalsIgnoreCase(mode)) {
-      return true;
-    }
-    if (SNAPSHOTS_ALL.equalsIgnoreCase(mode)) {
-      return false;
-    }
-    throw new BadRequestException(
-        "Invalid snapshots parameter: %s. Valid values are %s and %s.",
-        mode, SNAPSHOTS_ALL, SNAPSHOTS_REFS);
+  }
+
+  /** The name the mode travels under on the wire, which the client lowercases. */
+  private static String modeName(SnapshotMode mode) {
+    return mode.name().toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Namespace;
@@ -1072,6 +1073,51 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.message()).isEqualTo(expectedMessage);
   }
 
+  @Test
+  public void testLoadTableSnapshotsParameter() throws Exception {
+    createUniformIcebergTable("/iceberg.metadata.two-snapshots.json");
+    String tablePath =
+        TEST_BASE_PREFIX
+            + "/namespaces/"
+            + TestUtils.SCHEMA_NAME
+            + "/tables/"
+            + TestUtils.TABLE_NAME;
+
+    // The default is every snapshot the metadata holds, which includes the one no ref points at.
+    assertThat(loadedSnapshotIds(client.get(tablePath).aggregate().join())).hasSize(2);
+    assertThat(loadedSnapshotIds(client.get(tablePath + "?snapshots=all").aggregate().join()))
+        .hasSize(2);
+
+    // "refs" asks for only the snapshots the table's refs point at.
+    AggregatedHttpResponse refsOnly = client.get(tablePath + "?snapshots=refs").aggregate().join();
+    assertThat(refsOnly.status().code()).isEqualTo(200);
+    LoadTableResponse loaded =
+        IcebergObjectMapper.mapper().readValue(refsOnly.contentUtf8(), LoadTableResponse.class);
+    assertThat(loadedSnapshotIds(refsOnly))
+        .containsExactly(loaded.tableMetadata().currentSnapshot().snapshotId());
+    // The rest of the metadata is the same table, so a client can still use what it got back.
+    assertThat(loaded.tableMetadata().metadataFileLocation())
+        .isEqualTo(
+            IcebergObjectMapper.mapper()
+                .readValue(
+                    client.get(tablePath).aggregate().join().contentUtf8(), LoadTableResponse.class)
+                .tableMetadata()
+                .metadataFileLocation());
+
+    // Any other value is a bad request rather than a silently complete response.
+    AggregatedHttpResponse rejected = client.get(tablePath + "?snapshots=some").aggregate().join();
+    assertThat(rejected.status().code()).isEqualTo(400);
+    assertThat(ErrorResponseParser.fromJson(rejected.contentUtf8()).type())
+        .isEqualTo(BadRequestException.class.getSimpleName());
+  }
+
+  private static List<Long> loadedSnapshotIds(AggregatedHttpResponse resp) throws IOException {
+    assertThat(resp.status().code()).isEqualTo(200);
+    LoadTableResponse loaded =
+        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+    return loaded.tableMetadata().snapshots().stream().map(Snapshot::snapshotId).toList();
+  }
+
   private AggregatedHttpResponse postJson(String path, String body) {
     return client
         .execute(
@@ -1125,7 +1171,12 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
   /** Creates a table that the Iceberg endpoints see, i.e. one with uniform Iceberg metadata. */
   private void createUniformIcebergTable() throws IOException, URISyntaxException, ApiException {
-    Path metadataFile = writeIcebergMetadata();
+    createUniformIcebergTable("/iceberg.metadata.json");
+  }
+
+  private void createUniformIcebergTable(String metadataResource)
+      throws IOException, URISyntaxException, ApiException {
+    Path metadataFile = writeIcebergMetadata(metadataResource);
     catalogOperations.createCatalog(
         new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
     schemaOperations.createSchema(
@@ -1172,9 +1223,11 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   }
 
   private Path writeIcebergMetadata() throws IOException, URISyntaxException {
-    Path source =
-        Path.of(
-            Objects.requireNonNull(this.getClass().getResource("/iceberg.metadata.json")).toURI());
+    return writeIcebergMetadata("/iceberg.metadata.json");
+  }
+
+  private Path writeIcebergMetadata(String resource) throws IOException, URISyntaxException {
+    Path source = Path.of(Objects.requireNonNull(this.getClass().getResource(resource)).toURI());
     Path metadataFile = icebergTableLocation.resolve("iceberg.metadata.json");
     String tableLocation = NormalizedURL.from(icebergTableLocation.toUri()).toString();
     String metadata =

--- a/server/src/test/resources/iceberg.metadata.two-snapshots.json
+++ b/server/src/test/resources/iceberg.metadata.two-snapshots.json
@@ -1,0 +1,136 @@
+{
+  "format-version": 1,
+  "table-uuid": "55d4dc69-5b14-4483-bfc8-f33b80f99f99",
+  "location": "file:/tmp/uniform_iceberg_table",
+  "last-updated-ms": 1717798711566,
+  "last-column-id": 2,
+  "schema": {
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": false,
+        "type": "int"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": false,
+        "type": "string"
+      }
+    ]
+  },
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "partition-spec": [],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": []
+    }
+  ],
+  "last-partition-id": 999,
+  "default-sort-order-id": 0,
+  "sort-orders": [
+    {
+      "order-id": 0,
+      "fields": []
+    }
+  ],
+  "properties": {
+    "schema.name-mapping.default": "[ {\n  \"field-id\" : 1,\n  \"names\" : [ \"x\" ]\n}, {\n  \"field-id\" : 2,\n  \"names\" : [ \"y\" ]\n} ]",
+    "delta-timestamp": "1717798710940",
+    "delta-version": "1"
+  },
+  "current-snapshot-id": 6116814959227549927,
+  "refs": {
+    "main": {
+      "snapshot-id": 6116814959227549927,
+      "type": "branch"
+    }
+  },
+  "snapshots": [
+    {
+      "snapshot-id": 6116814959227549926,
+      "timestamp-ms": 1717798710520,
+      "summary": {
+        "operation": "append",
+        "added-data-files": "2",
+        "added-records": "2",
+        "added-files-size": "2548",
+        "changed-partition-count": "1",
+        "total-records": "2",
+        "total-files-size": "2548",
+        "total-data-files": "2",
+        "total-delete-files": "0",
+        "total-position-deletes": "0",
+        "total-equality-deletes": "0"
+      },
+      "manifest-list": "file:/tmp/uniform_iceberg_table/metadata/snap-6116814959227549927-1-d8f2f281-068d-4926-98e2-cb46aa8bb449.avro",
+      "schema-id": 0
+    },
+    {
+      "snapshot-id": 6116814959227549927,
+      "timestamp-ms": 1717798711520,
+      "summary": {
+        "operation": "append",
+        "added-data-files": "2",
+        "added-records": "2",
+        "added-files-size": "2548",
+        "changed-partition-count": "1",
+        "total-records": "2",
+        "total-files-size": "2548",
+        "total-data-files": "2",
+        "total-delete-files": "0",
+        "total-position-deletes": "0",
+        "total-equality-deletes": "0"
+      },
+      "manifest-list": "file:/tmp/uniform_iceberg_table/metadata/snap-6116814959227549927-1-d8f2f281-068d-4926-98e2-cb46aa8bb449.avro",
+      "schema-id": 0,
+      "parent-snapshot-id": 6116814959227549926
+    }
+  ],
+  "statistics": [],
+  "snapshot-log": [
+    {
+      "timestamp-ms": 1717798710520,
+      "snapshot-id": 6116814959227549926
+    },
+    {
+      "timestamp-ms": 1717798711520,
+      "snapshot-id": 6116814959227549927
+    }
+  ],
+  "metadata-log": [
+    {
+      "timestamp-ms": 1717798708045,
+      "metadata-file": "file:/tmp/uniform_iceberg_table/metadata/00000-dfec5831-d8c5-452f-9151-0b21f161ec77.metadata.json"
+    },
+    {
+      "timestamp-ms": 1717798708455,
+      "metadata-file": "file:/tmp/uniform_iceberg_table/metadata/00001-6b7ac64d-2bcb-42aa-9b30-b6d5b7bcd027.metadata.json"
+    }
+  ]
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1840.

`loadTable` took no `snapshots` parameter, so a client asking for `refs` was answered with the whole
metadata, and a value the spec does not define was accepted without a word.

The parameter is now read. For `refs` the response is built from metadata with the historical snapshots
suppressed, which is how Iceberg's own handler answers that mode; `all` and an absent parameter answer
as before. Any other value is a bad request, so a client asking for something this server does not
implement is told rather than handed a response that does not match its request.

For users: a client configured with `rest-snapshot-loading-mode=refs` gets what it asked for, which on
a table with a long history is a much smaller response. Clients that do not send the parameter see no
change.

`testLoadTableSnapshotsParameter` pins all three cases against a table whose metadata holds a snapshot
no ref points at (a new test fixture): `all` and no parameter return both snapshots, `refs` returns
only the referenced one while the rest of the metadata is unchanged, and an unknown value is a 400
typed `BadRequestException`. It fails on an unfixed tree and passes with the fix; the full
`server/test` suite shows no failure attributable to this change.
