### PR TITLE
[Server] Implement the Iceberg updateNamespaceProperties endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/ErrorCode.java
@@ -58,7 +58,11 @@ public enum ErrorCode {
   EXTERNAL_LOCATION_ALREADY_EXISTS(21, 400, DeltaErrorType.ALREADY_EXISTS_EXCEPTION, 409),
   // CCv2 commit whose idempotency the server could not determine (e.g. the published or staged
   // commit file could not be read for a content comparison). Retriable.
-  COMMIT_STATE_UNKNOWN(22, 500, DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION);
+  COMMIT_STATE_UNKNOWN(22, 500, DeltaErrorType.COMMIT_STATE_UNKNOWN_EXCEPTION),
+  // A request the server understood but cannot carry out as asked, which the Iceberg REST spec
+  // answers 422 (e.g. a namespace property named in both updates and removals). The Delta API has
+  // no 422, so it keeps reporting such a request as a bad one.
+  UNPROCESSABLE_ENTITY(3, 422, DeltaErrorType.INVALID_PARAMETER_VALUE_EXCEPTION, 400);
 
   // Canonical mapping from DeltaErrorType to HTTP status. Built at class-load time and validated
   // to ensure every ErrorCode that shares the same deltaErrorType also agrees on deltaHttpStatus.

--- a/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
+++ b/server/src/main/java/io/unitycatalog/server/exception/IcebergRestExceptionHandler.java
@@ -12,6 +12,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 
 /**
@@ -78,6 +79,11 @@ public class IcebergRestExceptionHandler extends BaseExceptionHandler {
     }
     if (cause instanceof BadRequestException) {
       return wrapException(ErrorCode.INVALID_ARGUMENT, cause);
+    }
+    if (cause instanceof UnprocessableEntityException) {
+      // Iceberg's own request validation raises this for a request that is well formed but cannot
+      // be carried out as asked, which the REST spec answers with 422.
+      return wrapException(ErrorCode.UNPROCESSABLE_ENTITY, cause);
     }
     return super.toBaseException(cause);
   }

--- a/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/SchemaRepository.java
@@ -30,8 +30,12 @@ import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ValidationUtils;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -214,6 +218,57 @@ public class SchemaRepository {
         },
         "Failed to get schema",
         /* readOnly= */ true);
+  }
+
+  /** Which of the requested property changes a schema was actually given. */
+  public record PropertyChanges(Set<String> updated, Set<String> removed, Set<String> missing) {}
+
+  /**
+   * Applies a patch to a schema's properties: {@code updates} are set, {@code removals} are
+   * dropped, and everything else is left alone. Unlike {@link #updateSchema}, which replaces the
+   * whole map and reads an empty one as "nothing to do", this can remove a schema's last property.
+   *
+   * <p>The read and the write happen in one transaction, so two callers patching different keys
+   * cannot lose each other's change.
+   *
+   * @return the keys that were set, the keys that were removed, and the keys asked to be removed
+   *     that the schema did not have
+   */
+  public PropertyChanges applyPropertyChanges(
+      String fullName, Map<String, String> updates, Set<String> removals) {
+    String callerId = IdentityUtils.findPrincipalEmailAddress();
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          SchemaInfoDAO schemaInfoDAO = getSchemaDaoOrThrow(session, fullName);
+          Map<String, String> properties = new HashMap<>();
+          PropertyRepository.findProperties(session, schemaInfoDAO.getId(), Constants.SCHEMA)
+              .forEach(property -> properties.put(property.getKey(), property.getValue()));
+
+          Set<String> removed = new LinkedHashSet<>();
+          Set<String> missing = new LinkedHashSet<>();
+          removals.forEach(
+              key -> {
+                if (properties.remove(key) != null) {
+                  removed.add(key);
+                } else {
+                  missing.add(key);
+                }
+              });
+          properties.putAll(updates);
+
+          PropertyRepository.findProperties(session, schemaInfoDAO.getId(), Constants.SCHEMA)
+              .forEach(session::remove);
+          session.flush();
+          PropertyDAO.from(properties, schemaInfoDAO.getId(), Constants.SCHEMA)
+              .forEach(session::persist);
+          schemaInfoDAO.setUpdatedAt(new Date());
+          schemaInfoDAO.setUpdatedBy(callerId);
+          session.merge(schemaInfoDAO);
+          return new PropertyChanges(new LinkedHashSet<>(updates.keySet()), removed, missing);
+        },
+        "Failed to update schema properties",
+        /* readOnly= */ false);
   }
 
   public SchemaInfo updateSchema(String fullName, UpdateSchema updateSchema) {

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -46,6 +46,7 @@ import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +70,7 @@ import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
+import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
@@ -76,6 +78,7 @@ import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +103,7 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
       List.of(
           Endpoint.V1_CREATE_NAMESPACE,
           Endpoint.V1_DELETE_NAMESPACE,
+          Endpoint.V1_UPDATE_NAMESPACE,
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
           Endpoint.V1_DELETE_TABLE);
@@ -250,6 +254,29 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     }
     clearDeletedResourceAuthorizations(deleted);
     return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/properties")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public UpdateNamespacePropertiesResponse updateNamespaceProperties(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      UpdateNamespacePropertiesRequest request) {
+    serverProperties.checkIcebergTableEnabled();
+    // Iceberg's own request rejects a key asked to be both set and removed.
+    request.validate();
+    SchemaRepository.PropertyChanges changes =
+        schemaRepository.applyPropertyChanges(
+            String.join(".", catalog, namespace),
+            request.updates(),
+            new LinkedHashSet<>(request.removals()));
+    return UpdateNamespacePropertiesResponse.builder()
+        .addUpdated(changes.updated())
+        .addRemoved(changes.removed())
+        .addMissing(changes.missing())
+        .build();
   }
 
   // Table APIs

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -65,6 +65,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.metrics.CommitMetrics;
 import org.apache.iceberg.metrics.CommitMetricsResult;
@@ -84,6 +85,7 @@ import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.types.Types;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -157,6 +159,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"GET /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces\","
                 + "\"DELETE /v1/{prefix}/namespaces/{namespace}\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/properties\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
                 + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
@@ -1070,6 +1073,57 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.code()).isEqualTo(expectedCode);
     assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
     assertThat(error.message()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  public void testUpdateNamespaceProperties() throws Exception {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema()
+            .catalogName(TestUtils.CATALOG_NAME)
+            .name(TestUtils.SCHEMA_NAME)
+            .properties(Map.of("keep", "me", "drop", "this")));
+    String propertiesPath =
+        TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/properties";
+
+    // What was set, what was removed, and what could not be removed because it was not there.
+    AggregatedHttpResponse resp =
+        postJson(
+            propertiesPath,
+            "{\"removals\": [\"drop\", \"absent\"], \"updates\": {\"added\": \"value\"}}");
+    assertThat(resp.status().code()).isEqualTo(200);
+    UpdateNamespacePropertiesResponse updated =
+        IcebergObjectMapper.mapper()
+            .readValue(resp.contentUtf8(), UpdateNamespacePropertiesResponse.class);
+    assertThat(updated.updated()).containsExactly("added");
+    assertThat(updated.removed()).containsExactly("drop");
+    assertThat(updated.missing()).containsExactly("absent");
+
+    // The namespace itself reflects the patch: keys not mentioned are left alone.
+    assertThat(
+            IcebergObjectMapper.mapper()
+                .readValue(
+                    client
+                        .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME)
+                        .aggregate()
+                        .join()
+                        .contentUtf8(),
+                    GetNamespaceResponse.class)
+                .properties())
+        .containsOnly(Map.entry("keep", "me"), Map.entry("added", "value"));
+
+    // A key both set and removed is the spec's 422, and a namespace that does not exist is a 404.
+    resp =
+        postJson(propertiesPath, "{\"removals\": [\"both\"], \"updates\": {\"both\": \"value\"}}");
+    assertThat(resp.status().code()).isEqualTo(422);
+    assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
+        .isEqualTo(UnprocessableEntityException.class.getSimpleName());
+    resp =
+        postJson(
+            TEST_BASE_PREFIX + "/namespaces/noSuchSchema/properties",
+            "{\"removals\": [], \"updates\": {\"a\": \"b\"}}");
+    assertThat(resp.status().code()).isEqualTo(404);
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -1101,17 +1101,19 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(updated.missing()).containsExactly("absent");
 
     // The namespace itself reflects the patch: keys not mentioned are left alone.
-    assertThat(
-            IcebergObjectMapper.mapper()
-                .readValue(
-                    client
-                        .get(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME)
-                        .aggregate()
-                        .join()
-                        .contentUtf8(),
-                    GetNamespaceResponse.class)
-                .properties())
+    assertThat(namespaceProperties(TestUtils.SCHEMA_NAME))
         .containsOnly(Map.entry("keep", "me"), Map.entry("added", "value"));
+
+    // Removing every key leaves the namespace with none. Worth pinning separately: a patch that
+    // ends in an empty property set is what a later "nothing to write" shortcut would get wrong.
+    resp = postJson(propertiesPath, "{\"removals\": [\"keep\", \"added\"], \"updates\": {}}");
+    assertThat(resp.status().code()).isEqualTo(200);
+    updated =
+        IcebergObjectMapper.mapper()
+            .readValue(resp.contentUtf8(), UpdateNamespacePropertiesResponse.class);
+    assertThat(updated.removed()).containsExactlyInAnyOrder("keep", "added");
+    assertThat(updated.updated()).isEmpty();
+    assertThat(namespaceProperties(TestUtils.SCHEMA_NAME)).isEmpty();
 
     // A key both set and removed is the spec's 422, and a namespace that does not exist is a 404.
     resp =
@@ -1124,6 +1126,16 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             TEST_BASE_PREFIX + "/namespaces/noSuchSchema/properties",
             "{\"removals\": [], \"updates\": {\"a\": \"b\"}}");
     assertThat(resp.status().code()).isEqualTo(404);
+  }
+
+  /** The properties the namespace reports, as a client reading it back would see them. */
+  private Map<String, String> namespaceProperties(String namespace) throws IOException {
+    AggregatedHttpResponse resp =
+        client.get(TEST_BASE_PREFIX + "/namespaces/" + namespace).aggregate().join();
+    assertThat(resp.status().code()).isEqualTo(200);
+    return IcebergObjectMapper.mapper()
+        .readValue(resp.contentUtf8(), GetNamespaceResponse.class)
+        .properties();
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Part of #1846.

`POST` on a namespace's properties had no route, so an engine's `ALTER NAMESPACE ... SET PROPERTIES` was
answered with a 405 before any service was reached. Unity Catalog has kept schema properties all along;
the endpoint that patches them was missing from the Iceberg REST surface.

This serves it and advertises `V1_UPDATE_NAMESPACE` with the other write endpoints. The response
reports which keys were `updated`, which were `removed`, and which were asked to be removed but were
not there, as the spec describes.

Two things worth a reviewer's attention:

- The patch is applied by a new `SchemaRepository` method rather than through `updateSchema`.
  `updateSchema` replaces the whole property map and reads an empty one as "nothing to do", so
  removing a schema's last property could not be expressed through it; and the patch has to read and
  write in one transaction, so two callers changing different keys do not lose each other's change.
- A key named in both `updates` and `removals` is refused by Iceberg's own request validation, which
  raises `UnprocessableEntityException`. The spec answers that with 422, a status the shared
  `ErrorCode` enum had no entry for, so this adds one; the Delta API has no 422, so that dialect keeps
  reporting such a request as a bad one, which the enum already expresses with its per-dialect status.
  Say so if you would rather this answered 400 and left `ErrorCode` alone.

For users: namespace properties can be set and removed from any Iceberg client, and the response says
exactly what the catalog did.

`testUpdateNamespaceProperties` pins the three reported sets, that keys not mentioned are left alone,
the 422, and the 404 for a namespace that is not there. It fails on an unfixed tree and passes with the
fix; the full `server/test` suite shows no failure attributable to this change.
