### PR TITLE
[Server] Add bounded ADLS storage cleanup

### DIFF
--- a/server/src/main/java/io/unitycatalog/server/cleanup/ADLSStorageCleanupAdapter.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/ADLSStorageCleanupAdapter.java
@@ -1,0 +1,105 @@
+package io.unitycatalog.server.cleanup;
+
+import com.azure.core.util.Context;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import io.unitycatalog.server.service.credential.azure.ADLSLocationUtils;
+import io.unitycatalog.server.service.credential.azure.ADLSLocationUtils.ADLSLocationParts;
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+/** Recursively deletes one exact ADLS task directory. */
+public final class ADLSStorageCleanupAdapter implements StorageCleanupAdapter {
+  private static final long MAX_TIMEOUT_MILLIS = Duration.ofSeconds(Integer.MAX_VALUE).toMillis();
+
+  private final DataLakeFileSystemClient client;
+  private final String location;
+  private final String path;
+  private final Duration requestTimeout;
+  private boolean deleted;
+
+  /** Creates a timeout-configured client for this cleanup attempt. */
+  public ADLSStorageCleanupAdapter(
+      String sasToken, NormalizedURL location, Duration requestTimeout) {
+    this(newClient(sasToken, location, requestTimeout), location, requestTimeout);
+  }
+
+  ADLSStorageCleanupAdapter(
+      DataLakeFileSystemClient client, NormalizedURL location, Duration requestTimeout) {
+    ADLSLocationParts parts = parseLocation(location);
+    this.client = Objects.requireNonNull(client, "client");
+    this.location = location.toString();
+    this.path = parts.path().replaceAll("^/+|/+$", "");
+    this.requestTimeout = validateTimeout(requestTimeout);
+  }
+
+  @Override
+  public List<String> listBatch(int maxFiles) {
+    if (maxFiles <= 0) {
+      throw new IllegalArgumentException("Cleanup batch size must be positive");
+    }
+    return deleted ? List.of() : List.of(location);
+  }
+
+  @Override
+  public void deleteBatch(List<String> locations) {
+    if (locations.isEmpty()) {
+      return;
+    }
+    if (locations.size() != 1 || !location.equals(locations.get(0))) {
+      throw new IllegalArgumentException("ADLS cleanup can delete only its exact task directory");
+    }
+    client.deleteDirectoryIfExistsWithResponse(
+        path, new DataLakePathDeleteOptions().setIsRecursive(true), requestTimeout, Context.NONE);
+    deleted = true;
+  }
+
+  private static DataLakeFileSystemClient newClient(
+      String sasToken, NormalizedURL location, Duration requestTimeout) {
+    ADLSLocationParts parts = parseLocation(location);
+    Duration timeout = validateTimeout(requestTimeout);
+    Duration tryTimeout = Duration.ofSeconds((timeout.toMillis() + 999) / 1000);
+    RequestRetryOptions retryOptions =
+        new RequestRetryOptions(null, null, tryTimeout, null, null, null);
+    return new DataLakeFileSystemClientBuilder()
+        .endpoint("https://" + parts.account() + "/" + parts.container())
+        .sasToken(Objects.requireNonNull(sasToken, "sasToken"))
+        .retryOptions(retryOptions)
+        .buildClient();
+  }
+
+  private static ADLSLocationParts parseLocation(NormalizedURL location) {
+    ADLSLocationParts parts =
+        ADLSLocationUtils.parseLocation(Objects.requireNonNull(location, "location"));
+    if (!("abfs".equals(parts.scheme()) || "abfss".equals(parts.scheme()))
+        || parts.container() == null
+        || parts.container().isBlank()
+        || parts.account() == null
+        || parts.account().isBlank()
+        || parts.accountName() == null
+        || parts.accountName().isBlank()
+        || parts.path() == null
+        || parts.path().chars().allMatch(character -> character == '/')) {
+      throw new IllegalArgumentException(
+          "ADLS cleanup requires an abfs or abfss directory location");
+    }
+    return parts;
+  }
+
+  private static Duration validateTimeout(Duration requestTimeout) {
+    try {
+      long millis = Objects.requireNonNull(requestTimeout, "requestTimeout").toMillis();
+      if (millis <= 0 || millis > MAX_TIMEOUT_MILLIS) {
+        throw new IllegalArgumentException(
+            "ADLS request timeout must be between 1 and " + MAX_TIMEOUT_MILLIS + " milliseconds");
+      }
+      return Duration.ofMillis(millis);
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException("ADLS request timeout is too large", e);
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/cleanup/GCSStorageCleanupAdapter.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/GCSStorageCleanupAdapter.java
@@ -1,0 +1,150 @@
+package io.unitycatalog.server.cleanup;
+
+import com.google.api.gax.paging.Page;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.auth.Credentials;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.HttpStorageOptions;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.UriScheme;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.StreamSupport;
+
+/** Lists and deletes bounded batches under one exact GCS task prefix. */
+public final class GCSStorageCleanupAdapter implements StorageCleanupAdapter {
+  // The GCS JSON batch API accepts at most 100 calls in one request.
+  private static final int MAX_BATCH_SIZE = 100;
+
+  private final Storage storage;
+  private final String bucket;
+  private final String key;
+  private final String keyPrefix;
+  private final String storageRoot;
+  private boolean exactKeyScheduled;
+
+  /** Creates an adapter with a new timeout-configured client for this attempt. */
+  public GCSStorageCleanupAdapter(
+      Credentials credentials, NormalizedURL location, Duration requestTimeout) {
+    this(storageOptions(credentials, requestTimeout).getService(), location);
+  }
+
+  GCSStorageCleanupAdapter(Storage storage, NormalizedURL location) {
+    this.storage = Objects.requireNonNull(storage, "storage");
+    URI uri = Objects.requireNonNull(location, "location").toUri();
+    if (UriScheme.fromURI(uri) != UriScheme.GS
+        || uri.getHost() == null
+        || uri.getHost().isBlank()) {
+      throw new IllegalArgumentException("GCS cleanup requires a GCS storage location");
+    }
+    String path = uri.getPath();
+    String objectKey = path == null ? "" : path.replaceFirst("^/+", "");
+    if (objectKey.isEmpty()) {
+      throw new IllegalArgumentException("GCS cleanup requires a bucket and object prefix");
+    }
+    this.bucket = uri.getHost();
+    this.key = objectKey;
+    this.keyPrefix = key + "/";
+    this.storageRoot = "gs://" + bucket + "/";
+  }
+
+  @Override
+  public List<String> listBatch(int maxFiles) {
+    if (maxFiles <= 0) {
+      throw new IllegalArgumentException("Cleanup batch size must be positive");
+    }
+    if (exactKeyScheduled) {
+      return List.of();
+    }
+    int limit = Math.min(maxFiles, MAX_BATCH_SIZE);
+    Page<Blob> page =
+        storage.list(bucket, BlobListOption.prefix(keyPrefix), BlobListOption.pageSize(limit));
+    List<String> locations =
+        StreamSupport.stream(page.getValues().spliterator(), false)
+            .limit(limit)
+            .map(this::toLocation)
+            .toList();
+    if (locations.isEmpty()) {
+      exactKeyScheduled = true;
+      return List.of(storageRoot + key);
+    }
+    return locations;
+  }
+
+  @Override
+  public void deleteBatch(List<String> locations) {
+    if (locations.isEmpty()) {
+      return;
+    }
+    if (locations.size() > MAX_BATCH_SIZE) {
+      throw new IllegalArgumentException("GCS cleanup batch cannot exceed 100 objects");
+    }
+    List<BlobId> blobIds = locations.stream().map(this::toBlobId).toList();
+    StorageBatch batch = storage.batch();
+    List<StorageBatchResult<Boolean>> results = blobIds.stream().map(batch::delete).toList();
+    batch.submit();
+    results.forEach(StorageBatchResult::get);
+  }
+
+  private String toLocation(Blob blob) {
+    BlobId blobId = blob.getBlobId();
+    if (!bucket.equals(blobId.getBucket()) || !blobId.getName().startsWith(keyPrefix)) {
+      throw new IllegalStateException("GCS listed an object outside the cleanup prefix");
+    }
+    return storageRoot + blobId.getName();
+  }
+
+  private BlobId toBlobId(String location) {
+    if (!location.startsWith(storageRoot)) {
+      throw new IllegalArgumentException("GCS cleanup cannot delete outside its task prefix");
+    }
+    String objectKey = location.substring(storageRoot.length());
+    if (!objectKey.equals(key) && !objectKey.startsWith(keyPrefix)) {
+      throw new IllegalArgumentException("GCS cleanup cannot delete outside its task prefix");
+    }
+    return BlobId.of(bucket, objectKey);
+  }
+
+  static HttpStorageOptions storageOptions(Credentials credentials, Duration requestTimeout) {
+    int timeoutMillis = timeoutMillis(requestTimeout);
+    org.threeten.bp.Duration timeout = org.threeten.bp.Duration.ofMillis(timeoutMillis);
+    RetrySettings retrySettings =
+        HttpStorageOptions.getDefaultInstance().getRetrySettings().toBuilder()
+            .setInitialRpcTimeout(timeout)
+            .setMaxRpcTimeout(timeout)
+            .setRpcTimeoutMultiplier(1.0)
+            .setTotalTimeout(timeout)
+            .build();
+    HttpTransportOptions transport =
+        HttpTransportOptions.newBuilder()
+            .setConnectTimeout(timeoutMillis)
+            .setReadTimeout(timeoutMillis)
+            .build();
+    return HttpStorageOptions.newBuilder()
+        .setCredentials(Objects.requireNonNull(credentials, "credentials"))
+        .setRetrySettings(retrySettings)
+        .setTransportOptions(transport)
+        .build();
+  }
+
+  private static int timeoutMillis(Duration requestTimeout) {
+    try {
+      long millis = requestTimeout.toMillis();
+      if (millis <= 0 || millis > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException(
+            "GCS request timeout must be between 1 and 2147483647 milliseconds");
+      }
+      return (int) millis;
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException("GCS request timeout is too large", e);
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/cleanup/LocalStorageCleanupAdapter.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/LocalStorageCleanupAdapter.java
@@ -1,0 +1,58 @@
+package io.unitycatalog.server.cleanup;
+
+import io.unitycatalog.server.persist.utils.SimpleLocalFileIO;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.UriScheme;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileInfo;
+
+/** Storage cleanup adapter for a local directory. */
+public final class LocalStorageCleanupAdapter implements StorageCleanupAdapter {
+  private final SimpleLocalFileIO fileIO = new SimpleLocalFileIO();
+  private final String location;
+
+  public LocalStorageCleanupAdapter(NormalizedURL location) {
+    UriScheme scheme = UriScheme.fromURI(location.toUri());
+    if (scheme != UriScheme.FILE && scheme != UriScheme.NULL) {
+      throw new IllegalArgumentException("Local cleanup requires a local storage location");
+    }
+    this.location = location.toString();
+  }
+
+  @Override
+  public List<String> listBatch(int maxFiles) {
+    if (maxFiles <= 0) {
+      throw new IllegalArgumentException("Maximum files must be positive");
+    }
+    List<String> batch = new ArrayList<>(maxFiles);
+    try (CloseableIterable<FileInfo> files = fileIO.listPrefix(location)) {
+      for (FileInfo file : files) {
+        batch.add(file.location());
+        if (batch.size() == maxFiles) {
+          break;
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close local storage listing", e);
+    }
+    return batch;
+  }
+
+  @Override
+  public void deleteBatch(List<String> locations) {
+    for (String file : locations) {
+      try {
+        fileIO.deleteFile(file);
+      } catch (UncheckedIOException e) {
+        if (!(e.getCause() instanceof NoSuchFileException)) {
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/cleanup/S3StorageCleanupAdapter.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/S3StorageCleanupAdapter.java
@@ -1,0 +1,139 @@
+package io.unitycatalog.server.cleanup;
+
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.NormalizedURL.S3Location;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/** Lists and deletes bounded batches under one exact S3 task prefix. */
+public final class S3StorageCleanupAdapter implements StorageCleanupAdapter {
+  private static final int MAX_BATCH_SIZE = 1000;
+
+  private final S3Client client;
+  private final String bucket;
+  private final String key;
+  private final String keyPrefix;
+  private final String storageRoot;
+  private final AwsRequestOverrideConfiguration requestOverride;
+  private boolean exactKeyScheduled;
+
+  /** Creates an adapter that owns and closes the supplied client. */
+  public S3StorageCleanupAdapter(S3Client client, NormalizedURL location, Duration requestTimeout) {
+    this.client = Objects.requireNonNull(client, "client");
+    S3Location s3Location;
+    try {
+      s3Location = Objects.requireNonNull(location, "location").toS3Location();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("S3 cleanup requires an S3 storage location");
+    }
+    if (s3Location.key().isEmpty()) {
+      throw new IllegalArgumentException("S3 cleanup requires a bucket and object prefix");
+    }
+    this.bucket = s3Location.bucket();
+    this.key = s3Location.key();
+    this.keyPrefix = key + "/";
+    this.storageRoot = "s3://" + bucket + "/";
+    this.requestOverride = requestOverride(requestTimeout);
+  }
+
+  @Override
+  public List<String> listBatch(int maxFiles) {
+    if (maxFiles <= 0) {
+      throw new IllegalArgumentException("Cleanup batch size must be positive");
+    }
+    if (exactKeyScheduled) {
+      return List.of();
+    }
+    int limit = Math.min(maxFiles, MAX_BATCH_SIZE);
+    ListObjectsV2Request request =
+        ListObjectsV2Request.builder()
+            .bucket(bucket)
+            .prefix(keyPrefix)
+            .maxKeys(limit)
+            .overrideConfiguration(requestOverride)
+            .build();
+    List<String> locations =
+        client.listObjectsV2(request).contents().stream()
+            .limit(limit)
+            .map(this::toLocation)
+            .toList();
+    if (locations.isEmpty()) {
+      exactKeyScheduled = true;
+      return List.of(storageRoot + key);
+    }
+    return locations;
+  }
+
+  @Override
+  public void deleteBatch(List<String> locations) {
+    if (locations.isEmpty()) {
+      return;
+    }
+    if (locations.size() > MAX_BATCH_SIZE) {
+      throw new IllegalArgumentException("S3 cleanup batch cannot exceed 1000 objects");
+    }
+    List<ObjectIdentifier> objects = locations.stream().map(this::toObjectIdentifier).toList();
+    DeleteObjectsRequest request =
+        DeleteObjectsRequest.builder()
+            .bucket(bucket)
+            .delete(Delete.builder().objects(objects).build())
+            .overrideConfiguration(requestOverride)
+            .build();
+    DeleteObjectsResponse response = client.deleteObjects(request);
+    if (response.hasErrors()) {
+      String errors =
+          response.errors().stream()
+              .map(error -> error.key() + " (" + error.code() + ")")
+              .collect(Collectors.joining(", "));
+      throw SdkClientException.create("S3 object deletion failed: " + errors);
+    }
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  private String toLocation(S3Object object) {
+    if (!object.key().startsWith(keyPrefix)) {
+      throw new IllegalStateException("S3 listed an object outside the cleanup prefix");
+    }
+    return storageRoot + object.key();
+  }
+
+  private ObjectIdentifier toObjectIdentifier(String location) {
+    if (!location.startsWith(storageRoot)) {
+      throw new IllegalArgumentException("S3 cleanup cannot delete outside its task prefix");
+    }
+    String objectKey = location.substring(storageRoot.length());
+    if (!objectKey.equals(key) && !objectKey.startsWith(keyPrefix)) {
+      throw new IllegalArgumentException("S3 cleanup cannot delete outside its task prefix");
+    }
+    return ObjectIdentifier.builder().key(objectKey).build();
+  }
+
+  private static AwsRequestOverrideConfiguration requestOverride(Duration requestTimeout) {
+    try {
+      if (requestTimeout.toMillis() <= 0) {
+        throw new IllegalArgumentException("S3 request timeout must be at least one millisecond");
+      }
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException("S3 request timeout is too large", e);
+    }
+    return AwsRequestOverrideConfiguration.builder()
+        .apiCallTimeout(requestTimeout)
+        .apiCallAttemptTimeout(requestTimeout)
+        .build();
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/cleanup/StorageCleanupAdapter.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/StorageCleanupAdapter.java
@@ -1,0 +1,20 @@
+package io.unitycatalog.server.cleanup;
+
+import java.util.List;
+
+/** Lists and deletes materialized, bounded batches from one storage location. */
+public interface StorageCleanupAdapter extends AutoCloseable {
+  /**
+   * Returns at most {@code maxFiles} file locations.
+   *
+   * @param maxFiles positive maximum number of files to return
+   * @throws IllegalArgumentException if {@code maxFiles} is not positive
+   */
+  List<String> listBatch(int maxFiles);
+
+  /** Deletes one batch returned by {@link #listBatch(int)}. */
+  void deleteBatch(List<String> locations);
+
+  @Override
+  default void close() {}
+}

--- a/server/src/main/java/io/unitycatalog/server/cleanup/StorageCleanupAttempt.java
+++ b/server/src/main/java/io/unitycatalog/server/cleanup/StorageCleanupAttempt.java
@@ -1,0 +1,72 @@
+package io.unitycatalog.server.cleanup;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+/** Runs bounded cleanup batches for one fixed storage-work time slice. */
+public final class StorageCleanupAttempt {
+  public enum Result {
+    COMPLETE,
+    PARTIAL
+  }
+
+  private final int batchSize;
+  private final long timeSliceNanos;
+  private final long requestTimeoutNanos;
+  private final LongSupplier nanoTime;
+
+  public StorageCleanupAttempt(int batchSize, Duration timeSlice, Duration requestTimeout) {
+    this(batchSize, timeSlice, requestTimeout, System::nanoTime);
+  }
+
+  StorageCleanupAttempt(
+      int batchSize, Duration timeSlice, Duration requestTimeout, LongSupplier nanoTime) {
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("Cleanup batch size must be positive");
+    }
+    this.timeSliceNanos = positiveNanos(timeSlice, "Cleanup time slice");
+    this.requestTimeoutNanos = positiveNanos(requestTimeout, "Storage request timeout");
+    if (requestTimeoutNanos > timeSliceNanos / 2) {
+      throw new IllegalArgumentException(
+          "Cleanup time slice must allow one list and delete request");
+    }
+    this.batchSize = batchSize;
+    this.nanoTime = nanoTime;
+  }
+
+  /** Runs and closes one adapter. Adapter failures are propagated to the caller. */
+  public Result run(StorageCleanupAdapter adapter) {
+    long startedAt = nanoTime.getAsLong();
+    try (adapter) {
+      while (hasTime(startedAt, requestTimeoutNanos * 2)) {
+        List<String> batch = adapter.listBatch(batchSize);
+        if (batch.isEmpty()) {
+          return Result.COMPLETE;
+        }
+        if (!hasTime(startedAt, requestTimeoutNanos)) {
+          return Result.PARTIAL;
+        }
+        adapter.deleteBatch(batch);
+      }
+      return Result.PARTIAL;
+    }
+  }
+
+  private boolean hasTime(long startedAt, long requiredNanos) {
+    long elapsed = nanoTime.getAsLong() - startedAt;
+    return elapsed >= 0 && elapsed <= timeSliceNanos - requiredNanos;
+  }
+
+  private static long positiveNanos(Duration duration, String name) {
+    try {
+      long nanos = duration.toNanos();
+      if (nanos <= 0) {
+        throw new IllegalArgumentException(name + " must be positive");
+      }
+      return nanos;
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException(name + " is too large", e);
+    }
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/Repositories.java
@@ -33,6 +33,7 @@ public class Repositories {
   private final ExternalLocationRepository externalLocationRepository;
   private final DeltaCommitRepository deltaCommitRepository;
   private final DependencyRepository dependencyRepository;
+  private final StorageCleanupTaskRepository storageCleanupTaskRepository;
 
   private final KeyMapper keyMapper;
 
@@ -75,6 +76,7 @@ public class Repositories {
     this.deltaCommitRepository =
         new DeltaCommitRepository(sessionFactory, serverProperties, fileOperations);
     this.dependencyRepository = new DependencyRepository();
+    this.storageCleanupTaskRepository = new StorageCleanupTaskRepository(sessionFactory);
 
     // KeyMapper uses all the repositories above.
     this.keyMapper = new KeyMapper(this);

--- a/server/src/main/java/io/unitycatalog/server/persist/StorageCleanupTaskRepository.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/StorageCleanupTaskRepository.java
@@ -1,0 +1,192 @@
+package io.unitycatalog.server.persist;
+
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO;
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO.ResourceType;
+import io.unitycatalog.server.persist.utils.TransactionManager;
+import io.unitycatalog.server.utils.NormalizedURL;
+import io.unitycatalog.server.utils.ValidationUtils;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
+public class StorageCleanupTaskRepository {
+  private static final String LEASE_ERROR = "Lease duration must be at least one millisecond";
+  private final SessionFactory sessionFactory;
+
+  public StorageCleanupTaskRepository(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
+  }
+
+  public StorageCleanupTaskDAO createTask(
+      Session session,
+      ResourceType resourceType,
+      UUID resourceId,
+      String storageLocation,
+      Instant cleanableAt) {
+    String normalized = NormalizedURL.normalize(storageLocation);
+    StorageCleanupTaskDAO task =
+        StorageCleanupTaskDAO.builder()
+            .resourceType(resourceType)
+            .resourceId(resourceId)
+            .storageLocation(normalized)
+            .cleanableAt(cleanableAt)
+            .build();
+    session.persist(task);
+    return task;
+  }
+
+  public boolean hasPathOverlap(String storageLocation) {
+    String normalized = NormalizedURL.normalize(storageLocation);
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session ->
+            session
+                .createQuery(
+                    "FROM StorageCleanupTaskDAO WHERE storageLocation IN :ancestors "
+                        + "OR storageLocation LIKE :descendants ESCAPE '\\'",
+                    StorageCleanupTaskDAO.class)
+                .setParameter("ancestors", ancestors(normalized))
+                .setParameter(
+                    "descendants", escapeLike(normalized) + (normalized.endsWith("/") ? "%" : "/%"))
+                .getResultList()
+                .stream()
+                .anyMatch(task -> pathsOverlap(task.getStorageLocation(), normalized)),
+        "Failed to check storage cleanup path",
+        /* readOnly= */ true);
+  }
+
+  public Optional<StorageCleanupTaskDAO> findReadyTask(Instant now) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session ->
+            session
+                .createQuery(
+                    "FROM StorageCleanupTaskDAO WHERE cleanableAt <= :now "
+                        + "AND (leaseToken IS NULL OR leaseExpiresAt <= :now) ORDER BY cleanableAt",
+                    StorageCleanupTaskDAO.class)
+                .setParameter("now", now)
+                .setMaxResults(1)
+                .uniqueResultOptional(),
+        "Failed to find ready storage cleanup task",
+        /* readOnly= */ true);
+  }
+
+  public Optional<UUID> claimTask(UUID resourceId, Instant now, Duration leaseDuration) {
+    ValidationUtils.checkArgument(leaseDuration.compareTo(Duration.ofMillis(1)) >= 0, LEASE_ERROR);
+    UUID leaseToken = UUID.randomUUID();
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          int updated =
+              session
+                  .createMutationQuery(
+                      "UPDATE StorageCleanupTaskDAO SET leaseToken = :token, "
+                          + "leaseExpiresAt = :expires WHERE resourceId = :id "
+                          + "AND cleanableAt <= :now "
+                          + "AND (leaseToken IS NULL OR leaseExpiresAt <= :now)")
+                  .setParameter("token", leaseToken)
+                  .setParameter("expires", now.plus(leaseDuration))
+                  .setParameter("id", resourceId)
+                  .setParameter("now", now)
+                  .executeUpdate();
+          return updated == 1 ? Optional.of(leaseToken) : Optional.empty();
+        },
+        "Failed to claim storage cleanup task",
+        /* readOnly= */ false);
+  }
+
+  public boolean releaseIncomplete(UUID resourceId, UUID leaseToken, Instant now) {
+    return updateClaimedTask(
+        "SET leaseToken = NULL, leaseExpiresAt = NULL, cleanableAt = :cleanableAt",
+        resourceId,
+        leaseToken,
+        now,
+        now,
+        null);
+  }
+
+  public boolean recordFailure(
+      UUID resourceId, UUID leaseToken, Instant now, Duration backoff, String sanitizedError) {
+    return updateClaimedTask(
+        "SET leaseToken = NULL, leaseExpiresAt = NULL, failureCount = failureCount + 1, "
+            + "lastError = :error, cleanableAt = :cleanableAt",
+        resourceId,
+        leaseToken,
+        now,
+        now.plus(backoff),
+        sanitizedError == null
+            ? null
+            : sanitizedError.substring(0, Math.min(sanitizedError.length(), 2048)));
+  }
+
+  private boolean updateClaimedTask(
+      String update, UUID resourceId, UUID leaseToken, Instant now, Instant nextRun, String error) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session -> {
+          var query =
+              session.createMutationQuery(
+                  "UPDATE StorageCleanupTaskDAO "
+                      + update
+                      + " WHERE resourceId = :id AND leaseToken = :token "
+                      + "AND leaseExpiresAt > :now");
+          query.setParameter("id", resourceId);
+          query.setParameter("token", leaseToken);
+          query.setParameter("now", now);
+          query.setParameter("cleanableAt", nextRun);
+          if (update.contains(":error")) query.setParameter("error", error);
+          return query.executeUpdate() == 1;
+        },
+        "Failed to update storage cleanup task",
+        /* readOnly= */ false);
+  }
+
+  public boolean completeTask(UUID resourceId, UUID leaseToken, Instant now) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session ->
+            session
+                    .createMutationQuery(
+                        "DELETE FROM StorageCleanupTaskDAO WHERE resourceId = :id "
+                            + "AND leaseToken = :token AND leaseExpiresAt > :now")
+                    .setParameter("id", resourceId)
+                    .setParameter("token", leaseToken)
+                    .setParameter("now", now)
+                    .executeUpdate()
+                == 1,
+        "Failed to complete storage cleanup task",
+        /* readOnly= */ false);
+  }
+
+  private static List<String> ancestors(String location) {
+    List<String> result = new ArrayList<>();
+    result.add(location);
+    int schemeEnd = location.indexOf("://") + 3;
+    int pathStart = location.indexOf('/', schemeEnd);
+    if (pathStart >= 0) {
+      String root = location.substring(0, pathStart + (pathStart == schemeEnd ? 1 : 0));
+      result.add(root);
+      for (int slash = location.indexOf('/', pathStart + 1);
+          slash >= 0;
+          slash = location.indexOf('/', slash + 1)) {
+        result.add(location.substring(0, slash));
+      }
+    }
+    return result;
+  }
+
+  private static String escapeLike(String value) {
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+
+  private static boolean pathsOverlap(String first, String second) {
+    String firstPrefix = first + (first.endsWith("/") ? "" : "/");
+    String secondPrefix = second + (second.endsWith("/") ? "" : "/");
+    return first.equals(second) || first.startsWith(secondPrefix) || second.startsWith(firstPrefix);
+  }
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/dao/StorageCleanupTaskDAO.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/dao/StorageCleanupTaskDAO.java
@@ -1,0 +1,65 @@
+package io.unitycatalog.server.persist.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(
+    name = "uc_storage_cleanup_tasks",
+    indexes = {@Index(name = "uc_storage_cleanup_tasks_ready_idx", columnList = "cleanable_at")})
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StorageCleanupTaskDAO {
+  public enum ResourceType {
+    TABLE,
+    VOLUME,
+    REGISTERED_MODEL,
+    MODEL_VERSION,
+    STAGING_TABLE
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "resource_type", nullable = false)
+  private ResourceType resourceType;
+
+  @Id
+  @Column(name = "resource_id", updatable = false, nullable = false)
+  private UUID resourceId;
+
+  @Column(name = "storage_location", length = 4096, nullable = false)
+  private String storageLocation;
+
+  @JdbcTypeCode(SqlTypes.TIMESTAMP_UTC)
+  @Column(name = "cleanable_at", nullable = false)
+  private Instant cleanableAt;
+
+  @Column(name = "lease_token")
+  private UUID leaseToken;
+
+  @JdbcTypeCode(SqlTypes.TIMESTAMP_UTC)
+  @Column(name = "lease_expires_at")
+  private Instant leaseExpiresAt;
+
+  @Column(name = "failure_count", nullable = false)
+  private int failureCount;
+
+  @Column(name = "last_error", length = 2048)
+  private String lastError;
+}

--- a/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
+++ b/server/src/main/java/io/unitycatalog/server/persist/utils/HibernateConfigurator.java
@@ -14,6 +14,7 @@ import io.unitycatalog.server.persist.dao.PropertyDAO;
 import io.unitycatalog.server.persist.dao.RegisteredModelInfoDAO;
 import io.unitycatalog.server.persist.dao.SchemaInfoDAO;
 import io.unitycatalog.server.persist.dao.StagingTableDAO;
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO;
 import io.unitycatalog.server.persist.dao.TableInfoDAO;
 import io.unitycatalog.server.persist.dao.UserDAO;
 import io.unitycatalog.server.persist.dao.VolumeInfoDAO;
@@ -81,6 +82,7 @@ public class HibernateConfigurator {
       configuration.addAnnotatedClass(ExternalLocationDAO.class);
       configuration.addAnnotatedClass(DeltaCommitDAO.class);
       configuration.addAnnotatedClass(DependencyDAO.class);
+      configuration.addAnnotatedClass(StorageCleanupTaskDAO.class);
 
       ServiceRegistry serviceRegistry =
           new StandardServiceRegistryBuilder().applySettings(configuration.getProperties()).build();

--- a/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
+++ b/server/src/main/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGenerator.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.unitycatalog.server.service.credential.CredentialContext;
 import io.unitycatalog.server.utils.NormalizedURL;
-import java.net.URI;
+import io.unitycatalog.server.utils.NormalizedURL.S3Location;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -267,11 +267,11 @@ public class AwsPolicyGenerator {
 
   private static Map<String, List<String>> getBucketToPathsMap(List<NormalizedURL> locations) {
     return locations.stream()
-        .map(NormalizedURL::toUri)
+        .map(NormalizedURL::toS3Location)
         .collect(
             Collectors.toMap(
-                URI::getHost,
-                uri -> new LinkedList<>(List.of(uri.getPath())),
+                S3Location::bucket,
+                location -> new LinkedList<>(List.of(location.key())),
                 (map, newPaths) -> {
                   map.addAll(newPaths);
                   return map;

--- a/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
+++ b/server/src/main/java/io/unitycatalog/server/utils/NormalizedURL.java
@@ -236,6 +236,24 @@ public final class NormalizedURL {
     return path.substring(start, end);
   }
 
+  /** Returns the S3 bucket and textual object key without decoding percent escapes. */
+  public S3Location toS3Location() {
+    URI uri = toUri();
+    if (UriScheme.fromURI(uri) != UriScheme.S3) {
+      throw new IllegalArgumentException("S3 location requires an S3 URI");
+    }
+    String bucket = uri.getHost();
+    if (bucket == null || bucket.isBlank()) {
+      throw new IllegalArgumentException("S3 location requires a bucket");
+    }
+    String rawPath = uri.getRawPath();
+    String key = rawPath == null ? "" : rawPath.replaceFirst("^/+", "");
+    return new S3Location(bucket, key);
+  }
+
+  /** One S3 bucket and object key. */
+  public record S3Location(String bucket, String key) {}
+
   public NormalizedURL getStorageBase() {
     URI uri = URI.create(url);
     return NormalizedURL.from(uri.getScheme() + "://" + uri.getAuthority());

--- a/server/src/test/java/io/unitycatalog/server/cleanup/ADLSStorageCleanupAdapterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/cleanup/ADLSStorageCleanupAdapterTest.java
@@ -1,0 +1,198 @@
+package io.unitycatalog.server.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+class ADLSStorageCleanupAdapterTest {
+  private static final String ACCOUNT = "account.dfs.core.windows.net";
+  private static final String LOCATION = "abfss://container@" + ACCOUNT + "/root/table";
+  private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+  private DataLakeFileSystemClient client;
+  private ADLSStorageCleanupAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    client = mock(DataLakeFileSystemClient.class);
+    adapter = adapter(client, LOCATION, TIMEOUT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abfs", "abfss"})
+  void deletesOneExactDirectoryRecursively(String scheme) {
+    String location = scheme + "://container@" + ACCOUNT + "/root/table";
+    adapter = adapter(client, location, TIMEOUT);
+
+    assertThat(adapter.listBatch(10)).containsExactly(location);
+    StorageCleanupAttempt.Result result =
+        new StorageCleanupAttempt(10, Duration.ofSeconds(30), TIMEOUT).run(adapter);
+
+    assertThat(result).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+    assertThat(adapter.listBatch(10)).isEmpty();
+
+    ArgumentCaptor<DataLakePathDeleteOptions> options =
+        ArgumentCaptor.forClass(DataLakePathDeleteOptions.class);
+    verify(client)
+        .deleteDirectoryIfExistsWithResponse(
+            eq("root/table"), options.capture(), eq(TIMEOUT), same(Context.NONE));
+    assertThat(options.getValue().getIsRecursive()).isTrue();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void missingDirectoryIsSuccessAndANewAttemptCanRepeatDelete() {
+    Response<Boolean> missing = mock(Response.class);
+    when(missing.getValue()).thenReturn(false);
+    when(client.deleteDirectoryIfExistsWithResponse(
+            anyString(),
+            any(DataLakePathDeleteOptions.class),
+            any(Duration.class),
+            any(Context.class)))
+        .thenReturn(missing);
+
+    adapter.deleteBatch(adapter.listBatch(1));
+    assertThat(adapter.listBatch(1)).isEmpty();
+    ADLSStorageCleanupAdapter retry = adapter(client, LOCATION, TIMEOUT);
+    retry.deleteBatch(retry.listBatch(1));
+
+    verify(client, times(2))
+        .deleteDirectoryIfExistsWithResponse(
+            anyString(),
+            any(DataLakePathDeleteOptions.class),
+            any(Duration.class),
+            any(Context.class));
+  }
+
+  @Test
+  void propagatesStorageAndTimeoutFailures() {
+    DataLakeStorageException storageFailure = mock(DataLakeStorageException.class);
+    RuntimeException timeoutFailure = new RuntimeException("timed out");
+    when(client.deleteDirectoryIfExistsWithResponse(
+            anyString(),
+            any(DataLakePathDeleteOptions.class),
+            any(Duration.class),
+            any(Context.class)))
+        .thenThrow(storageFailure)
+        .thenThrow(timeoutFailure);
+
+    assertThatThrownBy(() -> adapter.deleteBatch(adapter.listBatch(1))).isSameAs(storageFailure);
+    assertThat(adapter.listBatch(1)).containsExactly(LOCATION);
+    ADLSStorageCleanupAdapter retry = adapter(client, LOCATION, TIMEOUT);
+    assertThatThrownBy(() -> retry.deleteBatch(retry.listBatch(1))).isSameAs(timeoutFailure);
+  }
+
+  @Test
+  void rejectsInvalidLocations() {
+    for (String location :
+        List.of(
+            "s3://container@account.dfs.core.windows.net/root/table",
+            "abfss://account.dfs.core.windows.net/root/table",
+            "abfss://container@.dfs.core.windows.net/root/table",
+            "abfss://container@account.dfs.core.windows.net/")) {
+      assertThatThrownBy(() -> adapter(client, location, TIMEOUT))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("ADLS cleanup requires an abfs or abfss directory location");
+    }
+  }
+
+  @Test
+  void validatesBatchSizeAndExactLocation() {
+    for (int limit : List.of(0, -1)) {
+      assertThatThrownBy(() -> adapter.listBatch(limit))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Cleanup batch size must be positive");
+    }
+    assertThatCode(() -> adapter.deleteBatch(List.of())).doesNotThrowAnyException();
+    for (List<String> locations :
+        List.of(
+            List.of("abfss://container@" + ACCOUNT + "/root/table-other"),
+            List.of(LOCATION + "/child"),
+            List.of("abfss://other@" + ACCOUNT + "/root/table"),
+            List.of("abfss://container@other.dfs.core.windows.net/root/table"),
+            List.of(LOCATION, LOCATION))) {
+      assertThatThrownBy(() -> adapter.deleteBatch(locations))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("ADLS cleanup can delete only its exact task directory");
+    }
+    verify(client, never())
+        .deleteDirectoryIfExistsWithResponse(
+            anyString(),
+            any(DataLakePathDeleteOptions.class),
+            any(Duration.class),
+            any(Context.class));
+  }
+
+  @Test
+  void rejectsInvalidTimeouts() {
+    for (Duration timeout :
+        List.of(
+            Duration.ZERO,
+            Duration.ofMillis(-1),
+            Duration.ofNanos(999_999),
+            Duration.ofSeconds((long) Integer.MAX_VALUE + 1))) {
+      assertThatThrownBy(() -> adapter(client, LOCATION, timeout))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageStartingWith("ADLS request timeout must be between 1 and ");
+    }
+    assertThatThrownBy(() -> adapter(client, LOCATION, Duration.ofSeconds(Long.MAX_VALUE)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("ADLS request timeout is too large");
+  }
+
+  @Test
+  void buildsClientFromExactEndpointSasAndPerTryTimeout() {
+    DataLakeFileSystemClient builtClient = mock(DataLakeFileSystemClient.class);
+    try (MockedConstruction<DataLakeFileSystemClientBuilder> construction =
+        Mockito.mockConstruction(
+            DataLakeFileSystemClientBuilder.class,
+            (builder, context) -> {
+              when(builder.endpoint(anyString())).thenReturn(builder);
+              when(builder.sasToken(anyString())).thenReturn(builder);
+              when(builder.retryOptions(any(RequestRetryOptions.class))).thenReturn(builder);
+              when(builder.buildClient()).thenReturn(builtClient);
+            })) {
+      new ADLSStorageCleanupAdapter("sas-token", NormalizedURL.from(LOCATION), TIMEOUT);
+
+      DataLakeFileSystemClientBuilder builder = construction.constructed().get(0);
+      verify(builder).endpoint("https://" + ACCOUNT + "/container");
+      verify(builder).sasToken("sas-token");
+      ArgumentCaptor<RequestRetryOptions> retry =
+          ArgumentCaptor.forClass(RequestRetryOptions.class);
+      verify(builder).retryOptions(retry.capture());
+      assertThat(retry.getValue().getTryTimeoutDuration()).isEqualTo(TIMEOUT);
+    }
+  }
+
+  private static ADLSStorageCleanupAdapter adapter(
+      DataLakeFileSystemClient client, String location, Duration timeout) {
+    return new ADLSStorageCleanupAdapter(client, NormalizedURL.from(location), timeout);
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/cleanup/GCSStorageCleanupAdapterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/cleanup/GCSStorageCleanupAdapterTest.java
@@ -1,0 +1,281 @@
+package io.unitycatalog.server.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.paging.Page;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.auth.Credentials;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.HttpStorageOptions;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
+import com.google.cloud.storage.StorageException;
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class GCSStorageCleanupAdapterTest {
+  private static final String BUCKET = "bucket";
+  private static final String KEY = "root/table";
+  private static final String PREFIX = KEY + "/";
+  private static final String LOCATION = "gs://" + BUCKET + "/" + KEY;
+
+  private Storage storage;
+  private StorageBatch batch;
+  private GCSStorageCleanupAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    storage = mock(Storage.class);
+    batch = mock(StorageBatch.class);
+    adapter = new GCSStorageCleanupAdapter(storage, NormalizedURL.from(LOCATION));
+  }
+
+  @Test
+  void listsOnlyTheCurrentBoundedPage() {
+    Page<Blob> page = page(PREFIX + "a", PREFIX + "b", PREFIX + "c");
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenReturn(page);
+
+    assertThat(adapter.listBatch(2)).containsExactly(LOCATION + "/a", LOCATION + "/b");
+
+    assertThat(captureListOptions())
+        .containsExactly(BlobListOption.prefix(PREFIX), BlobListOption.pageSize(2));
+    verify(page).getValues();
+    verify(page, never()).iterateAll();
+    verify(page, never()).getNextPage();
+    verify(page, never()).getNextPageToken();
+  }
+
+  @Test
+  void capsAndValidatesListBatchSize() {
+    Page<Blob> page = page(PREFIX + "a");
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenReturn(page);
+
+    assertThat(adapter.listBatch(101)).containsExactly(LOCATION + "/a");
+    assertThat(captureListOptions())
+        .containsExactly(BlobListOption.prefix(PREFIX), BlobListOption.pageSize(100));
+    for (int limit : List.of(0, -1)) {
+      assertThatThrownBy(() -> adapter.listBatch(limit))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Cleanup batch size must be positive");
+    }
+    verify(storage).list(eq(BUCKET), any(BlobListOption[].class));
+  }
+
+  @Test
+  void deletesDescendantsWithOneStorageBatch() {
+    StorageBatchResult<Boolean> result = deleteResult(true);
+
+    adapter.deleteBatch(List.of(LOCATION + "/a", LOCATION + "/nested/b"));
+
+    ArgumentCaptor<BlobId> ids = ArgumentCaptor.forClass(BlobId.class);
+    verify(batch, times(2)).delete(ids.capture());
+    assertThat(ids.getAllValues())
+        .containsExactly(BlobId.of(BUCKET, PREFIX + "a"), BlobId.of(BUCKET, PREFIX + "nested/b"));
+    verify(batch).submit();
+    verify(result, times(2)).get();
+  }
+
+  @Test
+  void deletesExactKeyAfterDescendants() {
+    Page<Blob> descendants = page(PREFIX + "child");
+    Page<Blob> empty = page();
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class)))
+        .thenReturn(descendants)
+        .thenReturn(empty);
+    deleteResult(true);
+
+    StorageCleanupAttempt.Result result =
+        new StorageCleanupAttempt(10, Duration.ofSeconds(30), Duration.ofSeconds(3)).run(adapter);
+
+    assertThat(result).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+    ArgumentCaptor<BlobId> ids = ArgumentCaptor.forClass(BlobId.class);
+    verify(batch, times(2)).delete(ids.capture());
+    assertThat(ids.getAllValues())
+        .containsExactly(BlobId.of(BUCKET, PREFIX + "child"), BlobId.of(BUCKET, KEY));
+    verify(storage, times(2)).list(eq(BUCKET), any(BlobListOption[].class));
+  }
+
+  @Test
+  void treatsMissingExactKeyAsDeleted() {
+    Page<Blob> empty = page();
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenReturn(empty);
+    deleteResult(false);
+
+    assertThat(adapter.listBatch(10)).containsExactly(LOCATION);
+    assertThatCode(() -> adapter.deleteBatch(List.of(LOCATION))).doesNotThrowAnyException();
+    assertThat(adapter.listBatch(10)).isEmpty();
+
+    verify(batch).delete(BlobId.of(BUCKET, KEY));
+    verify(storage).list(eq(BUCKET), any(BlobListOption[].class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void newAttemptRepeatsExactKeyDeleteAfterFailure() {
+    Page<Blob> empty = page();
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenReturn(empty);
+    StorageBatchResult<Boolean> failed = mock(StorageBatchResult.class);
+    StorageBatchResult<Boolean> retried = mock(StorageBatchResult.class);
+    when(storage.batch()).thenReturn(batch);
+    when(batch.delete(any(BlobId.class))).thenReturn(failed).thenReturn(retried);
+    StorageException failure = new StorageException(500, "failed");
+    when(failed.get()).thenThrow(failure);
+    when(retried.get()).thenReturn(true);
+
+    List<String> firstBatch = adapter.listBatch(10);
+    assertThatThrownBy(() -> adapter.deleteBatch(firstBatch)).isSameAs(failure);
+    GCSStorageCleanupAdapter retryAdapter =
+        new GCSStorageCleanupAdapter(storage, NormalizedURL.from(LOCATION));
+    List<String> retryBatch = retryAdapter.listBatch(10);
+    retryAdapter.deleteBatch(retryBatch);
+
+    assertThat(firstBatch).containsExactly(LOCATION);
+    assertThat(retryBatch).containsExactly(LOCATION);
+    verify(batch, times(2)).delete(BlobId.of(BUCKET, KEY));
+  }
+
+  @Test
+  void rejectsDeletionOutsideExactPrefix() {
+    for (String location :
+        List.of("gs://bucket/root/table-other/file", "gs://other/root/table/file")) {
+      assertThatThrownBy(() -> adapter.deleteBatch(List.of(location)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("GCS cleanup cannot delete outside its task prefix");
+    }
+    assertThatThrownBy(() -> adapter.deleteBatch(Collections.nCopies(101, LOCATION + "/file")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("GCS cleanup batch cannot exceed 100 objects");
+    verify(storage, never()).batch();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rejectsListedObjectOutsideExactPrefix() {
+    Page<Blob> page = mock(Page.class);
+    Blob outside = blob("other", PREFIX + "file");
+    when(page.getValues()).thenReturn(List.of(outside));
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenReturn(page);
+
+    assertThatThrownBy(() -> adapter.listBatch(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("GCS listed an object outside the cleanup prefix");
+  }
+
+  @Test
+  void propagatesStorageFailures() {
+    StorageException listFailure = new StorageException(500, "list failed");
+    when(storage.list(eq(BUCKET), any(BlobListOption[].class))).thenThrow(listFailure);
+    assertThatThrownBy(() -> adapter.listBatch(1)).isSameAs(listFailure);
+
+    StorageBatchResult<Boolean> result = deleteResult(true);
+    StorageException deleteFailure = new StorageException(500, "delete failed");
+    when(result.get()).thenThrow(deleteFailure);
+    assertThatThrownBy(() -> adapter.deleteBatch(List.of(LOCATION))).isSameAs(deleteFailure);
+  }
+
+  @Test
+  void configuresRetryAndHttpTimeouts() {
+    Credentials credentials = mock(Credentials.class);
+
+    HttpStorageOptions options =
+        GCSStorageCleanupAdapter.storageOptions(credentials, Duration.ofSeconds(3));
+
+    assertThat(options.getCredentials()).isSameAs(credentials);
+    RetrySettings retry = options.getRetrySettings();
+    org.threeten.bp.Duration timeout = org.threeten.bp.Duration.ofSeconds(3);
+    assertThat(retry.getInitialRpcTimeout()).isEqualTo(timeout);
+    assertThat(retry.getMaxRpcTimeout()).isEqualTo(timeout);
+    assertThat(retry.getRpcTimeoutMultiplier()).isEqualTo(1.0);
+    assertThat(retry.getTotalTimeout()).isEqualTo(timeout);
+    HttpTransportOptions transport = (HttpTransportOptions) options.getTransportOptions();
+    assertThat(transport.getConnectTimeout()).isEqualTo(3000);
+    assertThat(transport.getReadTimeout()).isEqualTo(3000);
+  }
+
+  @Test
+  void rejectsInvalidTimeouts() {
+    Credentials credentials = mock(Credentials.class);
+    for (Duration timeout :
+        List.of(
+            Duration.ZERO,
+            Duration.ofMillis(-1),
+            Duration.ofNanos(999_999),
+            Duration.ofMillis((long) Integer.MAX_VALUE + 1))) {
+      assertThatThrownBy(() -> GCSStorageCleanupAdapter.storageOptions(credentials, timeout))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("GCS request timeout must be between 1 and 2147483647 milliseconds");
+    }
+    assertThatThrownBy(
+            () ->
+                GCSStorageCleanupAdapter.storageOptions(
+                    credentials, Duration.ofSeconds(Long.MAX_VALUE)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("GCS request timeout is too large");
+  }
+
+  @Test
+  void rejectsInvalidLocationAndDoesNotCloseStorage() throws Exception {
+    assertThatThrownBy(
+            () -> new GCSStorageCleanupAdapter(storage, NormalizedURL.from("s3://bucket/path")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("GCS cleanup requires a GCS storage location");
+    assertThatThrownBy(
+            () -> new GCSStorageCleanupAdapter(storage, NormalizedURL.from("gs://bucket")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("GCS cleanup requires a bucket and object prefix");
+
+    adapter.close();
+    verify(storage, never()).close();
+  }
+
+  private BlobListOption[] captureListOptions() {
+    ArgumentCaptor<BlobListOption[]> options = ArgumentCaptor.forClass(BlobListOption[].class);
+    verify(storage).list(eq(BUCKET), options.capture());
+    return options.getValue();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Page<Blob> page(String... names) {
+    List<Blob> blobs = java.util.Arrays.stream(names).map(this::blob).toList();
+    Page<Blob> page = mock(Page.class);
+    when(page.getValues()).thenReturn(blobs);
+    return page;
+  }
+
+  private Blob blob(String name) {
+    return blob(BUCKET, name);
+  }
+
+  private Blob blob(String bucket, String name) {
+    Blob blob = mock(Blob.class);
+    when(blob.getBlobId()).thenReturn(BlobId.of(bucket, name));
+    return blob;
+  }
+
+  @SuppressWarnings("unchecked")
+  private StorageBatchResult<Boolean> deleteResult(boolean deleted) {
+    StorageBatchResult<Boolean> result = mock(StorageBatchResult.class);
+    when(storage.batch()).thenReturn(batch);
+    when(batch.delete(any(BlobId.class))).thenReturn(result);
+    when(result.get()).thenReturn(deleted);
+    return result;
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/cleanup/S3StorageCleanupAdapterTest.java
+++ b/server/src/test/java/io/unitycatalog/server/cleanup/S3StorageCleanupAdapterTest.java
@@ -1,0 +1,291 @@
+package io.unitycatalog.server.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+class S3StorageCleanupAdapterTest {
+  private static final Duration TIMEOUT = Duration.ofSeconds(3);
+  private static final String PREFIX = "root/table/";
+  private static final String LOCATION = "s3://bucket/root/table";
+
+  private S3Client client;
+  private S3StorageCleanupAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    client = mock(S3Client.class);
+    adapter = new S3StorageCleanupAdapter(client, NormalizedURL.from(LOCATION), TIMEOUT);
+  }
+
+  @Test
+  void listsOneMaterializedExactBatch() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(
+            ListObjectsV2Response.builder()
+                .contents(object(PREFIX + "a"), object(PREFIX + "b"), object(PREFIX + "c"))
+                .nextContinuationToken("not-used")
+                .build());
+
+    assertThat(adapter.listBatch(2))
+        .containsExactly("s3://bucket/root/table/a", "s3://bucket/root/table/b");
+
+    ListObjectsV2Request request = captureListRequest();
+    assertThat(request.bucket()).isEqualTo("bucket");
+    assertThat(request.prefix()).isEqualTo(PREFIX);
+    assertThat(request.maxKeys()).isEqualTo(2);
+    assertThat(request.continuationToken()).isNull();
+    assertTimeouts(request.overrideConfiguration().orElseThrow());
+  }
+
+  @Test
+  void capsAndValidatesListBatchSize() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().contents(object(PREFIX + "a")).build());
+
+    assertThat(adapter.listBatch(1001)).containsExactly(LOCATION + "/a");
+    assertThat(captureListRequest().maxKeys()).isEqualTo(1000);
+    for (int limit : List.of(0, -1)) {
+      assertThatThrownBy(() -> adapter.listBatch(limit))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Cleanup batch size must be positive");
+    }
+    verify(client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
+  @Test
+  void deletesOnlyExpectedKeysWithTimeouts() {
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    adapter.deleteBatch(List.of("s3://bucket/root/table/a", "s3://bucket/root/table/nested/b"));
+
+    DeleteObjectsRequest request = captureDeleteRequest();
+    assertThat(request.bucket()).isEqualTo("bucket");
+    assertThat(request.delete().objects())
+        .extracting(object -> object.key())
+        .containsExactly("root/table/a", "root/table/nested/b");
+    assertTimeouts(request.overrideConfiguration().orElseThrow());
+  }
+
+  @Test
+  void rejectsDeletionOutsideExactPrefix() {
+    for (String location :
+        List.of("s3://bucket/root/table-other/file", "s3://other/root/table/file")) {
+      assertThatThrownBy(() -> adapter.deleteBatch(List.of(location)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("S3 cleanup cannot delete outside its task prefix");
+    }
+    assertThatThrownBy(
+            () ->
+                adapter.deleteBatch(
+                    java.util.Collections.nCopies(1001, "s3://bucket/root/table/file")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("S3 cleanup batch cannot exceed 1000 objects");
+    verify(client, never()).deleteObjects(any(DeleteObjectsRequest.class));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"%20", "%2A", "%3F", "%25"})
+  void preservesEncodedKeys(String encodedKey) {
+    String key = "root/" + encodedKey;
+    S3StorageCleanupAdapter encodedAdapter =
+        new S3StorageCleanupAdapter(client, NormalizedURL.from("s3://bucket/" + key), TIMEOUT);
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().contents(object(key + "/child")).build());
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    List<String> batch = encodedAdapter.listBatch(1);
+    encodedAdapter.deleteBatch(batch);
+
+    assertThat(captureListRequest().prefix()).isEqualTo(key + "/");
+    assertThat(batch).containsExactly("s3://bucket/" + key + "/child");
+    assertThat(captureDeleteRequest().delete().objects())
+        .extracting(object -> object.key())
+        .containsExactly(key + "/child");
+  }
+
+  @Test
+  void rejectsListedObjectOutsideExactPrefix() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(
+            ListObjectsV2Response.builder().contents(object("root/table-other/file")).build());
+
+    assertThatThrownBy(() -> adapter.listBatch(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("S3 listed an object outside the cleanup prefix");
+  }
+
+  @Test
+  void reportsEveryPerObjectDeleteError() {
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(
+            DeleteObjectsResponse.builder()
+                .errors(
+                    S3Error.builder().key(PREFIX + "a").code("AccessDenied").build(),
+                    S3Error.builder().key(PREFIX + "b").code("InternalError").build())
+                .build());
+
+    assertThatThrownBy(
+            () ->
+                adapter.deleteBatch(
+                    List.of("s3://bucket/root/table/a", "s3://bucket/root/table/b")))
+        .isInstanceOf(SdkClientException.class)
+        .hasMessageContaining("root/table/a (AccessDenied)")
+        .hasMessageContaining("root/table/b (InternalError)");
+  }
+
+  @Test
+  void deletesExactKeyAfterDescendants() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(
+            ListObjectsV2Response.builder().contents(object(PREFIX + "child")).build(),
+            ListObjectsV2Response.builder().build());
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    StorageCleanupAttempt.Result result =
+        new StorageCleanupAttempt(10, Duration.ofSeconds(30), TIMEOUT).run(adapter);
+
+    assertThat(result).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+    ArgumentCaptor<DeleteObjectsRequest> requests =
+        ArgumentCaptor.forClass(DeleteObjectsRequest.class);
+    verify(client, times(2)).deleteObjects(requests.capture());
+    assertThat(requests.getAllValues())
+        .extracting(request -> request.delete().objects().get(0).key())
+        .containsExactly(PREFIX + "child", "root/table");
+    verify(client, times(2)).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
+  @Test
+  void treatsMissingExactKeyAsDeleted() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().build());
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    assertThat(adapter.listBatch(10)).containsExactly(LOCATION);
+    adapter.deleteBatch(List.of(LOCATION));
+    assertThat(adapter.listBatch(10)).isEmpty();
+
+    assertThat(captureDeleteRequest().delete().objects())
+        .extracting(object -> object.key())
+        .containsExactly("root/table");
+    verify(client).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
+  @Test
+  void newAttemptRepeatsExactKeyDeleteAfterFailure() {
+    when(client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().build());
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(
+            DeleteObjectsResponse.builder()
+                .errors(S3Error.builder().key("root/table").code("InternalError").build())
+                .build(),
+            DeleteObjectsResponse.builder().build());
+
+    List<String> firstBatch = adapter.listBatch(10);
+    assertThatThrownBy(() -> adapter.deleteBatch(firstBatch))
+        .isInstanceOf(SdkClientException.class);
+    S3StorageCleanupAdapter retryAdapter =
+        new S3StorageCleanupAdapter(client, NormalizedURL.from(LOCATION), TIMEOUT);
+    List<String> retryBatch = retryAdapter.listBatch(10);
+    retryAdapter.deleteBatch(retryBatch);
+
+    assertThat(firstBatch).containsExactly(LOCATION);
+    assertThat(retryBatch).containsExactly(LOCATION);
+
+    ArgumentCaptor<DeleteObjectsRequest> requests =
+        ArgumentCaptor.forClass(DeleteObjectsRequest.class);
+    verify(client, times(2)).deleteObjects(requests.capture());
+    assertThat(requests.getAllValues())
+        .allSatisfy(
+            request ->
+                assertThat(request.delete().objects())
+                    .extracting(object -> object.key())
+                    .containsExactly("root/table"));
+  }
+
+  @Test
+  void propagatesSdkFailure() {
+    SdkClientException failure = SdkClientException.create("list failed");
+    when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(failure);
+
+    assertThatThrownBy(() -> adapter.listBatch(1)).isSameAs(failure);
+  }
+
+  @Test
+  void rejectsInvalidLocationAndTimeout() {
+    assertThatThrownBy(
+            () ->
+                new S3StorageCleanupAdapter(
+                    client, NormalizedURL.from("gs://bucket/path"), TIMEOUT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("S3 cleanup requires an S3 storage location");
+    assertThatThrownBy(
+            () -> new S3StorageCleanupAdapter(client, NormalizedURL.from("s3://bucket"), TIMEOUT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("S3 cleanup requires a bucket and object prefix");
+    assertThatThrownBy(
+            () ->
+                new S3StorageCleanupAdapter(
+                    client, NormalizedURL.from(LOCATION), Duration.ofNanos(999_999)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("S3 request timeout must be at least one millisecond");
+  }
+
+  @Test
+  void closesSuppliedClient() {
+    adapter.close();
+
+    verify(client).close();
+  }
+
+  private ListObjectsV2Request captureListRequest() {
+    ArgumentCaptor<ListObjectsV2Request> request =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    verify(client).listObjectsV2(request.capture());
+    return request.getValue();
+  }
+
+  private DeleteObjectsRequest captureDeleteRequest() {
+    ArgumentCaptor<DeleteObjectsRequest> request =
+        ArgumentCaptor.forClass(DeleteObjectsRequest.class);
+    verify(client).deleteObjects(request.capture());
+    return request.getValue();
+  }
+
+  private static void assertTimeouts(RequestOverrideConfiguration configuration) {
+    assertThat(configuration.apiCallTimeout()).contains(TIMEOUT);
+    assertThat(configuration.apiCallAttemptTimeout()).contains(TIMEOUT);
+  }
+
+  private static S3Object object(String key) {
+    return S3Object.builder().key(key).build();
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/cleanup/StorageCleanupAttemptTest.java
+++ b/server/src/test/java/io/unitycatalog/server/cleanup/StorageCleanupAttemptTest.java
@@ -1,0 +1,184 @@
+package io.unitycatalog.server.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.unitycatalog.server.utils.NormalizedURL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+
+class StorageCleanupAttemptTest {
+  private static final int BATCH_SIZE = 2;
+  private static final Duration TIME_SLICE = Duration.ofNanos(100);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofNanos(30);
+
+  @TempDir Path tempDir;
+
+  @Test
+  void deletesBatchesUntilStorageIsEmpty() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+    when(adapter.listBatch(BATCH_SIZE))
+        .thenReturn(List.of("a", "b"))
+        .thenReturn(List.of("c"))
+        .thenReturn(List.of());
+
+    StorageCleanupAttempt.Result result = attempt(() -> 0L).run(adapter);
+
+    assertThat(result).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+    InOrder calls = inOrder(adapter);
+    calls.verify(adapter).listBatch(BATCH_SIZE);
+    calls.verify(adapter).deleteBatch(List.of("a", "b"));
+    calls.verify(adapter).listBatch(BATCH_SIZE);
+    calls.verify(adapter).deleteBatch(List.of("c"));
+    calls.verify(adapter).listBatch(BATCH_SIZE);
+    calls.verify(adapter).close();
+    verifyNoMoreInteractions(adapter);
+  }
+
+  @Test
+  void doesNotListWithoutTimeForListAndDelete() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+
+    assertThat(attempt(times(0, 41)).run(adapter)).isEqualTo(StorageCleanupAttempt.Result.PARTIAL);
+    verify(adapter, never()).listBatch(BATCH_SIZE);
+    verify(adapter).close();
+  }
+
+  @Test
+  void doesNotDeleteWithoutTimeForOneRequest() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+    when(adapter.listBatch(BATCH_SIZE)).thenReturn(List.of("a"));
+
+    assertThat(attempt(times(0, 0, 71)).run(adapter))
+        .isEqualTo(StorageCleanupAttempt.Result.PARTIAL);
+    verify(adapter, never()).deleteBatch(List.of("a"));
+    verify(adapter).close();
+  }
+
+  @Test
+  void successfulDeleteDoesNotExtendTheTimeSlice() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+    when(adapter.listBatch(BATCH_SIZE)).thenReturn(List.of("a"));
+
+    assertThat(attempt(times(0, 0, 0, 41)).run(adapter))
+        .isEqualTo(StorageCleanupAttempt.Result.PARTIAL);
+    verify(adapter).deleteBatch(List.of("a"));
+    verify(adapter).close();
+  }
+
+  @Test
+  void propagatesStorageFailureAndClosesAdapter() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+    when(adapter.listBatch(BATCH_SIZE)).thenReturn(List.of("a"));
+    doThrow(new IllegalStateException("delete failed")).when(adapter).deleteBatch(List.of("a"));
+
+    assertThatThrownBy(() -> attempt(() -> 0L).run(adapter))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("delete failed");
+    verify(adapter).close();
+  }
+
+  @Test
+  void propagatesListingFailureAndClosesAdapter() {
+    StorageCleanupAdapter adapter = mock(StorageCleanupAdapter.class);
+    when(adapter.listBatch(BATCH_SIZE)).thenThrow(new IllegalStateException("list failed"));
+
+    assertThatThrownBy(() -> attempt(() -> 0L).run(adapter))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("list failed");
+    verify(adapter).close();
+  }
+
+  @Test
+  void rejectsInvalidLimits() {
+    assertThatThrownBy(() -> new StorageCleanupAttempt(0, TIME_SLICE, REQUEST_TIMEOUT, () -> 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cleanup batch size must be positive");
+    assertThatThrownBy(
+            () -> new StorageCleanupAttempt(BATCH_SIZE, Duration.ZERO, REQUEST_TIMEOUT, () -> 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cleanup time slice must be positive");
+    assertThatThrownBy(
+            () -> new StorageCleanupAttempt(BATCH_SIZE, TIME_SLICE, Duration.ofNanos(51), () -> 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cleanup time slice must allow one list and delete request");
+  }
+
+  @Test
+  void localAdapterDeletesBoundedBatches() throws Exception {
+    Files.createDirectories(tempDir.resolve("nested"));
+    Files.writeString(tempDir.resolve("a"), "a");
+    Files.writeString(tempDir.resolve("nested/b"), "b");
+    Files.writeString(tempDir.resolve("nested/c"), "c");
+
+    LocalStorageCleanupAdapter adapter =
+        new LocalStorageCleanupAdapter(NormalizedURL.from(tempDir.toUri().toString()));
+    assertThat(adapter.listBatch(BATCH_SIZE)).hasSize(BATCH_SIZE);
+
+    StorageCleanupAttempt.Result result = attempt(() -> 0L).run(adapter);
+
+    assertThat(result).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+    assertThat(tempDir.resolve("a")).doesNotExist();
+    assertThat(tempDir.resolve("nested/b")).doesNotExist();
+    assertThat(tempDir.resolve("nested/c")).doesNotExist();
+  }
+
+  @Test
+  void localAdapterTreatsMissingStorageAndFilesAsDeleted() throws Exception {
+    LocalStorageCleanupAdapter missing =
+        new LocalStorageCleanupAdapter(
+            NormalizedURL.from(tempDir.resolve("missing").toUri().toString()));
+    assertThat(attempt(() -> 0L).run(missing)).isEqualTo(StorageCleanupAttempt.Result.COMPLETE);
+
+    Path file = tempDir.resolve("file");
+    Files.writeString(file, "data");
+    LocalStorageCleanupAdapter adapter =
+        new LocalStorageCleanupAdapter(NormalizedURL.from(tempDir.toUri().toString()));
+    List<String> batch = adapter.listBatch(1);
+    Files.delete(file);
+    assertThatCode(() -> adapter.deleteBatch(batch)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void localAdapterRejectsCloudLocation() {
+    assertThatThrownBy(() -> new LocalStorageCleanupAdapter(NormalizedURL.from("s3://bucket/path")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Local cleanup requires a local storage location");
+  }
+
+  @Test
+  void localAdapterRejectsInvalidBatchLimits() {
+    LocalStorageCleanupAdapter adapter =
+        new LocalStorageCleanupAdapter(NormalizedURL.from(tempDir.toUri().toString()));
+
+    for (int maxFiles : List.of(0, -1)) {
+      assertThatThrownBy(() -> adapter.listBatch(maxFiles))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Maximum files must be positive");
+    }
+  }
+
+  private static StorageCleanupAttempt attempt(LongSupplier nanoTime) {
+    return new StorageCleanupAttempt(BATCH_SIZE, TIME_SLICE, REQUEST_TIMEOUT, nanoTime);
+  }
+
+  private static LongSupplier times(long... values) {
+    AtomicInteger next = new AtomicInteger();
+    return () -> values[Math.min(next.getAndIncrement(), values.length - 1)];
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/StorageCleanupTaskRepositoryTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/StorageCleanupTaskRepositoryTest.java
@@ -1,0 +1,255 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.exception.BaseException;
+import io.unitycatalog.server.exception.ErrorCode;
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO;
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO.ResourceType;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import io.unitycatalog.server.persist.utils.TransactionManager;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StorageCleanupTaskRepositoryTest {
+  private static final Instant NOW = Instant.parse("2026-09-08T12:00:00Z");
+
+  private SessionFactory sessionFactory;
+  private StorageCleanupTaskRepository repository;
+
+  protected void configureDatabase(Properties properties) {
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+  }
+
+  @BeforeEach
+  void setUpRepository() {
+    Properties properties = new Properties();
+    configureDatabase(properties);
+    properties.setProperty("hibernate.hbm2ddl.auto", "create-drop");
+    properties.setProperty("hibernate.show_sql", "false");
+    sessionFactory = new HibernateConfigurator(properties).getSessionFactory();
+    repository = new StorageCleanupTaskRepository(sessionFactory);
+  }
+
+  @AfterEach
+  void closeSessionFactory() {
+    sessionFactory.close();
+  }
+
+  @Test
+  void createsNormalizedTaskAndFindsPathOverlaps() {
+    StorageCleanupTaskDAO task = create("s3://bucket/a/unused/../b/c///", NOW);
+
+    assertThat(task.getStorageLocation()).isEqualTo("s3://bucket/a/b/c");
+    assertThat(repository.hasPathOverlap("s3://bucket/a/b")).isTrue();
+    assertThat(repository.hasPathOverlap("s3://bucket/a/b/c/")).isTrue();
+    assertThat(repository.hasPathOverlap("s3://bucket/a/b/c/child")).isTrue();
+    assertThat(repository.hasPathOverlap("s3://bucket/a/b/d")).isFalse();
+    assertThat(repository.hasPathOverlap("s3://bucket/A/b/c")).isFalse();
+  }
+
+  @Test
+  void createsTaskInCallerTransaction() {
+    UUID resourceId = UUID.randomUUID();
+
+    assertThatThrownBy(
+            () ->
+                TransactionManager.executeWithTransaction(
+                    sessionFactory,
+                    session -> {
+                      repository.createTask(
+                          session, ResourceType.TABLE, resourceId, "s3://bucket/path", NOW);
+                      throw new IllegalStateException("rollback");
+                    },
+                    "Expected rollback",
+                    /* readOnly= */ false))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(find(resourceId)).isEmpty();
+  }
+
+  @Test
+  void findsLongPathOverlapsUsingFullLocation() {
+    String commonPrefix = "s3://bucket/" + "a".repeat(800);
+    String location = commonPrefix + "/stored";
+    StorageCleanupTaskDAO task = create(location, NOW);
+
+    assertThat(task.getStorageLocation()).isEqualTo(location);
+    assertThat(repository.hasPathOverlap(commonPrefix)).isTrue();
+    assertThat(repository.hasPathOverlap(location)).isTrue();
+    assertThat(repository.hasPathOverlap(location + "/child")).isTrue();
+    assertThat(repository.hasPathOverlap(commonPrefix + "/sibling")).isFalse();
+  }
+
+  @Test
+  void escapesLikeMetacharactersInPathChecks() {
+    create("s3://bucket/literalX/child", NOW);
+    create("s3://bucket/percentXYZ25/child", NOW);
+
+    assertThat(repository.hasPathOverlap("s3://bucket/literal_")).isFalse();
+    assertThat(repository.hasPathOverlap("s3://bucket/percent%25")).isFalse();
+  }
+
+  @Test
+  void selectsEarliestReadyTaskAndRespectsLeases() {
+    StorageCleanupTaskDAO earliest = create("s3://bucket/earliest", NOW.minusSeconds(120));
+    StorageCleanupTaskDAO later = create("s3://bucket/later", NOW.minusSeconds(60));
+    create("s3://bucket/future", NOW.plusSeconds(1));
+
+    assertThat(repository.findReadyTask(NOW))
+        .get()
+        .extracting(StorageCleanupTaskDAO::getResourceId)
+        .isEqualTo(earliest.getResourceId());
+    UUID firstClaim =
+        repository.claimTask(earliest.getResourceId(), NOW, Duration.ofMinutes(10)).orElseThrow();
+    assertThat(repository.claimTask(earliest.getResourceId(), NOW, Duration.ofMinutes(10)))
+        .isEmpty();
+    assertThat(repository.findReadyTask(NOW))
+        .get()
+        .extracting(StorageCleanupTaskDAO::getResourceId)
+        .isEqualTo(later.getResourceId());
+
+    UUID secondClaim =
+        repository
+            .claimTask(
+                earliest.getResourceId(), NOW.plus(Duration.ofMinutes(10)), Duration.ofMinutes(10))
+            .orElseThrow();
+    assertThat(secondClaim).isNotEqualTo(firstClaim);
+  }
+
+  @Test
+  void validatesMinimumLeaseDuration() {
+    StorageCleanupTaskDAO task = create("s3://bucket/duration", NOW);
+
+    for (Duration duration :
+        java.util.List.of(Duration.ZERO, Duration.ofNanos(-1), Duration.ofNanos(1))) {
+      assertThatThrownBy(() -> repository.claimTask(task.getResourceId(), NOW, duration))
+          .isInstanceOfSatisfying(
+              BaseException.class,
+              exception -> {
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+                assertThat(exception).hasMessage("Lease duration must be at least one millisecond");
+              });
+    }
+    assertThat(repository.claimTask(task.getResourceId(), NOW, Duration.ofMillis(1))).isPresent();
+  }
+
+  @Test
+  void onlyOneCompetingClaimSucceeds() throws Exception {
+    StorageCleanupTaskDAO task = create("s3://bucket/competing", NOW);
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      java.util.concurrent.Callable<Optional<UUID>> claim =
+          () -> {
+            ready.countDown();
+            start.await();
+            return repository.claimTask(task.getResourceId(), NOW, Duration.ofMinutes(10));
+          };
+      Future<Optional<UUID>> first = executor.submit(claim);
+      Future<Optional<UUID>> second = executor.submit(claim);
+      ready.await();
+      start.countDown();
+
+      assertThat(java.util.List.of(first.get(), second.get()))
+          .filteredOn(Optional::isPresent)
+          .hasSize(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void expiredLeaseCannotUpdateOrCompleteTask() {
+    StorageCleanupTaskDAO task = create("s3://bucket/expired", NOW);
+    UUID claim =
+        repository.claimTask(task.getResourceId(), NOW, Duration.ofMinutes(10)).orElseThrow();
+    Instant expiredAt = NOW.plus(Duration.ofMinutes(10));
+
+    assertThat(repository.releaseIncomplete(task.getResourceId(), claim, expiredAt)).isFalse();
+    assertThat(
+            repository.recordFailure(
+                task.getResourceId(), claim, expiredAt, Duration.ofMinutes(1), "error"))
+        .isFalse();
+    assertThat(repository.completeTask(task.getResourceId(), claim, expiredAt)).isFalse();
+    assertThat(repository.claimTask(task.getResourceId(), expiredAt, Duration.ofMinutes(10)))
+        .isPresent();
+  }
+
+  @Test
+  void staleWorkerCannotUpdateOrCompleteReclaimedTask() {
+    StorageCleanupTaskDAO task = create("s3://bucket/stale", NOW);
+    UUID stale =
+        repository.claimTask(task.getResourceId(), NOW, Duration.ofMinutes(10)).orElseThrow();
+    Instant reclaimedAt = NOW.plus(Duration.ofMinutes(10));
+    UUID current =
+        repository
+            .claimTask(task.getResourceId(), reclaimedAt, Duration.ofMinutes(10))
+            .orElseThrow();
+
+    assertThat(repository.releaseIncomplete(task.getResourceId(), stale, reclaimedAt)).isFalse();
+    assertThat(
+            repository.recordFailure(
+                task.getResourceId(), stale, reclaimedAt, Duration.ofMinutes(30), "stale"))
+        .isFalse();
+    assertThat(repository.completeTask(task.getResourceId(), stale, reclaimedAt)).isFalse();
+
+    Instant failedAt = reclaimedAt.plusSeconds(1);
+    assertThat(
+            repository.recordFailure(
+                task.getResourceId(), current, failedAt, Duration.ofMinutes(30), "x".repeat(2100)))
+        .isTrue();
+    StorageCleanupTaskDAO failed = get(task.getResourceId());
+    assertThat(failed.getFailureCount()).isOne();
+    assertThat(failed.getLastError()).hasSize(2048);
+    assertThat(failed.getLeaseToken()).isNull();
+    assertThat(repository.findReadyTask(failedAt.plus(Duration.ofMinutes(30)).minusMillis(1)))
+        .isEmpty();
+
+    Instant retryAt = failedAt.plus(Duration.ofMinutes(30));
+    UUID retry =
+        repository.claimTask(task.getResourceId(), retryAt, Duration.ofMinutes(10)).orElseThrow();
+    assertThat(repository.releaseIncomplete(task.getResourceId(), retry, retryAt)).isTrue();
+    UUID finalClaim =
+        repository.claimTask(task.getResourceId(), retryAt, Duration.ofMinutes(10)).orElseThrow();
+    assertThat(repository.completeTask(task.getResourceId(), UUID.randomUUID(), retryAt)).isFalse();
+    assertThat(repository.completeTask(task.getResourceId(), finalClaim, retryAt)).isTrue();
+    assertThat(find(task.getResourceId())).isEmpty();
+  }
+
+  private StorageCleanupTaskDAO create(String location, Instant cleanableAt) {
+    return TransactionManager.executeWithTransaction(
+        sessionFactory,
+        session ->
+            repository.createTask(
+                session, ResourceType.TABLE, UUID.randomUUID(), location, cleanableAt),
+        "Failed to create test storage cleanup task",
+        /* readOnly= */ false);
+  }
+
+  private StorageCleanupTaskDAO get(UUID resourceId) {
+    return find(resourceId).orElseThrow();
+  }
+
+  private Optional<StorageCleanupTaskDAO> find(UUID resourceId) {
+    try (Session session = sessionFactory.openSession()) {
+      return Optional.ofNullable(session.find(StorageCleanupTaskDAO.class, resourceId));
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/persist/StorageCleanupTaskSchemaTest.java
+++ b/server/src/test/java/io/unitycatalog/server/persist/StorageCleanupTaskSchemaTest.java
@@ -1,0 +1,186 @@
+package io.unitycatalog.server.persist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO;
+import io.unitycatalog.server.persist.dao.StorageCleanupTaskDAO.ResourceType;
+import io.unitycatalog.server.persist.utils.HibernateConfigurator;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class StorageCleanupTaskSchemaTest {
+  private SessionFactory sessionFactory;
+
+  protected void configureDatabase(Properties properties) {
+    properties.setProperty("hibernate.connection.driver_class", "org.h2.Driver");
+    properties.setProperty(
+        "hibernate.connection.url", "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+  }
+
+  @AfterEach
+  void closeSessionFactory() {
+    if (sessionFactory != null) {
+      sessionFactory.close();
+    }
+  }
+
+  @Test
+  void freshSchemaPersistsCleanupTask() {
+    sessionFactory = new HibernateConfigurator(properties("create")).getSessionFactory();
+    UUID resourceId = UUID.randomUUID();
+    Instant cleanableAt = Instant.parse("2026-09-08T13:34:56Z");
+    String storageLocation = "s3://bucket/" + "a".repeat(4084);
+
+    StorageCleanupTaskDAO task = task(ResourceType.TABLE, resourceId, storageLocation, cleanableAt);
+    task.setLeaseExpiresAt(cleanableAt.plusSeconds(3600));
+    inTransaction(session -> session.persist(task));
+
+    try (Session session = sessionFactory.openSession()) {
+      assertTaskSchema(session);
+      StorageCleanupTaskDAO stored = session.find(StorageCleanupTaskDAO.class, resourceId);
+      assertThat(stored.getResourceType()).isEqualTo(ResourceType.TABLE);
+      assertThat(stored.getResourceId()).isEqualTo(resourceId);
+      assertThat(stored.getStorageLocation()).isEqualTo(storageLocation);
+      assertThat(stored.getCleanableAt()).isEqualTo(cleanableAt);
+      assertThat(stored.getLeaseToken()).isNull();
+      assertThat(stored.getLeaseExpiresAt()).isEqualTo(cleanableAt.plusSeconds(3600));
+      assertThat(stored.getFailureCount()).isZero();
+      assertThat(stored.getLastError()).isNull();
+    }
+  }
+
+  @Test
+  void resourceIdIsUnique() {
+    sessionFactory = new HibernateConfigurator(properties("create")).getSessionFactory();
+    UUID resourceId = UUID.randomUUID();
+    Instant cleanableAt = Instant.parse("2026-09-08T12:34:56Z");
+    inTransaction(
+        session ->
+            session.persist(
+                task(ResourceType.TABLE, resourceId, "s3://bucket/table", cleanableAt)));
+
+    assertThatThrownBy(
+            () ->
+                inTransaction(
+                    session ->
+                        session.persist(
+                            task(
+                                ResourceType.VOLUME,
+                                resourceId,
+                                "s3://bucket/duplicate",
+                                cleanableAt))))
+        .isInstanceOf(ConstraintViolationException.class);
+  }
+
+  @Test
+  void updateAddsCleanupTaskTableWithoutReplacingExistingSchema() {
+    Properties properties = properties("create");
+    sessionFactory = new HibernateConfigurator(properties).getSessionFactory();
+    inTransaction(
+        session -> {
+          session
+              .createNativeMutationQuery("CREATE TABLE uc_migration_marker (marker_value INTEGER)")
+              .executeUpdate();
+          session
+              .createNativeMutationQuery("INSERT INTO uc_migration_marker VALUES (7)")
+              .executeUpdate();
+          session.createNativeMutationQuery("DROP TABLE uc_storage_cleanup_tasks").executeUpdate();
+        });
+    sessionFactory.close();
+
+    properties.setProperty("hibernate.hbm2ddl.auto", "update");
+    sessionFactory = new HibernateConfigurator(properties).getSessionFactory();
+
+    try (Session session = sessionFactory.openSession()) {
+      assertTaskSchema(session);
+      assertThat(
+              session
+                  .createNativeQuery("SELECT marker_value FROM uc_migration_marker", Integer.class)
+                  .getSingleResult())
+          .isEqualTo(7);
+      assertThat(
+              session
+                  .createNativeQuery("SELECT COUNT(*) FROM uc_storage_cleanup_tasks", Long.class)
+                  .getSingleResult())
+          .isZero();
+    }
+  }
+
+  private Properties properties(String schemaAction) {
+    Properties properties = new Properties();
+    configureDatabase(properties);
+    properties.setProperty("hibernate.hbm2ddl.auto", schemaAction);
+    properties.setProperty("hibernate.show_sql", "false");
+    return properties;
+  }
+
+  private void assertTaskSchema(Session session) {
+    session.doWork(
+        connection -> {
+          Set<String> columns = new HashSet<>();
+          try (java.sql.ResultSet result =
+              connection
+                  .createStatement()
+                  .executeQuery("SELECT * FROM uc_storage_cleanup_tasks WHERE 1 = 0")) {
+            java.sql.ResultSetMetaData metadata = result.getMetaData();
+            for (int index = 1; index <= metadata.getColumnCount(); index++) {
+              columns.add(metadata.getColumnName(index).toLowerCase(Locale.ROOT));
+            }
+          }
+          assertThat(columns)
+              .containsExactlyInAnyOrder(
+                  "resource_type",
+                  "resource_id",
+                  "storage_location",
+                  "cleanable_at",
+                  "lease_token",
+                  "lease_expires_at",
+                  "failure_count",
+                  "last_error");
+
+          String tableName =
+              connection.getMetaData().storesUpperCaseIdentifiers()
+                  ? "UC_STORAGE_CLEANUP_TASKS"
+                  : "uc_storage_cleanup_tasks";
+          Set<String> indexes = new HashSet<>();
+          try (java.sql.ResultSet result =
+              connection.getMetaData().getIndexInfo(null, null, tableName, false, false)) {
+            while (result.next()) {
+              String indexName = result.getString("INDEX_NAME");
+              if (indexName != null) {
+                indexes.add(indexName.toLowerCase(Locale.ROOT));
+              }
+            }
+          }
+          assertThat(indexes).contains("uc_storage_cleanup_tasks_ready_idx");
+        });
+  }
+
+  private StorageCleanupTaskDAO task(
+      ResourceType resourceType, UUID resourceId, String location, Instant cleanableAt) {
+    return StorageCleanupTaskDAO.builder()
+        .resourceType(resourceType)
+        .resourceId(resourceId)
+        .storageLocation(location)
+        .cleanableAt(cleanableAt)
+        .build();
+  }
+
+  private void inTransaction(java.util.function.Consumer<Session> action) {
+    try (Session session = sessionFactory.openSession()) {
+      org.hibernate.Transaction transaction = session.beginTransaction();
+      action.accept(session);
+      transaction.commit();
+    }
+  }
+}

--- a/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
+++ b/server/src/test/java/io/unitycatalog/server/service/credential/aws/AwsPolicyGeneratorTest.java
@@ -78,17 +78,15 @@ public class AwsPolicyGeneratorTest {
 
   @ParameterizedTest(name = "{index}: {0} becomes {1}")
   @CsvSource({
-    "%2A, ${*}",
-    "%2a, ${*}",
-    "%3F, ${?}",
-    "%3f, ${?}",
+    "%20, %20",
+    "%2A, %2A",
+    "%3F, %3F",
+    "%25, %25",
     "prefix*middle, prefix${*}middle",
-    "prefix%3Fmiddle, prefix${?}middle",
-    "%24%7Baws:username%7D, ${$}{aws:username}",
-    "$%7B*%7D, ${$}{${*}}"
+    "$%7B*%7D, ${$}%7B${*}%7D"
   })
-  public void testPolicyEscapesIamSpecialCharacters(String encodedPath, String expectedPath)
-      throws Exception {
+  public void testPolicyPreservesEncodedKeysAndEscapesRawIamCharacters(
+      String encodedPath, String expectedPath) throws Exception {
     String bucket = "victim-bucket";
     String policy =
         AwsPolicyGenerator.generatePolicy(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/unitycatalog/unitycatalog/pull/1868/files/c37deb5907fac2ac3e80a5a4865f09eabf898392..f4fd304defa4eb33472af5895ec9fc2d200906ee) to review incremental changes.
- [stack/cleanup-persistence-schema-clean](https://github.com/unitycatalog/unitycatalog/pull/1857) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1857/files)]
  - [stack/cleanup-task-persistence-clean](https://github.com/unitycatalog/unitycatalog/pull/1858) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1858/files/b71fcac517ea9b069498ee76fbb202f647bca4f0..3e2525f28397dc95da8c6f8cd627421cdabb56a9)]
    - [stack/storage-cleanup-attempt](https://github.com/unitycatalog/unitycatalog/pull/1865) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1865/files/3e2525f28397dc95da8c6f8cd627421cdabb56a9..eb5b0f2708ad23284353ecda7e90ada7c3cdb4c1)]
      - [stack/s3-storage-cleanup-adapter](https://github.com/unitycatalog/unitycatalog/pull/1866) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1866/files/eb5b0f2708ad23284353ecda7e90ada7c3cdb4c1..4a667217a820217a3eb7887160918f872231fe82)]
        - [stack/gcs-storage-cleanup-adapter](https://github.com/unitycatalog/unitycatalog/pull/1867) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1867/files/4a667217a820217a3eb7887160918f872231fe82..c37deb5907fac2ac3e80a5a4865f09eabf898392)]
          - [**stack/adls-storage-cleanup-adapter**](https://github.com/unitycatalog/unitycatalog/pull/1868) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1868/files/c37deb5907fac2ac3e80a5a4865f09eabf898392..f4fd304defa4eb33472af5895ec9fc2d200906ee)] ← _this PR_
        - [stack/storage-cleanup-adapter-factory](https://github.com/unitycatalog/unitycatalog/pull/1869) [[Files changed](https://github.com/unitycatalog/unitycatalog/pull/1869/files/4a667217a820217a3eb7887160918f872231fe82..edbfcfc9565ae38caf307406a3055ec8d378627f)]

---------
Signed-off-by: Timothy Wang <timothy.art@gmail.com>

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR adds bounded Azure Data Lake Storage cleanup. ADLS does not provide the same multi-object delete operation as S3 or GCS, so deleting child paths one at a time could leave parent directories behind or consume the whole cleanup attempt.

The adapter represents the exact managed directory as one item. It asks the Azure SDK to delete that directory recursively, including any continuation pages handled inside the SDK call. A successful delete or an already-missing directory completes cleanup. Other Azure errors are returned to the caller so a later worker can retry.

Each attempt builds a filesystem client from the supplied SAS token. The configured method timeout bounds the complete recursive SDK call, and the retry policy also limits each HTTP try. Azure requires its per-try setting to be at least one second, so a sub-second value is rounded up there while the method timeout keeps the exact millisecond limit. Cancellation is handled by the Azure SDK; this adapter does not add a separate socket-level timeout.

The adapter accepts `abfs://` and `abfss://` directories with an account, container, and non-root path. It rejects any delete request that is not the exact task directory.

This PR does not add worker polling, task repository integration, credential vending, resource-deletion hooks, or path protection.

Tests passed:

- `build/sbt javafmtAll`
- `build/sbt "server/testOnly io.unitycatalog.server.cleanup.ADLSStorageCleanupAdapterTest io.unitycatalog.server.cleanup.StorageCleanupAttemptTest"`
