### PR TITLE
[Server] Fix IcebergRestCatalogTest 405 case broken by dropNamespace

### DIFF
--- a/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/IcebergRestCatalogTest.java
@@ -1028,10 +1028,9 @@ public class IcebergRestCatalogTest extends BaseServerTest {
             .join();
     assertIcebergStatusDocument(resp, 404, NotFoundException.class, "Not Found");
 
-    // Same for a method a served path does not accept, such as the namespace drop Iceberg's client
-    // sends to a path this server only serves GET on. Iceberg has no exception of its own for 405.
-    resp =
-        client.delete(TEST_BASE_PREFIX + "/namespaces/" + TestUtils.SCHEMA_NAME).aggregate().join();
+    // Same for a method a served path does not accept: the namespaces collection serves listing
+    // and creation but not DELETE. Iceberg has no exception of its own for 405.
+    resp = client.delete(TEST_BASE_PREFIX + "/namespaces").aggregate().join();
     assertIcebergStatusDocument(resp, 405, RESTException.class, "Method Not Allowed");
 
     // The mount point itself belongs to the Iceberg API too, even though nothing is served there,


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- #1847 added `@Delete(".../namespaces/{namespace}")`, so the 405 assertion in `testUnroutedIcebergRequestsAnswerWithAnIcebergError` now hits a routed path
- Point it at `DELETE /namespaces` instead (collection serves GET/POST, not DELETE)