### PR TITLE
[Server] Implement the Iceberg registerTable endpoint

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -20,6 +20,7 @@ import io.unitycatalog.server.exception.BaseException;
 import io.unitycatalog.server.exception.ErrorCode;
 import io.unitycatalog.server.exception.IcebergRestExceptionHandler;
 import io.unitycatalog.server.model.CatalogInfo;
+import io.unitycatalog.server.model.ColumnInfo;
 import io.unitycatalog.server.model.CreateSchema;
 import io.unitycatalog.server.model.CreateStagingTable;
 import io.unitycatalog.server.model.CreateTable;
@@ -68,6 +69,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -102,7 +104,8 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
           Endpoint.V1_CREATE_NAMESPACE,
           Endpoint.V1_CREATE_TABLE,
           Endpoint.V1_UPDATE_TABLE,
-          Endpoint.V1_DELETE_TABLE);
+          Endpoint.V1_DELETE_TABLE,
+          Endpoint.V1_REGISTER_TABLE);
 
   private final TableConfigService tableConfigService;
   private final MetadataService metadataService;
@@ -390,6 +393,69 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     NormalizedURL persistedTableLocation = NormalizedURL.from(tableInfo.getStorageLocation());
     return LoadTableResponse.builder()
         .withTableMetadata(committed)
+        .addAllConfig(tableConfigService.getTableConfig(persistedTableLocation, READ_WRITE))
+        .build();
+  }
+
+  @Post("/v1/catalogs/{catalog}/namespaces/{namespace}/register")
+  @ProducesJson
+  @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
+  @AuthorizeResourceKey(METASTORE)
+  public LoadTableResponse registerTable(
+      @Param("catalog") String catalog,
+      @Param("namespace") String namespace,
+      RegisterTableRequest request) {
+    serverProperties.checkIcebergTableEnabled();
+    request.validate();
+    NormalizedURL metadataLocation = NormalizedURL.from(request.metadataLocation());
+    // No metadata is written here: the file exists, and registering it must not touch it. That also
+    // means nothing has to be cleaned up if the row cannot be created.
+    TableMetadata tableMetadata = metadataService.readUnregisteredTableMetadata(metadataLocation);
+    NormalizedURL tableLocation = NormalizedURL.from(tableMetadata.location());
+    List<ColumnInfo> columns = IcebergSchemaConverter.toColumnInfos(tableMetadata.schema());
+
+    if (request.overwrite() && ucTableExists(catalog, namespace, request.name())) {
+      // Overwriting is a commit of the given metadata file over whatever the table points at now.
+      // The pointer read here is the one the commit requires to still be current, so a commit that
+      // lands in between is reported as a conflict rather than silently overwritten.
+      TableRepository.IcebergTableState state =
+          tableRepository.getIcebergTableState(catalog, namespace, request.name());
+      tableRepository.commitIcebergTable(
+          catalog,
+          namespace,
+          request.name(),
+          state.metadataLocation(),
+          metadataLocation,
+          columns,
+          tableMetadata.properties());
+      return loadRegisteredTable(tableMetadata, NormalizedURL.from(state.storageLocation()));
+    }
+
+    CreateTable createTable =
+        new CreateTable()
+            .name(request.name())
+            .catalogName(catalog)
+            .schemaName(namespace)
+            .tableType(TableType.EXTERNAL)
+            .dataSourceFormat(DataSourceFormat.ICEBERG)
+            .columns(columns)
+            .storageLocation(tableLocation.toString())
+            .properties(tableMetadata.properties());
+    TableInfo tableInfo = tableRepository.createTableForIceberg(createTable, metadataLocation);
+    SchemaInfo schemaInfo =
+        schemaRepository.getSchema(tableInfo.getCatalogName() + "." + tableInfo.getSchemaName());
+    initializeHierarchicalAuthorization(tableInfo.getTableId(), schemaInfo.getSchemaId());
+    return loadRegisteredTable(tableMetadata, NormalizedURL.from(tableInfo.getStorageLocation()));
+  }
+
+  /**
+   * The response for a registered table: the metadata as it was read from the file, so the pointer
+   * a client gets back is the file it named, with credentials for the location UC persisted.
+   */
+  private LoadTableResponse loadRegisteredTable(
+      TableMetadata tableMetadata, NormalizedURL persistedTableLocation) {
+    return LoadTableResponse.builder()
+        .withTableMetadata(tableMetadata)
         .addAllConfig(tableConfigService.getTableConfig(persistedTableLocation, READ_WRITE))
         .build();
   }

--- a/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/iceberg/MetadataService.java
@@ -44,6 +44,20 @@ public class MetadataService {
     return tableMetadata;
   }
 
+  /**
+   * Reads the metadata of a table Unity Catalog does not have yet, where the table location comes
+   * from the document itself rather than from a persisted row. The file still has to sit inside the
+   * location it declares, so a metadata file cannot register a table rooted somewhere else.
+   */
+  public TableMetadata readUnregisteredTableMetadata(NormalizedURL metadataLocation) {
+    TableMetadata tableMetadata;
+    try (FileIO fileIO = fileOperations.getFileIO(metadataLocation)) {
+      tableMetadata = TableMetadataParser.read(fileIO, metadataLocation.toString());
+    }
+    validateMetadataLocation(metadataLocation, NormalizedURL.from(tableMetadata.location()));
+    return tableMetadata;
+  }
+
   /** Writes metadata only within the table location persisted by UC. */
   public void writeTableMetadata(
       TableMetadata tableMetadata,

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -151,7 +151,8 @@ public class IcebergRestCatalogTest extends BaseServerTest {
                 + "\"POST /v1/{prefix}/namespaces\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables\","
                 + "\"POST /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
-                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\""
+                + "\"DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}\","
+                + "\"POST /v1/{prefix}/namespaces/{namespace}/register\""
                 + "]}");
 
     // not setting warehouse param should result in 400 BadRequestException
@@ -951,6 +952,73 @@ public class IcebergRestCatalogTest extends BaseServerTest {
         IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), ListTablesResponse.class);
     assertThat(listed.identifiers())
         .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "uniform_table"));
+  }
+
+  @Test
+  public void testRegisterTable() throws Exception {
+    catalogOperations.createCatalog(
+        new CreateCatalog().name(TestUtils.CATALOG_NAME).comment(TestUtils.COMMENT));
+    schemaOperations.createSchema(
+        new CreateSchema().catalogName(TestUtils.CATALOG_NAME).name(TestUtils.SCHEMA_NAME));
+    Path metadataFile = writeIcebergMetadata();
+    String registerPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/register";
+    String tablesPath = TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME + "/tables";
+
+    // Registering an existing metadata file answers the table it describes, pointing at that file.
+    AggregatedHttpResponse resp =
+        postJson(registerPath, registerRequest("registered", metadataFile, false));
+    assertThat(resp.status().code()).isEqualTo(200);
+    LoadTableResponse loaded =
+        IcebergObjectMapper.mapper().readValue(resp.contentUtf8(), LoadTableResponse.class);
+    // The pointer is the file the request named. Local locations come back without their scheme,
+    // which is how this server reports every metadata location on a local filesystem.
+    assertThat(loaded.tableMetadata().metadataFileLocation()).isEqualTo(metadataFile.toString());
+    assertThat(loaded.tableMetadata().schema().columns()).isNotEmpty();
+
+    // It is a table of this catalog afterwards: listed, loadable, and its columns are in UC.
+    ListTablesResponse listed =
+        IcebergObjectMapper.mapper()
+            .readValue(
+                client.get(tablesPath).aggregate().join().contentUtf8(), ListTablesResponse.class);
+    assertThat(listed.identifiers())
+        .containsExactly(TableIdentifier.of(Namespace.of(TestUtils.SCHEMA_NAME), "registered"));
+    assertThat(client.get(tablesPath + "/registered").aggregate().join().status().code())
+        .isEqualTo(200);
+    TableInfo registered =
+        tableOperations.getTable(
+            TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + ".registered");
+    assertThat(registered.getDataSourceFormat()).isEqualTo(DataSourceFormat.ICEBERG);
+    assertThat(registered.getColumns()).isNotEmpty();
+
+    // Registering the same name again is a 409 unless the request says to overwrite.
+    resp = postJson(registerPath, registerRequest("registered", metadataFile, false));
+    assertThat(resp.status().code()).isEqualTo(409);
+    resp = postJson(registerPath, registerRequest("registered", metadataFile, true));
+    assertThat(resp.status().code()).isEqualTo(200);
+
+    // A namespace that does not exist is a 404.
+    resp =
+        postJson(
+            TEST_BASE_PREFIX + "/namespaces/noSuchSchema/register",
+            registerRequest("registered", metadataFile, false));
+    assertThat(resp.status().code()).isEqualTo(404);
+
+    // A metadata file that is not inside the table location it declares is refused: it would
+    // register a table rooted somewhere the file does not live.
+    Path outside = Files.createTempDirectory("outside").resolve("iceberg.metadata.json");
+    Files.copy(metadataFile, outside);
+    resp = postJson(registerPath, registerRequest("elsewhere", outside, false));
+    assertThat(resp.status().code()).isEqualTo(400);
+  }
+
+  private static String registerRequest(String name, Path metadataFile, boolean overwrite) {
+    return "{\"name\": \""
+        + name
+        + "\", \"metadata-location\": \""
+        + NormalizedURL.from(metadataFile.toUri())
+        + "\", \"overwrite\": "
+        + overwrite
+        + "}";
   }
 
   private AggregatedHttpResponse postJson(String path, String body) {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1850.

The register endpoint was not served, so a table whose Iceberg metadata already exists could not be
brought into this catalog through the REST API: the request was answered with a 404 for a path this
server does not have. That is the path an engine takes to adopt a table written elsewhere, and the one a
migration onto Unity Catalog goes through.

This serves it and advertises `V1_REGISTER_TABLE` with the other write endpoints, so it is gated the
same way the other Iceberg writes are.

- The metadata file is read and never written. The table's columns, properties and location come from
  the document the request names, and because nothing is written there is nothing to clean up if the
  row cannot be created -- unlike `createTable`, which has to delete the metadata it wrote.
- The file has to sit inside the table location it declares, so a metadata file cannot register a table
  rooted somewhere it does not live. `MetadataService` gained a read for a table Unity Catalog does not
  have yet, because the location it validates against cannot come from a persisted row that is not
  there.
- A name that is already taken is the spec's 409. When the request asks to overwrite, the given file is
  committed over whatever the table points at now, through the same compare-and-swap a commit uses: a
  commit that lands in between is reported as a conflict rather than silently overwritten. Overwriting a
  table that is not a native Iceberg table is refused by that commit path, as it is for any other
  commit. Iceberg's client does send `overwrite`, which is why it is implemented rather than rejected.

For users: an existing Iceberg table can be adopted into Unity Catalog by naming its metadata file, and
the table is a full member of the catalog afterwards -- listed, loadable, and committable.

`testRegisterTable` pins the response's metadata pointer, that the table is then listed and loadable and
carries its columns in Unity Catalog, the 409 for a taken name, the 200 when overwrite is asked for, the
404 for a namespace that does not exist, and the rejection of a metadata file outside the location it
declares. It fails on an unfixed tree and passes with the fix; the full `server/test` suite shows no
failure attributable to this change (the one failure here is the GCP credential test, which needs
credentials this machine does not have).
