### PR TITLE
[Server] Wait for the client-facing port before reporting the server started

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -37,7 +37,7 @@ def uc_server():
             print(">> Waiting for server to accept connections ...")
             for _ in range(90):
                 try:
-                    response = requests.head("http://localhost:8081", timeout=60)
+                    response = requests.head("http://localhost:8080", timeout=60)
                     if response.status_code == 200:
                         print("Server is running.")
                         break

--- a/server/src/main/java/io/unitycatalog/server/URLTranscoderVerticle.java
+++ b/server/src/main/java/io/unitycatalog/server/URLTranscoderVerticle.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -25,7 +26,7 @@ class URLTranscoderVerticle extends AbstractVerticle {
   }
 
   @Override
-  public void start() {
+  public void start(Promise<Void> startPromise) {
     HttpServer server = vertx.createHttpServer();
     WebClient client = WebClient.create(vertx);
 
@@ -61,13 +62,16 @@ class URLTranscoderVerticle extends AbstractVerticle {
                   });
         });
 
+    // The port is bound asynchronously, so the deployment is only complete once it is listening:
+    // callers are told the server is ready when this verticle is deployed.
     server.listen(
         transcodePort,
         ar -> {
           if (ar.succeeded()) {
             LOGGER.info("URL transcoder started on port {}", transcodePort);
+            startPromise.complete();
           } else {
-            LOGGER.info("Failed to start URL transcoder: {}", String.valueOf(ar.cause()));
+            startPromise.fail(ar.cause());
           }
         });
   }

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -48,6 +48,7 @@ import io.unitycatalog.server.utils.VersionUtils;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
+import java.util.concurrent.CompletionException;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -304,11 +305,21 @@ public class UnityCatalogServer implements AutoCloseable {
         UnityCatalogServer.builder().port(options.getPort() + 1).build();
     unityCatalogServer.printArt();
     unityCatalogServer.start();
-    // Start URL transcoder
+    // Start URL transcoder. Clients use its port, not Armeria's, so wait for it to be listening
+    // before this process reports itself started, and fail rather than serve only the internal
+    // port if it cannot bind.
     Vertx vertx = Vertx.vertx();
     Verticle transcodeVerticle =
         new URLTranscoderVerticle(options.getPort(), options.getPort() + 1);
-    vertx.deployVerticle(transcodeVerticle);
+    try {
+      vertx.deployVerticle(transcodeVerticle).toCompletionStage().toCompletableFuture().join();
+    } catch (CompletionException e) {
+      LOGGER.error(
+          "Failed to start the URL transcoder on port {}", options.getPort(), e.getCause());
+      vertx.close();
+      unityCatalogServer.close();
+      throw e;
+    }
   }
 
   public void start() {

--- a/server/src/test/java/io/unitycatalog/server/URLTranscoderVerticleTest.java
+++ b/server/src/test/java/io/unitycatalog/server/URLTranscoderVerticleTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -8,8 +9,9 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import java.io.IOException;
+import java.net.BindException;
 import java.net.ServerSocket;
-import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,20 +25,20 @@ public class URLTranscoderVerticleTest {
   private static Vertx vertx;
   private static WebClient client;
   private static int transcodePort;
+  private static int servicePort;
 
   @BeforeAll
   public static void setUp() throws Exception {
     vertx = Vertx.vertx();
     client = WebClient.create(vertx);
-    int servicePort = findAvailablePort();
+    servicePort = findAvailablePort();
     transcodePort = findAvailablePort();
-    startService(servicePort);
+    startService();
     vertx
         .deployVerticle(new URLTranscoderVerticle(transcodePort, servicePort))
         .toCompletionStage()
         .toCompletableFuture()
         .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    awaitPort(transcodePort);
   }
 
   @AfterAll
@@ -95,7 +97,23 @@ public class URLTranscoderVerticleTest {
         .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
   }
 
-  private static void startService(int servicePort) throws Exception {
+  @Test
+  public void testDeploymentFailsWhenTheTranscodePortIsTaken() throws Exception {
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      CompletableFuture<String> deployment =
+          vertx
+              .deployVerticle(new URLTranscoderVerticle(occupied.getLocalPort(), servicePort))
+              .toCompletionStage()
+              .toCompletableFuture();
+
+      // A transcoder that cannot bind leaves clients with no port to talk to, so its deployment
+      // has to fail rather than report success and log the reason.
+      assertThatThrownBy(() -> deployment.get(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          .hasRootCauseInstanceOf(BindException.class);
+    }
+  }
+
+  private static void startService() throws Exception {
     vertx
         .createHttpServer()
         .requestHandler(
@@ -118,18 +136,6 @@ public class URLTranscoderVerticleTest {
         .toCompletionStage()
         .toCompletableFuture()
         .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-  }
-
-  /** The verticle binds its port asynchronously, so wait for it before sending any request. */
-  private static void awaitPort(int port) throws Exception {
-    for (int attempt = 0; attempt < 100; attempt++) {
-      try (Socket ignored = new Socket(HOST, port)) {
-        return;
-      } catch (IOException e) {
-        Thread.sleep(50);
-      }
-    }
-    throw new IllegalStateException("URL transcoder did not start on port " + port);
   }
 
   private static int findAvailablePort() throws IOException {

--- a/tests/test_tarball_generation.py
+++ b/tests/test_tarball_generation.py
@@ -92,7 +92,7 @@ else:
 
 # 4. Verify server is running
 try:
-    response = requests.head("http://localhost:8081", timeout=5)
+    response = requests.head("http://localhost:8080", timeout=5)
     if response.status_code == 200:
         print("Server is running.")
     else:

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -112,7 +112,7 @@ def start_server():
         success = False
         while i < 60 and not success:
             try:
-                response = requests.head("http://localhost:8081", timeout=60)
+                response = requests.head("http://localhost:8080", timeout=60)
                 if response.status_code == 200:
                     print("Server is running.")
                     success = True


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Fixes #1854.

The server reported itself started before the port clients use was listening. `main` awaited Armeria on `port + 1` and then deployed the Vert.x URL transcoder for the client-facing port without awaiting it, and `URLTranscoderVerticle.start()` returned as soon as `server.listen` had been called. A bind failure on that port was logged at INFO and dropped, since `deployVerticle`'s result was never inspected, so the process kept running and exited 0 while serving nothing on the port every client connects to.

The Python client suite hit the first half of this in CI (`1 failed, 34 passed`, the failure being the first test to issue a request), because its fixture waits for the internal port and then talks to the client-facing one.

Technical changes:

- `URLTranscoderVerticle` takes the `Promise<Void>` form of `start` and completes it from the `listen` callback, so the deployment completes only once the port is bound and fails with the bind error otherwise.
- `UnityCatalogServer.main` waits for that deployment and, if it fails, logs which port could not be bound, closes the server and rethrows. A server that cannot serve the port its clients use now exits non-zero instead of running half-up.
- The three readiness probes that waited on the internal port -- `clients/python/tests/conftest.py`, `tests/test_tutorial.py`, `tests/test_tarball_generation.py` -- now probe the port those suites actually use. The fixed `time.sleep` calls that were masking the race in the latter two are left as they are; this change is about waiting for the right thing, not about retuning those waits.

Testing:

- `URLTranscoderVerticleTest.testDeploymentFailsWhenTheTranscodePortIsTaken` occupies a port and asserts the deployment fails with a `BindException`. It fails on an unfixed tree, where the deployment reports success. The test class's `awaitPort` polling helper is gone: deployment now means the port is listening, which is what its comment used to work around.
- `build/sbt "server/testOnly io.unitycatalog.server.URLTranscoderVerticleTest"` and `build/sbt -J-Xmx2G "server/test"`.
- Validated against a running server. `HEAD /` on the client-facing port answers 200, which is what the probes assert. With that port occupied by another process, the server now logs `Failed to start the URL transcoder on port 8080`, stops cleanly ("Unity Catalog server stopped.", pool cleanup) and exits 1, where before it stayed up on the internal port only.
- Ran the Python client suite against a server started by `bin/start-uc-server` with the updated fixture: it came up and ran in 9.7s (`3 failed, 32 passed`); the three failures are `bin/uc` invocations, which need the CLI jar I had not built locally.

Backward compatibility: a deployment that could not bind the client-facing port used to leave the process running; it now fails the startup. That is the point of the change -- such a server cannot serve any client -- but it is a behaviour change for anyone who was starting the server with that port already in use.
