### PR TITLE
[Server] Make deny-triggered Casbin refresh causally fresh

### DIFF
--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -128,7 +128,7 @@ Optional tuning:
 | Property | Default | Purpose |
 |---|---|---|
 | `server.authorization.policy-refresh-interval` | `PT1M` | How often each instance polls `casbin_rule` |
-| `server.authorization.policy-refresh-min-probe-interval` | `PT0S` | Minimum gap between deny-path `max(id)` probes. Raise to cap DB load under 403s. |
+| `server.authorization.policy-refresh-min-probe-interval` | `PT1S` | Minimum gap between deny-path `max(id)` probes. Quiet traffic never waits. Lower toward `PT0S` under heavy 403 load for faster grant visibility; that increases `casbin_rule` queries. |
 
 Revocations propagate on the poll interval. A stale deny can trigger one `max(id)` probe
 before returning 403. Concurrent denials and list-filter items share a probe that started after the

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -128,7 +128,7 @@ Optional tuning:
 | Property | Default | Purpose |
 |---|---|---|
 | `server.authorization.policy-refresh-interval` | `PT1M` | How often each instance polls `casbin_rule` |
-| `server.authorization.policy-refresh-min-probe-interval` | `PT1S` | Minimum gap between deny-path `max(id)` probes. Quiet traffic never waits. Lower toward `PT0S` under heavy 403 load for faster grant visibility; that increases `casbin_rule` queries. |
+| `server.authorization.policy-refresh-min-probe-interval` | `PT1S` | Minimum gap between deny-path `max(id)` probes. Quiet traffic is unlikely to wait. Lower toward `PT0S` under heavy 403 load for faster grant visibility; that increases `casbin_rule` queries. |
 
 Revocations propagate on the poll interval. A stale deny can trigger one `max(id)` probe
 before returning 403. Concurrent denials and list-filter items share a probe that started after the

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -128,10 +128,11 @@ Optional tuning:
 | Property | Default | Purpose |
 |---|---|---|
 | `server.authorization.policy-refresh-interval` | `PT1M` | How often each instance polls `casbin_rule` |
-| `server.authorization.policy-refresh-debounce-interval` | `PT1S` | Minimum gap between deny-triggered reloads |
+| `server.authorization.policy-refresh-min-probe-interval` | `PT0S` | Minimum gap between deny-path `max(id)` probes. Raise to cap DB load under 403s. |
 
-Revocations propagate on the poll interval. A stale deny (a grant not yet seen) can trigger one
-debounced reload before returning 403.
+Revocations propagate on the poll interval. A stale deny can trigger one `max(id)` probe
+before returning 403. Concurrent denials and list-filter items share a probe that started after the
+request.
 
 ### Restart the UC Server
 

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -48,10 +48,9 @@ server.access-token-timeout=PT24H
 #   Lower this for faster revoke propagation across replicas; raise it for very large
 #   policy tables to reduce count(*)/max(id) load.
 #
-# server.authorization.policy-refresh-debounce-interval=PT1S
-#   Minimum time between deny-triggered reloads. On 403, we may reload once and
-#   re-check (covers stale denies across instances); debounce avoids a reload stampede
-#   under many legitimate denials.
+# server.authorization.policy-refresh-min-probe-interval=PT0S
+#   Minimum gap between deny-path max(id) probes (default: none). Raise to cap DB load under
+#   many 403s; requests wait, then one probe runs.
 
 # Enable MANAGED table
 # Default: true (enabled)

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -48,9 +48,10 @@ server.access-token-timeout=PT24H
 #   Lower this for faster revoke propagation across replicas; raise it for very large
 #   policy tables to reduce count(*)/max(id) load.
 #
-# server.authorization.policy-refresh-min-probe-interval=PT0S
-#   Minimum gap between deny-path max(id) probes (default: none). Raise to cap DB load under
-#   many 403s; requests wait, then one probe runs.
+# server.authorization.policy-refresh-min-probe-interval=PT1S
+#   Minimum gap between deny-path max(id) probes (default: 1s). Quiet traffic never waits.
+#   Under many 403s per second, lower this toward PT0S so denials probe immediately instead
+#   of waiting out the remainder of the 1s window. That increases casbin_rule load.
 
 # Enable MANAGED table
 # Default: true (enabled)

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -49,7 +49,7 @@ server.access-token-timeout=PT24H
 #   policy tables to reduce count(*)/max(id) load.
 #
 # server.authorization.policy-refresh-min-probe-interval=PT1S
-#   Minimum gap between deny-path max(id) probes (default: 1s). Quiet traffic never waits.
+#   Minimum gap between deny-path max(id) probes (default: 1s). Quiet traffic is unlikely to wait.
 #   Under many 403s per second, lower this toward PT0S so denials probe immediately instead
 #   of waiting out the remainder of the 1s window. That increases casbin_rule load.
 

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -18,8 +18,16 @@ import org.slf4j.LoggerFactory;
  * auto-save enabled, but each server process only loads that table into its enforcer at startup
  * unless this refresher reloads it.
  *
- * <p>The poller uses {@code count(*)} and {@code max(id)}; deny-path checks use {@code max(id)}
- * only. Reload is delegated to {@link JCasbinAuthorizer} so a fresh enforcer can be swapped without
+ * <p>Two probes, for different use cases:
+ *
+ * <ul>
+ *   <li>The background poller uses {@link #VERSION_QUERY} ({@code count(*)} and {@code max(id)}) so
+ *       a revoke that deletes a non-max row still shows up.
+ *   <li>The deny path uses {@link #MAX_ID_QUERY} ({@code max(id)} only). A stale deny after a grant
+ *       is a missing insert; revokes are left to the poller.
+ * </ul>
+ *
+ * <p>Reload is delegated to {@link JCasbinAuthorizer} so a fresh enforcer can be swapped without
  * blocking {@code enforce()}.
  */
 public class CasbinPolicyRefresher implements AutoCloseable {
@@ -32,8 +40,10 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     RELOADED
   }
 
+  // Poller: count(*) catches revokes that delete a non-max row; max(id) catches new grants.
   private static final String VERSION_QUERY =
       "select count(*), coalesce(max(id), 0) from casbin_rule";
+  // Deny path: a stale deny after a grant is a missing insert, which always raises max(id).
   private static final String MAX_ID_QUERY = "select coalesce(max(id), 0) from casbin_rule";
 
   private final Runnable reloader;
@@ -45,7 +55,7 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   private long lastMaxId = -1;
 
   // System.nanoTime() of the last successful probe start; Long.MIN_VALUE if none.
-  private volatile long lastCompletedProbeAt = Long.MIN_VALUE;
+  private volatile long lastCompletedProbeAtNanos = Long.MIN_VALUE;
 
   private ScheduledExecutorService executor;
 
@@ -84,26 +94,27 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   }
 
   /**
-   * Probes {@code casbin_rule} and reloads when the version changed.
+   * Poller probe: {@link #VERSION_QUERY} ({@code count(*)} and {@code max(id)}).
    *
    * @return true if a reload happened
    */
   public boolean checkAndReload() {
     synchronized (this) {
-      return probeAndReload(true) == ProbeResult.RELOADED;
+      return probeCountAndMaxId() == ProbeResult.RELOADED;
     }
   }
 
   /**
-   * Reloads if policy may have changed after {@code observedBefore} ({@link System#nanoTime()}).
+   * Reloads if policy may have changed after {@code operationStartNanos} ({@link System#nanoTime()}
+   * from the start of the denied operation).
    */
-  public boolean checkAndReloadAfter(long observedBefore) {
-    if (isCoveredByCompletedProbe(observedBefore)) {
+  public boolean checkAndReloadAfter(long operationStartNanos) {
+    if (isCoveredByCompletedProbe(operationStartNanos)) {
       return true;
     }
     synchronized (this) {
       while (true) {
-        if (isCoveredByCompletedProbe(observedBefore)) {
+        if (isCoveredByCompletedProbe(operationStartNanos)) {
           return true;
         }
         Duration remaining = remainingMinProbeInterval();
@@ -113,22 +124,23 @@ public class CasbinPolicyRefresher implements AutoCloseable {
           }
           continue;
         }
-        return probeAndReload(false) != ProbeResult.FAILED;
+        return probeMaxId() != ProbeResult.FAILED;
       }
     }
   }
 
-  private boolean isCoveredByCompletedProbe(long observedBefore) {
-    long lastStart = lastCompletedProbeAt;
-    return lastStart != Long.MIN_VALUE && lastStart - observedBefore >= 0;
+  private boolean isCoveredByCompletedProbe(long operationStartNanos) {
+    long lastStartNanos = lastCompletedProbeAtNanos;
+    return lastStartNanos != Long.MIN_VALUE && lastStartNanos - operationStartNanos >= 0;
   }
 
   private Duration remainingMinProbeInterval() {
-    long lastStart = lastCompletedProbeAt;
-    if (minProbeInterval.isZero() || lastStart == Long.MIN_VALUE) {
+    long lastStartNanos = lastCompletedProbeAtNanos;
+    if (minProbeInterval.isZero() || lastStartNanos == Long.MIN_VALUE) {
       return Duration.ZERO;
     }
-    Duration remaining = minProbeInterval.minus(Duration.ofNanos(System.nanoTime() - lastStart));
+    Duration remaining =
+        minProbeInterval.minus(Duration.ofNanos(System.nanoTime() - lastStartNanos));
     return remaining.isNegative() ? Duration.ZERO : remaining;
   }
 
@@ -142,38 +154,38 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     }
   }
 
-  private ProbeResult probeAndReload(boolean fullVersion) {
-    // Query snapshot is taken at start, so this instant is what the probe can cover.
-    long probeStarted = System.nanoTime();
-    if (fullVersion) {
-      long[] db = readVersion().orElse(null);
-      if (db == null) {
-        return ProbeResult.FAILED;
-      }
-      if (db[0] == lastCount && db[1] == lastMaxId) {
-        recordCompletedProbe(probeStarted);
-        return ProbeResult.UNCHANGED;
-      }
-      return reload(probeStarted, db[0], db[1]);
+  private ProbeResult probeCountAndMaxId() {
+    long probeStartedNanos = System.nanoTime();
+    long[] db = readVersion().orElse(null);
+    if (db == null) {
+      return ProbeResult.FAILED;
     }
+    if (db[0] == lastCount && db[1] == lastMaxId) {
+      recordCompletedProbe(probeStartedNanos);
+      return ProbeResult.UNCHANGED;
+    }
+    return reload(probeStartedNanos, db[0], db[1]);
+  }
 
+  private ProbeResult probeMaxId() {
+    long probeStartedNanos = System.nanoTime();
     Long maxId = readMaxId().orElse(null);
     if (maxId == null) {
       return ProbeResult.FAILED;
     }
     if (maxId == lastMaxId) {
-      recordCompletedProbe(probeStarted);
+      recordCompletedProbe(probeStartedNanos);
       return ProbeResult.UNCHANGED;
     }
-    return reload(probeStarted, lastCount, maxId);
+    return reload(probeStartedNanos, lastCount, maxId);
   }
 
-  private ProbeResult reload(long probeStarted, long count, long maxId) {
+  private ProbeResult reload(long probeStartedNanos, long count, long maxId) {
     long previousCount = lastCount;
     long previousMaxId = lastMaxId;
     reloader.run();
     recordVersion(count, maxId);
-    recordCompletedProbe(probeStarted);
+    recordCompletedProbe(probeStartedNanos);
     LOGGER.info(
         "Reloaded Casbin policy from casbin_rule (count {} -> {}, maxId {} -> {})",
         previousCount,
@@ -183,8 +195,8 @@ public class CasbinPolicyRefresher implements AutoCloseable {
     return ProbeResult.RELOADED;
   }
 
-  private void recordCompletedProbe(long probeStarted) {
-    lastCompletedProbeAt = probeStarted;
+  private void recordCompletedProbe(long probeStartedNanos) {
+    lastCompletedProbeAtNanos = probeStartedNanos;
     notifyAll();
   }
 

--- a/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/CasbinPolicyRefresher.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
@@ -19,36 +18,42 @@ import org.slf4j.LoggerFactory;
  * auto-save enabled, but each server process only loads that table into its enforcer at startup
  * unless this refresher reloads it.
  *
- * <p>Change detection uses {@code select count(*), coalesce(max(id), 0) from casbin_rule}. The JDBC
- * adapter only inserts and deletes rows with auto-incrementing ids, so any write changes at least
- * one of the two values. Reload is delegated to {@link JCasbinAuthorizer} so a fresh enforcer can
- * be built and swapped without blocking {@code enforce()} on the live instance.
+ * <p>The poller uses {@code count(*)} and {@code max(id)}; deny-path checks use {@code max(id)}
+ * only. Reload is delegated to {@link JCasbinAuthorizer} so a fresh enforcer can be swapped without
+ * blocking {@code enforce()}.
  */
 public class CasbinPolicyRefresher implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CasbinPolicyRefresher.class);
 
+  private enum ProbeResult {
+    FAILED,
+    UNCHANGED,
+    RELOADED
+  }
+
   private static final String VERSION_QUERY =
       "select count(*), coalesce(max(id), 0) from casbin_rule";
+  private static final String MAX_ID_QUERY = "select coalesce(max(id), 0) from casbin_rule";
 
   private final Runnable reloader;
   private final SessionFactory sessionFactory;
+  private final Duration minProbeInterval;
 
   // Initial -1 forces a reload on first check (see recordVersion).
   private long lastCount = -1;
   private long lastMaxId = -1;
 
-  /**
-   * Advanced only after a consistent check (no-op or successful reload). Callers that wait on the
-   * monitor while another thread finishes can skip by comparing against a pre-lock snapshot.
-   */
-  private final AtomicLong checkSeq = new AtomicLong();
+  // System.nanoTime() of the last successful probe start; Long.MIN_VALUE if none.
+  private volatile long lastCompletedProbeAt = Long.MIN_VALUE;
 
   private ScheduledExecutorService executor;
 
-  public CasbinPolicyRefresher(Runnable reloader, SessionFactory sessionFactory) {
+  public CasbinPolicyRefresher(
+      Runnable reloader, SessionFactory sessionFactory, Duration minProbeInterval) {
     this.reloader = reloader;
     this.sessionFactory = sessionFactory;
+    this.minProbeInterval = minProbeInterval == null ? Duration.ZERO : minProbeInterval;
   }
 
   public synchronized void start(Duration interval) {
@@ -64,7 +69,10 @@ public class CasbinPolicyRefresher implements AutoCloseable {
             });
     long millis = Math.max(1, interval.toMillis());
     executor.scheduleWithFixedDelay(this::pollQuietly, millis, millis, TimeUnit.MILLISECONDS);
-    LOGGER.info("Casbin policy refresh enabled, checking every {}ms", millis);
+    LOGGER.info(
+        "Casbin policy refresh enabled, checking every {}ms; deny-path min probe interval {}ms",
+        millis,
+        minProbeInterval.toMillis());
   }
 
   private void pollQuietly() {
@@ -78,45 +86,106 @@ public class CasbinPolicyRefresher implements AutoCloseable {
   /**
    * Probes {@code casbin_rule} and reloads when the version changed.
    *
-   * <p>Probe, reload, and version stamp run under one lock so concurrent callers coalesce: a waiter
-   * that blocked while another thread completed a consistent check skips. The stamped version is
-   * the one probed before reload, so the cache matches what was loaded.
-   *
    * @return true if a reload happened
    */
   public boolean checkAndReload() {
-    long seenCheck = checkSeq.get();
     synchronized (this) {
-      if (checkSeq.get() != seenCheck) {
-        return false;
-      }
+      return probeAndReload(true) == ProbeResult.RELOADED;
+    }
+  }
 
-      long[] db = readVersion().orElse(null);
-      if (db == null) {
-        // Probe failed: do not advance checkSeq so waiters retry.
-        return false;
-      }
-      if (db[0] == lastCount && db[1] == lastMaxId) {
-        checkSeq.incrementAndGet();
-        return false;
-      }
-
-      long previousCount = lastCount;
-      long previousMaxId = lastMaxId;
-      // May throw: leave checkSeq alone so waiters retry.
-      reloader.run();
-      // Stamp the probed version, not a post-reload re-read: a fresher DB stamp would claim we
-      // loaded state the new enforcer may not contain.
-      recordVersion(db[0], db[1]);
-      checkSeq.incrementAndGet();
-      LOGGER.info(
-          "Reloaded Casbin policy from casbin_rule (count {} -> {}, maxId {} -> {})",
-          previousCount,
-          db[0],
-          previousMaxId,
-          db[1]);
+  /**
+   * Reloads if policy may have changed after {@code observedBefore} ({@link System#nanoTime()}).
+   */
+  public boolean checkAndReloadAfter(long observedBefore) {
+    if (isCoveredByCompletedProbe(observedBefore)) {
       return true;
     }
+    synchronized (this) {
+      while (true) {
+        if (isCoveredByCompletedProbe(observedBefore)) {
+          return true;
+        }
+        Duration remaining = remainingMinProbeInterval();
+        if (!remaining.isZero()) {
+          if (!await(remaining)) {
+            return false;
+          }
+          continue;
+        }
+        return probeAndReload(false) != ProbeResult.FAILED;
+      }
+    }
+  }
+
+  private boolean isCoveredByCompletedProbe(long observedBefore) {
+    long lastStart = lastCompletedProbeAt;
+    return lastStart != Long.MIN_VALUE && lastStart - observedBefore >= 0;
+  }
+
+  private Duration remainingMinProbeInterval() {
+    long lastStart = lastCompletedProbeAt;
+    if (minProbeInterval.isZero() || lastStart == Long.MIN_VALUE) {
+      return Duration.ZERO;
+    }
+    Duration remaining = minProbeInterval.minus(Duration.ofNanos(System.nanoTime() - lastStart));
+    return remaining.isNegative() ? Duration.ZERO : remaining;
+  }
+
+  private boolean await(Duration remaining) {
+    try {
+      wait(Math.max(1, remaining.toMillis()));
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  private ProbeResult probeAndReload(boolean fullVersion) {
+    // Query snapshot is taken at start, so this instant is what the probe can cover.
+    long probeStarted = System.nanoTime();
+    if (fullVersion) {
+      long[] db = readVersion().orElse(null);
+      if (db == null) {
+        return ProbeResult.FAILED;
+      }
+      if (db[0] == lastCount && db[1] == lastMaxId) {
+        recordCompletedProbe(probeStarted);
+        return ProbeResult.UNCHANGED;
+      }
+      return reload(probeStarted, db[0], db[1]);
+    }
+
+    Long maxId = readMaxId().orElse(null);
+    if (maxId == null) {
+      return ProbeResult.FAILED;
+    }
+    if (maxId == lastMaxId) {
+      recordCompletedProbe(probeStarted);
+      return ProbeResult.UNCHANGED;
+    }
+    return reload(probeStarted, lastCount, maxId);
+  }
+
+  private ProbeResult reload(long probeStarted, long count, long maxId) {
+    long previousCount = lastCount;
+    long previousMaxId = lastMaxId;
+    reloader.run();
+    recordVersion(count, maxId);
+    recordCompletedProbe(probeStarted);
+    LOGGER.info(
+        "Reloaded Casbin policy from casbin_rule (count {} -> {}, maxId {} -> {})",
+        previousCount,
+        count,
+        previousMaxId,
+        maxId);
+    return ProbeResult.RELOADED;
+  }
+
+  private void recordCompletedProbe(long probeStarted) {
+    lastCompletedProbeAt = probeStarted;
+    notifyAll();
   }
 
   private void recordVersion(long count, long maxId) {
@@ -135,6 +204,20 @@ public class CasbinPolicyRefresher implements AutoCloseable {
           });
     } catch (Exception e) {
       LOGGER.debug("Could not read the Casbin policy version", e);
+      return Optional.empty();
+    }
+  }
+
+  private Optional<Long> readMaxId() {
+    try {
+      return sessionFactory.fromSession(
+          session -> {
+            NativeQuery<?> query = session.createNativeQuery(MAX_ID_QUERY);
+            Object result = query.getSingleResult();
+            return Optional.of(((Number) result).longValue());
+          });
+    } catch (Exception e) {
+      LOGGER.debug("Could not read the Casbin policy max id", e);
       return Optional.empty();
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -50,11 +49,8 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   private final JDBCAdapter adapter;
   private final String modelText;
   private final CasbinPolicyRefresher refresher;
-  private final long refreshDebounceNanos;
 
   private final boolean refreshEnabled;
-
-  private final AtomicLong lastRefreshNanos = new AtomicLong(Long.MIN_VALUE / 2);
 
   private static final int PRINCIPAL_INDEX = 0;
   private static final int RESOURCE_INDEX = 1;
@@ -78,10 +74,12 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
     this.modelText = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
     currentEnforcer.set(newEnforcer());
 
-    this.refreshDebounceNanos = serverProperties.getPolicyRefreshDebounceInterval().toNanos();
     this.refreshEnabled = serverProperties.isPolicyRefreshEnabled();
     this.refresher =
-        new CasbinPolicyRefresher(this::reloadFromStore, hibernateConfigurator.getSessionFactory());
+        new CasbinPolicyRefresher(
+            this::reloadFromStore,
+            hibernateConfigurator.getSessionFactory(),
+            serverProperties.getPolicyRefreshMinProbeInterval());
     if (refreshEnabled) {
       refresher.start(serverProperties.getPolicyRefreshInterval());
     } else {
@@ -250,26 +248,15 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   }
 
   /**
-   * Rate-limited policy check before returning 403, for cross-instance create-then-read.
-   *
-   * @return true if the current enforcer was replaced (this call or a coalesced concurrent check)
+   * Reload after a deny if the in-memory policy may be stale. Returns true when the caller should
+   * re-evaluate.
    */
   @Override
-  public boolean refreshAuthorizations() {
+  public boolean refreshAuthorizations(long observedBefore) {
     if (!refreshEnabled) {
       return false;
     }
-    long now = System.nanoTime();
-    long last = lastRefreshNanos.get();
-    if (now - last < refreshDebounceNanos) {
-      return false;
-    }
-    if (!lastRefreshNanos.compareAndSet(last, now)) {
-      return false;
-    }
-    SyncedEnforcer before = currentEnforcer.get();
-    refresher.checkAndReload();
-    return currentEnforcer.get() != before;
+    return refresher.checkAndReloadAfter(observedBefore);
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -252,11 +252,11 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
    * re-evaluate.
    */
   @Override
-  public boolean refreshAuthorizations(long observedBefore) {
+  public boolean refreshAuthorizations(long operationStartNanos) {
     if (!refreshEnabled) {
       return false;
     }
-    return refresher.checkAndReloadAfter(observedBefore);
+    return refresher.checkAndReloadAfter(operationStartNanos);
   }
 
   @Override

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -45,9 +45,10 @@ public interface UnityCatalogAuthorizer {
   /**
    * Reload cached authorization state after a deny, if supported. Default is a no-op.
    *
+   * @param operationStartNanos {@link System#nanoTime()} from the start of the denied operation
    * @return true if authorization should be re-evaluated
    */
-  default boolean refreshAuthorizations(long observedBefore) {
+  default boolean refreshAuthorizations(long operationStartNanos) {
     return false;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/UnityCatalogAuthorizer.java
@@ -43,13 +43,11 @@ public interface UnityCatalogAuthorizer {
   Map<UUID, List<Privileges>> listAuthorizations(UUID resource);
 
   /**
-   * Reload cached authorization state from the shared store, if supported. Called from
-   * authorization evaluation after a deny (request checks and list filters). Implementations should
-   * rate-limit; default is a no-op.
+   * Reload cached authorization state after a deny, if supported. Default is a no-op.
    *
-   * @return true if a refresh ran and re-evaluation may succeed
+   * @return true if authorization should be re-evaluated
    */
-  default boolean refreshAuthorizations() {
+  default boolean refreshAuthorizations(long observedBefore) {
     return false;
   }
 }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -121,6 +121,8 @@ public class ResultFilter {
       throw new RuntimeException("Securable type " + securableType + " is already resolved");
     }
 
+    long observedBefore = System.nanoTime();
+
     items.removeIf(
         item -> {
           try {
@@ -129,7 +131,8 @@ public class ResultFilter {
             Map<SecurableType, UUID> resourceIdsForItem =
                 resolveResourceIdsForItem(securableType, item, resourceIds);
             boolean authorized =
-                evaluator.evaluate(principalId, expression, resourceIdsForItem, nonResourceValues);
+                evaluator.evaluate(
+                    principalId, expression, resourceIdsForItem, nonResourceValues, observedBefore);
             if (!authorized) {
               LOGGER.debug("Item filtered out: {}", item.getClass().getSimpleName());
             }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/ResultFilter.java
@@ -121,7 +121,7 @@ public class ResultFilter {
       throw new RuntimeException("Securable type " + securableType + " is already resolved");
     }
 
-    long observedBefore = System.nanoTime();
+    long operationStartNanos = System.nanoTime();
 
     items.removeIf(
         item -> {
@@ -132,7 +132,11 @@ public class ResultFilter {
                 resolveResourceIdsForItem(securableType, item, resourceIds);
             boolean authorized =
                 evaluator.evaluate(
-                    principalId, expression, resourceIdsForItem, nonResourceValues, observedBefore);
+                    principalId,
+                    expression,
+                    resourceIdsForItem,
+                    nonResourceValues,
+                    operationStartNanos);
             if (!authorized) {
               LOGGER.debug("Item filtered out: {}", item.getClass().getSimpleName());
             }

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
@@ -76,9 +76,6 @@ public class UnityAccessEvaluator {
   /**
    * Evaluate authorization expression with resource IDs and parameter values.
    *
-   * <p>On deny, attempts one debounced policy refresh and re-evaluates the SpEL expression (context
-   * is reused). If refresh is disabled, debounced, or throws, the original deny is kept.
-   *
    * @param principal The principal UUID
    * @param expression The SpEL authorization expression
    * @param resourceIds Map of resource types to their UUIDs
@@ -89,6 +86,27 @@ public class UnityAccessEvaluator {
       String expression,
       Map<SecurableType, UUID> resourceIds,
       Map<String, Object> nonResourceValues) {
+    return evaluate(principal, expression, resourceIds, nonResourceValues, System.nanoTime());
+  }
+
+  /**
+   * Evaluate authorization expression with resource IDs and parameter values.
+   *
+   * <p>On deny, refreshes policy if needed and re-evaluates. If refresh is disabled or throws, the
+   * original deny is kept.
+   *
+   * @param principal The principal UUID
+   * @param expression The SpEL authorization expression
+   * @param resourceIds Map of resource types to their UUIDs
+   * @param nonResourceValues Map of parameter names to their values (from @AuthorizeKey)
+   * @param observedBefore {@link System#nanoTime()} from the start of this operation
+   */
+  public boolean evaluate(
+      UUID principal,
+      String expression,
+      Map<SecurableType, UUID> resourceIds,
+      Map<String, Object> nonResourceValues,
+      long observedBefore) {
 
     StandardEvaluationContext context = new StandardEvaluationContext(Privileges.class);
 
@@ -108,7 +126,7 @@ public class UnityAccessEvaluator {
     }
 
     try {
-      if (!authorizer.refreshAuthorizations()) {
+      if (!authorizer.refreshAuthorizations(observedBefore)) {
         return false;
       }
     } catch (RuntimeException e) {

--- a/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluator.java
@@ -99,14 +99,14 @@ public class UnityAccessEvaluator {
    * @param expression The SpEL authorization expression
    * @param resourceIds Map of resource types to their UUIDs
    * @param nonResourceValues Map of parameter names to their values (from @AuthorizeKey)
-   * @param observedBefore {@link System#nanoTime()} from the start of this operation
+   * @param operationStartNanos {@link System#nanoTime()} from the start of this operation
    */
   public boolean evaluate(
       UUID principal,
       String expression,
       Map<SecurableType, UUID> resourceIds,
       Map<String, Object> nonResourceValues,
-      long observedBefore) {
+      long operationStartNanos) {
 
     StandardEvaluationContext context = new StandardEvaluationContext(Privileges.class);
 
@@ -126,7 +126,7 @@ public class UnityAccessEvaluator {
     }
 
     try {
-      if (!authorizer.refreshAuthorizations(observedBefore)) {
+      if (!authorizer.refreshAuthorizations(operationStartNanos)) {
         return false;
       }
     } catch (RuntimeException e) {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -170,6 +170,20 @@ public class ServerProperties {
     }
   }
 
+  /** {@link Duration} that is zero or positive. */
+  private static class NonNegativeDurationValidator extends DurationValidator {
+    @Override
+    public void validate(String key, String value) {
+      super.validate(key, value);
+      if (Duration.parse(value).isNegative()) {
+        throw new BaseException(
+            ErrorCode.INVALID_ARGUMENT,
+            String.format(
+                "Invalid value '%s' for property '%s': must be zero or positive", value, key));
+      }
+    }
+  }
+
   /** No-op validator that accepts any value */
   private static class NoOpValidator implements PropertyValidator {
     @Override
@@ -185,6 +199,8 @@ public class ServerProperties {
       new PositiveIntegerValidator();
   private static final NoOpValidator NOOP_VALIDATOR = new NoOpValidator();
   private static final DurationValidator DURATION_VALIDATOR = new DurationValidator();
+  private static final NonNegativeDurationValidator NON_NEGATIVE_DURATION_VALIDATOR =
+      new NonNegativeDurationValidator();
 
   @Getter
   public enum Property {
@@ -194,8 +210,10 @@ public class ServerProperties {
     POLICY_REFRESH_ENABLED("server.authorization.policy-refresh", "false", BOOLEAN_VALIDATOR),
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
-    POLICY_REFRESH_DEBOUNCE_INTERVAL(
-        "server.authorization.policy-refresh-debounce-interval", "PT1S", DURATION_VALIDATOR),
+    POLICY_REFRESH_MIN_PROBE_INTERVAL(
+        "server.authorization.policy-refresh-min-probe-interval",
+        "PT0S",
+        NON_NEGATIVE_DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),
@@ -479,8 +497,8 @@ public class ServerProperties {
     return Duration.parse(get(Property.POLICY_REFRESH_INTERVAL));
   }
 
-  public Duration getPolicyRefreshDebounceInterval() {
-    return Duration.parse(get(Property.POLICY_REFRESH_DEBOUNCE_INTERVAL));
+  public Duration getPolicyRefreshMinProbeInterval() {
+    return Duration.parse(get(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL));
   }
 
   public boolean isIncludeStackTraceInError() {

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -202,7 +202,7 @@ public class ServerProperties {
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
     POLICY_REFRESH_MIN_PROBE_INTERVAL(
-        "server.authorization.policy-refresh-min-probe-interval", "PT0S", DURATION_VALIDATOR),
+        "server.authorization.policy-refresh-min-probe-interval", "PT1S", DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),

--- a/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/ServerProperties.java
@@ -155,27 +155,20 @@ public class ServerProperties {
 
   /**
    * Validator for the string format of {@code java.time.Duration}. Check function {@Duration.parse}
-   * for all the accepted forms.
+   * for all the accepted forms. Negative durations are rejected; zero is allowed.
    */
   private static class DurationValidator implements PropertyValidator {
     @Override
     public void validate(String key, String value) {
+      Duration duration;
       try {
-        Duration.parse(value);
+        duration = Duration.parse(value);
       } catch (DateTimeParseException e) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT,
             String.format("Invalid value '%s' for property '%s': %s", value, key, e.getMessage()));
       }
-    }
-  }
-
-  /** {@link Duration} that is zero or positive. */
-  private static class NonNegativeDurationValidator extends DurationValidator {
-    @Override
-    public void validate(String key, String value) {
-      super.validate(key, value);
-      if (Duration.parse(value).isNegative()) {
+      if (duration.isNegative()) {
         throw new BaseException(
             ErrorCode.INVALID_ARGUMENT,
             String.format(
@@ -199,8 +192,6 @@ public class ServerProperties {
       new PositiveIntegerValidator();
   private static final NoOpValidator NOOP_VALIDATOR = new NoOpValidator();
   private static final DurationValidator DURATION_VALIDATOR = new DurationValidator();
-  private static final NonNegativeDurationValidator NON_NEGATIVE_DURATION_VALIDATOR =
-      new NonNegativeDurationValidator();
 
   @Getter
   public enum Property {
@@ -211,9 +202,7 @@ public class ServerProperties {
     POLICY_REFRESH_INTERVAL(
         "server.authorization.policy-refresh-interval", "PT1M", DURATION_VALIDATOR),
     POLICY_REFRESH_MIN_PROBE_INTERVAL(
-        "server.authorization.policy-refresh-min-probe-interval",
-        "PT0S",
-        NON_NEGATIVE_DURATION_VALIDATOR),
+        "server.authorization.policy-refresh-min-probe-interval", "PT0S", DURATION_VALIDATOR),
     AUTHORIZATION_URL("server.authorization-url", URL_VALIDATOR),
     TOKEN_URL("server.token-url", URL_VALIDATOR),
     CLIENT_ID("server.client-id"),

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -57,9 +57,10 @@ public class JCasbinAuthorizerMultiInstanceTest {
     properties.setProperty(
         Property.POLICY_REFRESH_ENABLED.getKey(), Boolean.toString(refreshEnabled));
     properties.setProperty(Property.POLICY_REFRESH_INTERVAL.getKey(), interval);
-    if (minProbeInterval != null) {
-      properties.setProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL.getKey(), minProbeInterval);
-    }
+    // Production default is PT1S; tests pin PT0S unless they are covering the wait.
+    properties.setProperty(
+        Property.POLICY_REFRESH_MIN_PROBE_INTERVAL.getKey(),
+        minProbeInterval != null ? minProbeInterval : "PT0S");
     return new ServerProperties(properties);
   }
 

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -50,14 +50,15 @@ public class JCasbinAuthorizerMultiInstanceTest {
     return properties(refreshEnabled, interval, null);
   }
 
-  private ServerProperties properties(boolean refreshEnabled, String interval, String debounce) {
+  private ServerProperties properties(
+      boolean refreshEnabled, String interval, String minProbeInterval) {
     Properties properties = new Properties();
     properties.setProperty(Property.SERVER_ENV.getKey(), "test");
     properties.setProperty(
         Property.POLICY_REFRESH_ENABLED.getKey(), Boolean.toString(refreshEnabled));
     properties.setProperty(Property.POLICY_REFRESH_INTERVAL.getKey(), interval);
-    if (debounce != null) {
-      properties.setProperty(Property.POLICY_REFRESH_DEBOUNCE_INTERVAL.getKey(), debounce);
+    if (minProbeInterval != null) {
+      properties.setProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL.getKey(), minProbeInterval);
     }
     return new ServerProperties(properties);
   }
@@ -218,23 +219,129 @@ public class JCasbinAuthorizerMultiInstanceTest {
   }
 
   @Test
-  void denyTriggeredRefreshIsDebounced() throws Exception {
+  void denyTriggeredRefreshCoversGrantWrittenAfterPreviousProbe() throws Exception {
     JCasbinAuthorizer replica =
-        register(
-            new JCasbinAuthorizer(
-                hibernateConfigurator, properties(true, "PT1H", TEST_REFRESH_INTERVAL)));
+        register(new JCasbinAuthorizer(hibernateConfigurator, properties(true, "PT1H")));
     JCasbinAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
 
-    replica.refreshAuthorizations();
-    assertThat(replica.refreshAuthorizations())
-        .as("a second check inside the debounce window is skipped")
-        .isFalse();
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isFalse();
+    assertThat(replica.refreshAuthorizations(System.nanoTime())).isTrue();
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isFalse();
 
-    writer.grantAuthorization(UUID.randomUUID(), UUID.randomUUID(), Privileges.SELECT);
-    Thread.sleep(Duration.parse(TEST_REFRESH_INTERVAL).toMillis() + 50);
+    writer.grantAuthorization(principal, resource, Privileges.SELECT);
 
-    assertThat(replica.refreshAuthorizations())
-        .as("after the debounce window a changed policy is reloaded")
+    assertThat(replica.refreshAuthorizations(System.nanoTime()))
+        .as("a request starting after the grant requires a probe newer than the previous one")
+        .isTrue();
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isTrue();
+  }
+
+  @Test
+  void denyTriggeredRefreshDoesNotReloadOnRevokeOfNonMaxRow() throws Exception {
+    JCasbinAuthorizer replica =
+        register(new JCasbinAuthorizer(hibernateConfigurator, properties(true, "PT1H")));
+    JCasbinAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID revoked = UUID.randomUUID();
+    UUID kept = UUID.randomUUID();
+    writer.grantAuthorization(principal, revoked, Privileges.SELECT);
+    writer.grantAuthorization(principal, kept, Privileges.SELECT);
+    settle(replica);
+
+    writer.revokeAuthorization(principal, revoked, Privileges.SELECT);
+
+    assertThat(replica.refreshAuthorizations(System.nanoTime()))
+        .as("a deny-path max(id) probe cannot observe a delete that leaves max(id) unchanged")
+        .isTrue();
+    assertThat(replica.authorize(principal, revoked, Privileges.SELECT))
+        .as("revocations of non-max rows still wait for a full count(*) poll")
+        .isTrue();
+    assertThat(replica.authorize(principal, kept, Privileges.SELECT)).isTrue();
+
+    assertThat(replica.getRefresher().checkAndReload()).isTrue();
+    assertThat(replica.authorize(principal, revoked, Privileges.SELECT)).isFalse();
+    assertThat(replica.authorize(principal, kept, Privileges.SELECT)).isTrue();
+  }
+
+  @Test
+  void minProbeIntervalWaitsThenSeesAGrantWrittenAfterTheLastProbe() throws Exception {
+    JCasbinAuthorizer replica =
+        register(new JCasbinAuthorizer(hibernateConfigurator, properties(true, "PT1H", "PT0.2S")));
+    JCasbinAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    settle(replica);
+
+    writer.grantAuthorization(principal, resource, Privileges.SELECT);
+
+    long started = System.nanoTime();
+    assertThat(replica.refreshAuthorizations(System.nanoTime())).isTrue();
+    assertThat(Duration.ofNanos(System.nanoTime() - started))
+        .as("a positive min interval must wait rather than skip")
+        .isGreaterThanOrEqualTo(Duration.ofMillis(150));
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isTrue();
+  }
+
+  @Test
+  void deniesSharingOneRequestBarrierDoNotProbeAgain() throws Exception {
+    JCasbinAuthorizer replica =
+        register(new JCasbinAuthorizer(hibernateConfigurator, properties(true, "PT1H")));
+    JCasbinAuthorizer writer = startReplicaWithoutRefresh();
+    UUID principal = UUID.randomUUID();
+    UUID resource = UUID.randomUUID();
+    long requestStarted = System.nanoTime();
+
+    assertThat(replica.refreshAuthorizations(requestStarted)).isTrue();
+    writer.grantAuthorization(principal, resource, Privileges.SELECT);
+
+    assertThat(replica.refreshAuthorizations(requestStarted)).isTrue();
+    assertThat(replica.refreshAuthorizations(requestStarted)).isTrue();
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isFalse();
+
+    assertThat(replica.refreshAuthorizations(System.nanoTime())).isTrue();
+    assertThat(replica.authorize(principal, resource, Privileges.SELECT)).isTrue();
+  }
+
+  @Test
+  void concurrentDenyWaitsForRefreshAndThenReevaluates() throws Exception {
+    JCasbinAuthorizer replica =
+        register(new JCasbinAuthorizer(hibernateConfigurator, properties(true, "PT1H")));
+    AtomicBoolean firstResult = new AtomicBoolean(false);
+    AtomicBoolean secondResult = new AtomicBoolean(false);
+    // Separate requests, so each carries its own barrier.
+    Thread first =
+        new Thread(
+            () -> firstResult.set(replica.refreshAuthorizations(System.nanoTime())),
+            "first-deny-refresh");
+    Thread second =
+        new Thread(
+            () -> secondResult.set(replica.refreshAuthorizations(System.nanoTime())),
+            "second-deny-refresh");
+
+    synchronized (replica.getRefresher()) {
+      first.start();
+      await(
+          "the first deny to wait for the refresher",
+          () -> first.getState() == Thread.State.BLOCKED);
+
+      second.start();
+      await(
+          "the second deny to wait for the in-progress refresh",
+          () -> second.getState() == Thread.State.BLOCKED);
+      assertThat(secondResult.get())
+          .as("the second deny must not return before the refresh finishes")
+          .isFalse();
+    }
+
+    first.join(2000);
+    second.join(2000);
+    assertThat(first.isAlive()).isFalse();
+    assertThat(second.isAlive()).isFalse();
+    assertThat(firstResult.get()).isTrue();
+    assertThat(secondResult.get())
+        .as("the queued deny should re-evaluate against the completed refresh")
         .isTrue();
   }
 
@@ -243,7 +350,7 @@ public class JCasbinAuthorizerMultiInstanceTest {
     JCasbinAuthorizer replica = startReplicaWithoutRefresh();
 
     assertThat(replica.getRefresher().isRunning()).isFalse();
-    assertThat(replica.refreshAuthorizations()).isFalse();
+    assertThat(replica.refreshAuthorizations(System.nanoTime())).isFalse();
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluatorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/decorator/UnityAccessEvaluatorTest.java
@@ -1,6 +1,7 @@
 package io.unitycatalog.server.auth.decorator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -27,33 +28,34 @@ class UnityAccessEvaluatorTest {
             evaluator.evaluate(
                 UUID.randomUUID(), "#permit", Collections.emptyMap(), Collections.emptyMap()))
         .isTrue();
-    verify(authorizer, never()).refreshAuthorizations();
+    verify(authorizer, never()).refreshAuthorizations(anyLong());
   }
 
   @Test
   void evaluateKeepsDenyWhenRefreshReturnsFalse() throws Exception {
     UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
-    when(authorizer.refreshAuthorizations()).thenReturn(false);
+    when(authorizer.refreshAuthorizations(anyLong())).thenReturn(false);
     UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
 
     assertThat(
             evaluator.evaluate(
                 UUID.randomUUID(), "#deny", Collections.emptyMap(), Collections.emptyMap()))
         .isFalse();
-    verify(authorizer, times(1)).refreshAuthorizations();
+    verify(authorizer, times(1)).refreshAuthorizations(anyLong());
   }
 
   @Test
   void evaluateKeepsDenyWhenRefreshThrows() throws Exception {
     UnityCatalogAuthorizer authorizer = mock(UnityCatalogAuthorizer.class);
-    when(authorizer.refreshAuthorizations()).thenThrow(new RuntimeException("reload failed"));
+    when(authorizer.refreshAuthorizations(anyLong()))
+        .thenThrow(new RuntimeException("reload failed"));
     UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
 
     assertThat(
             evaluator.evaluate(
                 UUID.randomUUID(), "#deny", Collections.emptyMap(), Collections.emptyMap()))
         .isFalse();
-    verify(authorizer, times(1)).refreshAuthorizations();
+    verify(authorizer, times(1)).refreshAuthorizations(anyLong());
   }
 
   @Test
@@ -64,7 +66,7 @@ class UnityAccessEvaluatorTest {
 
     when(authorizer.authorize(eq(principal), eq(catalog), eq(Privileges.OWNER)))
         .thenReturn(false, true);
-    when(authorizer.refreshAuthorizations()).thenReturn(true);
+    when(authorizer.refreshAuthorizations(anyLong())).thenReturn(true);
 
     UnityAccessEvaluator evaluator = new UnityAccessEvaluator(authorizer);
 
@@ -75,7 +77,7 @@ class UnityAccessEvaluatorTest {
                 Map.of(SecurableType.CATALOG, catalog),
                 Collections.emptyMap()))
         .isTrue();
-    verify(authorizer, times(1)).refreshAuthorizations();
+    verify(authorizer, times(1)).refreshAuthorizations(anyLong());
     verify(authorizer, times(2)).authorize(eq(principal), eq(catalog), eq(Privileges.OWNER));
   }
 }

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -229,6 +229,18 @@ public class ServerPropertiesTest {
         "Invalid value '24 hours'",
         "server.access-token-timeout");
     testInvalidProperty(
+        Property.COOKIE_TIMEOUT, "PT-1S", "must be zero or positive", "server.cookie-timeout");
+    testInvalidProperty(
+        Property.ACCESS_TOKEN_TIMEOUT,
+        "PT-1S",
+        "must be zero or positive",
+        "server.access-token-timeout");
+    testInvalidProperty(
+        Property.POLICY_REFRESH_INTERVAL,
+        "PT-1S",
+        "must be zero or positive",
+        "server.authorization.policy-refresh-interval");
+    testInvalidProperty(
         Property.POLICY_REFRESH_MIN_PROBE_INTERVAL,
         "PT-1S",
         "must be zero or positive",

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -215,6 +215,8 @@ public class ServerPropertiesTest {
     testValidProperty(Property.COOKIE_TIMEOUT, "P1DT12H30M");
     testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT24H");
     testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT1H");
+    testValidProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL, "PT0S");
+    testValidProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL, "PT0.1S");
 
     // Invalid values
     testInvalidProperty(
@@ -226,6 +228,11 @@ public class ServerPropertiesTest {
         "24 hours",
         "Invalid value '24 hours'",
         "server.access-token-timeout");
+    testInvalidProperty(
+        Property.POLICY_REFRESH_MIN_PROBE_INTERVAL,
+        "PT-1S",
+        "must be zero or positive",
+        "server.authorization.policy-refresh-min-probe-interval");
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
+++ b/server/src/test/java/io/unitycatalog/server/utils/ServerPropertiesTest.java
@@ -217,6 +217,7 @@ public class ServerPropertiesTest {
     testValidProperty(Property.ACCESS_TOKEN_TIMEOUT, "PT1H");
     testValidProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL, "PT0S");
     testValidProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL, "PT0.1S");
+    testValidProperty(Property.POLICY_REFRESH_MIN_PROBE_INTERVAL, "PT1S");
 
     // Invalid values
     testInvalidProperty(


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Follow-up to [#1766](https://github.com/unitycatalog/unitycatalog/pull/1766).

Cross-replica create-then-read still 403s after that change. Two races in the deny-triggered refresh path:

1. A refresh that is already in flight claims the debounce timestamp before it checks the store. Concurrent denials keep the original 403 while the winner reloads.
2. Elapsed time since the last probe does not prove that probe could have seen a later grant. If a refresh finished just before OWNER was written, `getStagingTableCredentials` (and any other follow-up request) re-evaluates the stale enforcer inside the one-second window.

This PR replaces skip-if-recent debounce with causal freshness, and joins concurrent denials onto one probe:

- each authorized operation carries a monotonic barrier taken no later than its start (list filters stamp at `filter()`, after the list query);
- a successful policy probe publishes the timestamp from immediately before its database query;
- a completed probe covers every operation that started before that probe;
- concurrent uncovered requests coalesce behind one probe and at most one reload;
- an operation that started while a probe was already in flight triggers a subsequent probe;
- failed probes do not cover later denials (fail-closed).

The deny path probes `max(id)` only (a stale deny is a missing insert). The poller still uses `count(*)` and `max(id)` so delete-only revokes propagate.

**Config**

`server.authorization.policy-refresh-debounce-interval` is removed. Existing files that still set it start normally; the key is ignored and does not restore skip-if-recent behavior.

`server.authorization.policy-refresh-min-probe-interval` defaults to `PT1S`. Quiet traffic is unlikely to wait. Under many 403s per second, lower toward `PT0S` so each new request can probe immediately; that increases `casbin_rule` load.

Refresh remains off unless `server.authorization.policy-refresh=true`.

**Test plan**

- [x] `JCasbinAuthorizerMultiInstanceTest` — grant after a previous probe is visible to a new request; denials that share one request barrier do not probe again; concurrent denials wait and re-evaluate; min probe interval waits rather than skips; revoke of a non-max row still needs a full poller `count(*)`
- [x] `UnityAccessEvaluatorTest` — deny-path refresh + retry
- [x] `ServerPropertiesTest` — `PT0S` / `PT0.1S` / `PT1S` valid, `PT-1S` rejected
- [x] `JCasbinAuthorizerTest` — existing grant/revoke/hierarchy/list behavior
- [ ] `server/test` in CI

