### PR TITLE
[Server] Answer conditional Iceberg loadTable requests

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
+++ b/server/src/main/java/io/unitycatalog/server/ArmeriaServerBuilder.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
@@ -81,6 +82,11 @@ public class ArmeriaServerBuilder {
     this.armeriaServerBuilder =
         Server.builder()
             .localPort(port, SessionProtocol.HTTP)
+            // Armeria names HTTP/1 headers in their lowercase HTTP/2 form by default. Released
+            // Iceberg clients read our response headers out of a plain map keyed by the name as
+            // received, so a header they look up by its traditional spelling -- "ETag" for a
+            // conditional loadTable -- is invisible to them unless we write it that way.
+            .http1HeaderNaming(Http1HeaderNaming.traditional())
             .serviceUnder("/docs", new DocService());
     this.armeriaServerBuilder.service("/", (ctx, req) -> HttpResponse.of("Hello, Unity Catalog!"));
     this.basePath = basePath;

--- a/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
+++ b/server/src/main/java/io/unitycatalog/server/service/IcebergRestCatalogService.java
@@ -4,12 +4,18 @@ import static io.unitycatalog.server.model.SecurableType.METASTORE;
 import static io.unitycatalog.server.service.credential.CredentialContext.READ_ONLY;
 import static io.unitycatalog.server.service.credential.CredentialContext.READ_WRITE;
 
+import com.google.common.hash.Hashing;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Head;
+import com.linecorp.armeria.server.annotation.Header;
+import com.linecorp.armeria.server.annotation.HttpResult;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.ProducesJson;
@@ -45,7 +51,9 @@ import io.unitycatalog.server.service.iceberg.TableConfigService;
 import io.unitycatalog.server.utils.Constants;
 import io.unitycatalog.server.utils.NormalizedURL;
 import io.unitycatalog.server.utils.ServerProperties;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -278,22 +286,31 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   @ProducesJson
   @AuthorizeExpression("#authorize(#principal, #metastore, OWNER)")
   @AuthorizeResourceKey(METASTORE)
-  public LoadTableResponse loadTable(
+  public HttpResult<LoadTableResponse> loadTable(
       @Param("catalog") String catalog,
       @Param("namespace") String namespace,
       @Param("table") String table,
-      @Param(RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER) Optional<String> snapshots) {
+      @Param(RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER) Optional<String> snapshots,
+      @Header("if-none-match") Optional<String> ifNoneMatch) {
     TableRepository.IcebergTableState state =
         tableRepository.getIcebergTableState(catalog, namespace, table);
     if (state.metadataLocation() == null) {
       throw new NoSuchTableException("Table does not exist: %s", namespace + "." + table);
+    }
+    boolean refsOnly = refsOnly(snapshots);
+
+    // A caller holding this tag already has what this request would return, so answer it without
+    // reading the metadata file at all.
+    String etag = metadataETag(state.metadataLocation(), refsOnly);
+    if (holdsETag(ifNoneMatch, etag)) {
+      return HttpResult.of(ResponseHeaders.of(HttpStatus.NOT_MODIFIED, HttpHeaderNames.ETAG, etag));
     }
 
     NormalizedURL tableLocation = NormalizedURL.from(state.storageLocation());
     TableMetadata tableMetadata =
         metadataService.readTableMetadata(
             NormalizedURL.from(state.metadataLocation()), tableLocation);
-    if (refsOnly(snapshots)) {
+    if (refsOnly) {
       tableMetadata =
           TableMetadata.buildFrom(tableMetadata)
               .withMetadataLocation(tableMetadata.metadataFileLocation())
@@ -303,10 +320,12 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
     Map<String, String> config =
         tableConfigService.getTableConfig(tableLocation, getLoadCredentialPrivileges(state));
 
-    return LoadTableResponse.builder()
-        .withTableMetadata(tableMetadata)
-        .addAllConfig(config)
-        .build();
+    return HttpResult.of(
+        ResponseHeaders.builder(HttpStatus.OK)
+            .contentType(MediaType.JSON)
+            .add(HttpHeaderNames.ETAG, etag)
+            .build(),
+        LoadTableResponse.builder().withTableMetadata(tableMetadata).addAllConfig(config).build());
   }
 
   Set<CredentialContext.Privilege> getLoadCredentialPrivileges(
@@ -715,6 +734,31 @@ public class IcebergRestCatalogService extends AuthorizedService implements Regi
   /** The name the mode travels under on the wire, which the client lowercases. */
   private static String modeName(SnapshotMode mode) {
     return mode.name().toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Names the version of the metadata this endpoint would return for the given snapshots mode. The
+   * pointer is hashed rather than returned as-is so the tag does not hand callers a storage
+   * location, and the mode is part of it because {@code refs} and {@code all} return different
+   * bodies for the same version. The tag is weak: it identifies the metadata version, not a
+   * byte-for-byte body.
+   */
+  private static String metadataETag(String metadataLocation, boolean refsOnly) {
+    String version =
+        metadataLocation + "\n" + modeName(refsOnly ? SnapshotMode.REFS : SnapshotMode.ALL);
+    return "W/\"" + Hashing.sha256().hashString(version, StandardCharsets.UTF_8) + "\"";
+  }
+
+  /**
+   * Whether the caller's {@code If-None-Match} names the tag we would return. Only an exact match
+   * short-circuits; anything else -- including {@code *} -- gets the full response, which a
+   * conditional request always tolerates.
+   */
+  private static boolean holdsETag(Optional<String> ifNoneMatch, String etag) {
+    return ifNoneMatch.stream()
+        .flatMap(header -> Arrays.stream(header.split(",")))
+        .map(String::trim)
+        .anyMatch(etag::equals);
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -35,6 +36,8 @@ import io.unitycatalog.server.utils.ServerProperties.Property;
 import io.unitycatalog.server.utils.TestUtils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.Socket;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -95,6 +98,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class IcebergRestCatalogTest extends BaseServerTest {
 
+  private static final String ICEBERG_BASE_PATH = "/api/2.1/unity-catalog/iceberg";
   private static final String TEST_BASE_PREFIX = "/v1/catalogs/" + TestUtils.CATALOG_NAME;
   private static final String TEST_BASE_NON_PREFIX = "/v1";
   private static final int PAGE_SIZE = PagedListingHelper.DEFAULT_PAGE_SIZE;
@@ -116,7 +120,7 @@ public class IcebergRestCatalogTest extends BaseServerTest {
   @BeforeEach
   public void setUp() {
     super.setUp();
-    String uri = serverConfig.getServerUrl() + "/api/2.1/unity-catalog/iceberg";
+    String uri = serverConfig.getServerUrl() + ICEBERG_BASE_PATH;
     String token = serverConfig.getAuthToken();
     catalogOperations = new SdkCatalogOperations(TestUtils.createApiClient(serverConfig));
     schemaOperations = new SdkSchemaOperations(TestUtils.createApiClient(serverConfig));
@@ -1201,6 +1205,100 @@ public class IcebergRestCatalogTest extends BaseServerTest {
     assertThat(rejected.status().code()).isEqualTo(400);
     assertThat(ErrorResponseParser.fromJson(rejected.contentUtf8()).type())
         .isEqualTo(BadRequestException.class.getSimpleName());
+  }
+
+  @Test
+  public void testLoadTableConditionalGet() throws Exception {
+    createUniformIcebergTable("/iceberg.metadata.two-snapshots.json");
+    String tablePath =
+        TEST_BASE_PREFIX
+            + "/namespaces/"
+            + TestUtils.SCHEMA_NAME
+            + "/tables/"
+            + TestUtils.TABLE_NAME;
+
+    AggregatedHttpResponse loaded = client.get(tablePath).aggregate().join();
+    assertThat(loaded.status().code()).isEqualTo(200);
+    String etag = loaded.headers().get(HttpHeaderNames.ETAG);
+    // Weak, because the tag names the metadata version rather than the bytes of one response.
+    assertThat(etag).startsWith("W/\"").endsWith("\"");
+    // The tag must not hand out the metadata file location.
+    assertThat(etag).doesNotContain("iceberg.metadata");
+
+    // A caller that already holds this version gets a bodiless 304.
+    AggregatedHttpResponse notModified = conditionalGet(tablePath, etag);
+    assertThat(notModified.status().code()).isEqualTo(304);
+    assertThat(notModified.content().isEmpty()).isTrue();
+    assertThat(notModified.headers().get(HttpHeaderNames.ETAG)).isEqualTo(etag);
+
+    // The header may list several tags; ours being one of them is enough.
+    assertThat(conditionalGet(tablePath, "W/\"0\", " + etag).status().code()).isEqualTo(304);
+
+    // A tag from some other version, and the wildcard, both get the full response.
+    assertThat(conditionalGet(tablePath, "W/\"0\"").status().code()).isEqualTo(200);
+    assertThat(conditionalGet(tablePath, "*").status().code()).isEqualTo(200);
+
+    // "refs" returns a different body for the same version, so it carries its own tag and is not
+    // answered from a copy the default response handed out.
+    String refsPath = tablePath + "?snapshots=refs";
+    String refsETag = client.get(refsPath).aggregate().join().headers().get(HttpHeaderNames.ETAG);
+    assertThat(refsETag).isNotEqualTo(etag);
+    assertThat(conditionalGet(refsPath, etag).status().code()).isEqualTo(200);
+    assertThat(conditionalGet(refsPath, refsETag).status().code()).isEqualTo(304);
+
+    // An invalid snapshots value is still rejected rather than answered from the caller's copy.
+    assertThat(conditionalGet(tablePath + "?snapshots=some", etag).status().code()).isEqualTo(400);
+
+    // Moving the metadata pointer, as a commit does, retires the tag the caller holds.
+    TableInfo table =
+        tableOperations.getTable(
+            TestUtils.CATALOG_NAME + "." + TestUtils.SCHEMA_NAME + "." + TestUtils.TABLE_NAME);
+    Path committed =
+        Files.copy(
+            icebergTableLocation.resolve("iceberg.metadata.json"),
+            icebergTableLocation.resolve("committed.metadata.json"));
+    setUniformMetadata(table, committed);
+
+    AggregatedHttpResponse reloaded = conditionalGet(tablePath, etag);
+    assertThat(reloaded.status().code()).isEqualTo(200);
+    assertThat(reloaded.headers().get(HttpHeaderNames.ETAG)).isNotEqualTo(etag);
+
+    // Released Iceberg clients keep response headers in a map keyed by the name as received and
+    // look this one up as "ETag", so the name has to reach the wire spelled that way.
+    assertThat(responseHead(tablePath)).contains("ETag: W/\"");
+  }
+
+  /**
+   * Reads a response head straight off the socket. Both Armeria's client and the JDK's lowercase
+   * header names as they parse them, so neither can see how the server spelled them.
+   */
+  private String responseHead(String path) throws IOException {
+    URI server = URI.create(serverConfig.getServerUrl());
+    try (Socket socket = new Socket(server.getHost(), server.getPort())) {
+      socket
+          .getOutputStream()
+          .write(
+              ("GET "
+                      + ICEBERG_BASE_PATH
+                      + path
+                      + " HTTP/1.1\r\nHost: "
+                      + server.getAuthority()
+                      + "\r\nAuthorization: Bearer "
+                      + serverConfig.getAuthToken()
+                      + "\r\nConnection: close\r\n\r\n")
+                  .getBytes(StandardCharsets.UTF_8));
+      String response = new String(socket.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      int endOfHead = response.indexOf("\r\n\r\n");
+      return endOfHead < 0 ? response : response.substring(0, endOfHead);
+    }
+  }
+
+  private AggregatedHttpResponse conditionalGet(String path, String ifNoneMatch) {
+    return client
+        .execute(
+            RequestHeaders.of(HttpMethod.GET, path, HttpHeaderNames.IF_NONE_MATCH, ifNoneMatch))
+        .aggregate()
+        .join();
   }
 
   private static List<Long> loadedSnapshotIds(AggregatedHttpResponse resp) throws IOException {


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1852.

`loadTable` on the Iceberg REST endpoints read and parsed the table's metadata file from storage on every call, even for a caller that already held that version, because Unity Catalog implemented none of the conditional-request mechanism the Iceberg REST spec defines for the endpoint (`If-None-Match`, `304 Not Modified`, `ETag`).

It now returns an `ETag` naming the version it served, and answers a request whose `If-None-Match` names that tag with a bodiless `304` -- decided from the row alone, so the metadata file is never read. Every released Iceberg Java client benefits without any configuration: `RESTSessionCatalog` caches a table per session for five minutes once a load response carries an `ETag`, sends the tag back on the next load, and serves the table from its cache on a `304`.

Technical changes:

- `IcebergRestCatalogService.loadTable` returns an `HttpResult<LoadTableResponse>` so it can carry the header, and takes the `If-None-Match` header. The tag is a weak validator over a SHA-256 of the table's current metadata pointer -- hashed so the tag does not hand callers a storage location, weak because it identifies the metadata version rather than one exact body. The snapshots mode is part of it, since `refs` and `all` return different bodies for the same version; the spec's `ETag` parameter calls for exactly that. An invalid `snapshots` value is still rejected before any of this, so a conditional request cannot mask a bad one.
- `ArmeriaServerBuilder` sets `http1HeaderNaming(Http1HeaderNaming.traditional())`. Without it the feature has no effect on the clients it is for: Armeria writes HTTP/1 header names in their lowercase HTTP/2 form, while `HTTPClient` collects response headers into a plain `HashMap` keyed by the name as received and `RESTSessionCatalog` looks this one up as `ETag`. The option only changes the casing of standard header names on HTTP/1 responses (`Content-Type`, `ETag`); HTTP/1.1 field names are case-insensitive, so this is invisible to any client that reads them correctly, and unknown names are left alone.

Only `loadTable` gained a tag. The spec also allows one on `createTable` and `commitTable` responses, but no released client seeds its cache from those, so there is nothing to serve yet.

Testing:

- `IcebergRestCatalogTest.testLoadTableConditionalGet` covers the tag's shape (weak, and not the metadata location), the `304` and its empty body, a multi-tag `If-None-Match`, a stale tag and `*` both getting the full response, `refs` carrying its own tag that does not match the default one, an invalid `snapshots` value still being a 400, a moved metadata pointer retiring the tag, and the header reaching the wire spelled `ETag` (read off a socket, since both Armeria's client and the JDK's lowercase header names while parsing). It fails on an unfixed tree, in both halves: without the service change there is no tag at all, and without the naming option the wire assertion fails.
- `build/sbt "server/testOnly io.unitycatalog.server.service.IcebergRestCatalogTest"` and `build/sbt -J-Xmx2G "server/test"`.
- Validated against a running server rather than only in tests. A real Iceberg 1.11.0 `RESTCatalog` loaded a table, then loaded it again after the metadata file was made unreadable, and succeeded -- the second load was answered `304` from the pointer and served from the client's cache. By hand: the tag is issued and echoed on the `304`, a tag list containing it still matches, a stale tag and `*` get the full response, `snapshots=refs` carries a different tag, a real commit retires the tag, and a conditional request succeeds while the metadata file is unreadable where a plain one fails.

Backward compatibility: additive. A caller that sends no `If-None-Match` sees the same response it always did, plus a header it may ignore. Nothing changes for the Delta, native or SCIM surfaces beyond the casing of standard HTTP/1 response header names.

Stacked on #1844 (the `snapshots` parameter), whose branch this one builds on -- the tag has to distinguish `refs` from `all`, which only that PR makes possible. Review the top commit, or merge #1844 first.
