### PR TITLE
[Server] Give Hibernate and Casbin one HikariCP pool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -381,6 +381,7 @@ lazy val server = (project in file("server"))
       "com.h2database" %  "h2" % "2.2.224",
 
       "org.hibernate.orm" % "hibernate-core" % "6.5.0.Final",
+      "com.zaxxer" % "HikariCP" % "7.1.0",
 
       "jakarta.activation" % "jakarta.activation-api" % "2.1.3",
       "net.bytebuddy" % "byte-buddy" % "1.14.15",

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -45,6 +45,9 @@ This guide outlines how to deploy the Unity Catalog server.
     server environment and the s3 configuration.
 - Setting the server environment to `dev` will use properties located in `etc/conf/hibernate.properties` to configure
     the backend database whereas `test` will spin up an in-memory database.
+- The server builds a HikariCP pool from those connection properties and shares it between Hibernate and Casbin. Optional
+    pool settings can be set as `hibernate.hikari.*` keys (for example `hibernate.hikari.maximumPoolSize`). Autocommit
+    defaults to false so Hibernate can roll back JDBC work.
 - The `etc/data/` directory contains the data files that are used by the UC server. This includes the tables and volumes
     that are created.
 - The `etc/db/` directory contains the backend database that is used by the UC server.

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -53,9 +53,12 @@ This guide outlines how to deploy the Unity Catalog server.
 
 - The backend database can be configured by modifying the `etc/conf/hibernate.properties` file.
 - You need to provide the connection details to connect to your database server.
-- Hibernate and Casbin share a HikariCP pool built from those connection properties. Optional pool
-    settings use `hibernate.hikari.*` keys. Autocommit defaults to false so Hibernate can roll back
-    JDBC work.
+- Hibernate and Casbin use one HikariCP pool built from those connection properties, so total
+    database connections are capped by `hibernate.hikari.maximumPoolSize` (not Hibernate's pool
+    plus a separate Casbin connection). Optional pool settings use `hibernate.hikari.*` keys.
+    Autocommit defaults to false so Hibernate can roll back JDBC work. jdbc-adapter 2.7.0 still
+    holds one pooled connection for the process lifetime; Casbin enables autocommit on that
+    checkout so policy reads do not sit idle-in-transaction.
 
 ### Example MySQL Connection
 

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -45,9 +45,6 @@ This guide outlines how to deploy the Unity Catalog server.
     server environment and the s3 configuration.
 - Setting the server environment to `dev` will use properties located in `etc/conf/hibernate.properties` to configure
     the backend database whereas `test` will spin up an in-memory database.
-- The server builds a HikariCP pool from those connection properties and shares it between Hibernate and Casbin. Optional
-    pool settings can be set as `hibernate.hikari.*` keys (for example `hibernate.hikari.maximumPoolSize`). Autocommit
-    defaults to false so Hibernate can roll back JDBC work.
 - The `etc/data/` directory contains the data files that are used by the UC server. This includes the tables and volumes
     that are created.
 - The `etc/db/` directory contains the backend database that is used by the UC server.
@@ -56,6 +53,9 @@ This guide outlines how to deploy the Unity Catalog server.
 
 - The backend database can be configured by modifying the `etc/conf/hibernate.properties` file.
 - You need to provide the connection details to connect to your database server.
+- Hibernate and Casbin share a HikariCP pool built from those connection properties. Optional pool
+    settings use `hibernate.hikari.*` keys. Autocommit defaults to false so Hibernate can roll back
+    JDBC work.
 
 ### Example MySQL Connection
 
@@ -80,6 +80,8 @@ This guide outlines how to deploy the Unity Catalog server.
     hibernate.connection.url=jdbc:mysql://localhost:3306/ucdb
     hibernate.connection.user=uc_default_user
     hibernate.connection.password=uc_default_password
+    hibernate.hikari.maximumPoolSize=20
+    hibernate.hikari.minimumIdle=2
     ```
 
 - Modify the `jars/classpath` file and add path to your JDBC driver.
@@ -107,6 +109,8 @@ This guide outlines how to deploy the Unity Catalog server.
     hibernate.connection.url=jdbc:postgresql://localhost:5432/ucdb
     hibernate.connection.user=uc_default_user
     hibernate.connection.password=uc_default_password
+    hibernate.hikari.maximumPoolSize=20
+    hibernate.hikari.minimumIdle=2
     ```
 
 - Modify the `jars/classpath` file and add path to your jdbc driver.

--- a/etc/conf/hibernate.properties
+++ b/etc/conf/hibernate.properties
@@ -1,7 +1,9 @@
 hibernate.connection.driver_class=org.h2.Driver
 hibernate.connection.url=jdbc:h2:file:./etc/db/h2db;DB_CLOSE_DELAY=-1
 
-# Shared HikariCP pool for Hibernate and Casbin. Autocommit defaults to false.
+# One HikariCP pool for Hibernate and Casbin (a single maximumPoolSize cap).
+# Autocommit defaults to false. jdbc-adapter 2.7.0 still holds one pooled connection;
+# Casbin enables autocommit on that checkout only.
 hibernate.hikari.maximumPoolSize=20
 hibernate.hikari.minimumIdle=2
 

--- a/etc/conf/hibernate.properties
+++ b/etc/conf/hibernate.properties
@@ -1,6 +1,10 @@
 hibernate.connection.driver_class=org.h2.Driver
 hibernate.connection.url=jdbc:h2:file:./etc/db/h2db;DB_CLOSE_DELAY=-1
 
+# Shared HikariCP pool for Hibernate and Casbin. Autocommit defaults to false.
+hibernate.hikari.maximumPoolSize=20
+hibernate.hikari.minimumIdle=2
+
 hibernate.hbm2ddl.auto=update
 hibernate.show_sql=false
 hibernate.archive.autodetection=class

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -100,15 +100,16 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   /**
-   * Closes the SessionFactory if this server created it, leaving an injected one to its owner. A
-   * failure to close is attached to {@code primaryFailure} so it cannot mask the original error.
+   * Closes the Hibernate configurator if this server created it, leaving an injected one to its
+   * owner. A failure to close is attached to {@code primaryFailure} so it cannot mask the original
+   * error.
    */
   private void closeOwnedSessionFactory(Throwable primaryFailure) {
     if (!ownsHibernateConfigurator) {
       return;
     }
     try {
-      hibernateConfigurator.getSessionFactory().close();
+      hibernateConfigurator.close();
     } catch (Throwable closeFailure) {
       primaryFailure.addSuppressed(closeFailure);
     }
@@ -335,12 +336,12 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   /**
-   * Stops the server and closes the Hibernate SessionFactory it created, releasing its pooled
-   * database connections, which the Armeria shutdown does not touch and which would otherwise stay
-   * open until the JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is
-   * left open — the caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its
-   * SessionFactory must not be restarted after this call: the factory is closed, so all persistence
-   * operations would fail. Safe to call more than once and safe to call before {@link #start()}.
+   * Stops the server and closes the Hibernate configurator it created, releasing the shared Hikari
+   * pool, which the Armeria shutdown does not touch and which would otherwise stay open until the
+   * JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is left open — the
+   * caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its configurator must not
+   * be restarted after this call: the factory and pool are closed, so all persistence operations
+   * would fail. Safe to call more than once and safe to call before {@link #start()}.
    */
   @Override
   public void close() {
@@ -349,7 +350,7 @@ public class UnityCatalogServer implements AutoCloseable {
     } finally {
       closeAuthorizer(null);
       if (ownsHibernateConfigurator) {
-        hibernateConfigurator.getSessionFactory().close();
+        hibernateConfigurator.close();
       }
     }
   }

--- a/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
+++ b/server/src/main/java/io/unitycatalog/server/UnityCatalogServer.java
@@ -336,9 +336,9 @@ public class UnityCatalogServer implements AutoCloseable {
   }
 
   /**
-   * Stops the server and closes the Hibernate configurator it created, releasing the shared Hikari
-   * pool, which the Armeria shutdown does not touch and which would otherwise stay open until the
-   * JVM exits. A configurator supplied via {@link Builder#hibernateConfigurator} is left open — the
+   * Stops the server and closes the Hibernate configurator it created, releasing the Hikari pool,
+   * which the Armeria shutdown does not touch and which would otherwise stay open until the JVM
+   * exits. A configurator supplied via {@link Builder#hibernateConfigurator} is left open — the
    * caller owns its lifecycle. Unlike {@link #stop()}, a server that owns its configurator must not
    * be restarted after this call: the factory and pool are closed, so all persistence operations
    * would fail. Safe to call more than once and safe to call before {@link #start()}.

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -67,12 +66,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   public JCasbinAuthorizer(
       HibernateConfigurator hibernateConfigurator, ServerProperties serverProperties)
       throws Exception {
-    Properties properties = hibernateConfigurator.getHibernateProperties();
-    String driver = properties.getProperty("hibernate.connection.driver_class");
-    String url = properties.getProperty("hibernate.connection.url");
-    String user = resolveConnectionUsername(properties);
-    String password = properties.getProperty("hibernate.connection.password");
-    this.adapter = new JDBCAdapter(driver, url, user, password);
+    this.adapter = new JDBCAdapter(hibernateConfigurator.getDataSource());
 
     InputStream modelStream = this.getClass().getResourceAsStream("/jcasbin_auth_model.conf");
     this.modelText = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
@@ -90,24 +84,6 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
               + " instance will not be seen by this one, so running more than one instance against"
               + " this database is unsafe.");
     }
-  }
-
-  /**
-   * Resolves the database connection username from the Hibernate properties.
-   *
-   * <p>Prefers the standard Hibernate key {@code hibernate.connection.username} (used by the main
-   * session factory configuration and by the project's own tests) and falls back to the
-   * non-standard {@code hibernate.connection.user} that the deployment docs and Helm chart
-   * document. Reading only {@code hibernate.connection.user} left the casbin JDBC adapter with a
-   * null username for any standard configuration, which the JDBC driver then silently replaced with
-   * a process default.
-   */
-  static String resolveConnectionUsername(Properties properties) {
-    String username = properties.getProperty("hibernate.connection.username");
-    if (username == null) {
-      username = properties.getProperty("hibernate.connection.user");
-    }
-    return username;
   }
 
   private SyncedEnforcer newEnforcer() {
@@ -275,6 +251,11 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   @Override
   public void close() {
     refresher.close();
+    try {
+      adapter.close();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to close the Casbin JDBC adapter", e);
+    }
   }
 
   CasbinPolicyRefresher getRefresher() {

--- a/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
+++ b/server/src/main/java/io/unitycatalog/server/auth/JCasbinAuthorizer.java
@@ -4,7 +4,10 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.persist.utils.HibernateConfigurator;
 import io.unitycatalog.server.utils.ServerProperties;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +18,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import org.apache.commons.io.IOUtils;
 import org.casbin.adapter.JDBCAdapter;
 import org.casbin.jcasbin.main.Enforcer;
@@ -29,10 +33,13 @@ import org.slf4j.LoggerFactory;
  * <p>This class is an implementation of UnityCatalogAuthorizor that uses JCasbin as the back end to
  * both store and enforce access control policies.
  *
- * <p>The implementation stores the policies in a database using the JDBCAdapter class. A {@link
- * SyncedEnforcer} is used because the UC server shares one authorizer across concurrent REST
- * requests; jCasbin's plain {@link Enforcer} is not thread-safe for concurrent {@code enforce()}
- * and policy mutations.
+ * <p>The implementation stores the policies in a database using the JDBCAdapter class. jdbc-adapter
+ * 2.7.0 pins one pooled connection for the authorizer lifetime; it does not check connections out
+ * per operation, so this shares a connection bound with Hibernate rather than the connections
+ * themselves. That checkout is forced to autocommit so policy reads do not sit idle-in-transaction
+ * on the Hibernate pool's autocommit-off default. A {@link SyncedEnforcer} is used because the UC
+ * server shares one authorizer across concurrent REST requests; jCasbin's plain {@link Enforcer} is
+ * not thread-safe for concurrent {@code enforce()} and policy mutations.
  *
  * <p>{@link CasbinPolicyRefresher} polls the shared {@code casbin_rule} table so grants and
  * revocations made through other instances are picked up. Reload builds a fresh enforcer and swaps
@@ -66,7 +73,7 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
   public JCasbinAuthorizer(
       HibernateConfigurator hibernateConfigurator, ServerProperties serverProperties)
       throws Exception {
-    this.adapter = new JDBCAdapter(hibernateConfigurator.getDataSource());
+    this.adapter = new JDBCAdapter(autocommitOnCheckout(hibernateConfigurator.getDataSource()));
 
     InputStream modelStream = this.getClass().getResourceAsStream("/jcasbin_auth_model.conf");
     this.modelText = IOUtils.toString(modelStream, StandardCharsets.UTF_8);
@@ -84,6 +91,35 @@ public class JCasbinAuthorizer implements UnityCatalogAuthorizer, AutoCloseable 
               + " instance will not be seen by this one, so running more than one instance against"
               + " this database is unsafe.");
     }
+  }
+
+  /**
+   * jdbc-adapter 2.7.0 calls {@link DataSource#getConnection()} once and holds it. Force autocommit
+   * on that checkout so {@code loadPolicy} does not leave Postgres/MySQL idle-in-transaction.
+   */
+  static DataSource autocommitOnCheckout(DataSource pool) {
+    return (DataSource)
+        Proxy.newProxyInstance(
+            DataSource.class.getClassLoader(),
+            new Class<?>[] {DataSource.class},
+            (proxy, method, args) -> {
+              try {
+                Object result = method.invoke(pool, args);
+                if (!(result instanceof Connection connection)) {
+                  return result;
+                }
+                try {
+                  connection.setAutoCommit(true);
+                  return connection;
+                } catch (Exception e) {
+                  try (connection) {
+                    throw e;
+                  }
+                }
+              } catch (InvocationTargetException e) {
+                throw e.getCause();
+              }
+            });
   }
 
   private SyncedEnforcer newEnforcer() {

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -39,7 +39,9 @@ import org.slf4j.LoggerFactory;
 /**
  * This class configures the hibernate properties and adds annotated classes to the session factory.
  * This session factory is used to create sessions for database operations across the repository
- * classes. Hibernate and Casbin share the HikariCP DataSource built here.
+ * classes. Casbin's JDBC adapter is given the same DataSource so both sit under one Hikari {@code
+ * maximumPoolSize}. jdbc-adapter 2.7.0 still holds one pooled connection for its lifetime; Casbin
+ * enables autocommit on that checkout only.
  */
 @Getter
 public class HibernateConfigurator implements AutoCloseable {

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -1,5 +1,7 @@
 package io.unitycatalog.server.persist.utils;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import io.unitycatalog.server.persist.dao.CatalogInfoDAO;
 import io.unitycatalog.server.persist.dao.ColumnInfoDAO;
 import io.unitycatalog.server.persist.dao.CredentialDAO;
@@ -29,6 +31,7 @@ import lombok.Getter;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.service.ServiceRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,15 +39,17 @@ import org.slf4j.LoggerFactory;
 /**
  * This class configures the hibernate properties and adds annotated classes to the session factory.
  * This session factory is used to create sessions for database operations across the repository
- * classes.
+ * classes. Hibernate and Casbin share the HikariCP DataSource built here.
  */
 @Getter
-public class HibernateConfigurator {
+public class HibernateConfigurator implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HibernateConfigurator.class);
+  private static final String HIKARI_PREFIX = "hibernate.hikari.";
 
   private final SessionFactory sessionFactory;
   private final Properties hibernateProperties;
+  private final HikariDataSource dataSource;
 
   public HibernateConfigurator(ServerProperties serverProperties) {
     this(setupHibernateProperties(serverProperties));
@@ -56,12 +61,74 @@ public class HibernateConfigurator {
    */
   public HibernateConfigurator(Properties hibernateProperties) {
     this.hibernateProperties = hibernateProperties;
-    this.sessionFactory = createSessionFactory(hibernateProperties);
+    this.dataSource = createDataSource(hibernateProperties);
+    try {
+      this.sessionFactory = createSessionFactory(hibernateProperties, dataSource);
+    } catch (Throwable t) {
+      dataSource.close();
+      throw t;
+    }
   }
 
-  private static SessionFactory createSessionFactory(Properties hibernateProperties) {
+  private static HikariDataSource createDataSource(Properties hibernateProperties) {
+    Properties hikariProperties = new Properties();
+    hibernateProperties.stringPropertyNames().stream()
+        .filter(name -> name.startsWith(HIKARI_PREFIX))
+        .forEach(
+            name ->
+                hikariProperties.setProperty(
+                    name.substring(HIKARI_PREFIX.length()), hibernateProperties.getProperty(name)));
+
+    HikariConfig hikariConfig = new HikariConfig(hikariProperties);
+    hikariConfig.setJdbcUrl(hibernateProperties.getProperty("hibernate.connection.url"));
+    hikariConfig.setUsername(resolveConnectionUsername(hibernateProperties));
+    hikariConfig.setPassword(hibernateProperties.getProperty("hibernate.connection.password"));
+    hikariConfig.setDriverClassName(
+        hibernateProperties.getProperty("hibernate.connection.driver_class"));
+    if (!hikariProperties.containsKey("maximumPoolSize")) {
+      hikariConfig.setMaximumPoolSize(
+          Integer.parseInt(
+              hibernateProperties.getProperty("hibernate.connection.pool_size", "20")));
+    }
+    if (!hikariProperties.containsKey("minimumIdle")) {
+      hikariConfig.setMinimumIdle(Math.min(2, hikariConfig.getMaximumPoolSize()));
+    }
+    if (!hikariProperties.containsKey("autoCommit")) {
+      // Hibernate manages transactions and issues rollback() when JDBC work ends.
+      hikariConfig.setAutoCommit(false);
+    }
+    if (hikariConfig.getPoolName() == null) {
+      hikariConfig.setPoolName("unity-catalog");
+    }
+    return new HikariDataSource(hikariConfig);
+  }
+
+  /**
+   * Prefers {@code hibernate.connection.username} and falls back to {@code
+   * hibernate.connection.user}, which the deployment examples still document.
+   */
+  static String resolveConnectionUsername(Properties properties) {
+    String username = properties.getProperty("hibernate.connection.username");
+    return username != null ? username : properties.getProperty("hibernate.connection.user");
+  }
+
+  private static SessionFactory createSessionFactory(
+      Properties hibernateProperties, HikariDataSource dataSource) {
     try {
-      Configuration configuration = new Configuration().setProperties(hibernateProperties);
+      Properties sessionFactoryProperties = new Properties();
+      sessionFactoryProperties.putAll(hibernateProperties);
+      sessionFactoryProperties.remove("hibernate.connection.driver_class");
+      sessionFactoryProperties.remove("hibernate.connection.url");
+      sessionFactoryProperties.remove("hibernate.connection.user");
+      sessionFactoryProperties.remove("hibernate.connection.username");
+      sessionFactoryProperties.remove("hibernate.connection.password");
+      sessionFactoryProperties.remove("hibernate.connection.pool_size");
+      sessionFactoryProperties
+          .keySet()
+          .removeIf(key -> key instanceof String name && name.startsWith(HIKARI_PREFIX));
+      sessionFactoryProperties.put(JdbcSettings.JAKARTA_NON_JTA_DATASOURCE, dataSource);
+
+      Configuration configuration = new Configuration().setProperties(sessionFactoryProperties);
 
       // Add annotated classes
       configuration.addAnnotatedClass(CatalogInfoDAO.class);
@@ -88,6 +155,15 @@ public class HibernateConfigurator {
       return configuration.buildSessionFactory(serviceRegistry);
     } catch (Exception e) {
       throw new RuntimeException("Exception during creation of SessionFactory", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      sessionFactory.close();
+    } finally {
+      dataSource.close();
     }
   }
 

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/TransactionManager.java
@@ -68,17 +68,19 @@ public class TransactionManager {
       }
 
       // Save and set custom isolation level if specified.
-      // IMPORTANT: With autocommit=false (Hibernate default), pooled connections may have an
-      // open implicit transaction from their prior use. H2's setTransactionIsolation() takes
-      // effect for the NEXT transaction, not the current implicit one. We must end the
-      // implicit transaction first so the new isolation level applies to a fresh MVCC snapshot.
-      // Without this, REPEATABLE_READ reads can see stale data from before the connection was
-      // returned to the pool.
+      // IMPORTANT: without autocommit, a pooled connection may carry an open implicit transaction
+      // from its prior use. H2's setTransactionIsolation() takes effect for the NEXT transaction,
+      // not the current implicit one, so that transaction has to end first or REPEATABLE_READ
+      // reads can see stale data from before the connection was returned to the pool. MySQL and
+      // PostgreSQL reject rollback() on an autocommit connection, so only roll back when there is
+      // something to end.
       final int[] originalIsolation = new int[1];
       if (isolationLevel.isPresent()) {
         session.doWork(
             connection -> {
-              connection.rollback(); // End any stale implicit transaction from pool reuse
+              if (!connection.getAutoCommit()) {
+                connection.rollback();
+              }
               originalIsolation[0] = connection.getTransactionIsolation();
               connection.setTransactionIsolation(isolationLevel.get());
             });

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerMultiInstanceTest.java
@@ -43,7 +43,7 @@ public class JCasbinAuthorizerMultiInstanceTest {
   void tearDown() {
     replicas.forEach(JCasbinAuthorizer::close);
     replicas.clear();
-    hibernateConfigurator.getSessionFactory().close();
+    hibernateConfigurator.close();
   }
 
   private ServerProperties properties(boolean refreshEnabled, String interval) {

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 public class JCasbinAuthorizerTest {
   private UnityCatalogAuthorizer authenticator;
+  private HibernateConfigurator hibernateConfigurator;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -25,7 +26,7 @@ public class JCasbinAuthorizerTest {
     // Single-instance tests do not need background polling.
     properties.setProperty(Property.POLICY_REFRESH_ENABLED.getKey(), "false");
     ServerProperties serverProperties = new ServerProperties(properties);
-    HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);
+    hibernateConfigurator = new HibernateConfigurator(serverProperties);
     authenticator = new JCasbinAuthorizer(hibernateConfigurator, serverProperties);
   }
 
@@ -38,28 +39,7 @@ public class JCasbinAuthorizerTest {
         throw new RuntimeException(e);
       }
     }
-  }
-
-  @Test
-  void resolvesUsernameFromStandardHibernateProperty() {
-    Properties properties = new Properties();
-    properties.setProperty("hibernate.connection.username", "alice");
-    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("alice");
-  }
-
-  @Test
-  void fallsBackToLegacyUserProperty() {
-    Properties properties = new Properties();
-    properties.setProperty("hibernate.connection.user", "bob");
-    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("bob");
-  }
-
-  @Test
-  void prefersStandardUsernameWhenBothPresent() {
-    Properties properties = new Properties();
-    properties.setProperty("hibernate.connection.username", "alice");
-    properties.setProperty("hibernate.connection.user", "bob");
-    assertThat(JCasbinAuthorizer.resolveConnectionUsername(properties)).isEqualTo("alice");
+    hibernateConfigurator.close();
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/auth/JCasbinAuthorizerTest.java
@@ -6,6 +6,7 @@ import io.unitycatalog.server.persist.model.Privileges;
 import io.unitycatalog.server.persist.utils.HibernateConfigurator;
 import io.unitycatalog.server.utils.ServerProperties;
 import io.unitycatalog.server.utils.ServerProperties.Property;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,18 @@ public class JCasbinAuthorizerTest {
       }
     }
     hibernateConfigurator.close();
+  }
+
+  @Test
+  void casbinCheckoutEnablesAutocommitWithoutChangingThePoolDefault() throws Exception {
+    assertThat(hibernateConfigurator.getDataSource().isAutoCommit()).isFalse();
+    try (Connection casbin =
+            JCasbinAuthorizer.autocommitOnCheckout(hibernateConfigurator.getDataSource())
+                .getConnection();
+        Connection hibernate = hibernateConfigurator.getDataSource().getConnection()) {
+      assertThat(casbin.getAutoCommit()).isTrue();
+      assertThat(hibernate.getAutoCommit()).isFalse();
+    }
   }
 
   @Test

--- a/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/base/BaseServerTest.java
@@ -139,11 +139,11 @@ public abstract class BaseServerTest {
       // close() rather than stop() so a server that built its own SessionFactory releases it;
       // this harness injects one, so the server leaves it open and we close it below.
       unityCatalogServer.close();
-      // Release the factory this harness built and injected in setUp(). setUp() builds a fresh
-      // one per test, so leaked factories would otherwise accumulate for the whole JVM run. In
-      // test env hbm2ddl is create-drop, so closing also drops the schema — keep this after the
+      // Release the factory and pool this harness built and injected in setUp(). setUp() builds
+      // a fresh one per test, so leaked factories would otherwise accumulate for the whole JVM run.
+      // In test env hbm2ddl is create-drop, so closing also drops the schema — keep this after the
       // cleanup queries above.
-      sessionFactory.close();
+      hibernateConfigurator.close();
       // Null out so tearDown is idempotent if a subclass @AfterEach also invokes it.
       unityCatalogServer = null;
     }

--- a/server/src/test/java/io/unitycatalog/server/persist/UserRepositoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/UserRepositoryTest.java
@@ -19,21 +19,21 @@ class UserRepositoryTest {
 
   private static SessionFactory sessionFactory;
   private static UserRepository userRepository;
+  private static HibernateConfigurator hibernateConfigurator;
 
   @BeforeAll
   static void setUp() {
     Properties properties = new Properties();
     properties.setProperty("server.env", "test");
-    HibernateConfigurator hibernateConfigurator =
-        new HibernateConfigurator(new ServerProperties(properties));
+    hibernateConfigurator = new HibernateConfigurator(new ServerProperties(properties));
     sessionFactory = hibernateConfigurator.getSessionFactory();
     userRepository = new UserRepository(null, sessionFactory);
   }
 
   @AfterAll
   static void tearDown() {
-    if (sessionFactory != null) {
-      sessionFactory.close();
+    if (hibernateConfigurator != null) {
+      hibernateConfigurator.close();
     }
   }
 

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/ExternalLocationUtilsTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/ExternalLocationUtilsTest.java
@@ -25,13 +25,13 @@ public class ExternalLocationUtilsTest {
 
   private static SessionFactory sessionFactory;
   private static Session session;
+  private static HibernateConfigurator hibernateConfigurator;
 
   @BeforeAll
   public static void setUp() {
     // Create minimal properties
     ServerProperties serverProperties = new ServerProperties(new Properties());
-    // Create Hibernate configurator and session factory
-    HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);
+    hibernateConfigurator = new HibernateConfigurator(serverProperties);
     sessionFactory = hibernateConfigurator.getSessionFactory();
     session = sessionFactory.openSession();
   }
@@ -39,7 +39,7 @@ public class ExternalLocationUtilsTest {
   @AfterAll
   public static void tearDown() {
     session.close();
-    sessionFactory.close();
+    hibernateConfigurator.close();
   }
 
   /**

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/HibernateConfiguratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/HibernateConfiguratorTest.java
@@ -1,0 +1,54 @@
+package io.unitycatalog.server.persist.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class HibernateConfiguratorTest {
+
+  @Test
+  void configuresHikariAndExposesTheSharedDataSource() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+    properties.setProperty("hibernate.connection.user", "sa");
+    properties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+    properties.setProperty("hibernate.hikari.maximumPoolSize", "3");
+    properties.setProperty("hibernate.hikari.minimumIdle", "1");
+    properties.setProperty("hibernate.hikari.poolName", "unity-catalog-test");
+
+    try (HibernateConfigurator configurator = new HibernateConfigurator(properties)) {
+      assertThat(configurator.getDataSource().getMaximumPoolSize()).isEqualTo(3);
+      assertThat(configurator.getDataSource().getMinimumIdle()).isEqualTo(1);
+      assertThat(configurator.getDataSource().getPoolName()).isEqualTo("unity-catalog-test");
+      assertThat(configurator.getDataSource().isAutoCommit()).isFalse();
+      assertThat(configurator.getDataSource().getUsername()).isEqualTo("sa");
+      assertThat(configurator.getSessionFactory().isOpen()).isTrue();
+    }
+  }
+
+  @Test
+  void resolvesUsernameFromStandardHibernateProperty() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.username", "alice");
+    assertThat(HibernateConfigurator.resolveConnectionUsername(properties)).isEqualTo("alice");
+  }
+
+  @Test
+  void fallsBackToLegacyUserProperty() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.user", "bob");
+    assertThat(HibernateConfigurator.resolveConnectionUsername(properties)).isEqualTo("bob");
+  }
+
+  @Test
+  void prefersStandardUsernameWhenBothPresent() {
+    Properties properties = new Properties();
+    properties.setProperty("hibernate.connection.username", "alice");
+    properties.setProperty("hibernate.connection.user", "bob");
+    assertThat(HibernateConfigurator.resolveConnectionUsername(properties)).isEqualTo("alice");
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/utils/TransactionManagerTest.java
@@ -213,17 +213,18 @@ public class TransactionManagerTest {
   public class IsolationLevelWithRealDatabaseTest {
 
     private static SessionFactory realSessionFactory;
+    private static HibernateConfigurator hibernateConfigurator;
 
     @BeforeAll
     public static void setUp() {
       ServerProperties serverProperties = new ServerProperties(new Properties());
-      HibernateConfigurator hibernateConfigurator = new HibernateConfigurator(serverProperties);
+      hibernateConfigurator = new HibernateConfigurator(serverProperties);
       realSessionFactory = hibernateConfigurator.getSessionFactory();
     }
 
     @AfterAll
     public static void tearDown() {
-      realSessionFactory.close();
+      hibernateConfigurator.close();
     }
 
     @Test


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Hibernate currently uses its built-in non-production JDBC pool, and JCasbin opens a separate JDBC connection for policy storage. Those two paths have no shared bound, so total database connections are Hibernate's pool plus Casbin's extra connection.

This change puts both under one HikariCP pool so the cap is `hibernate.hikari.maximumPoolSize` (not Hibernate pool + 1). jdbc-adapter 2.7.0 still checks out one connection in its constructor and holds it for the authorizer lifetime, so this does not share connections with Hibernate and does not relieve reload-vs-catalog contention. Real sharing would need a per-operation-checkout adapter.

In detail:

- Adds HikariCP 7.1.0 and builds one pool in `HibernateConfigurator` from `hibernate.connection.*` plus optional `hibernate.hikari.*` keys.
- Hands that `DataSource` to Hibernate (`jakarta.nonJtaDataSource`) and to JCasbin's `JDBCAdapter`.
- Defaults pool autocommit to false so Hibernate can `rollback()` (MySQL and PostgreSQL reject rollback on autocommit connections). Casbin's one checkout is forced to autocommit so `loadPolicy` does not leave Postgres/MySQL idle-in-transaction.
- Closes the pool with the session factory, and closes the Casbin JDBC adapter with the authorizer.

Username resolution still prefers `hibernate.connection.username` and falls back to `hibernate.connection.user`.

**Test plan**

- [x] `HibernateConfiguratorTest` — pool size/name/autocommit, username fallback
- [x] `JCasbinAuthorizerTest` — grant/revoke/hierarchy/list; Casbin checkout is autocommit, Hibernate pool is not
- [x] `JCasbinAuthorizerMultiInstanceTest` — cross-replica refresh still works
- [x] `UnityAccessEvaluatorTest` — deny-path refresh
- [x] `TransactionManagerTest` — isolation restore and REPEATABLE_READ snapshot
- [x] `server/test` locally (498 passed, 2 skipped)
- [ ] `server/test` in CI
