### PR TITLE
[Server] Implement the Iceberg renameTable endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -588,6 +588,8 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   @AuthorizeResourceKey(METASTORE)
   public HttpResponse renameTable(@Param("catalog") String catalog, RenameTableRequest request) {
     serverProperties.checkIcebergTableEnabled();
+    // A request missing either identifier is a bad request, not the NPE reading it would raise.
+    request.validate();
     Namespace source = request.source().namespace();
     Namespace destination = request.destination().namespace();
     if (!source.equals(destination)) {
@@ -601,12 +603,17 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
               + destination);
     }
     String namespace = source.toString();
-    // Only tables this API serves can be renamed through it; anything else is not a table it has.
+    String fullName = catalog + "." + namespace + "." + request.source().name();
+    // As with dropTable, only a table created through this API may be changed through it: a UniForm
+    // table is a Delta table that these endpoints read, and renaming it here would rename the Delta
+    // table under its own API.
     TableRepository.IcebergTableState state =
         tableRepository.getIcebergTableState(catalog, namespace, request.source().name());
-    if (state.metadataLocation() == null) {
-      throw new NoSuchTableException(
-          "Table does not exist: %s", namespace + "." + request.source().name());
+    if (state.dataSourceFormat() != DataSourceFormat.ICEBERG) {
+      throw new BadRequestException(
+          "Table %s was not created through the Iceberg REST catalog; rename it through the Unity"
+              + " Catalog API instead.",
+          fullName);
     }
     tableRepository.renameTable(
         catalog, namespace, request.source().name(), request.destination().name());

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -68,6 +68,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -102,7 +103,8 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
           Endpoint.V1_DELETE_NAMESPACE,
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
-          Endpoint.V1_DELETE_TABLE);
+          Endpoint.V1_DELETE_TABLE,
+          Endpoint.V1_RENAME_TABLE);
 
   private final TableConfigService tableConfigService;
   private final MetadataService metadataService;
@@ -579,6 +581,36 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
       }
       throw e;
     }
+  }
+
+  @Post("/v1/catalogs/{catalog}/tables/rename")
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public HttpResponse renameTable(@Param("catalog") String catalog, RenameTableRequest request) {
+    serverProperties.checkIcebergTableEnabled();
+    Namespace source = request.source().namespace();
+    Namespace destination = request.destination().namespace();
+    if (!source.equals(destination)) {
+      // Unity Catalog has no way to move a table between schemas, so a rename that asks for one is
+      // reported as an operation this server does not implement rather than half-applied.
+      throw new BaseException(
+          ErrorCode.UNIMPLEMENTED,
+          "Renaming a table into another namespace is not supported: "
+              + source
+              + " to "
+              + destination);
+    }
+    String namespace = source.toString();
+    // Only tables this API serves can be renamed through it; anything else is not a table it has.
+    TableRepository.IcebergTableState state =
+        tableRepository.getIcebergTableState(catalog, namespace, request.source().name());
+    if (state.metadataLocation() == null) {
+      throw new NoSuchTableException(
+          "Table does not exist: %s", namespace + "." + request.source().name());
+    }
+    tableRepository.renameTable(
+        catalog, namespace, request.source().name(), request.destination().name());
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
   }
 
   @Get("/v1/catalogs/{catalog}/namespaces/{namespace}/views/{view}")

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -159,7 +159,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"DELETE /v1/{prefix}/namespaces/{namespace}\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
-                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
+                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
+                + "\"POST /v1/{prefix}/tables/rename\""
                 + "]}");
 
     // not setting warehouse param should result in 400 BadRequestException
@@ -1070,6 +1071,60 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.code()).isEqualTo(expectedCode);
     assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
     assertThat(error.message()).isEqualTo(expectedMessage);
+  }
+
+  @Test
+  public void testRenameTable() throws Exception {
+    createUniformIcebergTable();
+    String renamePath = "/v1/catalogs/" + TestUtils.CATALOG_NAME + "/tables/rename";
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+
+    // A rename answers 204 with no content, and the table is listed and loadable under its new
+    // name.
+    AggregatedHttpResponse resp =
+        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "renamed"));
+    assertThat(resp.status().code()).isEqualTo(204);
+    assertThat(resp.contentUtf8()).isEmpty();
+    ListTablesResponse listed =
+        IcebergObjectMapper.mapper()
+            .readValue(
+                client.get(tablesPath).aggregate().join().contentUtf8(), ListTablesResponse.class);
+    assertThat(listed.identifiers())
+        .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "renamed"));
+    assertThat(client.get(tablesPath + "/renamed").aggregate().join().status().code())
+        .isEqualTo(200);
+
+    // Renaming a table that is not there is a 404.
+    resp =
+        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "other"));
+    assertThat(resp.status().code()).isEqualTo(404);
+
+    // Renaming onto a name that is taken is a 409.
+    createTable("taken");
+    resp = postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "taken"));
+    assertThat(resp.status().code()).isEqualTo(409);
+
+    // Unity Catalog cannot move a table between namespaces, and says so rather than half-doing it.
+    resp =
+        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "moved", "other_ns"));
+    assertThat(resp.status().code()).isEqualTo(501);
+  }
+
+  private static String renameRequest(String namespace, String from, String to) {
+    return renameRequest(namespace, from, to, namespace);
+  }
+
+  private static String renameRequest(
+      String namespace, String from, String to, String destinationNamespace) {
+    return "{\"source\": {\"namespace\": [\""
+        + namespace
+        + "\"], \"name\": \""
+        + from
+        + "\"}, \"destination\": {\"namespace\": [\""
+        + destinationNamespace
+        + "\"], \"name\": \""
+        + to
+        + "\"}}";
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -475,6 +475,12 @@ public class IcebergRestCatalogTest extends BaseServerTest {
 
       resp = client.delete(tablePath).aggregate().join();
       assertThat(resp.status().code()).isEqualTo(400);
+
+      resp =
+          postJson(
+              "/v1/catalogs/" + TestUtils.CATALOG_NAME + "/tables/rename",
+              renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "renamed"));
+      assertThat(resp.status().code()).isEqualTo(400);
     }
 
     // Credentials must never be scoped by a conflicting location in the metadata payload. Repoint
@@ -678,6 +684,51 @@ public class IcebergRestCatalogTest extends BaseServerTest {
       assertThat(resp.status().code()).isEqualTo(409);
       assertThat(ErrorResponseParser.fromJson(resp.contentUtf8()).type())
           .isEqualTo(CommitFailedException.class.getSimpleName());
+    }
+
+    // Rename the table, and rename it back so the steps below still find it
+    {
+      String renamePath = "/v1/catalogs/" + TestUtils.CATALOG_NAME + "/tables/rename";
+      AggregatedHttpResponse resp =
+          postJson(
+              renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "renamed"));
+      assertThat(resp.status().code()).isEqualTo(204);
+      assertThat(resp.contentUtf8()).isEmpty();
+
+      // The table answers under its new name and no longer under the old one.
+      assertThat(client.get(tablesPath + "/renamed").aggregate().join().status().code())
+          .isEqualTo(200);
+      assertThat(client.get(tablePath).aggregate().join().status().code()).isEqualTo(404);
+      ListTablesResponse listed =
+          IcebergObjectMapper.mapper()
+              .readValue(
+                  client.get(tablesPath).aggregate().join().contentUtf8(),
+                  ListTablesResponse.class);
+      assertThat(listed.identifiers())
+          .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "renamed"));
+
+      // A source that is not there is a 404, and a destination that is taken is a 409.
+      resp =
+          postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "other"));
+      assertThat(resp.status().code()).isEqualTo(404);
+      createTable("taken");
+      resp = postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "taken"));
+      assertThat(resp.status().code()).isEqualTo(409);
+
+      // Unity Catalog cannot move a table between namespaces, and says so rather than half-doing
+      // it.
+      resp =
+          postJson(
+              renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "moved", "other_ns"));
+      assertThat(resp.status().code()).isEqualTo(501);
+
+      // A request without a source or a destination is a bad request, not a server error.
+      assertThat(postJson(renamePath, "{}").status().code()).isEqualTo(400);
+
+      resp =
+          postJson(
+              renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", TestUtils.TABLE_NAME));
+      assertThat(resp.status().code()).isEqualTo(204);
     }
 
     // Drop the table
@@ -1071,43 +1122,6 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(error.code()).isEqualTo(expectedCode);
     assertThat(error.type()).isEqualTo(expectedType.getSimpleName());
     assertThat(error.message()).isEqualTo(expectedMessage);
-  }
-
-  @Test
-  public void testRenameTable() throws Exception {
-    createUniformIcebergTable();
-    String renamePath = "/v1/catalogs/" + TestUtils.CATALOG_NAME + "/tables/rename";
-    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
-
-    // A rename answers 204 with no content, and the table is listed and loadable under its new
-    // name.
-    AggregatedHttpResponse resp =
-        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "renamed"));
-    assertThat(resp.status().code()).isEqualTo(204);
-    assertThat(resp.contentUtf8()).isEmpty();
-    ListTablesResponse listed =
-        IcebergObjectMapper.mapper()
-            .readValue(
-                client.get(tablesPath).aggregate().join().contentUtf8(), ListTablesResponse.class);
-    assertThat(listed.identifiers())
-        .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "renamed"));
-    assertThat(client.get(tablesPath + "/renamed").aggregate().join().status().code())
-        .isEqualTo(200);
-
-    // Renaming a table that is not there is a 404.
-    resp =
-        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, TestUtils.TABLE_NAME, "other"));
-    assertThat(resp.status().code()).isEqualTo(404);
-
-    // Renaming onto a name that is taken is a 409.
-    createTable("taken");
-    resp = postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "taken"));
-    assertThat(resp.status().code()).isEqualTo(409);
-
-    // Unity Catalog cannot move a table between namespaces, and says so rather than half-doing it.
-    resp =
-        postJson(renamePath, renameRequest(TestUtils.SCHEMA_NAME, "renamed", "moved", "other_ns"));
-    assertThat(resp.status().code()).isEqualTo(501);
   }
 
   private static String renameRequest(String namespace, String from, String to) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Part of #1846.

The rename endpoint had no route, so an engine's `ALTER TABLE ... RENAME TO` was answered with a 404
for a path this server does not serve. Unity Catalog has renamed tables all along, through
`TableRepository.renameTable`, which already refuses a name that is taken; the operation was only
missing from the Iceberg REST surface.

This serves it and advertises `V1_RENAME_TABLE` with the other write endpoints.

- The table is resolved the way `loadTable` resolves it, so a table this API does not expose cannot be
  renamed through it.
- A destination name that is taken is the spec's 409, which is what the repository already raises.
- A destination in a different namespace is refused as unimplemented (501). Unity Catalog has no way
  to move a table between schemas, and that status tells a client the catalog does not do it, rather
  than describing a well-formed request as malformed. The spec lists 406 for an unsupported rename;
  say so if you would rather have that.

For users: `ALTER TABLE ... RENAME TO` works from any Iceberg client, within a namespace.

`testRenameTable` pins the 204 and that the table is listed and loadable under its new name, the 404
for a table that is not there, the 409 for a name that is taken, and the 501 for a cross-namespace
rename. It fails on an unfixed tree and passes with the fix; the full `server/test` suite shows no
failure attributable to this change.
