### PR TITLE
[Server] Implement the Iceberg dropNamespace endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -36,6 +36,7 @@ import io.unitycatalog.server.persist.SchemaRepository;
 import io.unitycatalog.server.persist.StagingTableRepository;
 import io.unitycatalog.server.persist.TableRepository;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
+import io.unitycatalog.server.persist.model.DeletedResource;
 import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.service.iceberg.IcebergSchemaConverter;
@@ -63,6 +64,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
@@ -100,6 +102,7 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   private static final List<Endpoint> WRITE_ENDPOINTS =
       List.of(
           Endpoint.V1_CREATE_NAMESPACE,
+          Endpoint.V1_DELETE_NAMESPACE,
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
           Endpoint.V1_DELETE_TABLE);
@@ -217,6 +220,27 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
         .withNamespace(request.namespace())
         .setProperties(properties)
         .build();
+  }
+
+  @Delete("/v1/catalogs/{catalog}/namespaces/{namespace}")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse dropNamespace(
+      @Param("catalog") String catalog, @Param("namespace") String namespace) {
+    serverProperties.checkIcebergTableEnabled();
+    List<DeletedResource> deleted;
+    try {
+      deleted = schemaRepository.deleteSchema(String.join(".", catalog, namespace), false);
+    } catch (BaseException failure) {
+      if (failure.getErrorCode() == ErrorCode.FAILED_PRECONDITION) {
+        // A schema that still holds objects is a failed precondition to the repository, which is a
+        // 400; the REST spec answers a namespace that is not empty with 409.
+        throw new NamespaceNotEmptyException("Namespace is not empty: %s", namespace);
+      }
+      throw failure;
+    }
+    clearDeletedResourceAuthorizations(deleted);
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   // Table APIs

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -228,6 +228,30 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       resp = client.get(TEST_BASE_NON_PREFIX + "/namespaces").aggregate().join();
       assertThat(resp.status().code()).isEqualTo(404);
     }
+
+    // DropNamespace
+    {
+      String namespacePath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME;
+
+      // A namespace that still holds a table cannot be dropped, and the spec answers that with 409
+      // rather than the failed precondition the repository reports.
+      createTable(TestUtils.TABLE_NAME);
+      AggregatedHttpResponse resp = client.delete(namespacePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(409);
+      assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+          .isEqualTo(NamespaceNotEmptyException.class.getSimpleName());
+
+      // Once it is empty the drop answers 204 with no content, and the namespace is gone.
+      tableOperations.deleteTable(TestUtils.TABLE_FULL_NAME);
+      resp = client.delete(namespacePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(204);
+      assertThat(resp.contentUtf8()).isEmpty();
+      assertThat(client.get(namespacePath).aggregate().join().status().code()).isEqualTo(404);
+
+      // Dropping a namespace that is not there is a 404.
+      resp = client.delete(namespacePath).aggregate().join();
+      assertThat(resp.status().code()).isEqualTo(404);
+    }
   }
 
   @Test
@@ -953,30 +977,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
-  }
-
-  @Test
-  public void testDropNamespace() throws Exception {
-    createUniformIcebergTable();
-    String namespacePath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME;
-
-    // A namespace that still holds a table cannot be dropped, and the spec answers that with 409
-    // rather than the failed precondition the repository reports.
-    AggregatedHttpResponse resp = client.delete(namespacePath).aggregate().join();
-    assertThat(resp.status().code()).isEqualTo(409);
-    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
-        .isEqualTo(NamespaceNotEmptyException.class.getSimpleName());
-
-    // Once it is empty the drop answers 204 with no content, and the namespace is gone.
-    tableOperations.deleteTable(TestUtils.TABLE_FULL_NAME);
-    resp = client.delete(namespacePath).aggregate().join();
-    assertThat(resp.status().code()).isEqualTo(204);
-    assertThat(resp.contentUtf8()).isEmpty();
-    assertThat(client.get(namespacePath).aggregate().join().status().code()).isEqualTo(404);
-
-    // Dropping a namespace that is not there is a 404.
-    resp = client.delete(namespacePath).aggregate().join();
-    assertThat(resp.status().code()).isEqualTo(404);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -61,6 +61,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.metrics.CommitMetrics;
@@ -149,6 +150,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics\","
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces\","
+                + "\"DELETE /v1/{prefix}/namespaces/{namespace}\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
@@ -951,6 +953,30 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
+  }
+
+  @Test
+  public void testDropNamespace() throws Exception {
+    createUniformIcebergTable();
+    String namespacePath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME;
+
+    // A namespace that still holds a table cannot be dropped, and the spec answers that with 409
+    // rather than the failed precondition the repository reports.
+    AggregatedHttpResponse resp = client.delete(namespacePath).aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(409);
+    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+        .isEqualTo(NamespaceNotEmptyException.class.getSimpleName());
+
+    // Once it is empty the drop answers 204 with no content, and the namespace is gone.
+    tableOperations.deleteTable(TestUtils.TABLE_FULL_NAME);
+    resp = client.delete(namespacePath).aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(204);
+    assertThat(resp.contentUtf8()).isEmpty();
+    assertThat(client.get(namespacePath).aggregate().join().status().code()).isEqualTo(404);
+
+    // Dropping a namespace that is not there is a 404.
+    resp = client.delete(namespacePath).aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(404);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Part of #1846.

`DELETE` on a namespace had no route, so an engine's `DROP NAMESPACE` was answered by Armeria before
any service was reached, with a 405 saying the path takes no such method. Unity Catalog has dropped
schemas all along, through `SchemaRepository.deleteSchema`; the operation was only missing from the
Iceberg REST surface.

This serves it and advertises `V1_DELETE_NAMESPACE` with the other write endpoints, so it is gated the
same way the other Iceberg writes are.

- A namespace that still holds objects is refused. The repository reports that as a failed
  precondition, which would go out as 400; the spec answers a namespace that is not empty with 409, so
  it is raised as Iceberg's `NamespaceNotEmptyException`.
- Authorizations of everything deleted are cleared exactly as `SchemaService` clears them, so dropping
  a namespace here leaves nothing behind that dropping it through the Unity Catalog API would remove.

For users: `DROP NAMESPACE` works from Spark, Trino and any other Iceberg client, and a namespace that
still has tables is refused with the status the client understands as "not empty".

`testDropNamespace` pins the 409 while a table is there, the 204 and empty body once it is not, the
404 for the namespace afterwards, and the updated `endpoints` list. It fails on an unfixed tree and
passes with the fix; the full `server/test` suite shows no failure attributable to this change.
